### PR TITLE
[WIP] Mutable -> FST Segment rotation for un-sealed index.Block

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -392,7 +392,7 @@ imports:
 - name: github.com/philhofer/fwd
   version: bb6d471dc95d4fe11e432687f8b70ff496cf3136
 - name: github.com/pilosa/pilosa
-  version: a112b2d46af94e3ecfa74b8158381e3595b24e4b
+  version: b22780ccf149c564f8ca271f66965aca1beb3dfa
   subpackages:
   - roaring
 - name: github.com/pkg/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -129,7 +129,7 @@ import:
   version: 0bce6a6887123b67a60366d2c9fe2dfb74289d2e
 
 - package: github.com/pilosa/pilosa/roaring
-  version: ^0.9 # FOLLOWUP: should move to 1.0 once that's released
+  version: ^1
 
 # NB(prateek): ideally, the following dependencies would be under testImport, but
 # Glide doesn't like that. https://github.com/Masterminds/glide/issues/564

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -472,9 +472,10 @@ func TestCommitLogReaderIsNotReusable(t *testing.T) {
 	reader := newCommitLogReader(opts, ReadAllSeriesPredicate())
 	_, _, _, err = reader.Open(files[0])
 	require.NoError(t, err)
-	reader.Close()
+	require.NoError(t, reader.Close())
 	_, _, _, err = reader.Open(files[0])
 	require.Equal(t, errCommitLogReaderIsNotReusable, err)
+	reader.Close()
 }
 
 func TestCommitLogIteratorUsesPredicateFilter(t *testing.T) {

--- a/src/dbnode/persist/fs/persist_manager.go
+++ b/src/dbnode/persist/fs/persist_manager.go
@@ -99,7 +99,7 @@ type dataPersistManager struct {
 
 type indexPersistManager struct {
 	writer        IndexFileSetWriter
-	segmentWriter m3ninxpersist.MutableSegmentFileSetWriter
+	segmentWriter m3ninxpersist.ReusableSegmentFileSetWriter
 
 	// identifiers required to know which file to open
 	// after persistence is over
@@ -149,7 +149,7 @@ func NewPersistManager(opts Options) (persist.Manager, error) {
 	if err != nil {
 		return nil, err
 	}
-	segmentWriter, err := m3ninxpersist.NewMutableSegmentFileSetWriter()
+	segmentWriter, err := m3ninxpersist.NewReusableSegmentFileSetWriter()
 	if err != nil {
 		return nil, err
 	}

--- a/src/dbnode/persist/fs/persist_manager_test.go
+++ b/src/dbnode/persist/fs/persist_manager_test.go
@@ -646,7 +646,7 @@ func testDataPersistManager(
 }
 
 func testIndexPersistManager(t *testing.T, ctrl *gomock.Controller,
-) (*persistManager, *MockIndexFileSetWriter, *m3ninxpersist.MockMutableSegmentFileSetWriter, Options) {
+) (*persistManager, *MockIndexFileSetWriter, *m3ninxpersist.MockReusableSegmentFileSetWriter, Options) {
 	dir := createTempDir(t)
 
 	opts := testDefaultOpts.
@@ -654,7 +654,7 @@ func testIndexPersistManager(t *testing.T, ctrl *gomock.Controller,
 		SetWriterBufferSize(10)
 
 	writer := NewMockIndexFileSetWriter(ctrl)
-	segmentWriter := m3ninxpersist.NewMockMutableSegmentFileSetWriter(ctrl)
+	segmentWriter := m3ninxpersist.NewMockReusableSegmentFileSetWriter(ctrl)
 
 	mgr, err := NewPersistManager(opts)
 	require.NoError(t, err)

--- a/src/dbnode/storage/bootstrap/bootstrapper/base_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base_test.go
@@ -461,11 +461,8 @@ func TestBaseBootstrapperIndexHalfCurrentHalfNext(t *testing.T) {
 		}),
 	}
 
-	segFirst, err := mem.NewSegment(0, mem.NewOptions())
-	require.NoError(t, err)
-
-	segSecond, err := mem.NewSegment(0, mem.NewOptions())
-	require.NoError(t, err)
+	segFirst := mem.NewSegment(0, mem.NewOptions())
+	segSecond := mem.NewSegment(0, mem.NewOptions())
 
 	currResult := result.NewIndexBootstrapResult()
 	currResult.Add(result.NewIndexBlock(testTargetStart,

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -133,8 +133,7 @@ func writeTSDBPersistedIndexBlock(
 	shards map[uint32]struct{},
 	block []testSeries,
 ) {
-	seg, err := mem.NewSegment(0, mem.NewOptions())
-	require.NoError(t, err)
+	seg := mem.NewSegment(0, mem.NewOptions())
 
 	for _, series := range block {
 		d, err := convert.FromMetric(series.ID(), series.Tags())
@@ -148,7 +147,7 @@ func writeTSDBPersistedIndexBlock(
 		require.NoError(t, err)
 	}
 
-	_, err = seg.Seal()
+	_, err := seg.Seal()
 	require.NoError(t, err)
 
 	pm := newTestOptionsWithPersistManager(t, dir).PersistManager()

--- a/src/dbnode/storage/bootstrap/result/result_index.go
+++ b/src/dbnode/storage/bootstrap/result/result_index.go
@@ -34,7 +34,7 @@ import (
 // allocator.
 func NewDefaultMutableSegmentAllocator() MutableSegmentAllocator {
 	return func() (segment.MutableSegment, error) {
-		return mem.NewSegment(0, mem.NewOptions())
+		return mem.NewSegment(0, mem.NewOptions()), nil
 	}
 }
 

--- a/src/dbnode/storage/bootstrap_test.go
+++ b/src/dbnode/storage/bootstrap_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3x/ident"
+	xtest "github.com/m3db/m3x/test"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,7 @@ import (
 )
 
 func TestDatabaseBootstrapWithBootstrapError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -63,7 +64,7 @@ func TestDatabaseBootstrapWithBootstrapError(t *testing.T) {
 }
 
 func TestDatabaseBootstrapSubsequentCallsQueued(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()

--- a/src/dbnode/storage/cleanup_prop_test.go
+++ b/src/dbnode/storage/cleanup_prop_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	xtest "github.com/m3db/m3x/test"
 
 	"github.com/golang/mock/gomock"
 	"github.com/leanovate/gopter"
@@ -91,7 +92,7 @@ func newCleanupMgrTestProperties() *gopter.Properties {
 }
 
 func TestPropertyCommitLogNotCleanedForUnflushedData(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	properties := newCleanupMgrTestProperties()
@@ -126,7 +127,7 @@ func TestPropertyCommitLogNotCleanedForUnflushedData(t *testing.T) {
 }
 
 func TestPropertyCommitLogNotCleanedForUnflushedDataMultipleNs(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	properties := newCleanupMgrTestProperties()

--- a/src/dbnode/storage/cleanup_test.go
+++ b/src/dbnode/storage/cleanup_test.go
@@ -48,7 +48,7 @@ var (
 )
 
 func TestCleanupManagerCleanup(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ts := timeFor(36000)
@@ -123,7 +123,7 @@ func TestCleanupManagerNamespaceCleanup(t *testing.T) {
 
 // Test NS doesn't cleanup when flag is present
 func TestCleanupManagerDoesntNeedCleanup(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 	ts := timeFor(36000)
 	rOpts := retention.NewOptions().
@@ -155,7 +155,7 @@ func TestCleanupManagerDoesntNeedCleanup(t *testing.T) {
 }
 
 func TestCleanupDataAndSnapshotFileSetFiles(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 	ts := timeFor(36000)
 
@@ -186,7 +186,7 @@ type deleteInactiveDirectoriesCall struct {
 }
 
 func TestDeleteInactiveDataAndSnapshotFileSetFiles(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 	ts := timeFor(36000)
 
@@ -246,7 +246,7 @@ func TestDeleteInactiveDataAndSnapshotFileSetFiles(t *testing.T) {
 }
 
 func TestCleanupManagerPropagatesGetOwnedNamespacesError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ts := timeFor(36000)
@@ -474,7 +474,7 @@ func newCleanupManagerCommitLogTimesTestMultiNS(
 }
 
 func TestCleanupManagerCommitLogTimesAllFlushed(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, mgr := newCleanupManagerCommitLogTimesTest(t, ctrl)
@@ -501,7 +501,7 @@ func TestCleanupManagerCommitLogTimesAllFlushed(t *testing.T) {
 }
 
 func TestCleanupManagerCommitLogTimesMiddlePendingFlush(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, mgr := newCleanupManagerCommitLogTimesTest(t, ctrl)
@@ -529,7 +529,7 @@ func TestCleanupManagerCommitLogTimesMiddlePendingFlush(t *testing.T) {
 }
 
 func TestCleanupManagerCommitLogTimesStartPendingFlush(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, mgr := newCleanupManagerCommitLogTimesTest(t, ctrl)
@@ -558,7 +558,7 @@ func TestCleanupManagerCommitLogTimesStartPendingFlush(t *testing.T) {
 }
 
 func TestCleanupManagerCommitLogTimesAllPendingFlush(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, mgr := newCleanupManagerCommitLogTimesTest(t, ctrl)
@@ -597,7 +597,7 @@ func contains(arr []commitlog.File, t time.Time) bool {
 }
 
 func TestCleanupManagerCommitLogTimesAllPendingFlushButHaveSnapshot(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -642,7 +642,7 @@ func TestCleanupManagerCommitLogTimesAllPendingFlushButHaveSnapshot(t *testing.T
 }
 
 func TestCleanupManagerCommitLogTimesHandlesIsCapturedBySnapshotError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, mgr := newCleanupManagerCommitLogTimesTest(t, ctrl)
@@ -663,7 +663,7 @@ func TestCleanupManagerCommitLogTimesHandlesIsCapturedBySnapshotError(t *testing
 }
 
 func TestCleanupManagerCommitLogTimesMultiNS(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns1, ns2, mgr := newCleanupManagerCommitLogTimesTestMultiNS(t, ctrl)

--- a/src/dbnode/storage/flush_test.go
+++ b/src/dbnode/storage/flush_test.go
@@ -111,7 +111,7 @@ func TestFlushManagerFlushAlreadyInProgress(t *testing.T) {
 }
 
 func TestFlushManagerFlushDoneDataError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	fakeErr := errors.New("fake error while marking flush done")
@@ -137,7 +137,7 @@ func TestFlushManagerFlushDoneDataError(t *testing.T) {
 }
 
 func TestFlushManagerFlushDoneIndexError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	mockFlusher := persist.NewMockDataFlush(ctrl)
@@ -238,7 +238,7 @@ func TestFlushManagerNamespaceIndexingEnabled(t *testing.T) {
 }
 
 func TestFlushManagerFlushTimeStart(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	inputs := []struct {
@@ -258,7 +258,7 @@ func TestFlushManagerFlushTimeStart(t *testing.T) {
 }
 
 func TestFlushManagerFlushTimeEnd(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	inputs := []struct {
@@ -278,7 +278,7 @@ func TestFlushManagerFlushTimeEnd(t *testing.T) {
 }
 
 func TestFlushManagerNamespaceFlushTimesNoNeedFlush(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	fm, ns1, _ := newMultipleFlushManagerNeedsFlush(t, ctrl)
@@ -290,7 +290,7 @@ func TestFlushManagerNamespaceFlushTimesNoNeedFlush(t *testing.T) {
 }
 
 func TestFlushManagerNamespaceFlushTimesAllNeedFlush(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	fm, ns1, _ := newMultipleFlushManagerNeedsFlush(t, ctrl)
@@ -311,7 +311,7 @@ func TestFlushManagerNamespaceFlushTimesAllNeedFlush(t *testing.T) {
 }
 
 func TestFlushManagerNamespaceFlushTimesSomeNeedFlush(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	fm, ns1, _ := newMultipleFlushManagerNeedsFlush(t, ctrl)
@@ -343,7 +343,7 @@ func TestFlushManagerNamespaceFlushTimesSomeNeedFlush(t *testing.T) {
 }
 
 func TestFlushManagerFlushSnapshot(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	fm, ns1, ns2 := newMultipleFlushManagerNeedsFlush(t, ctrl)
@@ -379,7 +379,7 @@ func TestFlushManagerFlushSnapshot(t *testing.T) {
 }
 
 func TestFlushManagerFlushNoSnapshotWhileFlushPending(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	fm, ns1, ns2 := newMultipleFlushManagerNeedsFlush(t, ctrl)
@@ -414,7 +414,7 @@ func TestFlushManagerFlushNoSnapshotWhileFlushPending(t *testing.T) {
 }
 
 func TestFlushManagerSnapshotBlockStart(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	fm, _, _ := newMultipleFlushManagerNeedsFlush(t, ctrl)

--- a/src/dbnode/storage/fs_test.go
+++ b/src/dbnode/storage/fs_test.go
@@ -26,11 +26,12 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	xtest "github.com/m3db/m3x/test"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFileSystemManagerShouldRunDuringBootstrap(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	database := newMockdatabase(ctrl)
@@ -45,7 +46,7 @@ func TestFileSystemManagerShouldRunDuringBootstrap(t *testing.T) {
 }
 
 func TestFileSystemManagerShouldRunWhileRunning(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 	database := newMockdatabase(ctrl)
 	fsm := newFileSystemManager(database, testDatabaseOptions())
@@ -57,7 +58,7 @@ func TestFileSystemManagerShouldRunWhileRunning(t *testing.T) {
 }
 
 func TestFileSystemManagerShouldRunEnableDisable(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 	database := newMockdatabase(ctrl)
 	fsm := newFileSystemManager(database, testDatabaseOptions())
@@ -71,7 +72,7 @@ func TestFileSystemManagerShouldRunEnableDisable(t *testing.T) {
 }
 
 func TestFileSystemManagerRun(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 	database := newMockdatabase(ctrl)
 	database.EXPECT().IsBootstrapped().Return(true).AnyTimes()

--- a/src/dbnode/storage/index/active_segment.go
+++ b/src/dbnode/storage/index/active_segment.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package index
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/storage/index/compaction"
+	"github.com/m3db/m3/src/dbnode/storage/index/segments"
+	m3ninxindex "github.com/m3db/m3/src/m3ninx/index"
+	"github.com/m3db/m3/src/m3ninx/index/segment"
+)
+
+const (
+	secondsPerMinute       = 60
+	secondsPerHour         = 60 * 60
+	secondsPerDay          = 24 * secondsPerHour
+	unixToInternal   int64 = (1969*365 + 1969/4 - 1969/100 + 1969/400) * secondsPerDay
+)
+
+var (
+	maxTime = time.Unix(1<<63-1-unixToInternal, 999999999)
+)
+
+var (
+	errActiveSegmentNotSealed     = errors.New("active segment is not sealed")
+	errActiveSegmentAlreadySealed = errors.New("segment already sealed")
+	errActiveSegmentSealed        = errors.New("segment is sealed")
+)
+
+func newMutableActiveSegment(
+	creationTime time.Time,
+	seg segment.MutableSegment,
+) *activeSegment {
+	return &activeSegment{
+		writable:       true,
+		creationTime:   creationTime,
+		segmentType:    segments.MutableType,
+		mutableSegment: seg,
+		earliestWrite:  maxTime,
+	}
+}
+
+func newFSTActiveSegment(
+	creationTime time.Time,
+	seg segment.Segment,
+	compactionNumber int,
+) *activeSegment {
+	return &activeSegment{
+		creationTime:     creationTime,
+		segmentType:      segments.FSTType,
+		fstSegment:       seg,
+		compactionNumber: compactionNumber,
+	}
+}
+
+// activeSegment starts out backed by a mutable segment, which is rotated
+// to a FST segment based on size constraints.
+type activeSegment struct {
+	// vars used for the write/compaction lifecycle maintenance.
+	// compacting is used to track whether the segment is currently involved
+	// in a compaction.
+	compacting bool
+	// writable indicates if the segment can still be used for writes.
+	writable bool
+
+	// the following vars are used for the read lifecycle maintenance.
+	// readsWg is used to track any pending read accesors for the given segment.
+	readsWg sync.WaitGroup
+	// sealed indicates if the segment has been marked for removal, once it's marked
+	// sealed, no new reads are allowed from the segment.
+	sealed bool
+
+	creationTime   time.Time
+	segmentType    segments.Type
+	mutableSegment segment.MutableSegment
+	fstSegment     segment.Segment
+
+	// some stats used for metrics
+	// if the segment is backed by a mutableSegment, this value represents the earliest
+	// write received. it's meaningless if the segment have been compacted
+	earliestWrite time.Time
+	// compactionNumber reflects the number of times the segments have been compacted.
+	// It's a measure of repeated resource usage.
+	compactionNumber int
+}
+
+func (a *activeSegment) MutableAndCompactable(opts compaction.PlannerOptions) bool {
+	if a.segmentType != segments.MutableType {
+		return false
+	}
+	size := a.mutableSegment.Size()
+	if size >= opts.MutableSegmentSizeThreshold {
+		return true
+	}
+	if size > 0 && time.Since(a.creationTime) > opts.MutableCompactionAgeThreshold {
+		return true
+	}
+	return false
+}
+
+func (a *activeSegment) UpdateEarliestWrite(t time.Time) {
+	if t.Before(a.earliestWrite) {
+		a.earliestWrite = t
+	}
+}
+
+func (a *activeSegment) Segment() segment.Segment {
+	if a.segmentType == segments.FSTType {
+		return a.fstSegment
+	}
+	return a.mutableSegment
+}
+
+func (a *activeSegment) Size() int64 {
+	return a.Segment().Size()
+}
+
+func (a *activeSegment) IsSealed() bool {
+	return a.sealed
+}
+
+func (a *activeSegment) Reader() (m3ninxindex.Reader, error) {
+	if a.IsSealed() {
+		return nil, errActiveSegmentSealed
+	}
+	reader, err := a.Segment().Reader()
+	if err == nil {
+		a.readsWg.Add(1)
+	}
+	return reader, err
+}
+
+func (a *activeSegment) ReaderDone() {
+	a.readsWg.Done()
+}
+
+func (a *activeSegment) Seal() error {
+	if a.IsSealed() {
+		return errActiveSegmentAlreadySealed
+	}
+	a.sealed = true
+	return nil
+}
+
+func (a *activeSegment) Close() error {
+	if !a.IsSealed() {
+		return errActiveSegmentNotSealed
+	}
+
+	// ensure there are no readers and clean up the resources async
+	go func() {
+		a.readsWg.Wait()
+		if err := a.Segment().Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "bad active segement close: %v", err)
+		}
+		a.mutableSegment = nil
+		a.fstSegment = nil
+	}()
+	return nil
+}

--- a/src/dbnode/storage/index/allocator.go
+++ b/src/dbnode/storage/index/allocator.go
@@ -32,6 +32,6 @@ func NewBootstrapResultMutableSegmentAllocator(
 	opts Options,
 ) result.MutableSegmentAllocator {
 	return func() (segment.MutableSegment, error) {
-		return mem.NewSegment(0, opts.MemSegmentOptions())
+		return mem.NewSegment(0, opts.MemSegmentOptions()), nil
 	}
 }

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -21,16 +21,22 @@
 package index
 
 import (
+	goctx "context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
+	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	"github.com/m3db/m3/src/dbnode/storage/index/compaction"
+	"github.com/m3db/m3/src/dbnode/storage/index/segments"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	m3ninxindex "github.com/m3db/m3/src/m3ninx/index"
 	"github.com/m3db/m3/src/m3ninx/index/segment"
 	"github.com/m3db/m3/src/m3ninx/index/segment/mem"
+	m3ninxpersist "github.com/m3db/m3/src/m3ninx/persist"
 	"github.com/m3db/m3/src/m3ninx/postings"
 	"github.com/m3db/m3/src/m3ninx/search"
 	"github.com/m3db/m3/src/m3ninx/search/executor"
@@ -38,6 +44,9 @@ import (
 	xerrors "github.com/m3db/m3x/errors"
 	"github.com/m3db/m3x/instrument"
 	xtime "github.com/m3db/m3x/time"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/atomic"
 )
 
 var (
@@ -60,14 +69,26 @@ const (
 	blockStateSealed
 )
 
-type newExecutorFn func() (search.Executor, error)
+type doneFn func()
+
+type newExecutorFn func() (search.Executor, doneFn, error)
 
 type block struct {
 	sync.RWMutex
 	state               blockState
-	activeSegment       segment.MutableSegment
-	shardRangesSegments []blockShardRangesSegments
+	shardRangesSegments []*blockShardRangesSegments
+	activeSegments      []*activeSegment
 
+	// the following are used to help compactions
+	numActiveCompactions *atomic.Int64
+	compactOpts          CompactionOptions
+	rotateCh             chan struct{}
+	closeCtx             goctx.Context
+	closeCtxCancelFn     goctx.CancelFunc
+
+	nowFn         clock.NowFn
+	metrics       blockMetrics
+	segmentID     atomic.Int64
 	newExecutorFn newExecutorFn
 	startTime     time.Time
 	endTime       time.Time
@@ -76,36 +97,29 @@ type block struct {
 	nsMD          namespace.Metadata
 }
 
-// blockShardsSegments is a collection of segments that has a mapping of what shards
-// and time ranges they completely cover, this can only ever come from computing
-// from data that has come from shards, either on an index flush or a bootstrap.
-type blockShardRangesSegments struct {
-	shardTimeRanges result.ShardTimeRanges
-	segments        []segment.Segment
-}
-
 // NewBlock returns a new Block, representing a complete reverse index for the
 // duration of time specified. It is backed by one or more segments.
 func NewBlock(
 	startTime time.Time,
 	md namespace.Metadata,
 	opts Options,
-) (Block, error) {
+) Block {
 	var (
 		blockSize = md.Options().IndexOptions().BlockSize()
 	)
 
-	// FOLLOWUP(prateek): use this to track segments when we have multiple segments in a Block.
-	postingsOffset := postings.ID(0)
-	seg, err := mem.NewSegment(postingsOffset, opts.MemSegmentOptions())
-	if err != nil {
-		return nil, err
-	}
-
+	closeCtx, closeFn := goctx.WithCancel(goctx.Background())
 	b := &block{
-		state:         blockStateOpen,
-		activeSegment: seg,
+		state: blockStateOpen,
 
+		numActiveCompactions: atomic.NewInt64(0),
+		compactOpts:          opts.CompactionOptions(),
+		rotateCh:             make(chan struct{}, 1),
+		closeCtx:             closeCtx,
+		closeCtxCancelFn:     closeFn,
+
+		metrics:   newBlockMetrics(opts.InstrumentOptions()),
+		nowFn:     opts.ClockOptions().NowFn(),
 		startTime: startTime,
 		endTime:   startTime.Add(blockSize),
 		blockSize: blockSize,
@@ -113,8 +127,9 @@ func NewBlock(
 		nsMD:      md,
 	}
 	b.newExecutorFn = b.executorWithRLock
-
-	return b, nil
+	b.addActiveSegmentWithLock()
+	go b.monitorRotations()
+	return b
 }
 
 func (b *block) StartTime() time.Time {
@@ -137,9 +152,11 @@ func (b *block) WriteBatch(inserts *WriteBatch) (WriteBatchResult, error) {
 		}, err
 	}
 
-	// NB: we're guaranteed the block (i.e. has a valid activeSegment) because
-	// of the state check above. the if check below is additional paranoia.
-	if b.activeSegment == nil { // should never happen
+	// NB: we're guaranteed the block has a mutable activeSegment because
+	// of the state check above; the if check below is additional paranoia.
+	mutableActiveSeg := b.mutableActiveSegmentWithRLock()
+	mutableSeg := mutableActiveSeg.mutableSegment
+	if mutableSeg == nil { // should never happen
 		err := b.openBlockHasNilActiveSegmentInvariantErrorWithRLock()
 		inserts.MarkUnmarkedEntriesError(err)
 		return WriteBatchResult{
@@ -147,7 +164,29 @@ func (b *block) WriteBatch(inserts *WriteBatch) (WriteBatchResult, error) {
 		}, err
 	}
 
-	err := b.activeSegment.InsertBatch(m3ninxindex.Batch{
+	defer func() {
+		// no compaction needed if it's empty
+		if mutableSeg.Size() == 0 {
+			return
+		}
+
+		// see if we need to compact (either if there are no active compactions,
+		// or if it's hit the size/age thresholds).
+		noActive := b.numActiveCompactions.Load() == 0
+		if noActive || mutableActiveSeg.MutableAndCompactable(b.compactOpts.PlannerOptions()) {
+			mutableActiveSeg.writable = false
+			mutableSeg.Seal()
+			b.addActiveSegmentWithLock()
+			b.triggerRotations()
+		}
+	}()
+
+	earliestWrite, ok := inserts.PendingEntries().EarliestEnqueuedAt()
+	if ok {
+		mutableActiveSeg.UpdateEarliestWrite(earliestWrite)
+	}
+
+	err := mutableSeg.InsertBatch(m3ninxindex.Batch{
 		Docs:                inserts.PendingDocs(),
 		AllowPartialUpdates: true,
 	})
@@ -180,19 +219,27 @@ func (b *block) WriteBatch(inserts *WriteBatch) (WriteBatchResult, error) {
 	}, partialErr
 }
 
-func (b *block) executorWithRLock() (search.Executor, error) {
-	var expectedReaders int
-	if b.activeSegment != nil {
-		expectedReaders++
-	}
+func (b *block) executorWithRLock() (search.Executor, doneFn, error) {
+	expectedReaders := len(b.activeSegments)
 	for _, group := range b.shardRangesSegments {
 		expectedReaders += len(group.segments)
 	}
 
 	var (
-		readers = make([]m3ninxindex.Reader, 0, expectedReaders)
-		success = false
+		activeSegs    = make([]*activeSegment, 0, expectedReaders)
+		nonActiveSegs = make([]*blockShardRangesSegments, 0, expectedReaders)
+		readers       = make([]m3ninxindex.Reader, 0, expectedReaders)
+		success       = false
 	)
+
+	done := func() {
+		for _, seg := range activeSegs {
+			seg.ReaderDone()
+		}
+		for _, group := range nonActiveSegs {
+			group.readsWg.Done()
+		}
+	}
 
 	// cleanup in case any of the readers below fail.
 	defer func() {
@@ -204,12 +251,16 @@ func (b *block) executorWithRLock() (search.Executor, error) {
 	}()
 
 	// start with the segment that's being actively written to (if we have one)
-	if b.activeSegment != nil {
-		reader, err := b.activeSegment.Reader()
+	for _, seg := range b.activeSegments {
+		if seg.segmentType != segments.FSTType {
+			continue
+		}
+		reader, err := seg.Reader()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		readers = append(readers, reader)
+		activeSegs = append(activeSegs, seg)
 	}
 
 	// loop over the segments associated to shard time ranges
@@ -217,14 +268,16 @@ func (b *block) executorWithRLock() (search.Executor, error) {
 		for _, seg := range group.segments {
 			reader, err := seg.Reader()
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
+			group.readsWg.Add(1)
 			readers = append(readers, reader)
+			nonActiveSegs = append(nonActiveSegs, group)
 		}
 	}
 
 	success = true
-	return executor.NewExecutor(readers), nil
+	return executor.NewExecutor(readers), done, nil
 }
 
 func (b *block) Query(
@@ -233,15 +286,17 @@ func (b *block) Query(
 	results Results,
 ) (bool, error) {
 	b.RLock()
-	defer b.RUnlock()
 	if b.state == blockStateClosed {
+		b.RUnlock()
 		return false, errUnableToQueryBlockClosed
 	}
 
-	exec, err := b.newExecutorFn()
+	exec, done, err := b.newExecutorFn()
+	b.RUnlock()
 	if err != nil {
 		return false, err
 	}
+	defer done()
 
 	// FOLLOWUP(prateek): push down QueryOptions to restrict results
 	// TODO(jeromefroe): Use the idx query directly once we implement an index in m3ninx
@@ -315,28 +370,40 @@ func (b *block) AddResults(
 			results.Fulfilled().SummaryString(), blockRange.String())
 	}
 
-	// NB: need to check if the current block has been marked 'Sealed' and if so,
-	// mark all incoming mutable segments the same.
-	isSealed := b.IsSealedWithRLock()
-
-	var multiErr xerrors.MultiError
-	for _, seg := range results.Segments() {
-		if x, ok := seg.(segment.MutableSegment); ok {
-			if isSealed {
-				_, err := x.Seal()
-				if err != nil {
-					// if this happens it means a Mutable segment was marked sealed
-					// in the bootstrappers, this should never happen.
-					err := b.bootstrappingSealedMutableSegmentInvariant(err)
-					multiErr = multiErr.Add(err)
-				}
-			}
+	var (
+		resultSegments  = results.Segments()
+		segments        = make([]segment.Segment, 0, len(resultSegments))
+		mutableSegments = make([]segment.Segment, 0, len(resultSegments))
+	)
+	for _, seg := range resultSegments {
+		mutableSeg, ok := seg.(segment.MutableSegment)
+		if !ok {
+			segments = append(segments, seg)
+			continue
 		}
+		if _, err := mutableSeg.Seal(); err != nil {
+			return err
+		}
+		mutableSegments = append(mutableSegments, mutableSeg)
 	}
 
-	entry := blockShardRangesSegments{
+	// NB(prateek): compact any mutable segments and treat them as "activeSegments" to
+	// ensure they are further compacted with other transient segments as required.
+	if len(mutableSegments) > 0 {
+		fstSeg, err := b.compactSegments(mutableSegments)
+		if err != nil {
+			return err
+		}
+		for idx := range mutableSegments {
+			mutableSegments[idx].Close() // cleanup any old resources
+			mutableSegments[idx] = nil
+		}
+		b.activeSegments = append(b.activeSegments, newFSTActiveSegment(b.nowFn(), fstSeg, 1))
+	}
+
+	entry := &blockShardRangesSegments{
 		shardTimeRanges: results.Fulfilled(),
-		segments:        results.Segments(),
+		segments:        segments,
 	}
 
 	// First see if this block can cover all our current blocks covering shard
@@ -352,21 +419,43 @@ func (b *block) AddResults(
 		// This is the case where it cannot wholly replace the current set of blocks
 		// so simply append the segments in this case
 		b.shardRangesSegments = append(b.shardRangesSegments, entry)
-		return multiErr.FinalError()
+		return nil
 	}
 
 	// This is the case where the new segments can wholly replace the
 	// current set of blocks since unfullfilled by the new segments is zero
 	for i, group := range b.shardRangesSegments {
-		for _, seg := range group.segments {
-			// Make sure to close the existing segments
-			multiErr = multiErr.Add(seg.Close())
-		}
-		b.shardRangesSegments[i] = blockShardRangesSegments{}
+		group.Close()
+		b.shardRangesSegments[i] = nil
 	}
 	b.shardRangesSegments = append(b.shardRangesSegments[:0], entry)
 
-	return multiErr.FinalError()
+	return nil
+}
+
+// compactSegments returns a new FST segment representing the compaction of the given segments.
+// NB: if it returns success, it closes the provided segments.
+func (b *block) compactSegments(segments []segment.Segment) (segment.Segment, error) {
+	mergedMutableSegment := mem.NewSegment(0, b.opts.MemSegmentOptions())
+	if err := mem.Merge(mergedMutableSegment, segments...); err != nil {
+		return nil, fmt.Errorf("unable to merge simple segments, err = %v", err)
+	}
+
+	if _, err := mergedMutableSegment.Seal(); err != nil {
+		return nil, fmt.Errorf("unable to seal merged segment, err = %v", err)
+	}
+
+	fstSegment, err := m3ninxpersist.TransformAndMmap(mergedMutableSegment, b.opts.FSTSegmentOptions())
+	if err != nil {
+		return nil, fmt.Errorf("unable to fst-ify merged segment, err = %v", err)
+	}
+
+	if err := mergedMutableSegment.Close(); err != nil {
+		fstSegment.Close() // ensure we don't leak any mmap'd memory
+		return nil, err
+	}
+
+	return fstSegment, nil
 }
 
 func (b *block) Tick(c context.Cancellable, tickStart time.Time) (BlockTickResult, error) {
@@ -377,13 +466,13 @@ func (b *block) Tick(c context.Cancellable, tickStart time.Time) (BlockTickResul
 		return result, errUnableToTickBlockClosed
 	}
 
-	// active segment, can be nil incase we've evicted it already.
-	if b.activeSegment != nil {
+	// active segments
+	for _, seg := range b.activeSegments {
 		result.NumSegments++
-		result.NumDocs += b.activeSegment.Size()
+		result.NumDocs += seg.Size()
 	}
 
-	// any other segments
+	// all other segments (bootstrapped/etc)
 	for _, group := range b.shardRangesSegments {
 		for _, seg := range group.segments {
 			result.NumSegments++
@@ -404,23 +493,13 @@ func (b *block) Seal() error {
 	}
 	b.state = blockStateSealed
 
-	var multiErr xerrors.MultiError
+	// Stop on-going compactions, and force-compact all mutable segments.
+	b.closeCtxCancelFn()
+	b.closeCtxCancelFn = nil
 
-	// seal active mutable segment.
-	_, err := b.activeSegment.Seal()
-	multiErr = multiErr.Add(err)
+	go b.forceCompactAllMutable()
 
-	// loop over any added mutable segments and seal them too.
-	for _, group := range b.shardRangesSegments {
-		for _, seg := range group.segments {
-			if unsealed, ok := seg.(segment.MutableSegment); ok {
-				_, err := unsealed.Seal()
-				multiErr = multiErr.Add(err)
-			}
-		}
-	}
-
-	return multiErr.FinalError()
+	return nil
 }
 
 func (b *block) IsSealedWithRLock() bool {
@@ -433,61 +512,38 @@ func (b *block) IsSealed() bool {
 	return b.IsSealedWithRLock()
 }
 
-func (b *block) NeedsMutableSegmentsEvicted() bool {
+func (b *block) NeedsFlush() bool {
 	b.RLock()
 	defer b.RUnlock()
-	anyMutableSegmentNeedsEviction := b.activeSegment != nil && b.activeSegment.Size() > 0
 
-	// can early terminate if we already know we need to flush.
-	if anyMutableSegmentNeedsEviction {
-		return true
-	}
-
-	// otherwise we check all the boostrapped segments and to see if any of them
-	// need a flush
-	for _, shardRangeSegments := range b.shardRangesSegments {
-		for _, seg := range shardRangeSegments.segments {
-			if mutableSeg, ok := seg.(segment.MutableSegment); ok {
-				anyMutableSegmentNeedsEviction = anyMutableSegmentNeedsEviction || mutableSeg.Size() > 0
-			}
+	// loop thru active segments and see if they require to be flushed
+	for _, seg := range b.activeSegments {
+		if seg.Size() > 0 {
+			return true
 		}
 	}
 
-	return anyMutableSegmentNeedsEviction
+	return false
 }
 
-func (b *block) EvictMutableSegments() (EvictMutableSegmentResults, error) {
-	var results EvictMutableSegmentResults
+func (b *block) EvictActiveSegments() (EvictActiveSegmentResults, error) {
+	var results EvictActiveSegmentResults
 	b.Lock()
 	defer b.Unlock()
 	if b.state != blockStateSealed {
 		return results, fmt.Errorf("unable to evict mutable segments, block must be sealed, found: %v", b.state)
 	}
+
 	var multiErr xerrors.MultiError
-
-	// close active segment.
-	if b.activeSegment != nil {
-		results.NumMutableSegments++
-		results.NumDocs += b.activeSegment.Size()
-		multiErr = multiErr.Add(b.activeSegment.Close())
-		b.activeSegment = nil
+	// close active segments
+	for _, seg := range b.activeSegments {
+		results.NumSegments++
+		results.NumDocs += seg.Size()
+		multiErr = multiErr.Add(seg.Seal())
+		multiErr = multiErr.Add(seg.Close())
 	}
-
-	// close any other mutable segments too.
-	for idx := range b.shardRangesSegments {
-		segments := make([]segment.Segment, 0, len(b.shardRangesSegments[idx].segments))
-		for _, seg := range b.shardRangesSegments[idx].segments {
-			mutableSeg, ok := seg.(segment.MutableSegment)
-			if !ok {
-				segments = append(segments, seg)
-				continue
-			}
-			results.NumMutableSegments++
-			results.NumDocs += mutableSeg.Size()
-			multiErr = multiErr.Add(mutableSeg.Close())
-		}
-		b.shardRangesSegments[idx].segments = segments
-	}
+	// clear any references to active segments
+	b.activeSegments = nil
 
 	return results, multiErr.FinalError()
 }
@@ -502,21 +558,283 @@ func (b *block) Close() error {
 
 	var multiErr xerrors.MultiError
 
-	// close active segment.
-	if b.activeSegment != nil {
-		multiErr = multiErr.Add(b.activeSegment.Close())
-		b.activeSegment = nil
+	// cancel any rotations that might be happening.
+	if b.closeCtxCancelFn != nil {
+		b.closeCtxCancelFn()
 	}
+	b.closeCtxCancelFn = nil
+
+	// close any active segments.
+	for _, seg := range b.activeSegments {
+		multiErr = multiErr.Add(seg.Seal())
+		multiErr = multiErr.Add(seg.Close())
+	}
+	b.activeSegments = nil
 
 	// close any other added segments too.
 	for _, group := range b.shardRangesSegments {
-		for _, seg := range group.segments {
-			multiErr = multiErr.Add(seg.Close())
-		}
+		group.Close()
 	}
 	b.shardRangesSegments = nil
 
 	return multiErr.FinalError()
+}
+
+func (b *block) triggerRotations() {
+	select {
+	case b.rotateCh <- struct{}{}: // all good, we enqueued
+	default: // i.e. there's already a rotation enqueued, so we're good.
+	}
+}
+
+// monitorRotations monitors rotateCh and triggers activeSegment rotations when signaled.
+func (b *block) monitorRotations() {
+	for {
+		select {
+		case <-b.closeCtx.Done():
+			return
+		case <-b.rotateCh:
+			b.coordinateCompactions()
+		}
+	}
+}
+
+func (b *block) forceCompactAllMutable() {
+	b.Lock()
+
+	// mark all activeSegments that are writable as not writable
+	//  to ensure we compact them
+	for _, seg := range b.activeSegments {
+		if seg.writable {
+			seg.writable = false
+		}
+	}
+
+	// create a "fake" compaction task with all tasks
+	forceCompaction := compaction.Task{
+		Segments: b.newCompactionCandidatesWithRLock(),
+	}
+
+	// mark all segments about to be compacted as such to avoid double-compacting
+	b.setCompactingStatusWithLock(true, forceCompaction)
+	b.Unlock()
+
+	// at long last, actually compact the segments
+	b.compactAndSwapSegments(forceCompaction)
+}
+
+func (b *block) coordinateCompactions() {
+	// find group of active segments which need to be rotated
+	b.Lock()
+	candidates := b.newCompactionCandidatesWithRLock()
+	compactionPlan, err := compaction.NewPlan(candidates, b.compactOpts.PlannerOptions())
+	if err != nil {
+		b.opts.InstrumentOptions().Logger().Errorf("unable to create compaction plan, err = %v", err)
+		b.Unlock()
+		return
+	}
+	// can early terminate if we don't need to do any work.
+	if len(compactionPlan.Tasks) == 0 {
+		b.Unlock()
+		return
+	}
+	// mark all segments about to be compacted as such to avoid double-compacting
+	b.setCompactingStatusWithLock(true, compactionPlan.Tasks...)
+	b.Unlock()
+
+	// at long last, actually compact the segments
+	workers := b.compactOpts.WorkerPool()
+	for idx := range compactionPlan.Tasks {
+		task := compactionPlan.Tasks[idx]
+		workers.Go(func() { b.compactAndSwapSegments(task) })
+	}
+}
+
+func (b *block) setCompactingStatusWithLock(compacting bool, tasks ...compaction.Task) {
+	// mark segments w/ appropriate compacting status in activeSegments
+	for _, seg := range b.activeSegments {
+		candidateSegment := seg.Segment()
+		for _, task := range tasks {
+			for _, taskSeg := range task.Segments {
+				if candidateSegment == taskSeg.Segment {
+					seg.compacting = compacting
+				}
+			}
+		}
+	}
+}
+
+func (b *block) setCompactingStatus(compacting bool, tasks ...compaction.Task) {
+	b.Lock()
+	b.setCompactingStatusWithLock(compacting, tasks...)
+	b.Unlock()
+}
+
+func (b *block) compactAndSwapSegments(task compaction.Task) {
+	b.numActiveCompactions.Inc()
+	defer func() {
+		b.numActiveCompactions.Dec()
+	}()
+
+	start := b.nowFn()
+	// create slice of segments to compact
+	maxCompactionNumber := int64(0)
+	segmentsToCompact := make([]segment.Segment, 0, len(task.Segments))
+	for _, s := range task.Segments {
+		segmentsToCompact = append(segmentsToCompact, s.Segment)
+		if s.CompactionNumber > maxCompactionNumber {
+			maxCompactionNumber = s.CompactionNumber
+		}
+	}
+
+	// compact segments into single mutable segment
+	fstSegment, err := b.compactSegments(segmentsToCompact)
+	if err != nil {
+		b.opts.InstrumentOptions().Logger().Errorf("unable to compact, err = %v", err)
+		b.metrics.CompactionFailure.Inc(1)
+		b.setCompactingStatus(false, task) // reset compacting state to ensure retries
+		return
+	}
+
+	compactionTime := b.nowFn().Sub(start)
+	b.metrics.CompactionLatency.Record(compactionTime)
+	newActiveSegment := newFSTActiveSegment(b.nowFn(), fstSegment, int(1+maxCompactionNumber))
+
+	// swap the successfully converted activeSegments with the newly created FST
+	b.Lock()
+	mutableSegmentTimes := make([]time.Time, 0, 10)
+	compactedActiveSegments := make([]*activeSegment, 0, len(segmentsToCompact))
+	newActiveSegments := make([]*activeSegment, 0, len(b.activeSegments))
+	for _, activeSeg := range b.activeSegments {
+		// skip all the activeSegments which have been converted above
+		isCompactedSegment := false
+		for _, seg := range segmentsToCompact {
+			if activeSeg.Segment() == seg {
+				isCompactedSegment = true
+				break
+			}
+		}
+		// add all other activeSegments
+		if !isCompactedSegment {
+			newActiveSegments = append(newActiveSegments, activeSeg)
+			continue
+		}
+
+		// i.e. this is a compacted segment
+		compactedActiveSegments = append(compactedActiveSegments, activeSeg)
+
+		// track earliest enqueued time for mutable segments to report e2e latency
+		if activeSeg.segmentType == segments.MutableType {
+			mutableSegmentTimes = append(mutableSegmentTimes, activeSeg.earliestWrite)
+		}
+	}
+	// finally, add the newly created activeSegment and update active segments
+	newActiveSegments = append(newActiveSegments, newActiveSegment)
+	b.activeSegments = newActiveSegments
+	b.Unlock()
+
+	// report e2e latency for any mutable segments that are finally available now
+	newSegmentAvailableTime := b.nowFn()
+	for _, t := range mutableSegmentTimes {
+		b.metrics.InsertEndToEndLatency.Record(newSegmentAvailableTime.Sub(t))
+	}
+
+	// release resources from all compacted segments
+	for _, seg := range compactedActiveSegments {
+		// can skip error checking here as we've got the equivalent compacted segment
+		seg.Seal()
+		seg.Close()
+	}
+}
+
+func (b *block) newCompactionCandidatesWithRLock() []compaction.Segment {
+	now := b.nowFn()
+	candidates := make([]compaction.Segment, 0, len(b.activeSegments))
+	for _, seg := range b.activeSegments {
+		if seg.compacting || seg.writable {
+			continue
+		}
+		candidates = append(candidates, compaction.Segment{
+			CompactionNumber: int64(seg.compactionNumber),
+			Size:             seg.Size(),
+			Type:             seg.segmentType,
+			Age:              now.Sub(seg.creationTime),
+			Segment:          seg.Segment(),
+		})
+	}
+	return candidates
+}
+
+func (b *block) addActiveSegmentWithLock() {
+	postingsOffset := postings.ID(b.segmentID.Inc())
+	mutableSeg := mem.NewSegment(postingsOffset, b.opts.MemSegmentOptions())
+
+	// move the new mutable segment to the front to make it easier for writes
+	// to find a mutable segment.
+	b.activeSegments = append([]*activeSegment{
+		newMutableActiveSegment(b.nowFn(), mutableSeg)}, b.activeSegments...)
+}
+
+// mutableActiveSegmentWithRLock returns any activeSegment marked as a mutableSegment.
+// NB: it can return nil if no such segment exists.
+func (b *block) mutableActiveSegmentWithRLock() *activeSegment {
+	for _, seg := range b.activeSegments {
+		if seg.segmentType == segments.MutableType && seg.writable {
+			return seg
+		}
+	}
+	return nil
+}
+
+func (b *block) Stats() BlockStats {
+	b.RLock()
+
+	// active segments
+	active := ActiveSegmentsStats{
+		NumActiveCompactions: b.numActiveCompactions.Load(),
+	}
+	for _, seg := range b.activeSegments {
+		active.NumDocs += seg.Size()
+		active.NumSegments++
+		if seg.compacting {
+			active.NumSegmentsCompacting++
+		}
+		if seg.segmentType == segments.FSTType {
+			active.NumFSTSegments++
+		} else {
+			active.NumMutableSegments++
+		}
+	}
+
+	// all other segments
+	shard := ShardRangeSegmentsStats{}
+	for _, group := range b.shardRangesSegments {
+		for _, seg := range group.segments {
+			shard.NumSegments++
+			shard.NumDocs += seg.Size()
+		}
+	}
+	b.RUnlock()
+
+	return BlockStats{
+		Active: active,
+		Shard:  shard,
+	}
+}
+
+type blockMetrics struct {
+	CompactionFailure     tally.Counter
+	CompactionLatency     tally.Timer
+	InsertEndToEndLatency tally.Timer
+}
+
+func newBlockMetrics(iopts instrument.Options) blockMetrics {
+	scope := iopts.MetricsScope()
+	return blockMetrics{
+		CompactionFailure:     scope.Counter("compaction-failure"),
+		CompactionLatency:     scope.Timer("compaction-latency"),
+		InsertEndToEndLatency: scope.Timer("insert-end-to-end-latency"),
+	}
 }
 
 func (b *block) writeBatchErrorInvalidState(state blockState) error {
@@ -545,9 +863,31 @@ func (b *block) bootstrappingSealedMutableSegmentInvariant(err error) error {
 }
 
 func (b *block) openBlockHasNilActiveSegmentInvariantErrorWithRLock() error {
-	err := fmt.Errorf("internal error: block has open block state [%v] has nil active segment", b.state)
+	err := fmt.Errorf("internal error: block has open block state [%v] has no mutable active segment", b.state)
 	instrument.EmitInvariantViolationAndGetLogger(b.opts.InstrumentOptions()).Errorf(err.Error())
 	return err
+}
+
+// blockShardsSegments is a collection of segments that has a mapping of what shards
+// and time ranges they completely cover, this can only ever come from computing
+// from data that has come from shards, either on an index flush or a bootstrap.
+type blockShardRangesSegments struct {
+	readsWg         sync.WaitGroup
+	shardTimeRanges result.ShardTimeRanges
+	segments        []segment.Segment
+	sealed          bool
+}
+
+func (b *blockShardRangesSegments) Close() {
+	b.sealed = true
+	go func() {
+		b.readsWg.Wait()
+		for _, seg := range b.segments {
+			if err := seg.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "error closing segment: %v\n", err)
+			}
+		}
+	}()
 }
 
 type closable interface {

--- a/src/dbnode/storage/index/compaction/plan.go
+++ b/src/dbnode/storage/index/compaction/plan.go
@@ -36,21 +36,13 @@ var (
 
 var (
 	// DefaultLevels are the default Level(s) used for compaction options.
-	DefaultLevels = []Level{ // i.e. tiers for compaction [0, 262K), [262K, 524K), [524K, 1M), [1M, 2M), [2M, 8M)
+	DefaultLevels = []Level{ // i.e. tiers for compaction [0, 524K), [524K, 2M), [2M, 8M)
 		Level{
 			MinSizeInclusive: 0,
-			MaxSizeExclusive: 1 << 18,
-		},
-		Level{
-			MinSizeInclusive: 1 << 18,
 			MaxSizeExclusive: 1 << 19,
 		},
 		Level{
 			MinSizeInclusive: 1 << 19,
-			MaxSizeExclusive: 1 << 20,
-		},
-		Level{
-			MinSizeInclusive: 1 << 20,
 			MaxSizeExclusive: 1 << 21,
 		},
 		Level{
@@ -174,6 +166,12 @@ func NewPlan(compactableSegments []Segment, opts PlannerOptions) (*Plan, error) 
 			accumulatedSize int64
 		)
 		sort.Slice(levelSegments, func(i, j int) bool {
+			// i.e. order to prefer mutable segments first, and then smaller segments
+			iMutable := levelSegments[i].Type == segments.MutableType
+			jMutable := levelSegments[j].Type == segments.MutableType
+			if iMutable != jMutable {
+				return iMutable
+			}
 			return levelSegments[i].Size < levelSegments[j].Size
 		})
 		for _, seg := range levelSegments {

--- a/src/dbnode/storage/index/compaction/types.go
+++ b/src/dbnode/storage/index/compaction/types.go
@@ -30,10 +30,11 @@ import (
 
 // Segment identifies a candidate for compaction.
 type Segment struct {
-	Age     time.Duration
-	Size    int64
-	Type    segments.Type
-	Segment segment.Segment
+	CompactionNumber int64
+	Size             int64
+	Age              time.Duration
+	Type             segments.Type
+	Segment          segment.Segment
 }
 
 // Task identifies a collection of segments to compact.

--- a/src/dbnode/storage/index/for_each_test.go
+++ b/src/dbnode/storage/index/for_each_test.go
@@ -26,13 +26,14 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
+	xtest "github.com/m3db/m3x/test"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWriteBatchForEachUnmarkedBatchByBlockStart(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	blockSize := time.Hour
@@ -79,7 +80,7 @@ func TestWriteBatchForEachUnmarkedBatchByBlockStart(t *testing.T) {
 }
 
 func TestWriteBatchForEachUnmarkedBatchByBlockStartMore(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	blockSize := time.Hour

--- a/src/dbnode/storage/index/index_mock.go
+++ b/src/dbnode/storage/index/index_mock.go
@@ -189,17 +189,17 @@ func (mr *MockBlockMockRecorder) EndTime() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndTime", reflect.TypeOf((*MockBlock)(nil).EndTime))
 }
 
-// EvictMutableSegments mocks base method
-func (m *MockBlock) EvictMutableSegments() (EvictMutableSegmentResults, error) {
-	ret := m.ctrl.Call(m, "EvictMutableSegments")
-	ret0, _ := ret[0].(EvictMutableSegmentResults)
+// EvictActiveSegments mocks base method
+func (m *MockBlock) EvictActiveSegments() (EvictActiveSegmentResults, error) {
+	ret := m.ctrl.Call(m, "EvictActiveSegments")
+	ret0, _ := ret[0].(EvictActiveSegmentResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EvictMutableSegments indicates an expected call of EvictMutableSegments
-func (mr *MockBlockMockRecorder) EvictMutableSegments() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictMutableSegments", reflect.TypeOf((*MockBlock)(nil).EvictMutableSegments))
+// EvictActiveSegments indicates an expected call of EvictActiveSegments
+func (mr *MockBlockMockRecorder) EvictActiveSegments() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictActiveSegments", reflect.TypeOf((*MockBlock)(nil).EvictActiveSegments))
 }
 
 // IsSealed mocks base method
@@ -214,16 +214,16 @@ func (mr *MockBlockMockRecorder) IsSealed() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSealed", reflect.TypeOf((*MockBlock)(nil).IsSealed))
 }
 
-// NeedsMutableSegmentsEvicted mocks base method
-func (m *MockBlock) NeedsMutableSegmentsEvicted() bool {
-	ret := m.ctrl.Call(m, "NeedsMutableSegmentsEvicted")
+// NeedsFlush mocks base method
+func (m *MockBlock) NeedsFlush() bool {
+	ret := m.ctrl.Call(m, "NeedsFlush")
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// NeedsMutableSegmentsEvicted indicates an expected call of NeedsMutableSegmentsEvicted
-func (mr *MockBlockMockRecorder) NeedsMutableSegmentsEvicted() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedsMutableSegmentsEvicted", reflect.TypeOf((*MockBlock)(nil).NeedsMutableSegmentsEvicted))
+// NeedsFlush indicates an expected call of NeedsFlush
+func (mr *MockBlockMockRecorder) NeedsFlush() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedsFlush", reflect.TypeOf((*MockBlock)(nil).NeedsFlush))
 }
 
 // Query mocks base method
@@ -261,6 +261,18 @@ func (m *MockBlock) StartTime() time.Time {
 // StartTime indicates an expected call of StartTime
 func (mr *MockBlockMockRecorder) StartTime() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartTime", reflect.TypeOf((*MockBlock)(nil).StartTime))
+}
+
+// Stats mocks base method
+func (m *MockBlock) Stats() BlockStats {
+	ret := m.ctrl.Call(m, "Stats")
+	ret0, _ := ret[0].(BlockStats)
+	return ret0
+}
+
+// Stats indicates an expected call of Stats
+func (mr *MockBlockMockRecorder) Stats() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockBlock)(nil).Stats))
 }
 
 // Tick mocks base method

--- a/src/dbnode/storage/index/options.go
+++ b/src/dbnode/storage/index/options.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 
 	"github.com/m3db/m3/src/dbnode/clock"
+	"github.com/m3db/m3/src/m3ninx/index/segment/fst"
 	"github.com/m3db/m3/src/m3ninx/index/segment/mem"
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
@@ -47,9 +48,11 @@ type opts struct {
 	clockOpts      clock.Options
 	instrumentOpts instrument.Options
 	memOpts        mem.Options
+	fstOpts        fst.Options
 	idPool         ident.Pool
 	bytesPool      pool.CheckedBytesPool
 	resultsPool    ResultsPool
+	compactOpts    CompactionOptions
 }
 
 var undefinedUUIDFn = func() ([]byte, error) { return nil, errIDGenerationDisabled }
@@ -62,14 +65,21 @@ func NewOptions() Options {
 	})
 	bytesPool.Init()
 	idPool := ident.NewPool(bytesPool, ident.PoolOptions{})
+	// TODO(prateek): transitively update dependent fst/mem opts when any of the shared knobs are set
+	memOpts := mem.NewOptions().SetNewUUIDFn(undefinedUUIDFn)
+	fstOpts := fst.NewOptions().
+		SetPostingsListPool(memOpts.PostingsListPool()).
+		SetBytesPool(bytesPool.BytesPool())
 	opts := &opts{
 		insertMode:     defaultIndexInsertMode,
 		clockOpts:      clock.NewOptions(),
 		instrumentOpts: instrument.NewOptions(),
-		memOpts:        mem.NewOptions().SetNewUUIDFn(undefinedUUIDFn),
 		bytesPool:      bytesPool,
+		memOpts:        memOpts,
+		fstOpts:        fstOpts,
 		idPool:         idPool,
 		resultsPool:    resultsPool,
+		compactOpts:    NewCompactionOptions(),
 	}
 	resultsPool.Init(func() Results { return NewResults(opts) })
 	return opts
@@ -120,6 +130,16 @@ func (o *opts) InstrumentOptions() instrument.Options {
 	return o.instrumentOpts
 }
 
+func (o *opts) SetFSTSegmentOptions(value fst.Options) Options {
+	opts := *o
+	opts.fstOpts = value
+	return &opts
+}
+
+func (o *opts) FSTSegmentOptions() fst.Options {
+	return o.fstOpts
+}
+
 func (o *opts) SetMemSegmentOptions(value mem.Options) Options {
 	opts := *o
 	opts.memOpts = value
@@ -158,4 +178,14 @@ func (o *opts) SetResultsPool(value ResultsPool) Options {
 
 func (o *opts) ResultsPool() ResultsPool {
 	return o.resultsPool
+}
+
+func (o *opts) SetCompactionOptions(value CompactionOptions) Options {
+	opts := *o
+	opts.compactOpts = value
+	return &opts
+}
+
+func (o *opts) CompactionOptions() CompactionOptions {
+	return o.compactOpts
 }

--- a/src/dbnode/storage/index_insert_queue_test.go
+++ b/src/dbnode/storage/index_insert_queue_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3x/ident"
+	xtest "github.com/m3db/m3x/test"
 
 	"github.com/fortytw2/leaktest"
 	"github.com/golang/mock/gomock"
@@ -77,7 +78,7 @@ func TestIndexInsertQueueLifecycleLeaks(t *testing.T) {
 
 func TestIndexInsertQueueCallback(t *testing.T) {
 	defer leaktest.CheckTimeout(t, time.Second)()
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -111,7 +112,7 @@ func TestIndexInsertQueueCallback(t *testing.T) {
 }
 
 func TestIndexInsertQueueRateLimit(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 	defer leaktest.CheckTimeout(t, time.Second)()
 	var (
@@ -186,7 +187,7 @@ func TestIndexInsertQueueRateLimit(t *testing.T) {
 }
 
 func TestIndexInsertQueueBatchBackoff(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 	var (
 		inserts  [][]*index.WriteBatch

--- a/src/dbnode/storage/index_queue_test.go
+++ b/src/dbnode/storage/index_queue_test.go
@@ -31,12 +31,10 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	"github.com/m3db/m3/src/m3ninx/doc"
-	m3ninxidx "github.com/m3db/m3/src/m3ninx/idx"
-	"github.com/m3db/m3x/context"
 	"github.com/m3db/m3x/ident"
+	xtest "github.com/m3db/m3x/test"
 	xtime "github.com/m3db/m3x/time"
 
-	"github.com/fortytw2/leaktest"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,41 +45,42 @@ func testNamespaceIndexOptions() index.Options {
 	return testDatabaseOptions().IndexOptions()
 }
 
-func newTestNamespaceIndex(t *testing.T, ctrl *gomock.Controller) (namespaceIndex, *MocknamespaceIndexInsertQueue) {
+func newTestNamespaceIndex(t *testing.T, ctrl *gomock.Controller) (namespaceIndex, *MocknamespaceIndexInsertQueue, *index.MockBlock) {
 	q := NewMocknamespaceIndexInsertQueue(ctrl)
-	newFn := func(fn nsIndexInsertBatchFn, nowFn clock.NowFn, s tally.Scope) namespaceIndexInsertQueue {
+	newQueueFn := func(fn nsIndexInsertBatchFn, nowFn clock.NowFn, s tally.Scope) namespaceIndexInsertQueue {
 		return q
 	}
 	q.EXPECT().Start().Return(nil)
+
+	b := index.NewMockBlock(ctrl)
+	b.EXPECT().Stats().Return(index.BlockStats{}).AnyTimes()
+	newBlockFn := func(startTime time.Time, md namespace.Metadata, opts index.Options) index.Block {
+		return b
+	}
 	md, err := namespace.NewMetadata(defaultTestNs1ID, defaultTestNs1Opts)
 	require.NoError(t, err)
-	idx, err := newNamespaceIndexWithInsertQueueFn(md, newFn, testDatabaseOptions())
+	idx, err := newNamespaceIndexWithOptions(newNamespaceIndexOpts{
+		md:              md,
+		opts:            testDatabaseOptions(),
+		newIndexQueueFn: newQueueFn,
+		newBlockFn:      newBlockFn,
+	})
 	assert.NoError(t, err)
-	return idx, q
+	return idx, q, b
 }
 
 func TestNamespaceIndexHappyPath(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
-	q := NewMocknamespaceIndexInsertQueue(ctrl)
-	newFn := func(fn nsIndexInsertBatchFn, nowFn clock.NowFn, s tally.Scope) namespaceIndexInsertQueue {
-		return q
-	}
-	q.EXPECT().Start().Return(nil)
-
-	md, err := namespace.NewMetadata(defaultTestNs1ID, defaultTestNs1Opts)
-	require.NoError(t, err)
-	idx, err := newNamespaceIndexWithInsertQueueFn(md, newFn, testDatabaseOptions())
-	assert.NoError(t, err)
-	assert.NotNil(t, idx)
-
+	idx, q, b := newTestNamespaceIndex(t, ctrl)
 	q.EXPECT().Stop().Return(nil)
+	b.EXPECT().Close().Return(nil)
 	assert.NoError(t, idx.Close())
 }
 
 func TestNamespaceIndexStartErr(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	q := NewMocknamespaceIndexInsertQueue(ctrl)
@@ -97,30 +96,21 @@ func TestNamespaceIndexStartErr(t *testing.T) {
 }
 
 func TestNamespaceIndexStopErr(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
-	q := NewMocknamespaceIndexInsertQueue(ctrl)
-	newFn := func(fn nsIndexInsertBatchFn, nowFn clock.NowFn, s tally.Scope) namespaceIndexInsertQueue {
-		return q
-	}
-	q.EXPECT().Start().Return(nil)
-
-	md, err := namespace.NewMetadata(defaultTestNs1ID, defaultTestNs1Opts)
-	require.NoError(t, err)
-	idx, err := newNamespaceIndexWithInsertQueueFn(md, newFn, testDatabaseOptions())
-	assert.NoError(t, err)
-	assert.NotNil(t, idx)
-
+	idx, q, b := newTestNamespaceIndex(t, ctrl)
+	b.EXPECT().Close().Return(nil)
 	q.EXPECT().Stop().Return(fmt.Errorf("random err"))
+
 	assert.Error(t, idx.Close())
 }
 
 func TestNamespaceIndexWriteAfterClose(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
-	dbIdx, q := newTestNamespaceIndex(t, ctrl)
+	dbIdx, q, b := newTestNamespaceIndex(t, ctrl)
 	idx, ok := dbIdx.(*nsIndex)
 	assert.True(t, ok)
 
@@ -130,6 +120,7 @@ func TestNamespaceIndexWriteAfterClose(t *testing.T) {
 	)
 
 	q.EXPECT().Stop().Return(nil)
+	b.EXPECT().Close().Return(nil)
 	assert.NoError(t, idx.Close())
 
 	now := time.Now()
@@ -143,10 +134,10 @@ func TestNamespaceIndexWriteAfterClose(t *testing.T) {
 }
 
 func TestNamespaceIndexWriteQueueError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
-	dbIdx, q := newTestNamespaceIndex(t, ctrl)
+	dbIdx, q, _ := newTestNamespaceIndex(t, ctrl)
 	idx, ok := dbIdx.(*nsIndex)
 	assert.True(t, ok)
 
@@ -168,7 +159,7 @@ func TestNamespaceIndexWriteQueueError(t *testing.T) {
 }
 
 func TestNamespaceIndexInsertRetentionPeriod(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -246,10 +237,10 @@ func TestNamespaceIndexInsertRetentionPeriod(t *testing.T) {
 }
 
 func TestNamespaceIndexInsertQueueInteraction(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
-	dbIdx, q := newTestNamespaceIndex(t, ctrl)
+	dbIdx, q, _ := newTestNamespaceIndex(t, ctrl)
 	idx, ok := dbIdx.(*nsIndex)
 	assert.True(t, ok)
 
@@ -267,59 +258,4 @@ func TestNamespaceIndexInsertQueueInteraction(t *testing.T) {
 	q.EXPECT().InsertBatch(gomock.Any()).Return(&wg, nil)
 	assert.NoError(t, idx.WriteBatch(testWriteBatch(testWriteBatchEntry(id,
 		tags, now, lifecycle))))
-}
-
-func TestNamespaceIndexInsertQuery(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	defer leaktest.CheckTimeout(t, 2*time.Second)()
-
-	newFn := func(fn nsIndexInsertBatchFn, nowFn clock.NowFn, s tally.Scope) namespaceIndexInsertQueue {
-		q := newNamespaceIndexInsertQueue(fn, nowFn, s)
-		q.(*nsIndexInsertQueue).indexBatchBackoff = 10 * time.Millisecond
-		return q
-	}
-	md, err := namespace.NewMetadata(defaultTestNs1ID, defaultTestNs1Opts)
-	require.NoError(t, err)
-	idx, err := newNamespaceIndexWithInsertQueueFn(md, newFn, testDatabaseOptions().
-		SetIndexOptions(testNamespaceIndexOptions().SetInsertMode(index.InsertSync)))
-	assert.NoError(t, err)
-	defer idx.Close()
-
-	var (
-		blockSize  = idx.(*nsIndex).blockSize
-		indexState = idx.(*nsIndex).state
-		ts         = indexState.latestBlock.StartTime()
-		now        = time.Now()
-		id         = ident.StringID("foo")
-		tags       = ident.NewTags(
-			ident.StringTag("name", "value"),
-		)
-		ctx          = context.NewContext()
-		lifecycleFns = index.NewMockOnIndexSeries(ctrl)
-	)
-
-	lifecycleFns.EXPECT().OnIndexFinalize(xtime.ToUnixNano(ts))
-	lifecycleFns.EXPECT().OnIndexSuccess(xtime.ToUnixNano(ts))
-
-	entry, doc := testWriteBatchEntry(id, tags, now, lifecycleFns)
-	batch := testWriteBatch(entry, doc, testWriteBatchBlockSizeOption(blockSize))
-	assert.NoError(t, idx.WriteBatch(batch))
-
-	reQuery, err := m3ninxidx.NewRegexpQuery([]byte("name"), []byte("val.*"))
-	assert.NoError(t, err)
-	res, err := idx.Query(ctx, index.Query{reQuery}, index.QueryOptions{
-		StartInclusive: now.Add(-1 * time.Minute),
-		EndExclusive:   now.Add(1 * time.Minute),
-	})
-	assert.NoError(t, err)
-
-	assert.True(t, res.Exhaustive)
-	results := res.Results
-	assert.Equal(t, "testns1", results.Namespace().String())
-	tags, ok := results.Map().Get(ident.StringID("foo"))
-	assert.True(t, ok)
-	assert.True(t, ident.NewTagIterMatcher(
-		ident.MustNewTagStringsIterator("name", "value")).Matches(
-		ident.NewTagsIterator(tags)))
 }

--- a/src/dbnode/storage/mediator_test.go
+++ b/src/dbnode/storage/mediator_test.go
@@ -25,11 +25,12 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	xtest "github.com/m3db/m3x/test"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDatabaseMediatorOpenClose(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions().SetRepairEnabled(false)
@@ -57,7 +58,7 @@ func TestDatabaseMediatorOpenClose(t *testing.T) {
 }
 
 func TestDatabaseMediatorDisableFileOps(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions().SetRepairEnabled(false)

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -94,7 +94,7 @@ func TestNamespaceName(t *testing.T) {
 }
 
 func TestNamespaceTick(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, closer := newTestNamespace(t)
@@ -110,7 +110,7 @@ func TestNamespaceTick(t *testing.T) {
 }
 
 func TestNamespaceTickError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	fakeErr := errors.New("fake error")
@@ -148,7 +148,7 @@ func TestNamespaceWriteShardNotOwned(t *testing.T) {
 }
 
 func TestNamespaceWriteShardOwned(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -184,7 +184,7 @@ func TestNamespaceReadEncodedShardNotOwned(t *testing.T) {
 }
 
 func TestNamespaceReadEncodedShardOwned(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -228,7 +228,7 @@ func TestNamespaceFetchBlocksShardNotOwned(t *testing.T) {
 }
 
 func TestNamespaceFetchBlocksShardOwned(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -275,7 +275,7 @@ func TestNamespaceFetchBlocksMetadataShardNotOwned(t *testing.T) {
 }
 
 func TestNamespaceFetchBlocksMetadataShardOwned(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -363,7 +363,7 @@ func TestNamespaceBootstrapAllShards(t *testing.T) {
 }
 
 func TestNamespaceBootstrapOnlyNonBootstrappedShards(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var needsBootstrap, alreadyBootstrapped []shard.Shard
@@ -424,7 +424,7 @@ func TestNamespaceFlushDontNeedFlush(t *testing.T) {
 }
 
 func TestNamespaceFlushSkipFlushed(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -459,7 +459,7 @@ func TestNamespaceFlushSkipFlushed(t *testing.T) {
 }
 
 func TestNamespaceFlushSkipShardNotBootstrappedBeforeTick(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -489,7 +489,7 @@ type snapshotTestCase struct {
 }
 
 func TestNamespaceSnapshotNotBootstrapped(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -552,7 +552,7 @@ func TestNamespaceSnapshotShardError(t *testing.T) {
 }
 
 func testSnapshotWithShardSnapshotErrs(t *testing.T, shardMethodResults []snapshotTestCase) error {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -589,7 +589,7 @@ func testSnapshotWithShardSnapshotErrs(t *testing.T, shardMethodResults []snapsh
 }
 
 func TestNamespaceTruncate(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, closer := newTestNamespace(t)
@@ -608,7 +608,7 @@ func TestNamespaceTruncate(t *testing.T) {
 }
 
 func TestNamespaceRepair(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, closer := newTestNamespaceWithIDOpts(t, defaultTestNs1ID,
@@ -642,7 +642,7 @@ func TestNamespaceRepair(t *testing.T) {
 }
 
 func TestNamespaceShardAt(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, closer := newTestNamespace(t)
@@ -669,7 +669,7 @@ func TestNamespaceShardAt(t *testing.T) {
 }
 
 func TestNamespaceAssignShardSet(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	shards := sharding.NewShards([]uint32{0, 1, 2, 3, 4}, shard.Available)
@@ -790,7 +790,7 @@ func setShardExpects(ns *dbNamespace, ctrl *gomock.Controller, cases []needsFlus
 }
 
 func TestNamespaceNeedsFlushRange(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -818,7 +818,7 @@ func TestNamespaceNeedsFlushRange(t *testing.T) {
 }
 
 func TestNamespaceNeedsFlushRangeMultipleShardConflict(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -851,7 +851,7 @@ func TestNamespaceNeedsFlushRangeMultipleShardConflict(t *testing.T) {
 	assert.False(t, ns.NeedsFlush(t2, t0))
 }
 func TestNamespaceNeedsFlushRangeSingleShardConflict(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -885,7 +885,7 @@ func TestNamespaceNeedsFlushRangeSingleShardConflict(t *testing.T) {
 }
 
 func TestNamespaceNeedsFlushAllSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -926,7 +926,7 @@ func TestNamespaceNeedsFlushAllSuccess(t *testing.T) {
 }
 
 func TestNamespaceNeedsFlushAnyFailed(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -978,7 +978,7 @@ func TestNamespaceNeedsFlushAnyFailed(t *testing.T) {
 }
 
 func TestNamespaceNeedsFlushAnyNotStarted(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -1029,7 +1029,7 @@ func TestNamespaceNeedsFlushAnyNotStarted(t *testing.T) {
 }
 
 func TestNamespaceCloseWillCloseShard(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -1059,7 +1059,7 @@ func TestNamespaceCloseDoesNotLeak(t *testing.T) {
 	leakCheck := leaktest.Check(t)
 	defer leakCheck()
 
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ctx := context.NewContext()
@@ -1082,7 +1082,7 @@ func TestNamespaceCloseDoesNotLeak(t *testing.T) {
 }
 
 func TestNamespaceIndexInsert(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	idx := NewMocknamespaceIndex(ctrl)
@@ -1107,7 +1107,7 @@ func TestNamespaceIndexInsert(t *testing.T) {
 }
 
 func TestNamespaceIndexQuery(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	idx := NewMocknamespaceIndex(ctrl)
@@ -1127,7 +1127,7 @@ func TestNamespaceIndexQuery(t *testing.T) {
 }
 
 func TestNamespaceTicksIndex(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	idx := NewMocknamespaceIndex(ctrl)
@@ -1155,7 +1155,7 @@ func TestNamespaceIndexDisabledQuery(t *testing.T) {
 }
 
 func TestNamespaceBootstrapState(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, closer := newTestNamespace(t)
@@ -1178,7 +1178,7 @@ func TestNamespaceBootstrapState(t *testing.T) {
 }
 
 func TestNamespaceIsCapturedBySnapshot(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	ns, closer := newTestNamespace(t)

--- a/src/dbnode/storage/namespace_watch_test.go
+++ b/src/dbnode/storage/namespace_watch_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	"github.com/m3db/m3x/instrument"
+	xtest "github.com/m3db/m3x/test"
 
 	"github.com/fortytw2/leaktest"
 	"github.com/golang/mock/gomock"
@@ -52,7 +53,7 @@ func newTestNamespaceWatch(t *testing.T, ctrl *gomock.Controller) (
 }
 
 func TestNamespaceWatchStartStop(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	ch := make(chan struct{}, 1)
 	defer func() {
 		ctrl.Finish()
@@ -73,7 +74,7 @@ func TestNamespaceWatchStartStop(t *testing.T) {
 }
 
 func TestNamespaceWatchStopWithoutStart(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	ch := make(chan struct{}, 1)
 	defer func() {
 		ctrl.Finish()
@@ -87,7 +88,7 @@ func TestNamespaceWatchStopWithoutStart(t *testing.T) {
 }
 
 func TestNamespaceWatchUpdatePropagation(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	ch := make(chan struct{}, 1)
 	defer func() {
 		ctrl.Finish()

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -157,7 +157,7 @@ func newOptions(poolOpts pool.ObjectPoolOptions) Options {
 	seriesOpts := series.NewOptions()
 
 	// Default to using half of the available cores for querying IDs
-	queryIDsWorkerPool := xsync.NewWorkerPool(int(math.Ceil(float64(runtime.NumCPU()) / 2)))
+	queryIDsWorkerPool := xsync.NewWorkerPool(int(math.Ceil(float64(runtime.NumCPU()))))
 	queryIDsWorkerPool.Init()
 
 	o := &options{

--- a/src/dbnode/storage/repair_test.go
+++ b/src/dbnode/storage/repair_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3x/context"
 	"github.com/m3db/m3x/ident"
+	xtest "github.com/m3db/m3x/test"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/golang/mock/gomock"
@@ -42,7 +43,7 @@ import (
 )
 
 func TestDatabaseRepairerStartStop(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions().SetRepairOptions(testRepairOptions(ctrl))
@@ -92,7 +93,7 @@ func TestDatabaseRepairerStartStop(t *testing.T) {
 }
 
 func TestDatabaseRepairerHaveNotReachedOffset(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -137,7 +138,7 @@ func TestDatabaseRepairerHaveNotReachedOffset(t *testing.T) {
 }
 
 func TestDatabaseRepairerOnlyOncePerInterval(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var (
@@ -194,7 +195,7 @@ func TestDatabaseRepairerOnlyOncePerInterval(t *testing.T) {
 }
 
 func TestDatabaseRepairerRepairNotBootstrapped(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions().SetRepairOptions(testRepairOptions(ctrl))
@@ -209,7 +210,7 @@ func TestDatabaseRepairerRepairNotBootstrapped(t *testing.T) {
 }
 
 func TestDatabaseShardRepairerRepair(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	session := client.NewMockAdminSession(ctrl)
@@ -333,7 +334,7 @@ func TestDatabaseShardRepairerRepair(t *testing.T) {
 }
 
 func TestRepairerRepairTimes(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	now := time.Unix(188000, 0)
@@ -370,7 +371,7 @@ func TestRepairerRepairTimes(t *testing.T) {
 }
 
 func TestRepairerRepairWithTime(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	repairTimeRange := xtime.Range{Start: time.Unix(7200, 0), End: time.Unix(14400, 0)}
@@ -422,7 +423,7 @@ func TestRepairerTimesMultipleNamespaces(t *testing.T) {
 		return tf2(2 * i)
 	}
 
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	now := time.Unix(188000, 0)

--- a/src/dbnode/storage/series/lookup/entry.go
+++ b/src/dbnode/storage/series/lookup/entry.go
@@ -195,7 +195,7 @@ func (s *entryIndexState) setSuccessWithWLock(t xtime.UnixNano) {
 	for i := range s.states {
 		if s.states[i].blockStart.Equal(t) {
 			s.states[i].success = true
-			break
+			return
 		}
 	}
 

--- a/src/dbnode/storage/shard_fetch_blocks_metadata_test.go
+++ b/src/dbnode/storage/shard_fetch_blocks_metadata_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/ident"
+	xtest "github.com/m3db/m3x/test"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/mock/gomock"
@@ -43,7 +44,7 @@ import (
 )
 
 func TestShardFetchBlocksMetadata(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -101,7 +102,7 @@ func TestShardFetchBlocksMetadata(t *testing.T) {
 }
 
 func TestShardFetchBlocksMetadataV2WithSeriesCachePolicyCacheAll(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions().SetSeriesCachePolicy(series.CacheAll)
@@ -185,7 +186,7 @@ func (b fetchBlockMetadataResultByStart) Less(i, j int) bool {
 }
 
 func TestShardFetchBlocksMetadataV2WithSeriesCachePolicyNotCacheAll(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions().SetSeriesCachePolicy(series.CacheRecentlyRead)

--- a/src/dbnode/storage/shard_ref_count_test.go
+++ b/src/dbnode/storage/shard_ref_count_test.go
@@ -36,6 +36,7 @@ import (
 	xclock "github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/context"
 	"github.com/m3db/m3x/ident"
+	xtest "github.com/m3db/m3x/test"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/fortytw2/leaktest"
@@ -111,7 +112,7 @@ func TestShardWriteSyncRefCount(t *testing.T) {
 }
 
 func TestShardWriteTaggedSyncRefCountMockIndex(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	blockSize := namespace.NewIndexOptions().BlockSize()
@@ -150,15 +151,13 @@ func TestShardWriteTaggedSyncRefCountSyncIndex(t *testing.T) {
 	}
 	md, err := namespace.NewMetadata(defaultTestNs1ID, defaultTestNs1Opts)
 	require.NoError(t, err)
-	idx, err := newNamespaceIndexWithInsertQueueFn(md, newFn, testDatabaseOptions().
-		SetIndexOptions(index.NewOptions().SetInsertMode(index.InsertSync)))
+	opts := testDatabaseOptions()
+	idx, err := newNamespaceIndexWithInsertQueueFn(md, newFn, opts.
+		SetIndexOptions(opts.IndexOptions().SetInsertMode(index.InsertSync)))
 	assert.NoError(t, err)
 
-	defer func() {
-		assert.NoError(t, idx.Close())
-	}()
-
 	testShardWriteTaggedSyncRefCount(t, idx)
+	assert.NoError(t, idx.Close())
 }
 
 func testShardWriteTaggedSyncRefCount(t *testing.T, idx namespaceIndex) {
@@ -308,7 +307,7 @@ func TestShardWriteAsyncRefCount(t *testing.T) {
 }
 
 func TestShardWriteTaggedAsyncRefCountMockIndex(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	blockSize := namespace.NewIndexOptions().BlockSize()

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -139,7 +139,7 @@ func TestShardFlushStateNotStarted(t *testing.T) {
 }
 
 func TestShardBootstrapWithError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -187,7 +187,7 @@ func TestShardFlushDuringBootstrap(t *testing.T) {
 }
 
 func TestShardFlushSeriesFlushError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	blockStart := time.Unix(21600, 0)
@@ -252,7 +252,7 @@ func TestShardFlushSeriesFlushError(t *testing.T) {
 }
 
 func TestShardFlushSeriesFlushSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	blockStart := time.Unix(21600, 0)
@@ -313,7 +313,7 @@ func TestShardFlushSeriesFlushSuccess(t *testing.T) {
 }
 
 func TestShardSnapshotShardNotBootstrapped(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	blockStart := time.Unix(21600, 0)
@@ -328,7 +328,7 @@ func TestShardSnapshotShardNotBootstrapped(t *testing.T) {
 }
 
 func TestShardSnapshotSeriesSnapshotSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	blockStart := time.Unix(21600, 0)
@@ -595,7 +595,7 @@ func TestShardTickCleanupSmallBatchSize(t *testing.T) {
 
 // This tests ensures the shard returns an error if two ticks are triggered concurrently.
 func TestShardReturnsErrorForConcurrentTicks(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -640,7 +640,7 @@ func TestShardReturnsErrorForConcurrentTicks(t *testing.T) {
 // This tests ensures the resources held in series contained in the shard are released
 // when closing the shard.
 func TestShardTicksWhenClosed(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -656,7 +656,7 @@ func TestShardTicksWhenClosed(t *testing.T) {
 
 // This tests ensures the shard terminates Ticks when closing.
 func TestShardTicksStopWhenClosing(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -738,7 +738,7 @@ func TestPurgeExpiredSeriesNonEmptySeries(t *testing.T) {
 // but receives writes after tickForEachSeries finishes but before purgeExpiredSeries
 // starts. The expected behavior is not to expire series in this case.
 func TestPurgeExpiredSeriesWriteAfterTicking(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -766,7 +766,7 @@ func TestPurgeExpiredSeriesWriteAfterTicking(t *testing.T) {
 // starts, we receive a write for a series, then purgeExpiredSeries runs, then we write to
 // the series. The expected behavior is not to expire series in this case.
 func TestPurgeExpiredSeriesWriteAfterPurging(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var entry *lookup.Entry
@@ -841,7 +841,7 @@ func TestShardFetchBlocksIDNotExists(t *testing.T) {
 }
 
 func TestShardFetchBlocksIDExists(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -961,7 +961,7 @@ func (c *testCloser) Close() {
 }
 
 func TestShardRegisterRuntimeOptionsListeners(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	callRegisterListenerOnShard := 0
@@ -999,7 +999,7 @@ func TestShardRegisterRuntimeOptionsListeners(t *testing.T) {
 }
 
 func TestShardReadEncodedCachesSeriesWithRecentlyReadPolicy(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions().SetSeriesCachePolicy(series.CacheRecentlyRead)
@@ -1087,7 +1087,7 @@ func TestShardReadEncodedCachesSeriesWithRecentlyReadPolicy(t *testing.T) {
 }
 
 func TestShardNewInvalidShardEntry(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	shard := testDatabaseShard(t, testDatabaseOptions())
@@ -1107,7 +1107,7 @@ func TestShardNewInvalidShardEntry(t *testing.T) {
 }
 
 func TestShardNewValidShardEntry(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	shard := testDatabaseShard(t, testDatabaseOptions())
@@ -1123,7 +1123,7 @@ func TestShardNewValidShardEntry(t *testing.T) {
 // either to retry inserting a series or to finalize the tags at the
 // end of a request/response cycle or from a disk retrieve cycle.
 func TestShardNewEntryDoesNotAlterIDOrTags(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	shard := testDatabaseShard(t, testDatabaseOptions())
@@ -1184,7 +1184,7 @@ func TestShardNewEntryDoesNotAlterIDOrTags(t *testing.T) {
 // marked as NoFinalize that newShardEntry simply takes a ref as it can
 // safely be assured the ID is not pooled.
 func TestShardNewEntryTakesRefToNoFinalizeID(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	shard := testDatabaseShard(t, testDatabaseOptions())

--- a/src/dbnode/storage/tick_test.go
+++ b/src/dbnode/storage/tick_test.go
@@ -27,13 +27,14 @@ import (
 	"time"
 
 	"github.com/m3db/m3x/context"
+	xtest "github.com/m3db/m3x/test"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTickManagerTickNormalFlow(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -52,7 +53,7 @@ func TestTickManagerTickNormalFlow(t *testing.T) {
 }
 
 func TestTickManagerTickCancelled(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var wg sync.WaitGroup
@@ -88,7 +89,7 @@ func TestTickManagerTickCancelled(t *testing.T) {
 }
 
 func TestTickManagerTickErrorFlow(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	opts := testDatabaseOptions()
@@ -110,7 +111,7 @@ func TestTickManagerTickErrorFlow(t *testing.T) {
 }
 
 func TestTickManagerNonForcedTickDuringOngoingTick(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var wg sync.WaitGroup
@@ -148,7 +149,7 @@ func TestTickManagerNonForcedTickDuringOngoingTick(t *testing.T) {
 }
 
 func TestTickManagerForcedTickDuringOngoingTick(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := gomock.NewController(xtest.Reporter{t})
 	defer ctrl.Finish()
 
 	var wg sync.WaitGroup

--- a/src/m3ninx/index/segment/fst/fst_mock.go
+++ b/src/m3ninx/index/segment/fst/fst_mock.go
@@ -96,7 +96,7 @@ func (mr *MockWriterMockRecorder) MinorVersion() *gomock.Call {
 }
 
 // Reset mocks base method
-func (m *MockWriter) Reset(arg0 segment.MutableSegment) error {
+func (m *MockWriter) Reset(arg0 segment.Segment) error {
 	ret := m.ctrl.Call(m, "Reset", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/src/m3ninx/index/segment/fst/fst_writer.go
+++ b/src/m3ninx/index/segment/fst/fst_writer.go
@@ -32,13 +32,21 @@ var (
 )
 
 var (
-	// TODO(prateek): tweak builderopts for vellum
+	// TODO(prateek): configure the opts below for different use-cases - flush v compaction differently.
+	// for compaction -
 	vellumBuilderOpts = &vellum.BuilderOpts{
 		Encoder:                  1,
-		RegistryTableSize:        20000,
-		RegistryMRUSize:          4,
+		RegistryTableSize:        10000,
+		RegistryMRUSize:          2,
 		UnfinishedNodesStackSize: 4096,
 	}
+	// for flush -
+	// vellumBuilderOpts = &vellum.BuilderOpts{
+	// 	Encoder:                  1,
+	// 	RegistryTableSize:        80000,
+	// 	RegistryMRUSize:          4,
+	// 	UnfinishedNodesStackSize: 4096,
+	// }
 )
 
 // fstWriter is a writer to help construct an FST.

--- a/src/m3ninx/index/segment/fst/postings_offsets_new_map.go
+++ b/src/m3ninx/index/segment/fst/postings_offsets_new_map.go
@@ -32,7 +32,7 @@ import (
 func newPostingsOffsetsMap(initialSize int) *postingsOffsetsMap {
 	return _postingsOffsetsMapAlloc(_postingsOffsetsMapOptions{
 		hash: func(f doc.Field) postingsOffsetsMapHash {
-			// NB(pratee): Similar to the standard composite key hashes for Java objects
+			// NB(prateek): Similar to the standard composite key hashes for Java objects
 			hash := uint64(7)
 			hash = 31*hash + xxhash.Sum64(f.Name)
 			hash = 31*hash + xxhash.Sum64(f.Value)

--- a/src/m3ninx/index/segment/fst/types.go
+++ b/src/m3ninx/index/segment/fst/types.go
@@ -46,8 +46,8 @@ type Segment interface {
 // Writer writes out a FST segment from the provided elements.
 type Writer interface {
 	// Reset sets the Writer to persist the provide segment.
-	// NB(prateek): the provided segment must be a Sealed Mutable segment.
-	Reset(s sgmt.MutableSegment) error
+	// NB(prateek): If the provided segment is Mutable, it must be Sealed.
+	Reset(s sgmt.Segment) error
 
 	// MajorVersion is the major version for the writer.
 	MajorVersion() int

--- a/src/m3ninx/index/segment/fst/writer.go
+++ b/src/m3ninx/index/segment/fst/writer.go
@@ -98,7 +98,7 @@ func (w *writer) clear() {
 	w.docOffsets = w.docOffsets[:0]
 }
 
-func (w *writer) Reset(s sgmt.MutableSegment) error {
+func (w *writer) Reset(s sgmt.Segment) error {
 	w.clear()
 
 	if s == nil {

--- a/src/m3ninx/index/segment/fst/writer_reader_test.go
+++ b/src/m3ninx/index/segment/fst/writer_reader_test.go
@@ -389,9 +389,7 @@ func newTestSegments(t *testing.T, docs []doc.Document) (memSeg sgmt.MutableSegm
 
 func newTestMemSegment(t *testing.T) sgmt.MutableSegment {
 	opts := mem.NewOptions()
-	s, err := mem.NewSegment(postings.ID(0), opts)
-	require.NoError(t, err)
-	return s
+	return mem.NewSegment(postings.ID(0), opts)
 }
 
 func assertSliceOfByteSlicesEqual(t *testing.T, a, b [][]byte) {

--- a/src/m3ninx/index/segment/mem/merge.go
+++ b/src/m3ninx/index/segment/mem/merge.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Merge merges the segments `srcs` into `target`.
-func Merge(target sgmt.MutableSegment, srcs ...sgmt.MutableSegment) error {
+func Merge(target sgmt.MutableSegment, srcs ...sgmt.Segment) error {
 	safeClosers := []io.Closer{}
 	defer func() {
 		for _, c := range safeClosers {

--- a/src/m3ninx/index/segment/mem/merge_test.go
+++ b/src/m3ninx/index/segment/mem/merge_test.go
@@ -76,21 +76,17 @@ func TestMemSegmentMerge(t *testing.T) {
 	rest := docs[1:]
 
 	opts := NewOptions()
-	m1, err := NewSegment(postings.ID(0), opts)
-	require.NoError(t, err)
-	_, err = m1.Insert(d)
+	m1 := NewSegment(postings.ID(0), opts)
+	_, err := m1.Insert(d)
 	require.NoError(t, err)
 
-	m2, err := NewSegment(postings.ID(0), opts)
-	require.NoError(t, err)
+	m2 := NewSegment(postings.ID(0), opts)
 	for _, d := range rest {
 		_, err = m2.Insert(d)
 		require.NoError(t, err)
 	}
 
-	m3, err := NewSegment(postings.ID(0), opts)
-	require.NoError(t, err)
-
+	m3 := NewSegment(postings.ID(0), opts)
 	require.NoError(t, Merge(m3, m1, m2))
 
 	reader, err := m3.Reader()

--- a/src/m3ninx/index/segment/mem/segment.go
+++ b/src/m3ninx/index/segment/mem/segment.go
@@ -68,7 +68,7 @@ type segment struct {
 
 // NewSegment returns a new in-memory mutable segment. It will start assigning
 // postings IDs at the provided offset.
-func NewSegment(offset postings.ID, opts Options) (sgmt.MutableSegment, error) {
+func NewSegment(offset postings.ID, opts Options) sgmt.MutableSegment {
 	s := &segment{
 		offset:    int(offset),
 		plPool:    opts.PostingsListPool(),
@@ -76,12 +76,10 @@ func NewSegment(offset postings.ID, opts Options) (sgmt.MutableSegment, error) {
 		termsDict: newTermsDict(opts),
 		readerID:  postings.NewAtomicID(offset),
 	}
-
 	s.docs.data = make([]doc.Document, opts.InitialCapacity())
-
 	s.writer.idSet = newIDsMap(256)
 	s.writer.nextID = offset
-	return s, nil
+	return s
 }
 
 func (s *segment) Size() int64 {

--- a/src/m3ninx/index/segment/mem/segment_bench_test.go
+++ b/src/m3ninx/index/segment/mem/segment_bench_test.go
@@ -70,10 +70,7 @@ func benchmarkInsertSegment(docs []doc.Document, b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
-		s, err := NewSegment(0, NewOptions())
-		if err != nil {
-			b.Fatalf("unable to construct new segment: %v", err)
-		}
+		s := NewSegment(0, NewOptions())
 		b.StartTimer()
 
 		for _, d := range docs {
@@ -85,10 +82,7 @@ func benchmarkInsertSegment(docs []doc.Document, b *testing.B) {
 func benchmarkMatchTermSegment(docs []doc.Document, b *testing.B) {
 	b.ReportAllocs()
 
-	sgmt, err := NewSegment(0, NewOptions())
-	if err != nil {
-		b.Fatalf("unable to construct new segment: %v", err)
-	}
+	sgmt := NewSegment(0, NewOptions())
 	s := sgmt.(*segment)
 	for _, d := range docs {
 		s.Insert(d)
@@ -107,10 +101,7 @@ func benchmarkMatchTermSegment(docs []doc.Document, b *testing.B) {
 func benchmarkMatchRegexSegment(docs []doc.Document, b *testing.B) {
 	b.ReportAllocs()
 
-	sgmt, err := NewSegment(0, NewOptions())
-	if err != nil {
-		b.Fatalf("unable to construct new segment: %v", err)
-	}
+	sgmt := NewSegment(0, NewOptions())
 	s := sgmt.(*segment)
 	for _, d := range docs {
 		s.Insert(d)

--- a/src/m3ninx/index/segment/mem/segment_test.go
+++ b/src/m3ninx/index/segment/mem/segment_test.go
@@ -106,8 +106,7 @@ func TestSegmentInsert(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			segment, err := NewSegment(0, testOptions)
-			require.NoError(t, err)
+			segment := NewSegment(0, testOptions)
 			require.Equal(t, int64(0), segment.Size())
 
 			id, err := segment.Insert(test.input)
@@ -168,11 +167,10 @@ func TestSegmentInsertDuplicateID(t *testing.T) {
 		}
 	)
 
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
+	segment := NewSegment(0, testOptions)
 	require.Equal(t, int64(0), segment.Size())
 
-	id, err = segment.Insert(first)
+	id, err := segment.Insert(first)
 	require.NoError(t, err)
 	ok, err := segment.ContainsID(id)
 	require.NoError(t, err)
@@ -244,12 +242,10 @@ func TestSegmentInsertBatch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			segment, err := NewSegment(0, testOptions)
-			require.NoError(t, err)
+			segment := NewSegment(0, testOptions)
 			require.Equal(t, int64(0), segment.Size())
 
-			err = segment.InsertBatch(test.input)
-			require.NoError(t, err)
+			require.NoError(t, segment.InsertBatch(test.input))
 			require.Equal(t, int64(len(test.input.Docs)), segment.Size())
 
 			r, err := segment.Reader()
@@ -305,11 +301,10 @@ func TestSegmentInsertBatchError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			segment, err := NewSegment(0, testOptions)
+			segment := NewSegment(0, testOptions)
 			require.Equal(t, int64(0), segment.Size())
-			require.NoError(t, err)
 
-			err = segment.InsertBatch(test.input)
+			err := segment.InsertBatch(test.input)
 			require.Error(t, err)
 			require.False(t, index.IsBatchPartialError(err))
 			require.Equal(t, int64(0), segment.Size())
@@ -393,11 +388,10 @@ func TestSegmentInsertBatchPartialError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			segment, err := NewSegment(0, testOptions)
-			require.NoError(t, err)
+			segment := NewSegment(0, testOptions)
 			require.Equal(t, int64(0), segment.Size())
 
-			err = segment.InsertBatch(test.input)
+			err := segment.InsertBatch(test.input)
 			require.Error(t, err)
 			require.True(t, index.IsBatchPartialError(err))
 			require.Equal(t, int64(1), segment.Size())
@@ -459,10 +453,9 @@ func TestSegmentInsertBatchPartialErrorInvalidDoc(t *testing.T) {
 		},
 		index.AllowPartialUpdates(),
 	)
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
+	segment := NewSegment(0, testOptions)
 
-	err = segment.InsertBatch(b1)
+	err := segment.InsertBatch(b1)
 	require.Error(t, err)
 	require.True(t, index.IsBatchPartialError(err))
 	be := err.(*index.BatchPartialError)
@@ -513,8 +506,7 @@ func TestSegmentContainsID(t *testing.T) {
 		},
 		index.AllowPartialUpdates(),
 	)
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
+	segment := NewSegment(0, testOptions)
 	ok, err := segment.ContainsID([]byte("abc"))
 	require.NoError(t, err)
 	require.False(t, ok)
@@ -597,10 +589,9 @@ func TestSegmentInsertBatchPartialErrorAlreadyIndexing(t *testing.T) {
 		},
 		index.AllowPartialUpdates())
 
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
+	segment := NewSegment(0, testOptions)
 
-	err = segment.InsertBatch(b1)
+	err := segment.InsertBatch(b1)
 	require.NoError(t, err)
 
 	err = segment.InsertBatch(b2)
@@ -652,15 +643,13 @@ func TestSegmentReaderMatchExact(t *testing.T) {
 		},
 	}
 
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
-
+	segment := NewSegment(0, testOptions)
 	for _, doc := range docs {
-		_, err = segment.Insert(doc)
+		_, err := segment.Insert(doc)
 		require.NoError(t, err)
 	}
 
-	_, err = segment.Seal()
+	_, err := segment.Seal()
 	require.NoError(t, err)
 
 	r, err := segment.Reader()
@@ -691,10 +680,9 @@ func TestSegmentReaderMatchExact(t *testing.T) {
 }
 
 func TestSegmentSealLifecycle(t *testing.T) {
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
+	segment := NewSegment(0, testOptions)
 
-	_, err = segment.Seal()
+	_, err := segment.Seal()
 	require.NoError(t, err)
 
 	_, err = segment.Seal()
@@ -702,21 +690,17 @@ func TestSegmentSealLifecycle(t *testing.T) {
 }
 
 func TestSegmentSealCloseLifecycle(t *testing.T) {
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
-
+	segment := NewSegment(0, testOptions)
 	require.NoError(t, segment.Close())
-	_, err = segment.Seal()
+	_, err := segment.Seal()
 	require.Error(t, err)
 }
 
 func TestSegmentIsSealed(t *testing.T) {
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
-
+	segment := NewSegment(0, testOptions)
 	require.False(t, segment.IsSealed())
 
-	_, err = segment.Seal()
+	_, err := segment.Seal()
 	require.NoError(t, err)
 	require.True(t, segment.IsSealed())
 
@@ -725,19 +709,18 @@ func TestSegmentIsSealed(t *testing.T) {
 }
 
 func TestSegmentFields(t *testing.T) {
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
+	segment := NewSegment(0, testOptions)
 
 	knownsFields := map[string]struct{}{}
 	for _, d := range testDocuments {
 		for _, f := range d.Fields {
 			knownsFields[string(f.Name)] = struct{}{}
 		}
-		_, err = segment.Insert(d)
+		_, err := segment.Insert(d)
 		require.NoError(t, err)
 	}
 
-	_, err = segment.Fields()
+	_, err := segment.Fields()
 	require.Error(t, err)
 
 	seg, err := segment.Seal()
@@ -754,8 +737,7 @@ func TestSegmentFields(t *testing.T) {
 }
 
 func TestSegmentTerms(t *testing.T) {
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
+	segment := NewSegment(0, testOptions)
 
 	knownsFields := map[string]map[string]struct{}{}
 	for _, d := range testDocuments {
@@ -767,11 +749,11 @@ func TestSegmentTerms(t *testing.T) {
 			}
 			knownVals[string(f.Value)] = struct{}{}
 		}
-		_, err = segment.Insert(d)
+		_, err := segment.Insert(d)
 		require.NoError(t, err)
 	}
 
-	_, err = segment.Seal()
+	_, err := segment.Seal()
 	require.NoError(t, err)
 
 	for field, expectedTerms := range knownsFields {
@@ -787,11 +769,10 @@ func TestSegmentTerms(t *testing.T) {
 
 func TestSegmentReaderMatchRegex(t *testing.T) {
 	docs := testDocuments
-	segment, err := NewSegment(0, testOptions)
-	require.NoError(t, err)
+	segment := NewSegment(0, testOptions)
 
 	for _, doc := range docs {
-		_, err = segment.Insert(doc)
+		_, err := segment.Insert(doc)
 		require.NoError(t, err)
 	}
 

--- a/src/m3ninx/index/types.go
+++ b/src/m3ninx/index/types.go
@@ -83,8 +83,8 @@ type Readable interface {
 // CompiledRegex is a collection of regexp compiled structs to allow
 // amortisation of regexp construction costs.
 type CompiledRegex struct {
-	Simple      *regexp.Regexp
-	FST         *vregex.Regexp
+	Simple      *regexp.Regexp // Simple corresponds to a Go compiled 'regexp.Regexp'.
+	FST         *vregex.Regexp // FST corresponds to a Vellum compiled DFA.
 	PrefixBegin []byte
 	PrefixEnd   []byte
 }

--- a/src/m3ninx/persist/persist.go
+++ b/src/m3ninx/persist/persist.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package persist
+
+import (
+	"bytes"
+
+	sgmt "github.com/m3db/m3/src/m3ninx/index/segment"
+	"github.com/m3db/m3/src/m3ninx/index/segment/fst"
+	"github.com/m3db/m3/src/x/mmap"
+)
+
+// TransformAndMmap transforms the given segment into a FST backed by
+// mmap'd bytes.
+func TransformAndMmap(seg sgmt.Segment, opts fst.Options) (sgmt.Segment, error) {
+	writer, err := NewReusableSegmentFileSetWriter()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := writer.Reset(seg); err != nil {
+		return nil, err
+	}
+
+	success := false
+	fstData := &fstSegmentMetadata{
+		major:    writer.MajorVersion(),
+		minor:    writer.MinorVersion(),
+		metadata: append([]byte{}, writer.SegmentMetadata()...),
+	}
+	// cleanup incase we run into issues
+	defer func() {
+		if !success {
+			for _, f := range fstData.files {
+				f.Close()
+			}
+		}
+	}()
+
+	var bytesWriter bytes.Buffer
+	for _, f := range writer.Files() {
+		bytesWriter.Reset()
+		if err := writer.WriteFile(f, &bytesWriter); err != nil {
+			return nil, err
+		}
+		fileBytes := bytesWriter.Bytes()
+		// memcpy bytes -> new mmap region to hide from the GC
+		mmapedResult, err := mmap.Bytes(int64(len(fileBytes)), mmap.Options{
+			Read:  true,
+			Write: true, // TODO(prateek): pass down huge TLB constraints here?
+		})
+		if err != nil {
+			return nil, err
+		}
+		copy(mmapedResult.Result, fileBytes)
+		fstData.files = append(fstData.files, NewMmapedIndexSegmentFile(f, nil, mmapedResult.Result))
+	}
+
+	// NB: need to mark success here as the NewSegment call assumes ownership of
+	// the provided bytes regardless of success/failure.
+	success = true
+	fstSegment, err := NewSegment(fstData, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return fstSegment, nil
+
+}
+
+type fstSegmentMetadata struct {
+	major    int
+	minor    int
+	metadata []byte
+	files    []IndexSegmentFile
+}
+
+var _ IndexSegmentFileSet = &fstSegmentMetadata{}
+
+func (f *fstSegmentMetadata) SegmentType() IndexSegmentType { return FSTIndexSegmentType }
+func (f *fstSegmentMetadata) MajorVersion() int             { return f.major }
+func (f *fstSegmentMetadata) MinorVersion() int             { return f.minor }
+func (f *fstSegmentMetadata) SegmentMetadata() []byte       { return f.metadata }
+func (f *fstSegmentMetadata) Files() []IndexSegmentFile     { return f.files }

--- a/src/m3ninx/persist/persist_mock.go
+++ b/src/m3ninx/persist/persist_mock.go
@@ -163,111 +163,111 @@ func (mr *MockIndexSegmentFileSetWriterMockRecorder) WriteFile(fileType, writer 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockIndexSegmentFileSetWriter)(nil).WriteFile), fileType, writer)
 }
 
-// MockMutableSegmentFileSetWriter is a mock of MutableSegmentFileSetWriter interface
-type MockMutableSegmentFileSetWriter struct {
+// MockReusableSegmentFileSetWriter is a mock of ReusableSegmentFileSetWriter interface
+type MockReusableSegmentFileSetWriter struct {
 	ctrl     *gomock.Controller
-	recorder *MockMutableSegmentFileSetWriterMockRecorder
+	recorder *MockReusableSegmentFileSetWriterMockRecorder
 }
 
-// MockMutableSegmentFileSetWriterMockRecorder is the mock recorder for MockMutableSegmentFileSetWriter
-type MockMutableSegmentFileSetWriterMockRecorder struct {
-	mock *MockMutableSegmentFileSetWriter
+// MockReusableSegmentFileSetWriterMockRecorder is the mock recorder for MockReusableSegmentFileSetWriter
+type MockReusableSegmentFileSetWriterMockRecorder struct {
+	mock *MockReusableSegmentFileSetWriter
 }
 
-// NewMockMutableSegmentFileSetWriter creates a new mock instance
-func NewMockMutableSegmentFileSetWriter(ctrl *gomock.Controller) *MockMutableSegmentFileSetWriter {
-	mock := &MockMutableSegmentFileSetWriter{ctrl: ctrl}
-	mock.recorder = &MockMutableSegmentFileSetWriterMockRecorder{mock}
+// NewMockReusableSegmentFileSetWriter creates a new mock instance
+func NewMockReusableSegmentFileSetWriter(ctrl *gomock.Controller) *MockReusableSegmentFileSetWriter {
+	mock := &MockReusableSegmentFileSetWriter{ctrl: ctrl}
+	mock.recorder = &MockReusableSegmentFileSetWriterMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockMutableSegmentFileSetWriter) EXPECT() *MockMutableSegmentFileSetWriterMockRecorder {
+func (m *MockReusableSegmentFileSetWriter) EXPECT() *MockReusableSegmentFileSetWriterMockRecorder {
 	return m.recorder
 }
 
 // SegmentType mocks base method
-func (m *MockMutableSegmentFileSetWriter) SegmentType() IndexSegmentType {
+func (m *MockReusableSegmentFileSetWriter) SegmentType() IndexSegmentType {
 	ret := m.ctrl.Call(m, "SegmentType")
 	ret0, _ := ret[0].(IndexSegmentType)
 	return ret0
 }
 
 // SegmentType indicates an expected call of SegmentType
-func (mr *MockMutableSegmentFileSetWriterMockRecorder) SegmentType() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SegmentType", reflect.TypeOf((*MockMutableSegmentFileSetWriter)(nil).SegmentType))
+func (mr *MockReusableSegmentFileSetWriterMockRecorder) SegmentType() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SegmentType", reflect.TypeOf((*MockReusableSegmentFileSetWriter)(nil).SegmentType))
 }
 
 // MajorVersion mocks base method
-func (m *MockMutableSegmentFileSetWriter) MajorVersion() int {
+func (m *MockReusableSegmentFileSetWriter) MajorVersion() int {
 	ret := m.ctrl.Call(m, "MajorVersion")
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
 // MajorVersion indicates an expected call of MajorVersion
-func (mr *MockMutableSegmentFileSetWriterMockRecorder) MajorVersion() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MajorVersion", reflect.TypeOf((*MockMutableSegmentFileSetWriter)(nil).MajorVersion))
+func (mr *MockReusableSegmentFileSetWriterMockRecorder) MajorVersion() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MajorVersion", reflect.TypeOf((*MockReusableSegmentFileSetWriter)(nil).MajorVersion))
 }
 
 // MinorVersion mocks base method
-func (m *MockMutableSegmentFileSetWriter) MinorVersion() int {
+func (m *MockReusableSegmentFileSetWriter) MinorVersion() int {
 	ret := m.ctrl.Call(m, "MinorVersion")
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
 // MinorVersion indicates an expected call of MinorVersion
-func (mr *MockMutableSegmentFileSetWriterMockRecorder) MinorVersion() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MinorVersion", reflect.TypeOf((*MockMutableSegmentFileSetWriter)(nil).MinorVersion))
+func (mr *MockReusableSegmentFileSetWriterMockRecorder) MinorVersion() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MinorVersion", reflect.TypeOf((*MockReusableSegmentFileSetWriter)(nil).MinorVersion))
 }
 
 // SegmentMetadata mocks base method
-func (m *MockMutableSegmentFileSetWriter) SegmentMetadata() []byte {
+func (m *MockReusableSegmentFileSetWriter) SegmentMetadata() []byte {
 	ret := m.ctrl.Call(m, "SegmentMetadata")
 	ret0, _ := ret[0].([]byte)
 	return ret0
 }
 
 // SegmentMetadata indicates an expected call of SegmentMetadata
-func (mr *MockMutableSegmentFileSetWriterMockRecorder) SegmentMetadata() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SegmentMetadata", reflect.TypeOf((*MockMutableSegmentFileSetWriter)(nil).SegmentMetadata))
+func (mr *MockReusableSegmentFileSetWriterMockRecorder) SegmentMetadata() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SegmentMetadata", reflect.TypeOf((*MockReusableSegmentFileSetWriter)(nil).SegmentMetadata))
 }
 
 // Files mocks base method
-func (m *MockMutableSegmentFileSetWriter) Files() []IndexSegmentFileType {
+func (m *MockReusableSegmentFileSetWriter) Files() []IndexSegmentFileType {
 	ret := m.ctrl.Call(m, "Files")
 	ret0, _ := ret[0].([]IndexSegmentFileType)
 	return ret0
 }
 
 // Files indicates an expected call of Files
-func (mr *MockMutableSegmentFileSetWriterMockRecorder) Files() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Files", reflect.TypeOf((*MockMutableSegmentFileSetWriter)(nil).Files))
+func (mr *MockReusableSegmentFileSetWriterMockRecorder) Files() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Files", reflect.TypeOf((*MockReusableSegmentFileSetWriter)(nil).Files))
 }
 
 // WriteFile mocks base method
-func (m *MockMutableSegmentFileSetWriter) WriteFile(fileType IndexSegmentFileType, writer io.Writer) error {
+func (m *MockReusableSegmentFileSetWriter) WriteFile(fileType IndexSegmentFileType, writer io.Writer) error {
 	ret := m.ctrl.Call(m, "WriteFile", fileType, writer)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteFile indicates an expected call of WriteFile
-func (mr *MockMutableSegmentFileSetWriterMockRecorder) WriteFile(fileType, writer interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockMutableSegmentFileSetWriter)(nil).WriteFile), fileType, writer)
+func (mr *MockReusableSegmentFileSetWriterMockRecorder) WriteFile(fileType, writer interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockReusableSegmentFileSetWriter)(nil).WriteFile), fileType, writer)
 }
 
 // Reset mocks base method
-func (m *MockMutableSegmentFileSetWriter) Reset(arg0 segment.MutableSegment) error {
+func (m *MockReusableSegmentFileSetWriter) Reset(arg0 segment.Segment) error {
 	ret := m.ctrl.Call(m, "Reset", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Reset indicates an expected call of Reset
-func (mr *MockMutableSegmentFileSetWriterMockRecorder) Reset(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockMutableSegmentFileSetWriter)(nil).Reset), arg0)
+func (mr *MockReusableSegmentFileSetWriterMockRecorder) Reset(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockReusableSegmentFileSetWriter)(nil).Reset), arg0)
 }
 
 // MockIndexFileSetReader is a mock of IndexFileSetReader interface

--- a/src/m3ninx/persist/types.go
+++ b/src/m3ninx/persist/types.go
@@ -53,13 +53,13 @@ type IndexSegmentFileSetWriter interface {
 	WriteFile(fileType IndexSegmentFileType, writer io.Writer) error
 }
 
-// MutableSegmentFileSetWriter is a new IndexSegmentFileSetWriter for writing
+// ReusableSegmentFileSetWriter is a new IndexSegmentFileSetWriter for writing
 // out Mutable Segments.
-type MutableSegmentFileSetWriter interface {
+type ReusableSegmentFileSetWriter interface {
 	IndexSegmentFileSetWriter
 
-	// Reset resets the writer to write the provided mutable segment.
-	Reset(segment.MutableSegment) error
+	// Reset resets the writer to write the provided segment.
+	Reset(segment.Segment) error
 }
 
 // IndexFileSetReader is an index file set reader, it can read many segments.

--- a/src/m3ninx/persist/writer.go
+++ b/src/m3ninx/persist/writer.go
@@ -28,13 +28,13 @@ import (
 	"github.com/m3db/m3/src/m3ninx/index/segment/fst"
 )
 
-// NewMutableSegmentFileSetWriter returns a new IndexSegmentFileSetWriter for writing
+// NewReusableSegmentFileSetWriter returns a new IndexSegmentFileSetWriter for writing
 // out the provided Mutable Segment.
-func NewMutableSegmentFileSetWriter() (MutableSegmentFileSetWriter, error) {
-	return newMutableSegmentFileSetWriter(fst.NewWriter())
+func NewReusableSegmentFileSetWriter() (ReusableSegmentFileSetWriter, error) {
+	return newReusableSegmentFileSetWriter(fst.NewWriter())
 }
 
-func newMutableSegmentFileSetWriter(fsWriter fst.Writer) (MutableSegmentFileSetWriter, error) {
+func newReusableSegmentFileSetWriter(fsWriter fst.Writer) (ReusableSegmentFileSetWriter, error) {
 	return &writer{
 		fsWriter: fsWriter,
 	}, nil
@@ -44,7 +44,7 @@ type writer struct {
 	fsWriter fst.Writer
 }
 
-func (w *writer) Reset(s segment.MutableSegment) error {
+func (w *writer) Reset(s segment.Segment) error {
 	return w.fsWriter.Reset(s)
 }
 

--- a/src/m3ninx/persist/writer_test.go
+++ b/src/m3ninx/persist/writer_test.go
@@ -33,10 +33,10 @@ import (
 
 func newTestWriter(t *testing.T, ctrl *gomock.Controller) (
 	*fst.MockWriter,
-	MutableSegmentFileSetWriter,
+	ReusableSegmentFileSetWriter,
 ) {
 	w := fst.NewMockWriter(ctrl)
-	writer, err := newMutableSegmentFileSetWriter(w)
+	writer, err := newReusableSegmentFileSetWriter(w)
 	require.NoError(t, err)
 	return w, writer
 }

--- a/src/m3ninx/search/proptest/segment_gen.go
+++ b/src/m3ninx/search/proptest/segment_gen.go
@@ -55,8 +55,7 @@ func collectDocs(iter doc.Iterator) ([]doc.Document, error) {
 
 func newTestMemSegment(t *testing.T, docs []doc.Document) segment.MutableSegment {
 	opts := mem.NewOptions()
-	s, err := mem.NewSegment(postings.ID(0), opts)
-	require.NoError(t, err)
+	s := mem.NewSegment(postings.ID(0), opts)
 	for _, d := range docs {
 		_, err := s.Insert(d)
 		require.NoError(t, err)
@@ -68,11 +67,10 @@ func (i propTestInput) generate(t *testing.T, docs []doc.Document) []segment.Seg
 	var result []segment.Segment
 	for j := 0; j < len(i.segments); j++ {
 		initialOffset := postings.ID(i.segments[j].initialDocIDOffset)
-		s, err := mem.NewSegment(initialOffset, memOptions)
-		require.NoError(t, err)
+		s := mem.NewSegment(initialOffset, memOptions)
 		for k := 0; k < len(i.docIds[j]); k++ {
 			idx := i.docIds[j][k]
-			_, err = s.Insert(docs[idx])
+			_, err := s.Insert(docs[idx])
 			require.NoError(t, err)
 		}
 


### PR DESCRIPTION
Smaller PRs:
- [ ] m3ninx persist PR

Pending:
- [x] e2e latency approximation per segment
- [x] Reduce contention between compacted segments/readers 
- [ ] Trigger mutable segment rotation based on time too (outside the insert path)
- [ ] TODOs in the code
- [ ] Unit/Integration tests 
- [x] FST-ify bootstraped segments 

### followups
- [ ] Filter cache: LRU cache `(segmentID, queryComponent) -> postingsList` for all FST segments over size X (what about doing this for commonly used field/term FSTs too?)
- [ ] Postings list benchmarks: roaring v pilosa for serialization/deserialization + query operations
- [ ] Query optimiser:
    - [ ] Ordering of postings lists based on size
    - [ ] Indexing (postings list/field) for "field exists" + query type
    - [ ] Executor/Searcher model to be optimised per reader instead of per query component
    - [ ] Add tracing for query component latency
    - [ ] Size/sketch fields for query execution heurisitcs (e.g. intersection of hll/bloomfilter) 
    - [ ] add size to be retrieved before postings list deserialisation 
- [ ] Tracing for compaction latency
- [ ] Remove locks from postings lists, mutable segment, etc 
- [ ] documents compression at storage time
