### PR TITLE
Fix docker Prometheus integration tests

### DIFF
--- a/scripts/integration-tests/prometheus/prometheus-integration-test.sh
+++ b/scripts/integration-tests/prometheus/prometheus-integration-test.sh
@@ -122,9 +122,9 @@ else
   echo "Result found"
 fi
 
-echo "Sleep for 10 seconds to let the remote write endpoint generate some data"
+echo "Sleep for 30 seconds to let the remote write endpoint generate some data"
 
-sleep 10
+sleep 30
 
 [ "$(curl -sSf localhost:9090/api/v1/query?query=prometheus_remote_storage_succeeded_samples_total | jq .data.result[].value[1])" != '"0"' ]
 

--- a/scripts/integration-tests/prometheus/prometheus-integration-test.sh
+++ b/scripts/integration-tests/prometheus/prometheus-integration-test.sh
@@ -128,4 +128,4 @@ sleep 30
 
 [ "$(curl -sSf localhost:9090/api/v1/query?query=prometheus_remote_storage_succeeded_samples_total | jq .data.result[].value[1])" != '"0"' ]
 
-docker-compose -f docker-compose.yml down
+docker-compose -f docker-compose.yml down || echo "unable to shutdown containers" # CI fails to stop all containers sometimes

--- a/scripts/integration-tests/prometheus/prometheus-integration-test.sh
+++ b/scripts/integration-tests/prometheus/prometheus-integration-test.sh
@@ -61,8 +61,8 @@ curl -vvvsSf -X POST localhost:7201/api/v1/placement/init -d '{
             "isolation_group": "rack-a",
             "zone": "embedded",
             "weight": 1024,
-            "endpoint": "127.0.0.1:9000",
-            "hostname": "127.0.0.1",
+            "endpoint": "dbnode01:9000",
+            "hostname": "dbnode01",
             "port": 9000
         }
     ]
@@ -122,9 +122,9 @@ else
   echo "Result found"
 fi
 
-echo "Sleep for 20 seconds to let the remote write endpoint generate some data"
+echo "Sleep for 10 seconds to let the remote write endpoint generate some data"
 
-sleep 20
+sleep 10
 
 [ "$(curl -sSf localhost:9090/api/v1/query?query=prometheus_remote_storage_succeeded_samples_total | jq .data.result[].value[1])" != '"0"' ]
 

--- a/scripts/integration-tests/prometheus/prometheus.yml
+++ b/scripts/integration-tests/prometheus/prometheus.yml
@@ -32,10 +32,10 @@ scrape_configs:
 
   - job_name: 'coordinator'
     static_configs:
-      - targets: ['dbnode01:7203']
+      - targets: ['coordinator01:7203']
 
 remote_read:
-  - url: http://dbnode01:7201/api/v1/prom/remote/read # when running on GCP, change to IP address of m3coordinator
+  - url: http://coordinator01:7201/api/v1/prom/remote/read
 
 remote_write:
-  - url: http://dbnode01:7201/api/v1/prom/remote/write # when running on GCP, change to IP address of m3coordinator
+  - url: http://coordinator01:7201/api/v1/prom/remote/write

--- a/src/query/api/v1/handler/prometheus/remote/test/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/test/remote/write.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package remote
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/stretchr/testify/require"
+)
+
+// GeneratePromWriteRequest generates a Prometheus remote
+// write request.
+func GeneratePromWriteRequest() *prompb.WriteRequest {
+	req := &prompb.WriteRequest{
+		Timeseries: []*prompb.TimeSeries{{
+			Labels: []*prompb.Label{
+				{Name: "__name__", Value: "first"},
+				{Name: "foo", Value: "bar"},
+				{Name: "biz", Value: "baz"},
+			},
+			Samples: []*prompb.Sample{
+				{Value: 1.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
+				{Value: 2.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
+			},
+		},
+			{
+				Labels: []*prompb.Label{
+					{Name: "__name__", Value: "second"},
+					{Name: "foo", Value: "qux"},
+					{Name: "bar", Value: "baz"},
+				},
+				Samples: []*prompb.Sample{
+					{Value: 3.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
+					{Value: 4.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
+				},
+			}},
+	}
+	return req
+}
+
+// GeneratePromWriteRequestBody generates a Prometheus remote
+// write request body.
+func GeneratePromWriteRequestBody(
+	t *testing.T,
+	req *prompb.WriteRequest,
+) io.Reader {
+	data, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	compressed := snappy.Encode(nil, data)
+	return bytes.NewReader(compressed)
+}

--- a/src/query/server/server_test.go
+++ b/src/query/server/server_test.go
@@ -1,0 +1,172 @@
+// +build big
+//
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3x/ident"
+
+	"github.com/m3db/m3/src/cmd/services/m3query/config"
+	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/remote"
+	remotetest "github.com/m3db/m3/src/query/api/v1/handler/prometheus/remote/test/remote"
+	"github.com/m3db/m3/src/query/storage/local"
+	xconfig "github.com/m3db/m3x/config"
+	xtest "github.com/m3db/m3x/test"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var configYAML = `
+listenAddress: 127.0.0.1:7201
+
+metrics:
+  scope:
+    prefix: "coordinator"
+  prometheus:
+    handlerPath: /metrics
+  sanitization: prometheus
+  samplingRate: 1.0
+
+clusters:
+  - namespaces:
+      - namespace: prometheus_metrics
+        storageMetricsType: unaggregated
+        retention: 48h
+`
+
+func TestRun(t *testing.T) {
+	ctrl := gomock.NewController(xtest.Reporter{t})
+	defer ctrl.Finish()
+
+	configFile, close := newTestFile(t, "config.yaml", configYAML)
+	defer close()
+
+	var cfg config.Configuration
+	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
+	require.NoError(t, err)
+
+	// Override the client creation
+	require.Equal(t, 1, len(cfg.Clusters))
+
+	session := client.NewMockSession(ctrl)
+	for _, value := range []float64{1, 2} {
+		session.EXPECT().WriteTagged(ident.NewIDMatcher("prometheus_metrics"),
+			ident.NewIDMatcher("__name__=first,biz=baz,foo=bar,"),
+			gomock.Any(),
+			gomock.Any(),
+			value,
+			gomock.Any(),
+			nil)
+	}
+	for _, value := range []float64{3, 4} {
+		session.EXPECT().WriteTagged(ident.NewIDMatcher("prometheus_metrics"),
+			ident.NewIDMatcher("__name__=second,bar=baz,foo=qux,"),
+			gomock.Any(),
+			gomock.Any(),
+			value,
+			gomock.Any(),
+			nil)
+	}
+	session.EXPECT().Close()
+
+	dbClient := client.NewMockClient(ctrl)
+	dbClient.EXPECT().DefaultSession().Return(session, nil)
+
+	cfg.Clusters[0].NewClientFromConfig = local.NewClientFromConfig(
+		func(
+			cfg client.Configuration,
+			params client.ConfigurationParameters,
+			custom ...client.CustomOption,
+		) (client.Client, error) {
+			return dbClient, nil
+		})
+
+	interruptCh := make(chan error)
+	doneCh := make(chan struct{})
+	go func() {
+		Run(RunOptions{
+			Config:      cfg,
+			InterruptCh: interruptCh,
+		})
+		doneCh <- struct{}{}
+	}()
+
+	// Wait for server to come up
+	waitForServerHealthy(t)
+
+	// Send Prometheus write request
+	promReq := remotetest.GeneratePromWriteRequest()
+	promReqBody := remotetest.GeneratePromWriteRequestBody(t, promReq)
+	req, err := http.NewRequest(http.MethodPost,
+		"http://127.0.0.1:7201"+remote.PromWriteURL, promReqBody)
+	require.NoError(t, err)
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	// Ensure close server performs as expected
+	interruptCh <- fmt.Errorf("interrupt")
+	<-doneCh
+}
+
+type closeFn func()
+
+func newTestFile(t *testing.T, fileName, contents string) (*os.File, closeFn) {
+	tmpFile, err := ioutil.TempFile("", fileName)
+	require.NoError(t, err)
+
+	_, err = tmpFile.Write([]byte(configYAML))
+	require.NoError(t, err)
+
+	return tmpFile, func() {
+		assert.NoError(t, tmpFile.Close())
+		assert.NoError(t, os.Remove(tmpFile.Name()))
+	}
+}
+
+func waitForServerHealthy(t *testing.T) {
+	maxWait := 10 * time.Second
+	startAt := time.Now()
+	for time.Since(startAt) < maxWait {
+		req, err := http.NewRequest("GET", "http://127.0.0.1:7201/health", nil)
+		require.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		if err != nil || res.StatusCode != http.StatusOK {
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		return
+	}
+	require.FailNow(t, "waited for server healthy longer than limit: "+
+		maxWait.String())
+}

--- a/src/query/storage/local/cluster_test.go
+++ b/src/query/storage/local/cluster_test.go
@@ -69,7 +69,7 @@ func TestNewClustersFromConfig(t *testing.T) {
 	newClient2, mockSession2 := newTestClientFromConfig(ctrl)
 	cfg := ClustersStaticConfiguration{
 		ClusterStaticConfiguration{
-			newClientFromConfig: newClient1,
+			NewClientFromConfig: newClient1,
 			Namespaces: []ClusterStaticNamespaceConfiguration{
 				ClusterStaticNamespaceConfiguration{
 					Namespace:          "unaggregated",
@@ -79,7 +79,7 @@ func TestNewClustersFromConfig(t *testing.T) {
 			},
 		},
 		ClusterStaticConfiguration{
-			newClientFromConfig: newClient2,
+			NewClientFromConfig: newClient2,
 			Namespaces: []ClusterStaticNamespaceConfiguration{
 				ClusterStaticNamespaceConfiguration{
 					Namespace:          "aggregated0",
@@ -151,7 +151,7 @@ func TestNewClustersFromConfig(t *testing.T) {
 }
 
 func newTestClientFromConfig(ctrl *gomock.Controller) (
-	newClientFromConfig,
+	NewClientFromConfig,
 	*client.MockSession,
 ) {
 	mockSession := client.NewMockSession(ctrl)

--- a/src/query/storage/local/config.go
+++ b/src/query/storage/local/config.go
@@ -38,7 +38,9 @@ var (
 // ClustersStaticConfiguration is a set of static cluster configurations.
 type ClustersStaticConfiguration []ClusterStaticConfiguration
 
-type newClientFromConfig func(
+// NewClientFromConfig is a method that can be set on
+// ClusterStaticConfiguration to allow overriding the client initialization.
+type NewClientFromConfig func(
 	cfg client.Configuration,
 	params client.ConfigurationParameters,
 	custom ...client.CustomOption,
@@ -46,7 +48,7 @@ type newClientFromConfig func(
 
 // ClusterStaticConfiguration is a static cluster configuration.
 type ClusterStaticConfiguration struct {
-	newClientFromConfig newClientFromConfig
+	NewClientFromConfig NewClientFromConfig
 	Namespaces          []ClusterStaticNamespaceConfiguration `yaml:"namespaces"`
 	Client              client.Configuration                  `yaml:"client"`
 }
@@ -55,8 +57,8 @@ func (c ClusterStaticConfiguration) newClient(
 	params client.ConfigurationParameters,
 	custom ...client.CustomOption,
 ) (client.Client, error) {
-	if c.newClientFromConfig != nil {
-		return c.newClientFromConfig(c.Client, params, custom...)
+	if c.NewClientFromConfig != nil {
+		return c.NewClientFromConfig(c.Client, params, custom...)
 	}
 	return c.Client.NewClient(params, custom...)
 }


### PR DESCRIPTION
Since we started spinning up the coordinator role as a dedicated role for the Prometheus integration test we need to change the remote read/write endpoint to the coordinator hostname in the Prometheus configuration file.