### PR TITLE
[docs] Fix docs deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ docs-serve: docs-container
 
 .PHONY: docs-deploy
 docs-deploy: docs-container
-	docker run -v $(PWD):/m3db --rm m3db-docs "mkdocs build -e docs/theme -t material && mkdocs gh-deploy --dirty"
+	docker run -v $(PWD):/m3db --rm -v $(HOME)/.ssh/id_rsa:/root/.ssh/id_rsa:ro -it m3db-docs "mkdocs build -e docs/theme -t material && mkdocs gh-deploy --dirty"
 
 .PHONY: docker-integration-test
 docker-integration-test:

--- a/scripts/docs.Dockerfile
+++ b/scripts/docs.Dockerfile
@@ -6,5 +6,9 @@ LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 
 WORKDIR /m3db
 EXPOSE 8000
-RUN pip install mkdocs==0.17.3 mkdocs-material==2.7.3
+
+# mkdocs needs git-fast-import which was stripped from the default git package
+# by default to reduce size
+RUN pip install mkdocs==0.17.3 mkdocs-material==2.7.3 && \
+    apk add --no-cache git-fast-import openssh-client
 ENTRYPOINT [ "/bin/ash", "-c" ]


### PR DESCRIPTION
The `docs-deploy` target was broken because 1) the version of default
version of git in alpine linux is lightweight and doesn't include
`fast-import`, which `mkdocs` relies on and 2) even if that was the case
the git process in the container couldn't push to github due to lack of
ssh key access. This fixes those issues.