### PR TITLE
[2/n] Cache regexp fst automata construction

### DIFF
--- a/src/dbnode/integration/commitlog_bootstrap_index_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_index_test.go
@@ -175,7 +175,7 @@ func TestCommitLogIndexBootstrap(t *testing.T) {
 	queryOpts := index.QueryOptions{StartInclusive: start, EndExclusive: end}
 
 	// Match all new_*r*
-	regexpQuery, err := idx.NewRegexpQuery([]byte("city"), []byte("^new_.*r.*$"))
+	regexpQuery, err := idx.NewRegexpQuery([]byte("city"), []byte("new_.*r.*"))
 	require.NoError(t, err)
 	iter, exhausitive, err := session.FetchTaggedIDs(ns1.ID(),
 		index.Query{regexpQuery}, queryOpts)
@@ -189,7 +189,7 @@ func TestCommitLogIndexBootstrap(t *testing.T) {
 	})
 
 	// Match all *e*e*
-	regexpQuery, err = idx.NewRegexpQuery([]byte("city"), []byte("^.*e.*e.*$"))
+	regexpQuery, err = idx.NewRegexpQuery([]byte("city"), []byte(".*e.*e.*"))
 	require.NoError(t, err)
 	iter, exhausitive, err = session.FetchTaggedIDs(ns1.ID(),
 		index.Query{regexpQuery}, queryOpts)

--- a/src/dbnode/integration/fs_bootstrap_index_test.go
+++ b/src/dbnode/integration/fs_bootstrap_index_test.go
@@ -161,7 +161,7 @@ func TestFilesystemBootstrapIndexWithIndexingEnabled(t *testing.T) {
 	queryOpts := index.QueryOptions{StartInclusive: start, EndExclusive: end}
 
 	// Match all new_*r*
-	regexpQuery, err := idx.NewRegexpQuery([]byte("city"), []byte("^new_.*r.*$"))
+	regexpQuery, err := idx.NewRegexpQuery([]byte("city"), []byte("new_.*r.*"))
 	require.NoError(t, err)
 	iter, exhausitive, err := session.FetchTaggedIDs(ns1.ID(),
 		index.Query{regexpQuery}, queryOpts)
@@ -175,7 +175,7 @@ func TestFilesystemBootstrapIndexWithIndexingEnabled(t *testing.T) {
 	})
 
 	// Match all *e*e*
-	regexpQuery, err = idx.NewRegexpQuery([]byte("city"), []byte("^.*e.*e.*$"))
+	regexpQuery, err = idx.NewRegexpQuery([]byte("city"), []byte(".*e.*e.*"))
 	require.NoError(t, err)
 	iter, exhausitive, err = session.FetchTaggedIDs(ns1.ID(),
 		index.Query{regexpQuery}, queryOpts)

--- a/src/dbnode/storage/shard_ref_count_test.go
+++ b/src/dbnode/storage/shard_ref_count_test.go
@@ -142,7 +142,7 @@ func TestShardWriteTaggedSyncRefCountMockIndex(t *testing.T) {
 }
 
 func TestShardWriteTaggedSyncRefCountSyncIndex(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 2*time.Second)()
+	defer leaktest.CheckTimeout(t, 10*time.Second)()
 	newFn := func(fn nsIndexInsertBatchFn, nowFn clock.NowFn, s tally.Scope) namespaceIndexInsertQueue {
 		q := newNamespaceIndexInsertQueue(fn, nowFn, s)
 		q.(*nsIndexInsertQueue).indexBatchBackoff = 10 * time.Millisecond
@@ -335,7 +335,7 @@ func TestShardWriteTaggedAsyncRefCountMockIndex(t *testing.T) {
 }
 
 func TestShardWriteTaggedAsyncRefCountSyncIndex(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 2*time.Second)()
+	defer leaktest.CheckTimeout(t, 10*time.Second)()
 	newFn := func(fn nsIndexInsertBatchFn, nowFn clock.NowFn, s tally.Scope) namespaceIndexInsertQueue {
 		q := newNamespaceIndexInsertQueue(fn, nowFn, s)
 		q.(*nsIndexInsertQueue).indexBatchBackoff = 10 * time.Millisecond
@@ -399,7 +399,7 @@ func testShardWriteTaggedAsyncRefCount(t *testing.T, idx namespaceIndex) {
 	inserted := xclock.WaitUntil(func() bool {
 		counter, ok := testReporter.Counters()["dbshard.insert-queue.inserts"]
 		return ok && counter == 3
-	}, 2*time.Second)
+	}, 5*time.Second)
 	assert.True(t, inserted)
 
 	// ensure all entries have no references left
@@ -422,7 +422,7 @@ func testShardWriteTaggedAsyncRefCount(t *testing.T, idx namespaceIndex) {
 
 	written := xclock.WaitUntil(func() bool {
 		return atomic.LoadInt32(&numCommitLogWrites) == 6
-	}, 2*time.Second)
+	}, 5*time.Second)
 	assert.True(t, written)
 
 	// ensure all entries have no references left

--- a/src/m3ninx/index/index_mock.go
+++ b/src/m3ninx/index/index_mock.go
@@ -121,7 +121,7 @@ func (mr *MockReaderMockRecorder) MatchAll() *gomock.Call {
 }
 
 // MatchRegexp mocks base method
-func (m *MockReader) MatchRegexp(arg0, arg1 []byte, arg2 *CompiledRegex) (postings.List, error) {
+func (m *MockReader) MatchRegexp(arg0, arg1 []byte, arg2 CompiledRegex) (postings.List, error) {
 	ret := m.ctrl.Call(m, "MatchRegexp", arg0, arg1, arg2)
 	ret0, _ := ret[0].(postings.List)
 	ret1, _ := ret[1].(error)

--- a/src/m3ninx/index/index_mock.go
+++ b/src/m3ninx/index/index_mock.go
@@ -26,7 +26,6 @@ package index
 
 import (
 	"reflect"
-	"regexp"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/m3db/m3/src/m3ninx/postings"
@@ -122,7 +121,7 @@ func (mr *MockReaderMockRecorder) MatchAll() *gomock.Call {
 }
 
 // MatchRegexp mocks base method
-func (m *MockReader) MatchRegexp(arg0, arg1 []byte, arg2 *regexp.Regexp) (postings.List, error) {
+func (m *MockReader) MatchRegexp(arg0, arg1 []byte, arg2 *CompiledRegex) (postings.List, error) {
 	ret := m.ctrl.Call(m, "MatchRegexp", arg0, arg1, arg2)
 	ret0, _ := ret[0].(postings.List)
 	ret1, _ := ret[1].(error)

--- a/src/m3ninx/index/segment/fst/fst_mock.go
+++ b/src/m3ninx/index/segment/fst/fst_mock.go
@@ -27,7 +27,6 @@ package fst
 import (
 	"io"
 	"reflect"
-	"regexp"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/m3db/m3/src/m3ninx/index"
@@ -282,7 +281,7 @@ func (mr *MockSegmentMockRecorder) MatchAll() *gomock.Call {
 }
 
 // MatchRegexp mocks base method
-func (m *MockSegment) MatchRegexp(arg0, arg1 []byte, arg2 *regexp.Regexp) (postings.List, error) {
+func (m *MockSegment) MatchRegexp(arg0, arg1 []byte, arg2 *index.CompiledRegex) (postings.List, error) {
 	ret := m.ctrl.Call(m, "MatchRegexp", arg0, arg1, arg2)
 	ret0, _ := ret[0].(postings.List)
 	ret1, _ := ret[1].(error)

--- a/src/m3ninx/index/segment/fst/fst_mock.go
+++ b/src/m3ninx/index/segment/fst/fst_mock.go
@@ -281,7 +281,7 @@ func (mr *MockSegmentMockRecorder) MatchAll() *gomock.Call {
 }
 
 // MatchRegexp mocks base method
-func (m *MockSegment) MatchRegexp(arg0, arg1 []byte, arg2 *index.CompiledRegex) (postings.List, error) {
+func (m *MockSegment) MatchRegexp(arg0, arg1 []byte, arg2 index.CompiledRegex) (postings.List, error) {
 	ret := m.ctrl.Call(m, "MatchRegexp", arg0, arg1, arg2)
 	ret0, _ := ret[0].(postings.List)
 	ret1, _ := ret[1].(error)

--- a/src/m3ninx/index/segment/fst/segment.go
+++ b/src/m3ninx/index/segment/fst/segment.go
@@ -297,7 +297,7 @@ func (r *fsSegment) MatchTerm(field []byte, term []byte) (postings.List, error) 
 	return pl, nil
 }
 
-func (r *fsSegment) MatchRegexp(field []byte, regexp []byte, compiled *index.CompiledRegex) (postings.List, error) {
+func (r *fsSegment) MatchRegexp(field []byte, regexp []byte, compiled index.CompiledRegex) (postings.List, error) {
 	r.RLock()
 	defer r.RUnlock()
 	if r.closed {
@@ -308,7 +308,7 @@ func (r *fsSegment) MatchRegexp(field []byte, regexp []byte, compiled *index.Com
 		re  *vregex.Regexp
 		err error
 	)
-	if compiled != nil && compiled.FST != nil {
+	if compiled.FST != nil {
 		re = compiled.FST
 	} else {
 		re, err = vregex.New(string(regexp))
@@ -517,7 +517,7 @@ func (sr *fsSegmentReader) MatchTerm(field []byte, term []byte) (postings.List, 
 	return sr.fsSegment.MatchTerm(field, term)
 }
 
-func (sr *fsSegmentReader) MatchRegexp(field []byte, regexp []byte, compiled *index.CompiledRegex) (postings.List, error) {
+func (sr *fsSegmentReader) MatchRegexp(field []byte, regexp []byte, compiled index.CompiledRegex) (postings.List, error) {
 	sr.RLock()
 	defer sr.RUnlock()
 	if sr.closed {

--- a/src/m3ninx/index/segment/fst/segment.go
+++ b/src/m3ninx/index/segment/fst/segment.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"regexp"
 	"sync"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
@@ -298,16 +297,24 @@ func (r *fsSegment) MatchTerm(field []byte, term []byte) (postings.List, error) 
 	return pl, nil
 }
 
-func (r *fsSegment) MatchRegexp(field []byte, regexp []byte, compiled *regexp.Regexp) (postings.List, error) {
+func (r *fsSegment) MatchRegexp(field []byte, regexp []byte, compiled *index.CompiledRegex) (postings.List, error) {
 	r.RLock()
 	defer r.RUnlock()
 	if r.closed {
 		return nil, errReaderClosed
 	}
 
-	re, err := vregex.New(string(regexp))
-	if err != nil {
-		return nil, err
+	var (
+		re  *vregex.Regexp
+		err error
+	)
+	if compiled != nil && compiled.FST != nil {
+		re = compiled.FST
+	} else {
+		re, err = vregex.New(string(regexp))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	termsFST, exists, err := r.retrieveTermsFSTWithRLock(field)
@@ -510,7 +517,7 @@ func (sr *fsSegmentReader) MatchTerm(field []byte, term []byte) (postings.List, 
 	return sr.fsSegment.MatchTerm(field, term)
 }
 
-func (sr *fsSegmentReader) MatchRegexp(field []byte, regexp []byte, compiled *regexp.Regexp) (postings.List, error) {
+func (sr *fsSegmentReader) MatchRegexp(field []byte, regexp []byte, compiled *index.CompiledRegex) (postings.List, error) {
 	sr.RLock()
 	defer sr.RUnlock()
 	if sr.closed {

--- a/src/m3ninx/index/segment/fst/writer_reader_test.go
+++ b/src/m3ninx/index/segment/fst/writer_reader_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
+	"github.com/m3db/m3/src/m3ninx/index"
 	sgmt "github.com/m3db/m3/src/m3ninx/index/segment"
 	"github.com/m3db/m3/src/m3ninx/index/segment/mem"
 	"github.com/m3db/m3/src/m3ninx/index/util"
@@ -281,12 +282,12 @@ func TestPostingsListRegexAll(t *testing.T) {
 			for _, f := range fields {
 				reader, err := memSeg.Reader()
 				require.NoError(t, err)
-				memPl, err := reader.MatchRegexp(f, []byte("."), nil)
+				memPl, err := reader.MatchRegexp(f, []byte("."), index.CompiledRegex{})
 				require.NoError(t, err)
 
 				fstReader, err := fstSeg.Reader()
 				require.NoError(t, err)
-				fstPl, err := fstReader.MatchRegexp(f, []byte(".*"), nil)
+				fstPl, err := fstReader.MatchRegexp(f, []byte(".*"), index.CompiledRegex{})
 				require.NoError(t, err)
 				require.True(t, memPl.Equal(fstPl))
 			}

--- a/src/m3ninx/index/segment/mem/reader.go
+++ b/src/m3ninx/index/segment/mem/reader.go
@@ -22,7 +22,6 @@ package mem
 
 import (
 	"errors"
-	re "regexp"
 	"sync"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
@@ -72,22 +71,18 @@ func (r *reader) MatchTerm(field, term []byte) (postings.List, error) {
 	return pl, err
 }
 
-func (r *reader) MatchRegexp(field, regexp []byte, compiled *index.CompiledRegex) (postings.List, error) {
+func (r *reader) MatchRegexp(field, regexp []byte, compiled index.CompiledRegex) (postings.List, error) {
 	r.RLock()
 	defer r.RUnlock()
 	if r.closed {
 		return nil, errSegmentReaderClosed
 	}
 
-	var compileRE *re.Regexp
-	if compiled != nil {
-		compileRE = compiled.Simple
-	}
-
 	// A reader can return IDs in the posting list which are greater than its maximum
 	// permitted ID. The reader only guarantees that when fetching the documents associated
 	// with a postings list through a call to Docs will IDs greater than the maximum be
 	// filtered out.
+	compileRE := compiled.Simple
 	pl, err := r.segment.matchRegexp(field, regexp, compileRE)
 	return pl, err
 }

--- a/src/m3ninx/index/segment/mem/reader_test.go
+++ b/src/m3ninx/index/segment/mem/reader_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
+	"github.com/m3db/m3/src/m3ninx/index"
 	"github.com/m3db/m3/src/m3ninx/postings"
 	"github.com/m3db/m3/src/m3ninx/postings/roaring"
 
@@ -77,8 +78,7 @@ func TestReaderMatchRegex(t *testing.T) {
 	)
 
 	reader := newReader(segment, readerDocRange{0, maxID}, postings.NewPool(nil, roaring.NewPostingsList))
-
-	actual, err := reader.MatchRegexp(name, regexp, compiled)
+	actual, err := reader.MatchRegexp(name, regexp, &index.CompiledRegex{Simple: compiled})
 	require.NoError(t, err)
 	require.True(t, postingsList.Equal(actual))
 

--- a/src/m3ninx/index/segment/mem/reader_test.go
+++ b/src/m3ninx/index/segment/mem/reader_test.go
@@ -78,7 +78,7 @@ func TestReaderMatchRegex(t *testing.T) {
 	)
 
 	reader := newReader(segment, readerDocRange{0, maxID}, postings.NewPool(nil, roaring.NewPostingsList))
-	actual, err := reader.MatchRegexp(name, regexp, &index.CompiledRegex{Simple: compiled})
+	actual, err := reader.MatchRegexp(name, regexp, index.CompiledRegex{Simple: compiled})
 	require.NoError(t, err)
 	require.True(t, postingsList.Equal(actual))
 

--- a/src/m3ninx/index/segment/mem/segment_test.go
+++ b/src/m3ninx/index/segment/mem/segment_test.go
@@ -106,7 +106,7 @@ func TestSegmentInsert(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			segment, err := NewSegment(0, NewOptions())
+			segment, err := NewSegment(0, testOptions)
 			require.NoError(t, err)
 			require.Equal(t, int64(0), segment.Size())
 
@@ -168,7 +168,7 @@ func TestSegmentInsertDuplicateID(t *testing.T) {
 		}
 	)
 
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), segment.Size())
 
@@ -244,7 +244,7 @@ func TestSegmentInsertBatch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			segment, err := NewSegment(0, NewOptions())
+			segment, err := NewSegment(0, testOptions)
 			require.NoError(t, err)
 			require.Equal(t, int64(0), segment.Size())
 
@@ -305,7 +305,7 @@ func TestSegmentInsertBatchError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			segment, err := NewSegment(0, NewOptions())
+			segment, err := NewSegment(0, testOptions)
 			require.Equal(t, int64(0), segment.Size())
 			require.NoError(t, err)
 
@@ -393,7 +393,7 @@ func TestSegmentInsertBatchPartialError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			segment, err := NewSegment(0, NewOptions())
+			segment, err := NewSegment(0, testOptions)
 			require.NoError(t, err)
 			require.Equal(t, int64(0), segment.Size())
 
@@ -459,7 +459,7 @@ func TestSegmentInsertBatchPartialErrorInvalidDoc(t *testing.T) {
 		},
 		index.AllowPartialUpdates(),
 	)
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	err = segment.InsertBatch(b1)
@@ -513,7 +513,7 @@ func TestSegmentContainsID(t *testing.T) {
 		},
 		index.AllowPartialUpdates(),
 	)
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 	ok, err := segment.ContainsID([]byte("abc"))
 	require.NoError(t, err)
@@ -597,7 +597,7 @@ func TestSegmentInsertBatchPartialErrorAlreadyIndexing(t *testing.T) {
 		},
 		index.AllowPartialUpdates())
 
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	err = segment.InsertBatch(b1)
@@ -652,7 +652,7 @@ func TestSegmentReaderMatchExact(t *testing.T) {
 		},
 	}
 
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	for _, doc := range docs {
@@ -691,7 +691,7 @@ func TestSegmentReaderMatchExact(t *testing.T) {
 }
 
 func TestSegmentSealLifecycle(t *testing.T) {
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	_, err = segment.Seal()
@@ -702,7 +702,7 @@ func TestSegmentSealLifecycle(t *testing.T) {
 }
 
 func TestSegmentSealCloseLifecycle(t *testing.T) {
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	require.NoError(t, segment.Close())
@@ -711,7 +711,7 @@ func TestSegmentSealCloseLifecycle(t *testing.T) {
 }
 
 func TestSegmentIsSealed(t *testing.T) {
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	require.False(t, segment.IsSealed())
@@ -725,7 +725,7 @@ func TestSegmentIsSealed(t *testing.T) {
 }
 
 func TestSegmentFields(t *testing.T) {
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	knownsFields := map[string]struct{}{}
@@ -754,7 +754,7 @@ func TestSegmentFields(t *testing.T) {
 }
 
 func TestSegmentTerms(t *testing.T) {
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	knownsFields := map[string]map[string]struct{}{}
@@ -787,7 +787,7 @@ func TestSegmentTerms(t *testing.T) {
 
 func TestSegmentReaderMatchRegex(t *testing.T) {
 	docs := testDocuments
-	segment, err := NewSegment(0, NewOptions())
+	segment, err := NewSegment(0, testOptions)
 	require.NoError(t, err)
 
 	for _, doc := range docs {
@@ -800,7 +800,7 @@ func TestSegmentReaderMatchRegex(t *testing.T) {
 
 	field, regexp := []byte("fruit"), []byte(".*ple")
 	compiled := re.MustCompile(string(regexp))
-	pl, err := r.MatchRegexp(field, regexp, compiled)
+	pl, err := r.MatchRegexp(field, regexp, &index.CompiledRegex{Simple: compiled})
 	require.NoError(t, err)
 
 	iter, err := r.Docs(pl)

--- a/src/m3ninx/index/segment/mem/segment_test.go
+++ b/src/m3ninx/index/segment/mem/segment_test.go
@@ -800,7 +800,7 @@ func TestSegmentReaderMatchRegex(t *testing.T) {
 
 	field, regexp := []byte("fruit"), []byte(".*ple")
 	compiled := re.MustCompile(string(regexp))
-	pl, err := r.MatchRegexp(field, regexp, &index.CompiledRegex{Simple: compiled})
+	pl, err := r.MatchRegexp(field, regexp, index.CompiledRegex{Simple: compiled})
 	require.NoError(t, err)
 
 	iter, err := r.Docs(pl)

--- a/src/m3ninx/index/types.go
+++ b/src/m3ninx/index/types.go
@@ -28,6 +28,8 @@ import (
 	"github.com/m3db/m3/src/m3ninx/postings"
 
 	xerrors "github.com/m3db/m3x/errors"
+
+	vregex "github.com/couchbase/vellum/regexp"
 )
 
 // ErrDocNotFound is the error returned when there is no document for a given postings ID.
@@ -66,7 +68,7 @@ type Readable interface {
 
 	// MatchRegexp returns a postings list over all documents which match the given
 	// regular expression.
-	MatchRegexp(field, regexp []byte, compiled *regexp.Regexp) (postings.List, error)
+	MatchRegexp(field, regexp []byte, c *CompiledRegex) (postings.List, error)
 
 	// MatchAll returns a postings list for all documents known to the Reader.
 	MatchAll() (postings.MutableList, error)
@@ -77,6 +79,13 @@ type Readable interface {
 
 	// AllDocs returns an iterator over the documents known to the Reader.
 	AllDocs() (IDDocIterator, error)
+}
+
+// CompiledRegex is a collection of regexp compiled structs to allow
+// amortisation of regexp construction costs.
+type CompiledRegex struct {
+	Simple *regexp.Regexp
+	FST    *vregex.Regexp
 }
 
 // DocRetriever returns the document associated with a postings ID. It returns

--- a/src/m3ninx/index/types.go
+++ b/src/m3ninx/index/types.go
@@ -68,7 +68,7 @@ type Readable interface {
 
 	// MatchRegexp returns a postings list over all documents which match the given
 	// regular expression.
-	MatchRegexp(field, regexp []byte, c *CompiledRegex) (postings.List, error)
+	MatchRegexp(field, regexp []byte, c CompiledRegex) (postings.List, error)
 
 	// MatchAll returns a postings list for all documents known to the Reader.
 	MatchAll() (postings.MutableList, error)

--- a/src/m3ninx/search/query/regexp.go
+++ b/src/m3ninx/search/query/regexp.go
@@ -37,14 +37,14 @@ import (
 type RegexpQuery struct {
 	field    []byte
 	regexp   []byte
-	compiled *index.CompiledRegex
+	compiled index.CompiledRegex
 }
 
 // NewRegexpQuery constructs a new query for the given regular expression.
 func NewRegexpQuery(field, regexp []byte) (search.Query, error) {
 	var (
 		stringRE      = string(regexp)
-		compiledRegex = &index.CompiledRegex{}
+		compiledRegex = index.CompiledRegex{}
 	)
 	simpleRE, err := re.Compile(stringRE)
 	if err != nil {

--- a/src/m3ninx/search/searcher/regexp.go
+++ b/src/m3ninx/search/searcher/regexp.go
@@ -28,7 +28,7 @@ import (
 
 type regexpSearcher struct {
 	field, regexp []byte
-	compiled      *index.CompiledRegex
+	compiled      index.CompiledRegex
 	readers       index.Readers
 
 	idx  int
@@ -38,7 +38,7 @@ type regexpSearcher struct {
 
 // NewRegexpSearcher returns a new searcher for finding documents which match the given regular
 // expression. It is not safe for concurrent access.
-func NewRegexpSearcher(rs index.Readers, field, regexp []byte, compiled *index.CompiledRegex) search.Searcher {
+func NewRegexpSearcher(rs index.Readers, field, regexp []byte, compiled index.CompiledRegex) search.Searcher {
 	return &regexpSearcher{
 		field:    field,
 		regexp:   regexp,

--- a/src/m3ninx/search/searcher/regexp.go
+++ b/src/m3ninx/search/searcher/regexp.go
@@ -21,8 +21,6 @@
 package searcher
 
 import (
-	re "regexp"
-
 	"github.com/m3db/m3/src/m3ninx/index"
 	"github.com/m3db/m3/src/m3ninx/postings"
 	"github.com/m3db/m3/src/m3ninx/search"
@@ -30,7 +28,7 @@ import (
 
 type regexpSearcher struct {
 	field, regexp []byte
-	compiled      *re.Regexp
+	compiled      *index.CompiledRegex
 	readers       index.Readers
 
 	idx  int
@@ -40,7 +38,7 @@ type regexpSearcher struct {
 
 // NewRegexpSearcher returns a new searcher for finding documents which match the given regular
 // expression. It is not safe for concurrent access.
-func NewRegexpSearcher(rs index.Readers, field, regexp []byte, compiled *re.Regexp) search.Searcher {
+func NewRegexpSearcher(rs index.Readers, field, regexp []byte, compiled *index.CompiledRegex) search.Searcher {
 	return &regexpSearcher{
 		field:    field,
 		regexp:   regexp,

--- a/src/m3ninx/search/searcher/regexp_test.go
+++ b/src/m3ninx/search/searcher/regexp_test.go
@@ -37,7 +37,7 @@ func TestRegexpSearcher(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	field, regexp := []byte("fruit"), []byte(".*pple")
-	compiled := &index.CompiledRegex{
+	compiled := index.CompiledRegex{
 		Simple: re.MustCompile(string(regexp)),
 	}
 

--- a/src/m3ninx/search/searcher/regexp_test.go
+++ b/src/m3ninx/search/searcher/regexp_test.go
@@ -37,7 +37,9 @@ func TestRegexpSearcher(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	field, regexp := []byte("fruit"), []byte(".*pple")
-	compiled := re.MustCompile(string(regexp))
+	compiled := &index.CompiledRegex{
+		Simple: re.MustCompile(string(regexp)),
+	}
 
 	// First reader.
 	firstPL := roaring.NewPostingsList()


### PR DESCRIPTION
- Only construct a regexp dfa once per regexp query. 