### PR TITLE
Improve speed of DataFileSetExistsAt

### DIFF
--- a/src/dbnode/integration/disk_cleanup_helpers.go
+++ b/src/dbnode/integration/disk_cleanup_helpers.go
@@ -178,7 +178,11 @@ func waitUntilDataCleanedUpExtended(
 func waitUntilNamespacesCleanedUp(filePathPrefix string, namespace ident.ID, waitTimeout time.Duration) error {
 	dataCleanedUp := func() bool {
 		namespaceDir := fs.NamespaceDataDirPath(filePathPrefix, namespace)
-		return !fs.FileExists(namespaceDir)
+		exists, err := fs.FileExists(namespaceDir)
+		if err != nil {
+			panic(err)
+		}
+		return !exists
 	}
 
 	if waitUntil(dataCleanedUp, waitTimeout) {
@@ -216,7 +220,11 @@ func waitUntilDataFileSetsCleanedUp(filePathPrefix string, namespaces []storage.
 	dataCleanedUp := func() bool {
 		for _, n := range namespaces {
 			shardDir := fs.ShardDataDirPath(filePathPrefix, n.ID(), extraShard)
-			if fs.FileExists(shardDir) {
+			exists, err := fs.FileExists(shardDir)
+			if err != nil {
+				panic(err)
+			}
+			if exists {
 				return false
 			}
 		}

--- a/src/dbnode/integration/disk_cleanup_helpers.go
+++ b/src/dbnode/integration/disk_cleanup_helpers.go
@@ -89,7 +89,10 @@ type cleanupTimesCommitLog struct {
 
 func (c *cleanupTimesCommitLog) anyExist() bool {
 	for _, t := range c.times {
-		_, index := fs.NextCommitLogsFile(c.filePathPrefix, t)
+		_, index, err := fs.NextCommitLogsFile(c.filePathPrefix, t)
+		if err != nil {
+			panic(err)
+		}
 		if index != 0 {
 			return true
 		}
@@ -99,7 +102,10 @@ func (c *cleanupTimesCommitLog) anyExist() bool {
 
 func (c *cleanupTimesCommitLog) allExist() bool {
 	for _, t := range c.times {
-		_, index := fs.NextCommitLogsFile(c.filePathPrefix, t)
+		_, index, err := fs.NextCommitLogsFile(c.filePathPrefix, t)
+		if err != nil {
+			panic(err)
+		}
 		if index == 0 {
 			return false
 		}

--- a/src/dbnode/persist/fs/commitlog/writer.go
+++ b/src/dbnode/persist/fs/commitlog/writer.go
@@ -133,7 +133,10 @@ func (w *writer) Open(start time.Time, duration time.Duration) error {
 		return err
 	}
 
-	filePath, index := fs.NextCommitLogsFile(w.filePathPrefix, start)
+	filePath, index, err := fs.NextCommitLogsFile(w.filePathPrefix, start)
+	if err != nil {
+		return err
+	}
 	logInfo := schema.LogInfo{
 		Start:    start.UnixNano(),
 		Duration: int64(duration),

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -1028,13 +1028,10 @@ func CommitLogsDirPath(prefix string) string {
 }
 
 // DataFileSetExistsAt determines whether data fileset files exist for the given namespace, shard, and block start.
-func DataFileSetExistsAt(prefix string, namespace ident.ID, shard uint32, blockStart time.Time) (bool, error) {
-	_, ok, err := FileSetAt(prefix, namespace, shard, blockStart)
-	if err != nil {
-		return false, err
-	}
-
-	return ok, nil
+func DataFileSetExistsAt(filePathPrefix string, namespace ident.ID, shard uint32, blockStart time.Time) (bool, error) {
+	dir := ShardDataDirPath(filePathPrefix, namespace, shard)
+	path := filesetPathFromTime(dir, blockStart, checkpointFileSuffix)
+	return FileExists(path), nil
 }
 
 // SnapshotFileSetExistsAt determines whether snapshot fileset files exist for the given namespace, shard, and block start time.

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -468,7 +468,11 @@ func forEachInfoFile(
 			digestsFilePath = filesetPathFromTimeAndIndex(dir, t, volume, digestFileSuffix)
 			infoFilePath = filesetPathFromTimeAndIndex(dir, t, volume, infoFileSuffix)
 		}
-		if !FileExists(checkpointFilePath) {
+		checkpointExists, err := FileExists(checkpointFilePath)
+		if err != nil {
+			continue
+		}
+		if !checkpointExists {
 			continue
 		}
 		checkpointFd, err := os.Open(checkpointFilePath)
@@ -1029,9 +1033,9 @@ func CommitLogsDirPath(prefix string) string {
 
 // DataFileSetExistsAt determines whether data fileset files exist for the given namespace, shard, and block start.
 func DataFileSetExistsAt(filePathPrefix string, namespace ident.ID, shard uint32, blockStart time.Time) (bool, error) {
-	dir := ShardDataDirPath(filePathPrefix, namespace, shard)
-	path := filesetPathFromTime(dir, blockStart, checkpointFileSuffix)
-	return FileExists(path), nil
+	shardDir := ShardDataDirPath(filePathPrefix, namespace, shard)
+	checkpointPath := filesetPathFromTime(shardDir, blockStart, checkpointFileSuffix)
+	return FileExists(checkpointPath)
 }
 
 // SnapshotFileSetExistsAt determines whether snapshot fileset files exist for the given namespace, shard, and block start time.
@@ -1050,13 +1054,17 @@ func SnapshotFileSetExistsAt(prefix string, namespace ident.ID, shard uint32, bl
 }
 
 // NextCommitLogsFile returns the next commit logs file.
-func NextCommitLogsFile(prefix string, start time.Time) (string, int) {
+func NextCommitLogsFile(prefix string, start time.Time) (string, int, error) {
 	for i := 0; ; i++ {
 		entry := fmt.Sprintf("%d%s%d", start.UnixNano(), separator, i)
 		fileName := fmt.Sprintf("%s%s%s%s", commitLogFilePrefix, separator, entry, fileSuffix)
 		filePath := path.Join(CommitLogsDirPath(prefix), fileName)
-		if !FileExists(filePath) {
-			return filePath, i
+		exists, err := FileExists(filePath)
+		if err != nil {
+			return "", -1, err
+		}
+		if !exists {
+			return filePath, i, nil
 		}
 	}
 }
@@ -1119,9 +1127,17 @@ func NextIndexSnapshotFileIndex(filePathPrefix string, namespace ident.ID, block
 }
 
 // FileExists returns whether a file at the given path exists.
-func FileExists(filePath string) bool {
+func FileExists(filePath string) (bool, error) {
 	_, err := os.Stat(filePath)
-	return err == nil
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 // OpenWritable opens a file for writing and truncating as necessary.

--- a/src/dbnode/persist/fs/index_read.go
+++ b/src/dbnode/persist/fs/index_read.go
@@ -138,7 +138,11 @@ func (r *indexReader) Open(
 }
 
 func (r *indexReader) readCheckpointFile(filePath string) error {
-	if !FileExists(filePath) {
+	exists, err := FileExists(filePath)
+	if err != nil {
+		return err
+	}
+	if !exists {
 		return ErrCheckpointFileNotFound
 	}
 	data, err := ioutil.ReadFile(filePath)

--- a/src/dbnode/persist/fs/index_write.go
+++ b/src/dbnode/persist/fs/index_write.go
@@ -175,7 +175,11 @@ func (w *indexWriter) WriteSegmentFileSet(
 			err := fmt.Errorf("unknown fileset type: %s", w.fileSetType)
 			return w.markSegmentWriteError(segType, segFileType, err)
 		}
-		if FileExists(filePath) {
+		exists, err := FileExists(filePath)
+		if err != nil {
+			return err
+		}
+		if exists {
 			err := fmt.Errorf("segment file type already exists at %s", filePath)
 			return w.markSegmentWriteError(segType, segFileType, err)
 		}

--- a/src/dbnode/persist/fs/read.go
+++ b/src/dbnode/persist/fs/read.go
@@ -248,7 +248,11 @@ func (r *reader) Status() DataFileSetReaderStatus {
 }
 
 func (r *reader) readCheckpointFile(filePath string) error {
-	if !FileExists(filePath) {
+	exists, err := FileExists(filePath)
+	if err != nil {
+		return err
+	}
+	if !exists {
 		return ErrCheckpointFileNotFound
 	}
 	fd, err := os.Open(filePath)

--- a/src/dbnode/persist/fs/read_test.go
+++ b/src/dbnode/persist/fs/read_test.go
@@ -271,7 +271,7 @@ func TestReadNoCheckpointFile(t *testing.T) {
 
 	shardDir := ShardDataDirPath(filePathPrefix, testNs1ID, shard)
 	checkpointFile := filesetPathFromTime(shardDir, testWriterStart, checkpointFileSuffix)
-	require.True(t, FileExists(checkpointFile))
+	require.True(t, mustFileExists(t, checkpointFile))
 	os.Remove(checkpointFile)
 
 	r := newTestReader(t, filePathPrefix)


### PR DESCRIPTION
- [X] Improve speed of DataFileSetExistsAt by just verifying if the checkpoint file exists (as opposed to  the existing code which uses a much more expensive codepath requiring use of filepath.Glob)
- [X] Refactor FileExists (and dependent code) to return errors