### PR TITLE
Pull latest upstream vellum

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -100,7 +100,7 @@ imports:
   subpackages:
   - capnslog
 - name: github.com/couchbase/vellum
-  version: 1782e2d46ce2a9f28bd1ac1b46cd141c0d887c9b
+  version: 28dce9c5a7c652389e0aaf428c393033f0199dc4
   repo: https://github.com/m3db/vellum
   subpackages:
   - regexp

--- a/glide.yaml
+++ b/glide.yaml
@@ -121,7 +121,7 @@ import:
 
 - package: github.com/couchbase/vellum
   repo:    https://github.com/m3db/vellum
-  version: 1782e2d46ce2a9f28bd1ac1b46cd141c0d887c9b
+  version: 28dce9c5a7c652389e0aaf428c393033f0199dc4
 
 - package: github.com/edsrzf/mmap-go # un-used but required for a compile time dep from vellum
   version: 0bce6a6887123b67a60366d2c9fe2dfb74289d2e

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -439,8 +439,10 @@ func TestCommitLogReaderIsNotReusable(t *testing.T) {
 	// Make sure we're not leaking goroutines
 	defer leaktest.CheckTimeout(t, time.Second)()
 
+	overrideFlushInterval := 10 * time.Millisecond
 	opts, scope := newTestOptions(t, overrides{
-		strategy: StrategyWriteWait,
+		strategy:      StrategyWriteWait,
+		flushInterval: &overrideFlushInterval,
 	})
 	defer cleanup(t, opts)
 


### PR DESCRIPTION
- This time ensuring the old sha1 sticks around to avoid old builds having issues