### PR TITLE
Fix LRU deadlock + regression test and improve comments / logging

### DIFF
--- a/src/cmd/services/m3dbnode/config/cache.go
+++ b/src/cmd/services/m3dbnode/config/cache.go
@@ -47,5 +47,6 @@ type SeriesCacheConfiguration struct {
 // LRUSeriesCachePolicyConfiguration contains configuration for the LRU
 // series caching policy.
 type LRUSeriesCachePolicyConfiguration struct {
-	MaxBlocks uint `yaml:"maxBlocks" validate:"nonzero"`
+	MaxBlocks         uint `yaml:"maxBlocks" validate:"nonzero"`
+	EventsChannelSize uint `yaml:"eventsChannelSize" validate:"nonzero"`
 }

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -298,11 +298,13 @@ func newTestSetup(t *testing.T, opts testOptions, fsOpts fs.Options) (*testSetup
 
 	// Set up wired list if required
 	if storageOpts.SeriesCachePolicy() == series.CacheLRU {
-		wiredList := block.NewWiredList(
-			runtimeOptsMgr,
-			storageOpts.InstrumentOptions(),
-			storageOpts.ClockOptions(),
-		)
+		wiredList := block.NewWiredList(block.WiredListOptions{
+			RuntimeOptionsManager: runtimeOptsMgr,
+			InstrumentOptions:     storageOpts.InstrumentOptions(),
+			ClockOptions:          storageOpts.ClockOptions(),
+			// Use a small event channel size to stress-test the implementation
+			EventsChannelSize: 1,
+		})
 		blockOpts := storageOpts.DatabaseBlockOptions().SetWiredList(wiredList)
 		blockPool := block.NewDatabaseBlockPool(nil)
 		// Have to manually set the blockpool because the default one uses a constructor

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -1015,7 +1015,7 @@ func withEncodingAndPoolingOptions(
 		)
 
 		if lruCfg != nil && lruCfg.EventsChannelSize > 0 {
-			wiredListOpts.EventsChannelSize = lruCfg.EventsChannelSize
+			wiredListOpts.EventsChannelSize = int(lruCfg.EventsChannelSize)
 		}
 		wiredList := block.NewWiredList(wiredListOpts)
 		blockOpts = blockOpts.SetWiredList(wiredList)

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -326,7 +326,7 @@ func Run(runOpts RunOptions) {
 	opts = opts.SetSeriesCachePolicy(seriesCachePolicy)
 
 	// Apply pooling options
-	opts = withEncodingAndPoolingOptions(logger, opts, cfg.PoolingPolicy)
+	opts = withEncodingAndPoolingOptions(cfg, logger, opts, cfg.PoolingPolicy)
 
 	// Setup the block retriever
 	switch seriesCachePolicy {
@@ -882,6 +882,7 @@ func kvWatchBootstrappers(
 }
 
 func withEncodingAndPoolingOptions(
+	cfg config.DBConfiguration,
 	logger xlog.Logger,
 	opts storage.Options,
 	policy config.PoolingPolicy,

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -1004,7 +1004,11 @@ func withEncodingAndPoolingOptions(
 
 	if opts.SeriesCachePolicy() == series.CacheLRU {
 		runtimeOpts := opts.RuntimeOptionsManager()
-		wiredList := block.NewWiredList(runtimeOpts, iopts, opts.ClockOptions())
+		wiredList := block.NewWiredList(block.WiredListOptions{
+			RuntimeOptionsManager: runtimeOpts,
+			InstrumentOptions:     iopts,
+			ClockOptions:          opts.ClockOptions(),
+		})
 		blockOpts = blockOpts.SetWiredList(wiredList)
 	}
 	blockPool := block.NewDatabaseBlockPool(poolOptions(policy.BlockPool,

--- a/src/dbnode/storage/block/block.go
+++ b/src/dbnode/storage/block/block.go
@@ -196,8 +196,8 @@ func (b *dbBlock) OnRetrieveBlock(
 	defer b.Unlock()
 
 	if b.closed ||
-		!id.Equal(b.retrieveID) ||
-		!startTime.Equal(b.startWithRLock()) {
+		!id.Equal(b.retrieveID) {
+		// !startTime.Equal(b.startWithRLock()) {
 		return
 	}
 
@@ -425,6 +425,7 @@ func (b *dbBlock) Close() {
 func (b *dbBlock) closeAndDiscard() ts.Segment {
 	b.Lock()
 	if b.closed {
+		panic("DOUBLE CLOSE")
 		b.Unlock()
 		return ts.Segment{}
 	}

--- a/src/dbnode/storage/block/block.go
+++ b/src/dbnode/storage/block/block.go
@@ -73,9 +73,9 @@ type dbBlock struct {
 }
 
 type listState struct {
-	next                      DatabaseBlock
-	prev                      DatabaseBlock
-	nextPrevUpdatedAtUnixNano int64
+	next                  DatabaseBlock
+	prev                  DatabaseBlock
+	enteredListAtUnixNano int64
 }
 
 // NewDatabaseBlock creates a new DatabaseBlock instance.
@@ -488,13 +488,13 @@ func (b *dbBlock) setPrev(value DatabaseBlock) {
 }
 
 // Should only be used by the WiredList.
-func (b *dbBlock) nextPrevUpdatedAtUnixNano() int64 {
-	return b.listState.nextPrevUpdatedAtUnixNano
+func (b *dbBlock) enteredListAtUnixNano() int64 {
+	return b.listState.enteredListAtUnixNano
 }
 
 // Should only be used by the WiredList.
-func (b *dbBlock) setNextPrevUpdatedAtUnixNano(value int64) {
-	b.listState.nextPrevUpdatedAtUnixNano = value
+func (b *dbBlock) setEnteredListAtUnixNano(value int64) {
+	b.listState.enteredListAtUnixNano = value
 }
 
 // wiredListEntry is a snapshot of a subset of the block's state that the WiredList

--- a/src/dbnode/storage/block/block.go
+++ b/src/dbnode/storage/block/block.go
@@ -425,7 +425,6 @@ func (b *dbBlock) Close() {
 func (b *dbBlock) closeAndDiscard() ts.Segment {
 	b.Lock()
 	if b.closed {
-		panic("DOUBLE CLOSE")
 		b.Unlock()
 		return ts.Segment{}
 	}

--- a/src/dbnode/storage/block/block.go
+++ b/src/dbnode/storage/block/block.go
@@ -196,8 +196,8 @@ func (b *dbBlock) OnRetrieveBlock(
 	defer b.Unlock()
 
 	if b.closed ||
-		!id.Equal(b.retrieveID) {
-		// !startTime.Equal(b.startWithRLock()) {
+		!id.Equal(b.retrieveID) ||
+		!startTime.Equal(b.startWithRLock()) {
 		return
 	}
 

--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -461,6 +461,18 @@ func (mr *MockDatabaseBlockMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDatabaseBlock)(nil).Close))
 }
 
+// CloseIfFromDisk mocks base method
+func (m *MockDatabaseBlock) CloseIfFromDisk() bool {
+	ret := m.ctrl.Call(m, "CloseIfFromDisk")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CloseIfFromDisk indicates an expected call of CloseIfFromDisk
+func (mr *MockDatabaseBlockMockRecorder) CloseIfFromDisk() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseIfFromDisk", reflect.TypeOf((*MockDatabaseBlock)(nil).CloseIfFromDisk))
+}
+
 // SetOnEvictedFromWiredList mocks base method
 func (m *MockDatabaseBlock) SetOnEvictedFromWiredList(arg0 OnEvictedFromWiredList) {
 	m.ctrl.Call(m, "SetOnEvictedFromWiredList", arg0)

--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -539,26 +539,26 @@ func (mr *MockDatabaseBlockMockRecorder) setPrev(block interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setPrev", reflect.TypeOf((*MockDatabaseBlock)(nil).setPrev), block)
 }
 
-// nextPrevUpdatedAtUnixNano mocks base method
-func (m *MockDatabaseBlock) nextPrevUpdatedAtUnixNano() int64 {
-	ret := m.ctrl.Call(m, "nextPrevUpdatedAtUnixNano")
+// enteredListAtUnixNano mocks base method
+func (m *MockDatabaseBlock) enteredListAtUnixNano() int64 {
+	ret := m.ctrl.Call(m, "enteredListAtUnixNano")
 	ret0, _ := ret[0].(int64)
 	return ret0
 }
 
-// nextPrevUpdatedAtUnixNano indicates an expected call of nextPrevUpdatedAtUnixNano
-func (mr *MockDatabaseBlockMockRecorder) nextPrevUpdatedAtUnixNano() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "nextPrevUpdatedAtUnixNano", reflect.TypeOf((*MockDatabaseBlock)(nil).nextPrevUpdatedAtUnixNano))
+// enteredListAtUnixNano indicates an expected call of enteredListAtUnixNano
+func (mr *MockDatabaseBlockMockRecorder) enteredListAtUnixNano() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "enteredListAtUnixNano", reflect.TypeOf((*MockDatabaseBlock)(nil).enteredListAtUnixNano))
 }
 
-// setNextPrevUpdatedAtUnixNano mocks base method
-func (m *MockDatabaseBlock) setNextPrevUpdatedAtUnixNano(value int64) {
-	m.ctrl.Call(m, "setNextPrevUpdatedAtUnixNano", value)
+// setEnteredListAtUnixNano mocks base method
+func (m *MockDatabaseBlock) setEnteredListAtUnixNano(value int64) {
+	m.ctrl.Call(m, "setEnteredListAtUnixNano", value)
 }
 
-// setNextPrevUpdatedAtUnixNano indicates an expected call of setNextPrevUpdatedAtUnixNano
-func (mr *MockDatabaseBlockMockRecorder) setNextPrevUpdatedAtUnixNano(value interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setNextPrevUpdatedAtUnixNano", reflect.TypeOf((*MockDatabaseBlock)(nil).setNextPrevUpdatedAtUnixNano), value)
+// setEnteredListAtUnixNano indicates an expected call of setEnteredListAtUnixNano
+func (mr *MockDatabaseBlockMockRecorder) setEnteredListAtUnixNano(value interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setEnteredListAtUnixNano", reflect.TypeOf((*MockDatabaseBlock)(nil).setEnteredListAtUnixNano), value)
 }
 
 // wiredListEntry mocks base method
@@ -640,26 +640,26 @@ func (mr *MockdatabaseBlockMockRecorder) setPrev(block interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setPrev", reflect.TypeOf((*MockdatabaseBlock)(nil).setPrev), block)
 }
 
-// nextPrevUpdatedAtUnixNano mocks base method
-func (m *MockdatabaseBlock) nextPrevUpdatedAtUnixNano() int64 {
-	ret := m.ctrl.Call(m, "nextPrevUpdatedAtUnixNano")
+// enteredListAtUnixNano mocks base method
+func (m *MockdatabaseBlock) enteredListAtUnixNano() int64 {
+	ret := m.ctrl.Call(m, "enteredListAtUnixNano")
 	ret0, _ := ret[0].(int64)
 	return ret0
 }
 
-// nextPrevUpdatedAtUnixNano indicates an expected call of nextPrevUpdatedAtUnixNano
-func (mr *MockdatabaseBlockMockRecorder) nextPrevUpdatedAtUnixNano() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "nextPrevUpdatedAtUnixNano", reflect.TypeOf((*MockdatabaseBlock)(nil).nextPrevUpdatedAtUnixNano))
+// enteredListAtUnixNano indicates an expected call of enteredListAtUnixNano
+func (mr *MockdatabaseBlockMockRecorder) enteredListAtUnixNano() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "enteredListAtUnixNano", reflect.TypeOf((*MockdatabaseBlock)(nil).enteredListAtUnixNano))
 }
 
-// setNextPrevUpdatedAtUnixNano mocks base method
-func (m *MockdatabaseBlock) setNextPrevUpdatedAtUnixNano(value int64) {
-	m.ctrl.Call(m, "setNextPrevUpdatedAtUnixNano", value)
+// setEnteredListAtUnixNano mocks base method
+func (m *MockdatabaseBlock) setEnteredListAtUnixNano(value int64) {
+	m.ctrl.Call(m, "setEnteredListAtUnixNano", value)
 }
 
-// setNextPrevUpdatedAtUnixNano indicates an expected call of setNextPrevUpdatedAtUnixNano
-func (mr *MockdatabaseBlockMockRecorder) setNextPrevUpdatedAtUnixNano(value interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setNextPrevUpdatedAtUnixNano", reflect.TypeOf((*MockdatabaseBlock)(nil).setNextPrevUpdatedAtUnixNano), value)
+// setEnteredListAtUnixNano indicates an expected call of setEnteredListAtUnixNano
+func (mr *MockdatabaseBlockMockRecorder) setEnteredListAtUnixNano(value interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setEnteredListAtUnixNano", reflect.TypeOf((*MockdatabaseBlock)(nil).setEnteredListAtUnixNano), value)
 }
 
 // wiredListEntry mocks base method

--- a/src/dbnode/storage/block/block_test.go
+++ b/src/dbnode/storage/block/block_test.go
@@ -551,6 +551,18 @@ func TestDatabaseBlockStreamMergePerformsCopy(t *testing.T) {
 	require.NoError(t, iter.Err())
 }
 
+func TestDatabaseBlockCloseIfFromDisk(t *testing.T) {
+	var (
+		blockOpts        = NewOptions()
+		blockNotFromDisk = NewDatabaseBlock(time.Time{}, time.Hour, ts.Segment{}, blockOpts).(*dbBlock)
+		blockFromDisk    = NewDatabaseBlock(time.Time{}, time.Hour, ts.Segment{}, blockOpts).(*dbBlock)
+	)
+	blockFromDisk.wasRetrievedFromDisk = true
+
+	require.False(t, blockNotFromDisk.CloseIfFromDisk())
+	require.True(t, blockFromDisk.CloseIfFromDisk())
+}
+
 func TestDatabaseSeriesBlocksAddBlock(t *testing.T) {
 	now := time.Now()
 	blockTimes := []time.Time{now, now.Add(time.Second), now.Add(time.Minute), now.Add(-time.Second), now.Add(-time.Hour)}

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -218,8 +218,8 @@ type databaseBlock interface {
 	setNext(block DatabaseBlock)
 	prev() DatabaseBlock
 	setPrev(block DatabaseBlock)
-	nextPrevUpdatedAtUnixNano() int64
-	setNextPrevUpdatedAtUnixNano(value int64)
+	enteredListAtUnixNano() int64
+	setEnteredListAtUnixNano(value int64)
 	wiredListEntry() wiredListEntry
 }
 

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -197,6 +197,11 @@ type DatabaseBlock interface {
 	// Close closes the block.
 	Close()
 
+	// CloseIfFromDisk atomically checks if the disk was retrieved from disk, and
+	// if so, closes it. It is meant as a layered protection for the WiredList
+	// which should only close blocks that were retrieved from disk.
+	CloseIfFromDisk() bool
+
 	// SetOnEvictedFromWiredList sets the owner of the block
 	SetOnEvictedFromWiredList(OnEvictedFromWiredList)
 

--- a/src/dbnode/storage/block/wired_list.go
+++ b/src/dbnode/storage/block/wired_list.go
@@ -242,7 +242,6 @@ func (l *WiredList) insertAfter(v, at DatabaseBlock) {
 	at.setNext(v)
 	v.setPrev(at)
 	v.setNext(n)
-	v.setNextPrevUpdatedAtUnixNano(now.UnixNano())
 	n.setPrev(v)
 	l.length++
 
@@ -292,8 +291,8 @@ func (l *WiredList) insertAfter(v, at DatabaseBlock) {
 
 		l.metrics.evicted.Inc(1)
 
-		lastUpdatedAt := time.Unix(0, bl.nextPrevUpdatedAtUnixNano())
-		l.metrics.evictedAfterDuration.Record(now.Sub(lastUpdatedAt))
+		enteredListAt := time.Unix(0, bl.enteredListAtUnixNano())
+		l.metrics.evictedAfterDuration.Record(now.Sub(enteredListAt))
 
 		bl = nextBl
 	}
@@ -320,6 +319,7 @@ func (l *WiredList) pushBack(v DatabaseBlock) {
 
 	l.metrics.inserted.Inc(1)
 	l.insertAfter(v, l.root.prev())
+	v.setEnteredListAtUnixNano(l.nowFn().UnixNano())
 }
 
 func (l *WiredList) moveToBack(v DatabaseBlock) {

--- a/src/dbnode/storage/block/wired_list.go
+++ b/src/dbnode/storage/block/wired_list.go
@@ -286,9 +286,9 @@ func (l *WiredList) insertAfter(v, at DatabaseBlock) {
 			onEvict.OnEvictedFromWiredList(entry.retrieveID, entry.startTime)
 		}
 
-		// bl.Close() will return the block to the pool. In order to avoid races
-		// with the pool itself, we capture the value of the next block and remove
-		// the block from the wired list before we close it.
+		// bl.CloseIfFromDisk() will return the block to the pool. In order to avoid
+		// races with the pool itself, we capture the value of the next block and
+		// remove the block from the wired list before we close it.
 		nextBl := bl.next()
 		l.remove(bl)
 		if wasFromDisk := bl.CloseIfFromDisk(); !wasFromDisk {

--- a/src/dbnode/storage/block/wired_list_test.go
+++ b/src/dbnode/storage/block/wired_list_test.go
@@ -98,10 +98,10 @@ func TestWiredListInsertsAndUpdatesWiredBlocks(t *testing.T) {
 		blocks = append(blocks, bl)
 	}
 
-	l.Update(blocks[0])
-	l.Update(blocks[1])
-	l.Update(blocks[2])
-	l.Update(blocks[1])
+	l.BlockingUpdate(blocks[0])
+	l.BlockingUpdate(blocks[1])
+	l.BlockingUpdate(blocks[2])
+	l.BlockingUpdate(blocks[1])
 
 	l.Stop()
 
@@ -133,9 +133,9 @@ func TestWiredListRemovesUnwiredBlocks(t *testing.T) {
 		blocks = append(blocks, bl)
 	}
 
-	l.Update(blocks[0])
-	l.Update(blocks[1])
-	l.Update(blocks[0])
+	l.BlockingUpdate(blocks[0])
+	l.BlockingUpdate(blocks[1])
+	l.BlockingUpdate(blocks[0])
 
 	l.Stop()
 
@@ -147,7 +147,7 @@ func TestWiredListRemovesUnwiredBlocks(t *testing.T) {
 	blocks[1].closed = true
 
 	l.Start()
-	l.Update(blocks[1])
+	l.BlockingUpdate(blocks[1])
 	l.Stop()
 
 	require.Equal(t, 1, l.length)
@@ -158,7 +158,7 @@ func TestWiredListRemovesUnwiredBlocks(t *testing.T) {
 	blocks[0].closed = true
 
 	l.Start()
-	l.Update(blocks[0])
+	l.BlockingUpdate(blocks[0])
 	l.Stop()
 
 	require.Equal(t, 0, l.length)

--- a/src/dbnode/storage/block/wired_list_test.go
+++ b/src/dbnode/storage/block/wired_list_test.go
@@ -166,51 +166,6 @@ func TestWiredListRemovesUnwiredBlocks(t *testing.T) {
 	require.Equal(t, &l.root, l.root.prev())
 }
 
-func TestDeadlock(t *testing.T) {
-	wiredListEventsChannelLength = 1
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	l, _ := newTestWiredList(runtime.NewOptions().SetMaxWiredBlocks(1), nil)
-
-	opts := testOptions.SetWiredList(l)
-
-	// l.Start()
-	bl := newTestUnwireableBlock(ctrl, fmt.Sprintf("foo.%d", 0), opts)
-
-	l.Start()
-	l.Update(bl)
-	l.Update(bl)
-	l.Stop()
-
-	// Order due to LRU should be: 1, 0
-	require.Equal(t, bl, l.root.next())
-	// require.Equal(t, blocks[0], l.root.next().next())
-
-	// Unwire block and assert removed
-	// blocks[1].closed = true
-
-	// l.Start()
-	// l.Update(blocks[1])
-	// l.Stop()
-
-	// require.Equal(t, 1, l.length)
-	// require.Equal(t, blocks[0], l.root.next())
-	// require.Equal(t, &l.root, l.root.next().next())
-
-	// // Unwire final block and assert removed
-	// blocks[0].closed = true
-
-	// l.Start()
-	// l.Update(blocks[0])
-	// l.Stop()
-
-	// require.Equal(t, 0, l.length)
-	// require.Equal(t, &l.root, l.root.next())
-	// require.Equal(t, &l.root, l.root.prev())
-}
-
 // wiredListTestWiredBlocksString is used to debug the order of the wired list
 func wiredListTestWiredBlocksString(l *WiredList) string { // nolint: unused
 	b := bytes.NewBuffer(nil)

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -520,9 +520,14 @@ func (s *dbSeries) OnRetrieveBlock(
 	segment ts.Segment,
 ) {
 	s.Lock()
+	shouldUnlock := true
+	defer func() {
+		if shouldUnlock {
+			s.Unlock()
+		}
+	}()
 
 	if !id.Equal(s.id) {
-		s.Unlock()
 		return
 	}
 
@@ -551,6 +556,7 @@ func (s *dbSeries) OnRetrieveBlock(
 	s.addBlockWithLock(b)
 
 	list := s.opts.DatabaseBlockOptions().WiredList()
+	shouldUnlock = false
 	s.Unlock()
 
 	if list != nil {

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -564,8 +564,8 @@ func (s *dbSeries) OnRetrieveBlock(
 		// can enter the list (OnReadBlock is only called for blocks that
 		// were read from memory, regardless of whether the data originated
 		// from disk or a buffer rotation.)
-		// Also, doing this outside of the lock is safe because updating the
-		// wired list is asynchronous anyways (Update just puts the block in
+		// Doing this outside of the lock is safe because updating the
+		// wired list is asynchronous already (Update just puts the block in
 		// a channel to be processed later.)
 		list.Update(b)
 	}

--- a/src/dbnode/storage/series_wired_list_interaction_test.go
+++ b/src/dbnode/storage/series_wired_list_interaction_test.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/clock"
+	"github.com/m3db/m3/src/dbnode/runtime"
+	"github.com/m3db/m3/src/dbnode/storage/block"
+	"github.com/m3db/m3/src/dbnode/storage/series"
+	"github.com/m3db/m3/src/dbnode/storage/series/lookup"
+	"github.com/m3db/m3/src/dbnode/ts"
+	"github.com/m3db/m3x/ident"
+	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/pool"
+)
+
+// TestSeriesWiredListConcurrentInteractions was added as a regression test
+// after discovering that interactions between a single series and the wired
+// list could trigger a mutual dead lock. Specifically, if the wired list event
+// channel was full, then the series could get blocked on a call to list.Update()
+// in the OnRetrieveBlockMethod while the only goroutine pulling items off of that
+// channel was stuck on the same series OnEvictedFromWiredList method. In that case,
+// the OnRetrieveBlockMethod was stuck on a channel send while holding a lock that was
+// required for the OnEvictedFromWiredList method that the wired list worker routine
+// was calling.
+func TestSeriesWiredListConcurrentInteractions(t *testing.T) {
+	var (
+		runtimeOptsMgr = runtime.NewOptionsManager()
+		runtimeOpts    = runtime.NewOptions().SetMaxWiredBlocks(1)
+	)
+	runtimeOptsMgr.Update(runtimeOpts)
+
+	runtime.NewOptions().SetMaxWiredBlocks(1)
+	wl := block.NewWiredList(block.WiredListOptions{
+		RuntimeOptionsManager: runtimeOptsMgr,
+		InstrumentOptions:     instrument.NewOptions(),
+		ClockOptions:          clock.NewOptions(),
+		// Use a small channel to stress-test the implementation
+		EventsChannelSize: 1,
+	})
+	wl.Start()
+	defer wl.Stop()
+
+	var (
+		blOpts = testDatabaseOptions().DatabaseBlockOptions()
+		blPool = block.NewDatabaseBlockPool(
+			// Small pool size to make any pooling issues more
+			// likely to manifest.
+			pool.NewObjectPoolOptions().SetSize(5),
+		)
+	)
+	blPool.Init(func() block.DatabaseBlock {
+		return block.NewDatabaseBlock(time.Time{}, 0, ts.Segment{}, blOpts)
+	})
+
+	var (
+		opts = testDatabaseOptions().SetDatabaseBlockOptions(
+			blOpts.
+				SetWiredList(wl).
+				SetDatabaseBlockPool(blPool),
+		)
+		shard  = testDatabaseShard(t, opts)
+		id     = ident.StringID("foo")
+		series = series.NewDatabaseSeries(id, ident.Tags{}, shard.seriesOpts)
+	)
+
+	series.Reset(id, ident.Tags{}, nil, shard.seriesOnRetrieveBlock, shard, shard.seriesOpts)
+	series.Bootstrap(nil)
+	shard.Lock()
+	shard.insertNewShardEntryWithLock(lookup.NewEntry(series, 0))
+	shard.Unlock()
+
+	var (
+		wg     = sync.WaitGroup{}
+		doneCh = make(chan struct{})
+	)
+	go func() {
+		// Try and trigger any pooling issues
+		for {
+			select {
+			case <-doneCh:
+				return
+			default:
+				bl := blPool.Get()
+				bl.ResetRetrievable(time.Time{}, 2*time.Hour, nil, block.RetrievableBlockMetadata{})
+				bl.Close()
+			}
+		}
+	}()
+
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			blTime := time.Time{}.Add(2 * time.Hour)
+			shard.OnRetrieveBlock(id, nil, blTime, ts.Segment{})
+			shard.OnEvictedFromWiredList(id, blTime)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	close(doneCh)
+}

--- a/src/dbnode/storage/series_wired_list_interaction_test.go
+++ b/src/dbnode/storage/series_wired_list_interaction_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/block"
@@ -17,6 +15,8 @@ import (
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestSeriesWiredListConcurrentInteractions was added as a regression test

--- a/src/dbnode/storage/series_wired_list_interaction_test.go
+++ b/src/dbnode/storage/series_wired_list_interaction_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3/src/dbnode/storage/series/lookup"
 	"github.com/m3db/m3/src/dbnode/ts"
+	"github.com/m3db/m3x/context"
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSeriesWiredListConcurrentInteractions was added as a regression test
@@ -108,6 +110,9 @@ func TestSeriesWiredListConcurrentInteractions(t *testing.T) {
 		go func() {
 			blTime := getAndIncStart()
 			shard.OnRetrieveBlock(id, nil, blTime, ts.Segment{})
+			// Simulate concurrent reads
+			_, err := shard.ReadEncoded(context.NewContext(), id, blTime, blTime.Add(blockSize))
+			require.NoError(t, err)
 			wg.Done()
 		}()
 	}

--- a/src/dbnode/storage/series_wired_list_interaction_test.go
+++ b/src/dbnode/storage/series_wired_list_interaction_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/block"
@@ -15,7 +17,6 @@ import (
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
 	"github.com/m3db/m3x/pool"
-	"github.com/stretchr/testify/require"
 )
 
 // TestSeriesWiredListConcurrentInteractions was added as a regression test

--- a/src/dbnode/storage/series_wired_list_interaction_test.go
+++ b/src/dbnode/storage/series_wired_list_interaction_test.go
@@ -98,7 +98,6 @@ func TestSeriesWiredListConcurrentInteractions(t *testing.T) {
 			blTime := start
 			start = start.Add(blockSize)
 			shard.OnRetrieveBlock(id, nil, blTime, ts.Segment{})
-			// shard.OnEvictedFromWiredList(id, blTime)
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
- [X] Fix LRU deadlock that could occur when the events channel was filled up. Achieved this by making the series object call WiredList.Update() outside of a lock as well as adding the concept of a NonBlockingUpdate. Also added a regression test.
- [X] Made LRU events channel size configurable for stress testing purposes.
- [X] Improve "invariant violated" style logging so that metrics are emitted if wired list invariants are violated.
- [X] Added a new "CloseIfFromDisk" method to the database block as an additional layer of protection.