### PR TITLE
Refactor InitialTopologyState logic to exist at bootstrapper level instead of in peer bootstrapper source

### DIFF
--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -168,7 +168,7 @@ func (bsc BootstrapConfiguration) New(
 		providerOpts = providerOpts.SetCacheSeriesMetadata(*bsc.CacheSeriesMetadata)
 	}
 	providerOpts = providerOpts.SetAdminClient(adminClient)
-	return bootstrap.NewProcessProvider(bs, providerOpts, rsOpts), nil
+	return bootstrap.NewProcessProvider(bs, providerOpts, rsOpts)
 }
 
 // ValidateBootstrappersOrder will validate that a list of bootstrappers specified

--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -167,7 +167,7 @@ func (bsc BootstrapConfiguration) New(
 	if bsc.CacheSeriesMetadata != nil {
 		providerOpts = providerOpts.SetCacheSeriesMetadata(*bsc.CacheSeriesMetadata)
 	}
-	providerOpts = providerOpts.SetAdminClient(setup.m3dbAdminClient)
+	providerOpts = providerOpts.SetAdminClient(adminClient)
 	return bootstrap.NewProcessProvider(bs, providerOpts, rsOpts), nil
 }
 

--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -167,6 +167,7 @@ func (bsc BootstrapConfiguration) New(
 	if bsc.CacheSeriesMetadata != nil {
 		providerOpts = providerOpts.SetCacheSeriesMetadata(*bsc.CacheSeriesMetadata)
 	}
+	providerOpts = providerOpts.SetAdminClient(setup.m3dbAdminClient)
 	return bootstrap.NewProcessProvider(bs, providerOpts, rsOpts), nil
 }
 

--- a/src/dbnode/integration/admin_session_fetch_blocks_test.go
+++ b/src/dbnode/integration/admin_session_fetch_blocks_test.go
@@ -103,7 +103,7 @@ func testSetupMetadatas(
 ) map[uint32][]block.ReplicaMetadata {
 	// Retrieve written data using the AdminSession APIs
 	// FetchMetadataBlocksFromPeers/FetchBlocksFromPeers
-	adminClient := testSetup.m3dbAdminClient
+	adminClient := testSetup.m3dbVerificationAdminClient
 	level := topology.ReadConsistencyLevelMajority
 	version := client.FetchBlocksMetadataEndpointV2
 	metadatasByShard, err := m3dbClientFetchBlocksMetadata(adminClient,
@@ -172,7 +172,7 @@ func testSetupToSeriesMaps(
 	resultOpts := newDefaulTestResultOptions(testSetup.storageOpts)
 	consistencyLevel := testSetup.storageOpts.RepairOptions().RepairConsistencyLevel()
 	iterPool := testSetup.storageOpts.ReaderIteratorPool()
-	session, err := testSetup.m3dbAdminClient.DefaultAdminSession()
+	session, err := testSetup.m3dbVerificationAdminClient.DefaultAdminSession()
 	require.NoError(t, err)
 	require.NotNil(t, session)
 

--- a/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
+++ b/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
@@ -135,8 +135,9 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	processProvider := bootstrap.NewProcessProvider(
+	processProvider, err := bootstrap.NewProcessProvider(
 		test, processOpts, bootstrapOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(processProvider)
 
 	// Start a background goroutine which will wait until the server is started,

--- a/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
+++ b/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
@@ -132,8 +132,11 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 		},
 	}, bootstrapOpts, bootstrapper)
 
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
 	processProvider := bootstrap.NewProcessProvider(
-		test, bootstrap.NewProcessOptions(), bootstrapOpts)
+		test, processOpts, bootstrapOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(processProvider)
 
 	// Start a background goroutine which will wait until the server is started,

--- a/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
+++ b/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
@@ -148,7 +148,8 @@ func TestBootstrapBeforeBufferRotationNoTick(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	process := bootstrap.NewProcessProvider(test, processOpts, bootstrapOpts)
+	process, err := bootstrap.NewProcessProvider(test, processOpts, bootstrapOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	// Start a background goroutine which will wait until the server is started,

--- a/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
+++ b/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
@@ -145,8 +145,10 @@ func TestBootstrapBeforeBufferRotationNoTick(t *testing.T) {
 		},
 	}, bootstrapOpts, bootstrapper)
 
-	process := bootstrap.NewProcessProvider(
-		test, bootstrap.NewProcessOptions(), bootstrapOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	process := bootstrap.NewProcessProvider(test, processOpts, bootstrapOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	// Start a background goroutine which will wait until the server is started,

--- a/src/dbnode/integration/bootstrap_helpers.go
+++ b/src/dbnode/integration/bootstrap_helpers.go
@@ -44,7 +44,7 @@ func newTestBootstrapperSource(
 	if opts.availableData != nil {
 		src.availableData = opts.availableData
 	} else {
-		src.availableData = func(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges) result.ShardTimeRanges {
+		src.availableData = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.RunOptions) result.ShardTimeRanges {
 			return shardsTimeRanges
 		}
 	}
@@ -60,7 +60,7 @@ func newTestBootstrapperSource(
 	if opts.availableIndex != nil {
 		src.availableIndex = opts.availableIndex
 	} else {
-		src.availableIndex = func(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges) result.ShardTimeRanges {
+		src.availableIndex = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.RunOptions) result.ShardTimeRanges {
 			return shardsTimeRanges
 		}
 	}
@@ -104,9 +104,9 @@ type testBootstrapper struct {
 
 type testBootstrapperSourceOptions struct {
 	can            func(bootstrap.Strategy) bool
-	availableData  func(namespace.Metadata, result.ShardTimeRanges) result.ShardTimeRanges
+	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) result.ShardTimeRanges
 	readData       func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) (result.DataBootstrapResult, error)
-	availableIndex func(namespace.Metadata, result.ShardTimeRanges) result.ShardTimeRanges
+	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) result.ShardTimeRanges
 	readIndex      func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) (result.IndexBootstrapResult, error)
 }
 
@@ -114,9 +114,9 @@ var _ bootstrap.Source = &testBootstrapperSource{}
 
 type testBootstrapperSource struct {
 	can            func(bootstrap.Strategy) bool
-	availableData  func(namespace.Metadata, result.ShardTimeRanges) result.ShardTimeRanges
+	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) result.ShardTimeRanges
 	readData       func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) (result.DataBootstrapResult, error)
-	availableIndex func(namespace.Metadata, result.ShardTimeRanges) result.ShardTimeRanges
+	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) result.ShardTimeRanges
 	readIndex      func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) (result.IndexBootstrapResult, error)
 }
 
@@ -127,8 +127,9 @@ func (t testBootstrapperSource) Can(strategy bootstrap.Strategy) bool {
 func (t testBootstrapperSource) AvailableData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
-	return t.availableData(ns, shardsTimeRanges)
+	return t.availableData(ns, shardsTimeRanges, runOpts)
 }
 
 func (t testBootstrapperSource) ReadData(
@@ -142,8 +143,9 @@ func (t testBootstrapperSource) ReadData(
 func (t testBootstrapperSource) AvailableIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
-	return t.availableIndex(ns, shardsTimeRanges)
+	return t.availableIndex(ns, shardsTimeRanges, runOptions)
 }
 
 func (t testBootstrapperSource) ReadIndex(

--- a/src/dbnode/integration/bootstrap_helpers.go
+++ b/src/dbnode/integration/bootstrap_helpers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
+	bcl "github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	"github.com/stretchr/testify/require"

--- a/src/dbnode/integration/bootstrap_helpers.go
+++ b/src/dbnode/integration/bootstrap_helpers.go
@@ -145,7 +145,7 @@ func (t testBootstrapperSource) AvailableIndex(
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
-	return t.availableIndex(ns, shardsTimeRanges, runOptions)
+	return t.availableIndex(ns, shardsTimeRanges, runOpts)
 }
 
 func (t testBootstrapperSource) ReadIndex(

--- a/src/dbnode/integration/commitlog_bootstrap_helpers.go
+++ b/src/dbnode/integration/commitlog_bootstrap_helpers.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/integration/generate"
-	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	"github.com/m3db/m3x/context"
@@ -211,13 +210,4 @@ func writeSnapshotsWithPredicate(
 	err := writeTestSnapshotsToDiskWithPredicate(
 		namespace, s, data, pred, snapshotInterval)
 	require.NoError(t, err)
-}
-
-func mustInspectFilesystem(fsOpts fs.Options) fs.Inspection {
-	inspection, err := fs.InspectFilesystem(fsOpts)
-	if err != nil {
-		panic(err)
-	}
-
-	return inspection
 }

--- a/src/dbnode/integration/commitlog_bootstrap_index_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_index_test.go
@@ -145,8 +145,10 @@ func TestCommitLogIndexBootstrap(t *testing.T) {
 	bs, err := bcl.NewCommitLogBootstrapperProvider(
 		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
-	process := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)

--- a/src/dbnode/integration/commitlog_bootstrap_index_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_index_test.go
@@ -28,9 +28,6 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/integration/generate"
 	"github.com/m3db/m3/src/dbnode/retention"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
-	bcl "github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	"github.com/m3db/m3/src/m3ninx/idx"
@@ -136,21 +133,7 @@ func TestCommitLogIndexBootstrap(t *testing.T) {
 	log.Info("finished writing data")
 
 	// Setup bootstrapper after writing data so filesystem inspection can find it.
-	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
-	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
-	bclOpts := bcl.NewOptions().
-		SetResultOptions(bsOpts).
-		SetCommitLogOptions(commitLogOpts)
-	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-	bs, err := bcl.NewCommitLogBootstrapperProvider(
-		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
-	require.NoError(t, err)
-	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
-		setup.m3dbAdminClient,
-	)
-	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
-	require.NoError(t, err)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
+	setupCommitLogBootstrapperWithFSInspection(t, setup, commitLogOpts)
 
 	setup.setNowFn(now)
 	// Start the server with filesystem bootstrapper

--- a/src/dbnode/integration/commitlog_bootstrap_index_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_index_test.go
@@ -148,7 +148,8 @@ func TestCommitLogIndexBootstrap(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)

--- a/src/dbnode/integration/commitlog_bootstrap_merge_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_merge_test.go
@@ -144,8 +144,9 @@ func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	process := bootstrap.NewProcessProvider(
+	process, err := bootstrap.NewProcessProvider(
 		fsBootstrapper, processOpts, bsOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	log.Info("moving time forward and starting server")

--- a/src/dbnode/integration/commitlog_bootstrap_merge_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_merge_test.go
@@ -141,8 +141,11 @@ func TestCommitLogAndFSMergeBootstrap(t *testing.T) {
 	fsBootstrapper, err := fs.NewFileSystemBootstrapperProvider(bfsOpts, commitLogBootstrapper)
 	require.NoError(t, err)
 	// bootstrapper storage opts
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
 	process := bootstrap.NewProcessProvider(
-		fsBootstrapper, bootstrap.NewProcessOptions(), bsOpts)
+		fsBootstrapper, processOpts, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	log.Info("moving time forward and starting server")

--- a/src/dbnode/integration/commitlog_bootstrap_multi_ns_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_multi_ns_test.go
@@ -108,8 +108,10 @@ func TestCommitLogBootstrapMultipleNamespaces(t *testing.T) {
 	bs, err := bcl.NewCommitLogBootstrapperProvider(
 		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
-	process := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	later := now.Add(4 * ns1BlockSize)

--- a/src/dbnode/integration/commitlog_bootstrap_multi_ns_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_multi_ns_test.go
@@ -111,7 +111,8 @@ func TestCommitLogBootstrapMultipleNamespaces(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	later := now.Add(4 * ns1BlockSize)

--- a/src/dbnode/integration/commitlog_bootstrap_multi_ns_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_multi_ns_test.go
@@ -28,9 +28,6 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/integration/generate"
 	"github.com/m3db/m3/src/dbnode/retention"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
-	bcl "github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 
 	"github.com/stretchr/testify/require"
@@ -99,21 +96,7 @@ func TestCommitLogBootstrapMultipleNamespaces(t *testing.T) {
 	log.Info("written data - ns2")
 
 	// Setup bootstrapper after writing data so filesystem inspection can find it
-	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
-	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
-	bclOpts := bcl.NewOptions().
-		SetResultOptions(bsOpts).
-		SetCommitLogOptions(commitLogOpts)
-	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-	bs, err := bcl.NewCommitLogBootstrapperProvider(
-		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
-	require.NoError(t, err)
-	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
-		setup.m3dbAdminClient,
-	)
-	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
-	require.NoError(t, err)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
+	setupCommitLogBootstrapperWithFSInspection(t, setup, commitLogOpts)
 
 	later := now.Add(4 * ns1BlockSize)
 	setup.setNowFn(later)

--- a/src/dbnode/integration/commitlog_bootstrap_only_reads_required_files_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_only_reads_required_files_test.go
@@ -99,8 +99,10 @@ func TestCommitLogBootstrapOnlyReadsRequiredFiles(t *testing.T) {
 	bs, err := bcl.NewCommitLogBootstrapperProvider(
 		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
-	process := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)

--- a/src/dbnode/integration/commitlog_bootstrap_only_reads_required_files_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_only_reads_required_files_test.go
@@ -27,9 +27,6 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/retention"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
-	bcl "github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 
 	"github.com/stretchr/testify/require"
@@ -90,21 +87,7 @@ func TestCommitLogBootstrapOnlyReadsRequiredFiles(t *testing.T) {
 	log.Info("finished writing data to commitlog file with out of range timestamp")
 
 	// Setup bootstrapper after writing data so filesystem inspection can find it.
-	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
-	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
-	bclOpts := bcl.NewOptions().
-		SetResultOptions(bsOpts).
-		SetCommitLogOptions(commitLogOpts)
-	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-	bs, err := bcl.NewCommitLogBootstrapperProvider(
-		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
-	require.NoError(t, err)
-	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
-		setup.m3dbAdminClient,
-	)
-	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
-	require.NoError(t, err)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
+	setupCommitLogBootstrapperWithFSInspection(t, setup, commitLogOpts)
 
 	setup.setNowFn(now)
 	// Start the server with filesystem bootstrapper

--- a/src/dbnode/integration/commitlog_bootstrap_only_reads_required_files_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_only_reads_required_files_test.go
@@ -102,7 +102,8 @@ func TestCommitLogBootstrapOnlyReadsRequiredFiles(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)

--- a/src/dbnode/integration/commitlog_bootstrap_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_test.go
@@ -28,9 +28,6 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/integration/generate"
 	"github.com/m3db/m3/src/dbnode/retention"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
-	bcl "github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 
 	"github.com/stretchr/testify/require"
@@ -74,21 +71,7 @@ func TestCommitLogBootstrap(t *testing.T) {
 	log.Info("finished writing data")
 
 	// Setup bootstrapper after writing data so filesystem inspection can find it.
-	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
-	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
-	bclOpts := bcl.NewOptions().
-		SetResultOptions(bsOpts).
-		SetCommitLogOptions(commitLogOpts)
-	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-	bs, err := bcl.NewCommitLogBootstrapperProvider(
-		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
-	require.NoError(t, err)
-	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
-		setup.m3dbAdminClient,
-	)
-	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
-	require.NoError(t, err)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
+	setupCommitLogBootstrapperWithFSInspection(t, setup, commitLogOpts)
 
 	setup.setNowFn(now)
 	// Start the server with filesystem bootstrapper

--- a/src/dbnode/integration/commitlog_bootstrap_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_test.go
@@ -83,8 +83,10 @@ func TestCommitLogBootstrap(t *testing.T) {
 	bs, err := bcl.NewCommitLogBootstrapperProvider(
 		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
-	process := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)

--- a/src/dbnode/integration/commitlog_bootstrap_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_test.go
@@ -86,7 +86,8 @@ func TestCommitLogBootstrap(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)

--- a/src/dbnode/integration/commitlog_bootstrap_with_snapshots_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_with_snapshots_test.go
@@ -28,9 +28,6 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/integration/generate"
 	"github.com/m3db/m3/src/dbnode/retention"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
-	bcl "github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	"github.com/m3db/m3/src/dbnode/ts"
 
@@ -109,21 +106,7 @@ func TestCommitLogBootstrapWithSnapshots(t *testing.T) {
 	log.Info("finished writing data")
 
 	// Setup bootstrapper after writing data so filesystem inspection can find it.
-	noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
-	bsOpts := newDefaulTestResultOptions(setup.storageOpts)
-	bclOpts := bcl.NewOptions().
-		SetResultOptions(bsOpts).
-		SetCommitLogOptions(commitLogOpts)
-	fsOpts := setup.storageOpts.CommitLogOptions().FilesystemOptions()
-	bs, err := bcl.NewCommitLogBootstrapperProvider(
-		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
-	require.NoError(t, err)
-	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
-		setup.m3dbAdminClient,
-	)
-	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
-	require.NoError(t, err)
-	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
+	setupCommitLogBootstrapperWithFSInspection(t, setup, commitLogOpts)
 
 	setup.setNowFn(now)
 	// Start the server with filesystem bootstrapper

--- a/src/dbnode/integration/commitlog_bootstrap_with_snapshots_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_with_snapshots_test.go
@@ -121,7 +121,8 @@ func TestCommitLogBootstrapWithSnapshots(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)

--- a/src/dbnode/integration/commitlog_bootstrap_with_snapshots_test.go
+++ b/src/dbnode/integration/commitlog_bootstrap_with_snapshots_test.go
@@ -118,8 +118,10 @@ func TestCommitLogBootstrapWithSnapshots(t *testing.T) {
 	bs, err := bcl.NewCommitLogBootstrapperProvider(
 		bclOpts, mustInspectFilesystem(fsOpts), noOpAll)
 	require.NoError(t, err)
-	process := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	process := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(process)
 
 	setup.setNowFn(now)

--- a/src/dbnode/integration/fs_bootstrap_index_test.go
+++ b/src/dbnode/integration/fs_bootstrap_index_test.go
@@ -84,7 +84,8 @@ func TestFilesystemBootstrapIndexWithIndexingEnabled(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	processProvider := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	processProvider, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_bootstrap_index_test.go
+++ b/src/dbnode/integration/fs_bootstrap_index_test.go
@@ -81,8 +81,10 @@ func TestFilesystemBootstrapIndexWithIndexingEnabled(t *testing.T) {
 		SetPersistManager(persistMgr)
 	bs, err := fs.NewFileSystemBootstrapperProvider(bfsOpts, noOpAll)
 	require.NoError(t, err)
-	processProvider := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	processProvider := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_bootstrap_multi_ns_test.go
+++ b/src/dbnode/integration/fs_bootstrap_multi_ns_test.go
@@ -82,8 +82,10 @@ func TestFilesystemBootstrapMultipleNamespaces(t *testing.T) {
 	bs, err := fs.NewFileSystemBootstrapperProvider(bfsOpts, noOpAll)
 	require.NoError(t, err)
 
-	processProvider := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	processProvider := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_bootstrap_multi_ns_test.go
+++ b/src/dbnode/integration/fs_bootstrap_multi_ns_test.go
@@ -85,7 +85,8 @@ func TestFilesystemBootstrapMultipleNamespaces(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	processProvider := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	processProvider, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_bootstrap_tags_test.go
+++ b/src/dbnode/integration/fs_bootstrap_tags_test.go
@@ -82,7 +82,8 @@ func TestFilesystemBootstrapTagsWithIndexingDisabled(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	processProvider := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	processProvider, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_bootstrap_tags_test.go
+++ b/src/dbnode/integration/fs_bootstrap_tags_test.go
@@ -79,8 +79,10 @@ func TestFilesystemBootstrapTagsWithIndexingDisabled(t *testing.T) {
 		SetPersistManager(persistMgr)
 	bs, err := fs.NewFileSystemBootstrapperProvider(bfsOpts, noOpAll)
 	require.NoError(t, err)
-	processProvider := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	processProvider := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_bootstrap_test.go
+++ b/src/dbnode/integration/fs_bootstrap_test.go
@@ -76,8 +76,11 @@ func TestFilesystemBootstrap(t *testing.T) {
 		SetPersistManager(persistMgr)
 	bs, err := fs.NewFileSystemBootstrapperProvider(bfsOpts, noOpAll)
 	require.NoError(t, err)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
 	processProvider := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+		bs, processOpts, bsOpts)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_bootstrap_test.go
+++ b/src/dbnode/integration/fs_bootstrap_test.go
@@ -79,8 +79,8 @@ func TestFilesystemBootstrap(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	processProvider := bootstrap.NewProcessProvider(
-		bs, processOpts, bsOpts)
+	processProvider, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_commitlog_mixed_mode_read_write_test.go
+++ b/src/dbnode/integration/fs_commitlog_mixed_mode_read_write_test.go
@@ -245,8 +245,10 @@ func setCommitLogAndFilesystemBootstrapper(t *testing.T, opts testOptions, setup
 	require.NoError(t, err)
 
 	// bootstrapper storage opts
-	processProvider := bootstrap.NewProcessProvider(
-		fsBootstrapper, bootstrap.NewProcessOptions(), bsOpts)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
+	processProvider := bootstrap.NewProcessProvider(fsBootstrapper, processOpts, bsOpts)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(processProvider)
 
 	return setup

--- a/src/dbnode/integration/fs_commitlog_mixed_mode_read_write_test.go
+++ b/src/dbnode/integration/fs_commitlog_mixed_mode_read_write_test.go
@@ -248,7 +248,8 @@ func setCommitLogAndFilesystemBootstrapper(t *testing.T, opts testOptions, setup
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	processProvider := bootstrap.NewProcessProvider(fsBootstrapper, processOpts, bsOpts)
+	processProvider, err := bootstrap.NewProcessProvider(fsBootstrapper, processOpts, bsOpts)
+	require.NoError(t, err)
 	setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(processProvider)
 
 	return setup

--- a/src/dbnode/integration/fs_commitlog_mixed_mode_read_write_test.go
+++ b/src/dbnode/integration/fs_commitlog_mixed_mode_read_write_test.go
@@ -244,7 +244,7 @@ func setCommitLogAndFilesystemBootstrapper(t *testing.T, opts testOptions, setup
 	fsBootstrapper, err := fs.NewFileSystemBootstrapperProvider(bfsOpts, commitLogBootstrapper)
 	require.NoError(t, err)
 
-	// Need to make sure we have an active m3dbAdminClient because the previosu one
+	// Need to make sure we have an active m3dbAdminClient because the previous one
 	// may have been shutdown by stopServer().
 	setup.maybeResetClients()
 	// bootstrapper storage opts

--- a/src/dbnode/integration/fs_commitlog_mixed_mode_read_write_test.go
+++ b/src/dbnode/integration/fs_commitlog_mixed_mode_read_write_test.go
@@ -244,6 +244,9 @@ func setCommitLogAndFilesystemBootstrapper(t *testing.T, opts testOptions, setup
 	fsBootstrapper, err := fs.NewFileSystemBootstrapperProvider(bfsOpts, commitLogBootstrapper)
 	require.NoError(t, err)
 
+	// Need to make sure we have an active m3dbAdminClient because the previosu one
+	// may have been shutdown by stopServer().
+	setup.maybeResetClients()
 	// bootstrapper storage opts
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,

--- a/src/dbnode/integration/fs_data_expiry_bootstrap_test.go
+++ b/src/dbnode/integration/fs_data_expiry_bootstrap_test.go
@@ -95,8 +95,11 @@ func TestFilesystemDataExpiryBootstrap(t *testing.T) {
 		SetPersistManager(persistMgr)
 	bs, err := bfs.NewFileSystemBootstrapperProvider(bfsOpts, noOpAll)
 	require.NoError(t, err)
+	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
+		setup.m3dbAdminClient,
+	)
 	processProvider := bootstrap.NewProcessProvider(
-		bs, bootstrap.NewProcessOptions(), bsOpts)
+		bs, processOpts, bsOpts)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/fs_data_expiry_bootstrap_test.go
+++ b/src/dbnode/integration/fs_data_expiry_bootstrap_test.go
@@ -98,8 +98,8 @@ func TestFilesystemDataExpiryBootstrap(t *testing.T) {
 	processOpts := bootstrap.NewProcessOptions().SetAdminClient(
 		setup.m3dbAdminClient,
 	)
-	processProvider := bootstrap.NewProcessProvider(
-		bs, processOpts, bsOpts)
+	processProvider, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	require.NoError(t, err)
 
 	setup.storageOpts = setup.storageOpts.
 		SetBootstrapProcessProvider(processProvider)

--- a/src/dbnode/integration/integration.go
+++ b/src/dbnode/integration/integration.go
@@ -218,30 +218,28 @@ func newDefaultBootstrappableTestSetups(
 		noOpAll := bootstrapper.NewNoOpAllBootstrapperProvider()
 		var peersBootstrapper bootstrap.BootstrapperProvider
 
-		var adminClient client.AdminClient
+		adminOpts := client.NewAdminOptions()
+		if bootstrapBlocksBatchSize > 0 {
+			adminOpts = adminOpts.SetFetchSeriesBlocksBatchSize(bootstrapBlocksBatchSize)
+		}
+		if bootstrapBlocksConcurrency > 0 {
+			adminOpts = adminOpts.SetFetchSeriesBlocksBatchConcurrency(bootstrapBlocksConcurrency)
+		}
+		if topologyInitializer != nil {
+			adminOpts = adminOpts.SetTopologyInitializer(topologyInitializer).(client.AdminOptions)
+		}
+
+		// Prevent integration tests from timing out when a node is down
+		retryOpts := xretry.NewOptions().
+			SetInitialBackoff(1 * time.Millisecond).
+			SetMaxRetries(1).
+			SetJitter(true)
+		retrier := xretry.NewRetrier(retryOpts)
+		adminOpts = adminOpts.SetStreamBlocksRetrier(retrier)
+
+		adminClient := newMultiAddrAdminClient(
+			t, adminOpts, topologyInitializer, instrumentOpts, setup.shardSet, replicas, instance)
 		if usingPeersBootstrapper {
-			adminOpts := client.NewAdminOptions()
-			if bootstrapBlocksBatchSize > 0 {
-				adminOpts = adminOpts.SetFetchSeriesBlocksBatchSize(bootstrapBlocksBatchSize)
-			}
-			if bootstrapBlocksConcurrency > 0 {
-				adminOpts = adminOpts.SetFetchSeriesBlocksBatchConcurrency(bootstrapBlocksConcurrency)
-			}
-			if topologyInitializer != nil {
-				adminOpts = adminOpts.SetTopologyInitializer(topologyInitializer).(client.AdminOptions)
-			}
-
-			// Prevent integration tests from timing out when a node is down
-			retryOpts := xretry.NewOptions().
-				SetInitialBackoff(1 * time.Millisecond).
-				SetMaxRetries(1).
-				SetJitter(true)
-			retrier := xretry.NewRetrier(retryOpts)
-			adminOpts = adminOpts.SetStreamBlocksRetrier(retrier)
-
-			adminClient = newMultiAddrAdminClient(
-				t, adminOpts, topologyInitializer, instrumentOpts, setup.shardSet, replicas, instance)
-
 			runtimeOptsMgr := setup.storageOpts.RuntimeOptionsManager()
 			runtimeOpts := runtimeOptsMgr.Get().
 				SetClientBootstrapConsistencyLevel(bootstrapConsistencyLevel)

--- a/src/dbnode/integration/integration.go
+++ b/src/dbnode/integration/integration.go
@@ -276,9 +276,9 @@ func newDefaultBootstrappableTestSetups(
 		require.NoError(t, err)
 
 		processOpts := bootstrap.NewProcessOptions().SetAdminClient(adminClient)
-		setup.storageOpts = setup.storageOpts.
-			SetBootstrapProcessProvider(
-				bootstrap.NewProcessProvider(fsBootstrapper, processOpts, bsOpts))
+		provider, err := bootstrap.NewProcessProvider(fsBootstrapper, processOpts, bsOpts)
+		require.NoError(t, err)
+		setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(provider)
 
 		setups = append(setups, setup)
 		appendCleanupFn(func() {

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -82,16 +82,21 @@ type testSetup struct {
 
 	logger xlog.Logger
 
-	db                          cluster.Database
-	storageOpts                 storage.Options
-	fsOpts                      fs.Options
-	hostID                      string
-	topoInit                    topology.Initializer
-	shardSet                    sharding.ShardSet
-	getNowFn                    clock.NowFn
-	setNowFn                    nowSetterFn
-	tchannelClient              rpc.TChanNode
-	m3dbClient                  client.Client
+	db             cluster.Database
+	storageOpts    storage.Options
+	fsOpts         fs.Options
+	hostID         string
+	topoInit       topology.Initializer
+	shardSet       sharding.ShardSet
+	getNowFn       clock.NowFn
+	setNowFn       nowSetterFn
+	tchannelClient rpc.TChanNode
+	m3dbClient     client.Client
+	// We need two distinct clients where one has the origin set to the same ID as the
+	// node itself (I.E) the client will behave exactly as if it is the node itself
+	// making requests, and another client with the origin set to an ID different than
+	// the node itself so that we can make requests from the perspective of a "different"
+	// M3DB node for verification purposes in some of the tests.
 	m3dbAdminClient             client.AdminClient
 	m3dbVerificationAdminClient client.AdminClient
 	workerPool                  xsync.WorkerPool
@@ -612,11 +617,6 @@ func newClients(
 				SetWriteConsistencyLevel(opts.WriteConsistencyLevel()).
 				SetTopologyInitializer(topoInit)
 
-		// We need two distinct clients where one has the origin set to the same ID as the
-		// node itself (I.E) the client will behave exactly as if it is the node itself
-		// making requests, and another client with the origin set to an ID different than
-		// the node itself so that we can make requests from the perspective of a "different"
-		// M3DB node for verification purposes in some of the tests.
 		origin             = topology.NewHost(id, tchannelNodeAddr)
 		verificationOrigin = topology.NewHost(id+"-verification", tchannelNodeAddr)
 

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -165,6 +165,9 @@ func newTestSetup(t *testing.T, opts testOptions, fsOpts fs.Options) (*testSetup
 	}
 
 	adminClient, verificationAdminClient, err := newClients(topoInit, opts, id, tchannelNodeAddr)
+	if err != nil {
+		return nil, err
+	}
 
 	// Set up tchannel client
 	channel, tc, err := tchannelClient(tchannelNodeAddr)

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -173,6 +173,12 @@ func newTestSetup(t *testing.T, opts testOptions, fsOpts fs.Options) (*testSetup
 		return nil, fmt.Errorf("unable to cast to admin options")
 	}
 
+	// Have to set the ID of the host in the admin options origin as different
+	// than the actual ID because the client itself will not route requests for
+	// metadata to itself, but existing tests rely on this behavior.
+	origin := topology.NewHost(id+"-admin-client-hack", tchannelNodeAddr)
+	adminOpts = adminOpts.SetOrigin(origin)
+
 	// Set up tchannel client
 	channel, tc, err := tchannelClient(tchannelNodeAddr)
 	if err != nil {

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -510,13 +510,13 @@ func (ts *testSetup) startServer() error {
 func (ts *testSetup) stopServer() error {
 	ts.doneCh <- struct{}{}
 
-	if ts.m3dbClient.DefaultSessionActive() {
-		session, err := ts.m3dbClient.DefaultSession()
-		if err != nil {
-			return err
-		}
-		defer session.Close()
-	}
+	// if ts.m3dbClient.DefaultSessionActive() {
+	// 	session, err := ts.m3dbClient.DefaultSession()
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// 	defer session.Close()
+	// }
 
 	if err := ts.waitUntilServerIsDown(); err != nil {
 		return err

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -667,5 +667,3 @@ func newNodes(
 
 	return nodes, topoInit, nodeClose
 }
-
-func ()

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -667,3 +667,5 @@ func newNodes(
 
 	return nodes, topoInit, nodeClose
 }
+
+func ()

--- a/src/dbnode/storage/bootstrap/bootstrap_mock.go
+++ b/src/dbnode/storage/bootstrap/bootstrap_mock.go
@@ -28,6 +28,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 
@@ -175,6 +176,30 @@ func (mr *MockProcessOptionsMockRecorder) CacheSeriesMetadata() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheSeriesMetadata", reflect.TypeOf((*MockProcessOptions)(nil).CacheSeriesMetadata))
 }
 
+// SetAdminClient mocks base method
+func (m *MockProcessOptions) SetAdminClient(value client.AdminClient) ProcessOptions {
+	ret := m.ctrl.Call(m, "SetAdminClient", value)
+	ret0, _ := ret[0].(ProcessOptions)
+	return ret0
+}
+
+// SetAdminClient indicates an expected call of SetAdminClient
+func (mr *MockProcessOptionsMockRecorder) SetAdminClient(value interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAdminClient", reflect.TypeOf((*MockProcessOptions)(nil).SetAdminClient), value)
+}
+
+// AdminClient mocks base method
+func (m *MockProcessOptions) AdminClient() client.AdminClient {
+	ret := m.ctrl.Call(m, "AdminClient")
+	ret0, _ := ret[0].(client.AdminClient)
+	return ret0
+}
+
+// AdminClient indicates an expected call of AdminClient
+func (mr *MockProcessOptionsMockRecorder) AdminClient() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminClient", reflect.TypeOf((*MockProcessOptions)(nil).AdminClient))
+}
+
 // MockRunOptions is a mock of RunOptions interface
 type MockRunOptions struct {
 	ctrl     *gomock.Controller
@@ -244,6 +269,30 @@ func (m *MockRunOptions) CacheSeriesMetadata() bool {
 // CacheSeriesMetadata indicates an expected call of CacheSeriesMetadata
 func (mr *MockRunOptionsMockRecorder) CacheSeriesMetadata() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheSeriesMetadata", reflect.TypeOf((*MockRunOptions)(nil).CacheSeriesMetadata))
+}
+
+// SetInitialTopologyState mocks base method
+func (m *MockRunOptions) SetInitialTopologyState(value *TopologyState) RunOptions {
+	ret := m.ctrl.Call(m, "SetInitialTopologyState", value)
+	ret0, _ := ret[0].(RunOptions)
+	return ret0
+}
+
+// SetInitialTopologyState indicates an expected call of SetInitialTopologyState
+func (mr *MockRunOptionsMockRecorder) SetInitialTopologyState(value interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInitialTopologyState", reflect.TypeOf((*MockRunOptions)(nil).SetInitialTopologyState), value)
+}
+
+// InitialTopologyState mocks base method
+func (m *MockRunOptions) InitialTopologyState() *TopologyState {
+	ret := m.ctrl.Call(m, "InitialTopologyState")
+	ret0, _ := ret[0].(*TopologyState)
+	return ret0
+}
+
+// InitialTopologyState indicates an expected call of InitialTopologyState
+func (mr *MockRunOptionsMockRecorder) InitialTopologyState() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialTopologyState", reflect.TypeOf((*MockRunOptions)(nil).InitialTopologyState))
 }
 
 // MockBootstrapperProvider is a mock of BootstrapperProvider interface
@@ -403,40 +452,40 @@ func (mr *MockSourceMockRecorder) Can(strategy interface{}) *gomock.Call {
 }
 
 // AvailableData mocks base method
-func (m *MockSource) AvailableData(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges) result.ShardTimeRanges {
-	ret := m.ctrl.Call(m, "AvailableData", ns, shardsTimeRanges)
+func (m *MockSource) AvailableData(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, runOpts RunOptions) result.ShardTimeRanges {
+	ret := m.ctrl.Call(m, "AvailableData", ns, shardsTimeRanges, runOpts)
 	ret0, _ := ret[0].(result.ShardTimeRanges)
 	return ret0
 }
 
 // AvailableData indicates an expected call of AvailableData
-func (mr *MockSourceMockRecorder) AvailableData(ns, shardsTimeRanges interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableData", reflect.TypeOf((*MockSource)(nil).AvailableData), ns, shardsTimeRanges)
+func (mr *MockSourceMockRecorder) AvailableData(ns, shardsTimeRanges, runOpts interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableData", reflect.TypeOf((*MockSource)(nil).AvailableData), ns, shardsTimeRanges, runOpts)
 }
 
 // ReadData mocks base method
-func (m *MockSource) ReadData(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, opts RunOptions) (result.DataBootstrapResult, error) {
-	ret := m.ctrl.Call(m, "ReadData", ns, shardsTimeRanges, opts)
+func (m *MockSource) ReadData(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, runOpts RunOptions) (result.DataBootstrapResult, error) {
+	ret := m.ctrl.Call(m, "ReadData", ns, shardsTimeRanges, runOpts)
 	ret0, _ := ret[0].(result.DataBootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadData indicates an expected call of ReadData
-func (mr *MockSourceMockRecorder) ReadData(ns, shardsTimeRanges, opts interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadData", reflect.TypeOf((*MockSource)(nil).ReadData), ns, shardsTimeRanges, opts)
+func (mr *MockSourceMockRecorder) ReadData(ns, shardsTimeRanges, runOpts interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadData", reflect.TypeOf((*MockSource)(nil).ReadData), ns, shardsTimeRanges, runOpts)
 }
 
 // AvailableIndex mocks base method
-func (m *MockSource) AvailableIndex(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges) result.ShardTimeRanges {
-	ret := m.ctrl.Call(m, "AvailableIndex", ns, shardsTimeRanges)
+func (m *MockSource) AvailableIndex(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, opts RunOptions) result.ShardTimeRanges {
+	ret := m.ctrl.Call(m, "AvailableIndex", ns, shardsTimeRanges, opts)
 	ret0, _ := ret[0].(result.ShardTimeRanges)
 	return ret0
 }
 
 // AvailableIndex indicates an expected call of AvailableIndex
-func (mr *MockSourceMockRecorder) AvailableIndex(ns, shardsTimeRanges interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIndex", reflect.TypeOf((*MockSource)(nil).AvailableIndex), ns, shardsTimeRanges)
+func (mr *MockSourceMockRecorder) AvailableIndex(ns, shardsTimeRanges, opts interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIndex", reflect.TypeOf((*MockSource)(nil).AvailableIndex), ns, shardsTimeRanges, opts)
 }
 
 // ReadIndex mocks base method

--- a/src/dbnode/storage/bootstrap/bootstrap_mock.go
+++ b/src/dbnode/storage/bootstrap/bootstrap_mock.go
@@ -200,6 +200,18 @@ func (mr *MockProcessOptionsMockRecorder) AdminClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdminClient", reflect.TypeOf((*MockProcessOptions)(nil).AdminClient))
 }
 
+// Validate mocks base method
+func (m *MockProcessOptions) Validate() error {
+	ret := m.ctrl.Call(m, "Validate")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Validate indicates an expected call of Validate
+func (mr *MockProcessOptionsMockRecorder) Validate() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockProcessOptions)(nil).Validate))
+}
+
 // MockRunOptions is a mock of RunOptions interface
 type MockRunOptions struct {
 	ctrl     *gomock.Controller

--- a/src/dbnode/storage/bootstrap/bootstrap_mock.go
+++ b/src/dbnode/storage/bootstrap/bootstrap_mock.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	"github.com/m3db/m3/src/dbnode/topology"
 
 	"github.com/golang/mock/gomock"
 )
@@ -284,7 +285,7 @@ func (mr *MockRunOptionsMockRecorder) CacheSeriesMetadata() *gomock.Call {
 }
 
 // SetInitialTopologyState mocks base method
-func (m *MockRunOptions) SetInitialTopologyState(value *TopologyState) RunOptions {
+func (m *MockRunOptions) SetInitialTopologyState(value *topology.StateSnapshot) RunOptions {
 	ret := m.ctrl.Call(m, "SetInitialTopologyState", value)
 	ret0, _ := ret[0].(RunOptions)
 	return ret0
@@ -296,9 +297,9 @@ func (mr *MockRunOptionsMockRecorder) SetInitialTopologyState(value interface{})
 }
 
 // InitialTopologyState mocks base method
-func (m *MockRunOptions) InitialTopologyState() *TopologyState {
+func (m *MockRunOptions) InitialTopologyState() *topology.StateSnapshot {
 	ret := m.ctrl.Call(m, "InitialTopologyState")
-	ret0, _ := ret[0].(*TopologyState)
+	ret0, _ := ret[0].(*topology.StateSnapshot)
 	return ret0
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/base_data_step.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base_data_step.go
@@ -60,7 +60,7 @@ func (s *bootstrapData) prepare(
 	totalRanges result.ShardTimeRanges,
 ) bootstrapStepPreparedResult {
 	return bootstrapStepPreparedResult{
-		currAvailable: s.curr.AvailableData(s.namespace, totalRanges),
+		currAvailable: s.curr.AvailableData(s.namespace, totalRanges, s.opts),
 	}
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/base_index_step.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base_index_step.go
@@ -60,7 +60,7 @@ func (s *bootstrapIndex) prepare(
 	totalRanges result.ShardTimeRanges,
 ) bootstrapStepPreparedResult {
 	return bootstrapStepPreparedResult{
-		currAvailable: s.curr.AvailableIndex(s.namespace, totalRanges),
+		currAvailable: s.curr.AvailableIndex(s.namespace, totalRanges, s.opts),
 	}
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/base_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base_test.go
@@ -254,7 +254,7 @@ func TestBaseBootstrapperCurrentNoUnfulfilled(t *testing.T) {
 	})
 
 	source.EXPECT().
-		AvailableData(testNs, targetRanges).
+		AvailableData(testNs, targetRanges, testDefaultRunOpts).
 		Return(targetRanges)
 	source.EXPECT().
 		ReadData(testNs, targetRanges, testDefaultRunOpts).
@@ -292,7 +292,7 @@ func TestBaseBootstrapperCurrentSomeUnfulfilled(t *testing.T) {
 	})
 
 	source.EXPECT().
-		AvailableData(testNs, targetRanges).
+		AvailableData(testNs, targetRanges, testDefaultRunOpts).
 		Return(targetRanges)
 	source.EXPECT().
 		ReadData(testNs, targetRanges, testDefaultRunOpts).
@@ -329,7 +329,7 @@ func testBasebootstrapperNext(t *testing.T, nextUnfulfilled result.ShardTimeRang
 	nextResult.SetUnfulfilled(nextUnfulfilled)
 
 	source.EXPECT().
-		AvailableData(testNs, targetRanges).
+		AvailableData(testNs, targetRanges, testDefaultRunOpts).
 		Return(nil)
 	source.EXPECT().
 		ReadData(testNs, shardTimeRangesMatcher{nil},
@@ -406,7 +406,7 @@ func TestBaseBootstrapperBoth(t *testing.T) {
 	})
 
 	source.EXPECT().Can(bootstrap.BootstrapParallel).Return(true)
-	source.EXPECT().AvailableData(testNs, targetRanges).Return(availableRanges)
+	source.EXPECT().AvailableData(testNs, targetRanges, testDefaultRunOpts).Return(availableRanges)
 	source.EXPECT().
 		ReadData(testNs, shardTimeRangesMatcher{availableRanges},
 			testDefaultRunOpts).
@@ -473,7 +473,7 @@ func TestBaseBootstrapperIndexHalfCurrentHalfNext(t *testing.T) {
 
 	source.EXPECT().Can(bootstrap.BootstrapParallel).Return(false)
 	source.EXPECT().
-		AvailableIndex(testNs, shardTimeRangesMatcher{targetRanges}).
+		AvailableIndex(testNs, shardTimeRangesMatcher{targetRanges}, testDefaultRunOpts).
 		Return(firstHalf)
 	source.EXPECT().
 		ReadIndex(testNs, shardTimeRangesMatcher{firstHalf}, testDefaultRunOpts).

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -102,6 +102,7 @@ func (s *commitLogSource) Can(strategy bootstrap.Strategy) bool {
 func (s *commitLogSource) AvailableData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
 	// Commit log bootstrapper is a last ditch effort, so fulfill all
 	// time ranges requested even if not enough data, just to succeed
@@ -1246,6 +1247,7 @@ func (s *commitLogSource) logMergeShardsOutcome(shardErrs []int, shardEmptyErrs 
 func (s *commitLogSource) AvailableIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
 	// Commit log bootstrapper is a last ditch effort, so fulfill all
 	// time ranges requested even if not enough data, just to succeed

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -88,7 +88,7 @@ func testOptions() Options {
 func TestAvailableEmptyRangeError(t *testing.T) {
 	opts := testOptions()
 	src := newCommitLogSource(opts, fs.Inspection{})
-	res := src.AvailableData(testNsMetadata(t), result.ShardTimeRanges{})
+	res := src.AvailableData(testNsMetadata(t), result.ShardTimeRanges{}, testDefaultRunOpts)
 	require.True(t, result.ShardTimeRanges{}.Equal(res))
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -125,6 +125,7 @@ func (s *fileSystemSource) Can(strategy bootstrap.Strategy) bool {
 func (s *fileSystemSource) AvailableData(
 	md namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
 	return s.availability(md, shardsTimeRanges)
 }
@@ -144,6 +145,7 @@ func (s *fileSystemSource) ReadData(
 func (s *fileSystemSource) AvailableIndex(
 	md namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
 	return s.availability(md, shardsTimeRanges)
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
@@ -245,14 +245,22 @@ func validateTimeRanges(t *testing.T, tr xtime.Ranges, expected xtime.Ranges) {
 
 func TestAvailableEmptyRangeError(t *testing.T) {
 	src := newFileSystemSource(newTestOptions("foo"))
-	res := src.AvailableData(testNsMetadata(t), map[uint32]xtime.Ranges{0: xtime.Ranges{}})
+	res := src.AvailableData(
+		testNsMetadata(t),
+		map[uint32]xtime.Ranges{0: xtime.Ranges{}},
+		testDefaultRunOpts,
+	)
 	require.NotNil(t, res)
 	require.True(t, res.IsEmpty())
 }
 
 func TestAvailablePatternError(t *testing.T) {
 	src := newFileSystemSource(newTestOptions("[["))
-	res := src.AvailableData(testNsMetadata(t), testShardTimeRanges())
+	res := src.AvailableData(
+		testNsMetadata(t),
+		testShardTimeRanges(),
+		testDefaultRunOpts,
+	)
 	require.NotNil(t, res)
 	require.True(t, res.IsEmpty())
 }
@@ -269,7 +277,11 @@ func TestAvailableReadInfoError(t *testing.T) {
 	writeInfoFile(t, dir, testNs1ID, shard, testStart, []byte{0x1, 0x2})
 
 	src := newFileSystemSource(newTestOptions(dir))
-	res := src.AvailableData(testNsMetadata(t), testShardTimeRanges())
+	res := src.AvailableData(
+		testNsMetadata(t),
+		testShardTimeRanges(),
+		testDefaultRunOpts,
+	)
 	require.NotNil(t, res)
 	require.True(t, res.IsEmpty())
 }
@@ -286,7 +298,11 @@ func TestAvailableDigestOfDigestMismatch(t *testing.T) {
 	writeDigestFile(t, dir, testNs1ID, shard, testStart, nil)
 
 	src := newFileSystemSource(newTestOptions(dir))
-	res := src.AvailableData(testNsMetadata(t), testShardTimeRanges())
+	res := src.AvailableData(
+		testNsMetadata(t),
+		testShardTimeRanges(),
+		testDefaultRunOpts,
+	)
 	require.NotNil(t, res)
 	require.True(t, res.IsEmpty())
 }
@@ -299,7 +315,11 @@ func TestAvailableTimeRangeFilter(t *testing.T) {
 	writeGoodFiles(t, dir, testNs1ID, shard)
 
 	src := newFileSystemSource(newTestOptions(dir))
-	res := src.AvailableData(testNsMetadata(t), testShardTimeRanges())
+	res := src.AvailableData(
+		testNsMetadata(t),
+		testShardTimeRanges(),
+		testDefaultRunOpts,
+	)
 	require.NotNil(t, res)
 	require.Equal(t, 1, len(res))
 	require.NotNil(t, res[testShard])
@@ -320,7 +340,11 @@ func TestAvailableTimeRangePartialError(t *testing.T) {
 	writeInfoFile(t, dir, testNs1ID, shard, testStart.Add(4*time.Hour), []byte{0x1, 0x2})
 
 	src := newFileSystemSource(newTestOptions(dir))
-	res := src.AvailableData(testNsMetadata(t), testShardTimeRanges())
+	res := src.AvailableData(
+		testNsMetadata(t),
+		testShardTimeRanges(),
+		testDefaultRunOpts,
+	)
 	require.NotNil(t, res)
 	require.Equal(t, 1, len(res))
 	require.NotNil(t, res[testShard])

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -682,12 +682,12 @@ func (s *peersSource) peerAvailability(
 	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
 	var (
-		peerAvailabilityByShard = map[bootstrap.ShardID]*shardPeerAvailability{}
+		peerAvailabilityByShard = map[topology.ShardID]*shardPeerAvailability{}
 		initialTopologyState    = runOpts.InitialTopologyState()
 	)
 
 	for shardIDUint := range shardsTimeRanges {
-		shardID := bootstrap.ShardID(shardIDUint)
+		shardID := topology.ShardID(shardIDUint)
 		shardPeers, ok := peerAvailabilityByShard[shardID]
 		if !ok {
 			shardPeers = &shardPeerAvailability{}
@@ -702,7 +702,7 @@ func (s *peersSource) peerAvailability(
 
 		shardPeers.numPeers = len(hostShardStates)
 		for _, hostShardState := range hostShardStates {
-			if hostShardState.Host.ID() == initialTopologyState.Self {
+			if hostShardState.Host.ID() == initialTopologyState.Origin.ID() {
 				// Don't take self into account
 				continue
 			}
@@ -735,7 +735,7 @@ func (s *peersSource) peerAvailability(
 		availableShardTimeRanges  = result.ShardTimeRanges{}
 	)
 	for shardIDUint := range shardsTimeRanges {
-		shardID := bootstrap.ShardID(shardIDUint)
+		shardID := topology.ShardID(shardIDUint)
 		shardPeers := peerAvailabilityByShard[shardID]
 
 		total := shardPeers.numPeers

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
@@ -127,7 +127,7 @@ func TestPeersSourceEmptyShardTimeRanges(t *testing.T) {
 	var (
 		nsMetdata = testNamespaceMetadata(t)
 		target    = result.ShardTimeRanges{}
-		runOpts   = testDefaultRunOpts.SetInitialTopologyState(&bootstrap.TopologyState{})
+		runOpts   = testDefaultRunOpts.SetInitialTopologyState(&topology.StateSnapshot{})
 	)
 	available := src.AvailableData(nsMetdata, target, runOpts)
 	assert.Equal(t, target, available)

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
@@ -156,7 +156,7 @@ func TestPeersSourceEmptyShardTimeRanges(t *testing.T) {
 	nsMetdata := testNamespaceMetadata(t)
 
 	target := result.ShardTimeRanges{}
-	available := src.AvailableData(nsMetdata, target)
+	available := src.AvailableData(nsMetdata, target, testDefaultRunOpts)
 	assert.Equal(t, target, available)
 
 	r, err := src.ReadData(nsMetdata, target, testDefaultRunOpts)

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -26,7 +26,6 @@ import (
 
 	m3dbruntime "github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/sharding"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3cluster/shard"
@@ -48,25 +47,25 @@ type sourceAvailableHost struct {
 
 type sourceAvailableHosts []sourceAvailableHost
 
-func (s sourceAvailableHosts) topologyState() *bootstrap.TopologyState {
-	topoState := &bootstrap.TopologyState{
-		Self:             selfID,
+func (s sourceAvailableHosts) topologyState() *topology.StateSnapshot {
+	topoState := &topology.StateSnapshot{
+		Origin:           topology.NewHost(selfID, "127.0.0.1"),
 		MajorityReplicas: 2,
-		ShardStates:      make(map[bootstrap.ShardID]map[bootstrap.HostID]bootstrap.HostShardState),
+		ShardStates:      make(map[topology.ShardID]map[topology.HostID]topology.HostShardState),
 	}
 
 	for _, host := range s {
 		for _, shard := range host.shards {
-			hostShardStates, ok := topoState.ShardStates[bootstrap.ShardID(shard)]
+			hostShardStates, ok := topoState.ShardStates[topology.ShardID(shard)]
 			if !ok {
-				hostShardStates = make(map[bootstrap.HostID]bootstrap.HostShardState)
+				hostShardStates = make(map[topology.HostID]topology.HostShardState)
 			}
 
-			hostShardStates[bootstrap.HostID(host.name)] = bootstrap.HostShardState{
+			hostShardStates[topology.HostID(host.name)] = topology.HostShardState{
 				Host:       topology.NewHost(host.name, host.name+"address"),
 				ShardState: host.shardStates,
 			}
-			topoState.ShardStates[bootstrap.ShardID(shard)] = hostShardStates
+			topoState.ShardStates[topology.ShardID(shard)] = hostShardStates
 		}
 	}
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -229,23 +229,6 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 			mockMap.EXPECT().HostShardSets().Return(hostShardSets).AnyTimes()
 			mockMap.EXPECT().MajorityReplicas().Return(replicaMajority).AnyTimes()
 
-			// mockAdminSession := client.NewMockAdminSession(ctrl)
-			// mockAdminSession.EXPECT().
-			// 	TopologyMap().
-			// 	Return(mockMap, nil)
-
-			// mockClient := client.NewMockAdminClient(ctrl)
-			// mockClient.EXPECT().
-			// 	DefaultAdminSession().
-			// 	Return(mockAdminSession, nil)
-			// mockClient.EXPECT().
-			// 	Options().
-			// 	Return(
-			// 		client.NewAdminOptions().
-			// 			SetOrigin(topology.NewHost("self", "selfAddress")),
-			// 	).
-			// 	AnyTimes()
-
 			mockRuntimeOpts := m3dbruntime.NewMockOptions(ctrl)
 			mockRuntimeOpts.
 				EXPECT().

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -93,6 +93,7 @@ func (b *bootstrapProcessProvider) Provide() (Process, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return bootstrapProcess{
 		processOpts:          b.processOpts,
 		resultOpts:           b.resultOpts,

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -57,6 +57,10 @@ func NewProcessProvider(
 	processOpts ProcessOptions,
 	resultOpts result.Options,
 ) (ProcessProvider, error) {
+	if err := processOpts.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &bootstrapProcessProvider{
 		processOpts:          processOpts,
 		resultOpts:           resultOpts,

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -56,13 +56,13 @@ func NewProcessProvider(
 	bootstrapperProvider BootstrapperProvider,
 	processOpts ProcessOptions,
 	resultOpts result.Options,
-) ProcessProvider {
+) (ProcessProvider, error) {
 	return &bootstrapProcessProvider{
 		processOpts:          processOpts,
 		resultOpts:           resultOpts,
 		log:                  resultOpts.InstrumentOptions().Logger(),
 		bootstrapperProvider: bootstrapperProvider,
-	}
+	}, nil
 }
 
 func (b *bootstrapProcessProvider) SetBootstrapperProvider(bootstrapperProvider BootstrapperProvider) {

--- a/src/dbnode/storage/bootstrap/provider_options.go
+++ b/src/dbnode/storage/bootstrap/provider_options.go
@@ -20,6 +20,8 @@
 
 package bootstrap
 
+import "github.com/m3db/m3/src/dbnode/client"
+
 const (
 	// defaultCacheSeriesMetadata declares that by default bootstrap providers should
 	// cache series metadata between runs.
@@ -28,12 +30,14 @@ const (
 
 type processOptions struct {
 	cacheSeriesMetadata bool
+	adminClient         client.AdminClient
 }
 
 // NewProcessOptions creates new bootstrap run options
 func NewProcessOptions() ProcessOptions {
 	return &processOptions{
 		cacheSeriesMetadata: defaultCacheSeriesMetadata,
+		adminClient:         nil,
 	}
 }
 
@@ -45,4 +49,14 @@ func (o *processOptions) SetCacheSeriesMetadata(value bool) ProcessOptions {
 
 func (o *processOptions) CacheSeriesMetadata() bool {
 	return o.cacheSeriesMetadata
+}
+
+func (o *processOptions) SetAdminClient(value client.AdminClient) ProcessOptions {
+	opts := *o
+	opts.adminClient = value
+	return &opts
+}
+
+func (o *processOptions) AdminClient() client.AdminClient {
+	return o.adminClient
 }

--- a/src/dbnode/storage/bootstrap/provider_options.go
+++ b/src/dbnode/storage/bootstrap/provider_options.go
@@ -20,12 +20,20 @@
 
 package bootstrap
 
-import "github.com/m3db/m3/src/dbnode/client"
+import (
+	"errors"
+
+	"github.com/m3db/m3/src/dbnode/client"
+)
 
 const (
 	// defaultCacheSeriesMetadata declares that by default bootstrap providers should
 	// cache series metadata between runs.
 	defaultCacheSeriesMetadata = true
+)
+
+var (
+	errAdminClientShouldNotBeNil = errors.New("admin client should not be nil")
 )
 
 type processOptions struct {
@@ -39,6 +47,14 @@ func NewProcessOptions() ProcessOptions {
 		cacheSeriesMetadata: defaultCacheSeriesMetadata,
 		adminClient:         nil,
 	}
+}
+
+func (o *processOptions) Validate() error {
+	if o.adminClient == nil {
+		return errAdminClientShouldNotBeNil
+	}
+
+	return nil
 }
 
 func (o *processOptions) SetCacheSeriesMetadata(value bool) ProcessOptions {

--- a/src/dbnode/storage/bootstrap/run_options.go
+++ b/src/dbnode/storage/bootstrap/run_options.go
@@ -27,15 +27,17 @@ const (
 )
 
 type runOptions struct {
-	incremental         bool
-	cacheSeriesMetadata bool
+	incremental          bool
+	cacheSeriesMetadata  bool
+	initialTopologyState *TopologyState
 }
 
 // NewRunOptions creates new bootstrap run options
 func NewRunOptions() RunOptions {
 	return &runOptions{
-		incremental:         defaultIncremental,
-		cacheSeriesMetadata: defaultCacheSeriesMetadata,
+		incremental:          defaultIncremental,
+		cacheSeriesMetadata:  defaultCacheSeriesMetadata,
+		initialTopologyState: nil,
 	}
 }
 
@@ -57,4 +59,14 @@ func (o *runOptions) SetCacheSeriesMetadata(value bool) RunOptions {
 
 func (o *runOptions) CacheSeriesMetadata() bool {
 	return o.cacheSeriesMetadata
+}
+
+func (o *runOptions) SetInitialTopologyState(value *TopologyState) RunOptions {
+	opts := *o
+	opts.initialTopologyState = value
+	return &opts
+}
+
+func (o *runOptions) InitialTopologyState() *TopologyState {
+	return o.initialTopologyState
 }

--- a/src/dbnode/storage/bootstrap/run_options.go
+++ b/src/dbnode/storage/bootstrap/run_options.go
@@ -20,6 +20,8 @@
 
 package bootstrap
 
+import "github.com/m3db/m3/src/dbnode/topology"
+
 const (
 	// defaultIncremental declares the intent to by default not perform an
 	// incremental bootstrap.
@@ -29,7 +31,7 @@ const (
 type runOptions struct {
 	incremental          bool
 	cacheSeriesMetadata  bool
-	initialTopologyState *TopologyState
+	initialTopologyState *topology.StateSnapshot
 }
 
 // NewRunOptions creates new bootstrap run options
@@ -61,12 +63,12 @@ func (o *runOptions) CacheSeriesMetadata() bool {
 	return o.cacheSeriesMetadata
 }
 
-func (o *runOptions) SetInitialTopologyState(value *TopologyState) RunOptions {
+func (o *runOptions) SetInitialTopologyState(value *topology.StateSnapshot) RunOptions {
 	opts := *o
 	opts.initialTopologyState = value
 	return &opts
 }
 
-func (o *runOptions) InitialTopologyState() *TopologyState {
+func (o *runOptions) InitialTopologyState() *topology.StateSnapshot {
 	return o.initialTopologyState
 }

--- a/src/dbnode/storage/bootstrap/types.go
+++ b/src/dbnode/storage/bootstrap/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	"github.com/m3db/m3/src/dbnode/topology"
 	xtime "github.com/m3db/m3x/time"
 )
 
@@ -107,11 +108,11 @@ type RunOptions interface {
 
 	// SetInitialTopologyState sets the initial topology state as it was
 	// measured before the bootstrap process began.
-	SetInitialTopologyState(value *TopologyState) RunOptions
+	SetInitialTopologyState(value *topology.StateSnapshot) RunOptions
 
 	// InitialTopologyState returns the initial topology as it was measured
 	// before the bootstrap process began.
-	InitialTopologyState() *TopologyState
+	InitialTopologyState() *topology.StateSnapshot
 }
 
 // BootstrapperProvider constructs a bootstrapper.

--- a/src/dbnode/storage/bootstrap/types.go
+++ b/src/dbnode/storage/bootstrap/types.go
@@ -23,6 +23,7 @@ package bootstrap
 import (
 	"time"
 
+	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	xtime "github.com/m3db/m3x/time"
@@ -75,6 +76,12 @@ type ProcessOptions interface {
 	// CacheSeriesMetadata returns whether bootstrappers created by this
 	// provider should cache series metadata between runs.
 	CacheSeriesMetadata() bool
+
+	// SetAdminClient sets the admin client.
+	SetAdminClient(value client.AdminClient) ProcessOptions
+
+	// AdminClient returns the admin client.
+	AdminClient() client.AdminClient
 }
 
 // RunOptions is a set of options for a bootstrap run.
@@ -94,6 +101,14 @@ type RunOptions interface {
 	// CacheSeriesMetadata returns whether bootstrappers created by this
 	// provider should cache series metadata between runs.
 	CacheSeriesMetadata() bool
+
+	// SetInitialTopologyState sets the initial topology state as it was
+	// measured before the bootstrap process began.
+	SetInitialTopologyState(value *TopologyState) RunOptions
+
+	// InitialTopologyState returns the initial topology as it was measured
+	// before the bootstrap process began.
+	InitialTopologyState() *TopologyState
 }
 
 // BootstrapperProvider constructs a bootstrapper.
@@ -157,6 +172,7 @@ type Source interface {
 	AvailableData(
 		ns namespace.Metadata,
 		shardsTimeRanges result.ShardTimeRanges,
+		runOpts RunOptions,
 	) result.ShardTimeRanges
 
 	// ReadData returns raw series for a given set of shards & specified time ranges and
@@ -166,13 +182,14 @@ type Source interface {
 	ReadData(
 		ns namespace.Metadata,
 		shardsTimeRanges result.ShardTimeRanges,
-		opts RunOptions,
+		runOpts RunOptions,
 	) (result.DataBootstrapResult, error)
 
 	// AvailableIndex returns what time ranges are available for bootstrapping.
 	AvailableIndex(
 		ns namespace.Metadata,
 		shardsTimeRanges result.ShardTimeRanges,
+		opts RunOptions,
 	) result.ShardTimeRanges
 
 	// ReadIndex returns series index blocks.

--- a/src/dbnode/storage/bootstrap/types.go
+++ b/src/dbnode/storage/bootstrap/types.go
@@ -82,6 +82,9 @@ type ProcessOptions interface {
 
 	// AdminClient returns the admin client.
 	AdminClient() client.AdminClient
+
+	// Validate validates that the ProcessOptions are correct.
+	Validate() error
 }
 
 // RunOptions is a set of options for a bootstrap run.

--- a/src/dbnode/topology/types.go
+++ b/src/dbnode/topology/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
 )
@@ -216,3 +217,27 @@ type DynamicOptions interface {
 	// HashGen returns HashGen function
 	HashGen() sharding.HashGen
 }
+
+// StateSnapshot represents a snapshot of the state of the topology at a
+// given moment.
+type StateSnapshot struct {
+	Origin           Host
+	MajorityReplicas int
+	ShardStates      ShardStates
+}
+
+// ShardStates maps shard IDs to the state of each of the hosts that own
+// that shard.
+type ShardStates map[ShardID]map[HostID]HostShardState
+
+// HostShardState contains the state of a shard as owned by a given host.
+type HostShardState struct {
+	Host       Host
+	ShardState shard.State
+}
+
+// HostID is the string representation of a host ID.
+type HostID string
+
+// ShardID is the ID of a shard.
+type ShardID uint32


### PR DESCRIPTION
- [X] Move InitialTopologyState logic to shared bootstrap code and then refactor peer bootstrapper to use new shared logic
- [X] Adjust all interfaces to accomodate
- [X] Fix all unit / integration tests