### PR TITLE
Add support for putting commit log bootstrapper before peers

### DIFF
--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -177,7 +177,7 @@ data:
             - filesystem
             - commitlog
             - peers
-            - uninitialized
+            - uninitialized_topology
         fs:
             numProcessorsPerCPU: 0.125
 

--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -176,6 +176,7 @@ data:
         bootstrappers:
             - filesystem
             - commitlog
+            - peers
             - uninitialized
         fs:
             numProcessorsPerCPU: 0.125

--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -176,6 +176,7 @@ data:
         bootstrappers:
             - filesystem
             - commitlog
+            - uninitialized
         fs:
             numProcessorsPerCPU: 0.125
 

--- a/kube/m3dbnode-configmap.yaml
+++ b/kube/m3dbnode-configmap.yaml
@@ -68,6 +68,7 @@ data:
         bootstrappers:
             - filesystem
             - commitlog
+            - peers
             - uninitialized
         fs:
             numProcessorsPerCPU: 0.125

--- a/kube/m3dbnode-configmap.yaml
+++ b/kube/m3dbnode-configmap.yaml
@@ -69,7 +69,7 @@ data:
             - filesystem
             - commitlog
             - peers
-            - uninitialized
+            - uninitialized_topology
         fs:
             numProcessorsPerCPU: 0.125
 

--- a/kube/m3dbnode-configmap.yaml
+++ b/kube/m3dbnode-configmap.yaml
@@ -68,6 +68,7 @@ data:
         bootstrappers:
             - filesystem
             - commitlog
+            - uninitialized
         fs:
             numProcessorsPerCPU: 0.125
 

--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -163,10 +163,7 @@ func (bsc BootstrapConfiguration) New(
 			uopts := uninitialized.NewOptions().
 				SetResultOptions(rsOpts).
 				SetInstrumentOptions(opts.InstrumentOptions())
-			bs, err = uninitialized.NewuninitializedTopologyBootstrapperProvider(uopts, bs)
-			if err != nil {
-				return nil, err
-			}
+			bs = uninitialized.NewuninitializedTopologyBootstrapperProvider(uopts, bs)
 		default:
 			return nil, fmt.Errorf("unknown bootstrapper: %s", bsc.Bootstrappers[i])
 		}

--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -198,6 +198,8 @@ func ValidateBootstrappersOrder(names []string) error {
 		peers.PeersBootstrapperName: []string{
 			// Peers must always appear after filesystem
 			bfs.FileSystemBootstrapperName,
+			// Peers may appear before OR after commitlog
+			commitlog.CommitLogBootstrapperName,
 		},
 		commitlog.CommitLogBootstrapperName: []string{
 			// Commit log bootstrapper may appear after filesystem or peers

--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -159,11 +159,11 @@ func (bsc BootstrapConfiguration) New(
 			if err != nil {
 				return nil, err
 			}
-		case uninitialized.UninitializedBootstrapperName:
+		case uninitialized.UninitializedTopologyBootstrapperName:
 			uopts := uninitialized.NewOptions().
 				SetResultOptions(rsOpts).
 				SetInstrumentOptions(opts.InstrumentOptions())
-			bs, err = uninitialized.NewUninitializedBootstrapperProvider(uopts, bs)
+			bs, err = uninitialized.NewuninitializedTopologyBootstrapperProvider(uopts, bs)
 			if err != nil {
 				return nil, err
 			}
@@ -206,7 +206,7 @@ func ValidateBootstrappersOrder(names []string) error {
 			bfs.FileSystemBootstrapperName,
 			peers.PeersBootstrapperName,
 		},
-		uninitialized.UninitializedBootstrapperName: []string{
+		uninitialized.UninitializedTopologyBootstrapperName: []string{
 			// Unintialized bootstrapper may appear after filesystem or peers or commitlog
 			bfs.FileSystemBootstrapperName,
 			commitlog.CommitLogBootstrapperName,

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -328,7 +328,7 @@ db:
             - filesystem
             - commitlog
             - peers
-            - uninitialized
+            - uninitialized_topology
         fs:
             numProcessorsPerCPU: 0.125
 

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -327,6 +327,7 @@ db:
         bootstrappers:
             - filesystem
             - commitlog
+            - peers
             - uninitialized
         fs:
             numProcessorsPerCPU: 0.125

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -327,6 +327,7 @@ db:
         bootstrappers:
             - filesystem
             - commitlog
+            - uninitialized
         fs:
             numProcessorsPerCPU: 0.125
 

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -487,6 +487,7 @@ db:
         bootstrappers:
             - filesystem
             - commitlog
+            - peers
             - uninitialized
         fs:
             numProcessorsPerCPU: 0.125

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -487,6 +487,7 @@ db:
         bootstrappers:
             - filesystem
             - commitlog
+            - uninitialized
         fs:
             numProcessorsPerCPU: 0.125
 

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -488,7 +488,7 @@ db:
             - filesystem
             - commitlog
             - peers
-            - uninitialized
+            - uninitialized_topology
         fs:
             numProcessorsPerCPU: 0.125
 

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/m3db/m3cluster/integration/etcd"
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/services"
-	"github.com/m3db/m3cluster/shard"
 	xconfig "github.com/m3db/m3x/config"
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
@@ -632,35 +631,3 @@ db:
                   endpoint: {{.InitialClusterEndpoint}}
 `
 )
-
-// waitUntilAllShardsAreAvailable continually polls the session checking to see if the topology.Map
-// that the session is currently storing contains a non-zero number of host shard sets, and if so,
-// makes sure that all their shard states are Available.
-func waitUntilAllShardsAreAvailable(t *testing.T, session client.AdminSession) {
-outer:
-	for {
-		time.Sleep(10 * time.Millisecond)
-
-		topoMap, err := session.TopologyMap()
-		require.NoError(t, err)
-
-		var (
-			hostShardSets = topoMap.HostShardSets()
-		)
-
-		if len(hostShardSets) == 0 {
-			// We haven't received an actual topology yet.
-			continue
-		}
-
-		for _, hostShardSet := range hostShardSets {
-			for _, hostShard := range hostShardSet.ShardSet().All() {
-				if hostShard.State() != shard.Available {
-					continue outer
-				}
-			}
-		}
-
-		break
-	}
-}

--- a/src/dbnode/config/m3dbnode-local-etcd.yml
+++ b/src/dbnode/config/m3dbnode-local-etcd.yml
@@ -63,7 +63,7 @@ db:
     bootstrappers:
         - filesystem
         - commitlog
-        - noop-none
+        - uninitialized
     fs:
         numProcessorsPerCPU: 0.125
 

--- a/src/dbnode/config/m3dbnode-local-etcd.yml
+++ b/src/dbnode/config/m3dbnode-local-etcd.yml
@@ -64,7 +64,7 @@ db:
         - filesystem
         - commitlog
         - peers
-        - uninitialized
+        - uninitialized_topology
     fs:
         numProcessorsPerCPU: 0.125
 

--- a/src/dbnode/config/m3dbnode-local-etcd.yml
+++ b/src/dbnode/config/m3dbnode-local-etcd.yml
@@ -63,6 +63,7 @@ db:
     bootstrappers:
         - filesystem
         - commitlog
+        - peers
         - uninitialized
     fs:
         numProcessorsPerCPU: 0.125

--- a/src/dbnode/config/m3dbnode-local.yml
+++ b/src/dbnode/config/m3dbnode-local.yml
@@ -63,7 +63,7 @@ db:
     bootstrappers:
         - filesystem
         - commitlog
-        - noop-none
+        - uninitialized
     fs:
         numProcessorsPerCPU: 0.125
 

--- a/src/dbnode/config/m3dbnode-local.yml
+++ b/src/dbnode/config/m3dbnode-local.yml
@@ -64,7 +64,7 @@ db:
         - filesystem
         - commitlog
         - peers
-        - uninitialized
+        - uninitialized_topology
     fs:
         numProcessorsPerCPU: 0.125
 

--- a/src/dbnode/config/m3dbnode-local.yml
+++ b/src/dbnode/config/m3dbnode-local.yml
@@ -63,6 +63,7 @@ db:
     bootstrappers:
         - filesystem
         - commitlog
+        - peers
         - uninitialized
     fs:
         numProcessorsPerCPU: 0.125

--- a/src/dbnode/example/m3db-node-config.yaml
+++ b/src/dbnode/example/m3db-node-config.yaml
@@ -47,6 +47,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - uninitialized
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/dbnode/example/m3db-node-config.yaml
+++ b/src/dbnode/example/m3db-node-config.yaml
@@ -47,6 +47,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - peers
       - uninitialized
   fs:
       numProcessorsPerCPU: 0.125

--- a/src/dbnode/example/m3db-node-config.yaml
+++ b/src/dbnode/example/m3db-node-config.yaml
@@ -48,7 +48,7 @@ bootstrap:
       - filesystem
       - commitlog
       - peers
-      - uninitialized
+      - uninitialized_topology
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
+++ b/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
@@ -118,6 +118,7 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 	signalCh := make(chan struct{})
 	bootstrapper, err := commitlogBootstrapperProvider.Provide()
 	require.NoError(t, err)
+
 	test := newTestBootstrapperSource(testBootstrapperSourceOptions{
 		readData: func(
 			_ namespace.Metadata,

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -36,8 +36,10 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/index/convert"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"
+	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
@@ -104,10 +106,7 @@ func (s *commitLogSource) AvailableData(
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
-	// Commit log bootstrapper is a last ditch effort, so fulfill all
-	// time ranges requested even if not enough data, just to succeed
-	// the bootstrap
-	return shardsTimeRanges
+	return s.availability(ns, shardsTimeRanges, runOpts)
 }
 
 // ReadData will read a combination of the available snapshot files and commit log files to
@@ -1249,10 +1248,7 @@ func (s *commitLogSource) AvailableIndex(
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
 ) result.ShardTimeRanges {
-	// Commit log bootstrapper is a last ditch effort, so fulfill all
-	// time ranges requested even if not enough data, just to succeed
-	// the bootstrap
-	return shardsTimeRanges
+	return s.availability(ns, shardsTimeRanges, runOpts)
 }
 
 func (s *commitLogSource) ReadIndex(
@@ -1423,6 +1419,70 @@ func (s commitLogSource) maybeAddToIndex(
 
 	_, err = segment.Insert(d)
 	return err
+}
+
+func (s *commitLogSource) availability(
+	ns namespace.Metadata,
+	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
+) result.ShardTimeRanges {
+	var (
+		topoState                = runOpts.InitialTopologyState()
+		availableShardTimeRanges = result.ShardTimeRanges{}
+	)
+
+	for shardIDUint := range shardsTimeRanges {
+		shardID := topology.ShardID(shardIDUint)
+		hostShardStates, ok := topoState.ShardStates[shardID]
+		if !ok {
+			// This shard was not part of the topology when the bootstrapping
+			// process began.
+			continue
+		}
+
+		originHostShardState, ok := hostShardStates[topology.HostID(topoState.Origin.ID())]
+		if !ok {
+			// TODO(rartoul): Make this a hard error once we refactor the interface to support
+			// returning errors.
+			iOpts := s.opts.CommitLogOptions().InstrumentOptions()
+			invariantLogger := instrument.EmitInvariantViolationAndGetLogger(iOpts)
+			invariantLogger.Errorf(
+				"Initial topolgoy state does not contain shard state for origin node and shard: %d", shardIDUint)
+			continue
+		}
+
+		originShardState := originHostShardState.ShardState
+		switch originShardState {
+		// In the Initializing and Unknown states we have to assume that the commit log
+		// is missing data and can't satisfy the bootstrap request.
+		case shard.Initializing:
+		case shard.Unknown:
+		// In the Leaving and Available case, we assume that the commit log contains
+		// all the data required to satisfy the bootstrap request because the node
+		// had (at some point) been completely bootstrapped for the requested shard.
+		// This doesn't mean that the node can't be missing any data or wasn't down
+		// for some period of time and missing writes in a multi-node deployment, it
+		// only means that technically the node has successfully taken ownership of
+		// the data for this shard and made it to a "bootstrapped" state which is
+		// all that is required to maintain our cluster-level consistency guarantees.
+		case shard.Leaving:
+			fallthrough
+		case shard.Available:
+			// Assume that we can bootstrap any requested time range, which is valid as
+			// long as the FS bootstrapper precedes the commit log bootstrapper.
+			// TODO(rartoul): Once we make changes to the bootstrapping interfaces
+			// to distinguish between "unfulfilled" data and "corrupt" data, then
+			// modify this to only say the commit log bootstrapper can fullfil
+			// "unfulfilled" data, but not corrupt data.
+			availableShardTimeRanges[shardIDUint] = shardsTimeRanges[shardIDUint]
+		default:
+			// TODO(rartoul): Make this a hard error once we refactor the interface to support
+			// returning errors.
+			panic(fmt.Sprintf("unknown shard state: %v", originShardState))
+		}
+	}
+
+	return availableShardTimeRanges
 }
 
 func newReadSeriesPredicate(ns namespace.Metadata) commitlog.SeriesFilterPredicate {

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -1447,7 +1447,7 @@ func (s *commitLogSource) availability(
 			iOpts := s.opts.CommitLogOptions().InstrumentOptions()
 			invariantLogger := instrument.EmitInvariantViolationAndGetLogger(iOpts)
 			invariantLogger.Errorf(
-				"Initial topolgoy state does not contain shard state for origin node and shard: %d", shardIDUint)
+				"Initial topology state does not contain shard state for origin node and shard: %d", shardIDUint)
 			continue
 		}
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -1421,6 +1421,10 @@ func (s commitLogSource) maybeAddToIndex(
 	return err
 }
 
+// The commitlog bootstrapper determines availability primarily by checking if the
+// origin host has ever reached the "Initialized" state for the shard that is being
+// bootstrapped. If not, then it can't provide data for that shard because it doesn't
+// have all of it by definition.
 func (s *commitLogSource) availability(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -1422,7 +1422,7 @@ func (s commitLogSource) maybeAddToIndex(
 }
 
 // The commitlog bootstrapper determines availability primarily by checking if the
-// origin host has ever reached the "Initialized" state for the shard that is being
+// origin host has ever reached the "Available" state for the shard that is being
 // bootstrapped. If not, then it can't provide data for that shard because it doesn't
 // have all of it by definition.
 func (s *commitLogSource) availability(

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -86,14 +86,14 @@ func testOptions() Options {
 }
 
 func TestAvailableEmptyRangeError(t *testing.T) {
-	opts := testOptions()
+	opts := testDefaultOpts
 	src := newCommitLogSource(opts, fs.Inspection{})
 	res := src.AvailableData(testNsMetadata(t), result.ShardTimeRanges{}, testDefaultRunOpts)
 	require.True(t, result.ShardTimeRanges{}.Equal(res))
 }
 
 func TestReadEmpty(t *testing.T) {
-	opts := testOptions()
+	opts := testDefaultOpts
 
 	src := newCommitLogSource(opts, fs.Inspection{})
 
@@ -105,7 +105,7 @@ func TestReadEmpty(t *testing.T) {
 }
 
 func TestReadErrorOnNewIteratorError(t *testing.T) {
-	opts := testOptions()
+	opts := testDefaultOpts
 	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)
 
 	src.newIteratorFn = func(_ commitlog.IteratorOpts) (commitlog.Iterator, error) {
@@ -124,7 +124,7 @@ func TestReadErrorOnNewIteratorError(t *testing.T) {
 }
 
 func TestReadOrderedValues(t *testing.T) {
-	opts := testOptions()
+	opts := testDefaultOpts
 	md := testNsMetadata(t)
 	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)
 
@@ -169,7 +169,7 @@ func TestReadOrderedValues(t *testing.T) {
 }
 
 func TestReadUnorderedValues(t *testing.T) {
-	opts := testOptions()
+	opts := testDefaultOpts
 	md := testNsMetadata(t)
 	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)
 
@@ -216,7 +216,7 @@ func TestReadUnorderedValues(t *testing.T) {
 // files can span multiple M3DB processes which means that unique indexes could be re-used for multiple
 // different series.
 func TestReadHandlesDifferentSeriesWithIdenticalUniqueIndex(t *testing.T) {
-	opts := testOptions()
+	opts := testDefaultOpts
 	md := testNsMetadata(t)
 	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)
 
@@ -257,7 +257,7 @@ func TestReadHandlesDifferentSeriesWithIdenticalUniqueIndex(t *testing.T) {
 }
 
 func TestReadTrimsToRanges(t *testing.T) {
-	opts := testOptions()
+	opts := testDefaultOpts
 	md := testNsMetadata(t)
 	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)
 
@@ -302,7 +302,7 @@ func TestItMergesSnapshotsAndCommitLogs(t *testing.T) {
 	defer ctrl.Finish()
 
 	var (
-		opts      = testOptions()
+		opts      = testDefaultOpts
 		md        = testNsMetadata(t)
 		src       = newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)
 		blockSize = md.Options().RetentionOptions().BlockSize()

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
-	topotestutils "github.com/m3db/m3/src/dbnode/topology/testutil"
+	tu "github.com/m3db/m3/src/dbnode/topology/testutil"
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3x/checked"
@@ -328,13 +328,9 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 
 			// Perform the bootstrap
 			var (
-				initialTopoState = topotestutils.SourceAvailableHosts{
-					topotestutils.SourceAvailableHost{
-						Name:        topotestutils.SelfID,
-						Shards:      allShardsSlice,
-						ShardStates: shard.Available,
-					},
-				}.TopologyState(1)
+				initialTopoState = tu.NewStateSnapshot(1, tu.HostShardStates{
+					tu.SelfID: tu.Shards(allShardsSlice, shard.Available),
+				})
 				runOpts = testDefaultRunOpts.SetInitialTopologyState(initialTopoState)
 			)
 			dataResult, err := source.BootstrapData(nsMeta, shardTimeRanges, runOpts)

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -40,7 +40,9 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	topotestutils "github.com/m3db/m3/src/dbnode/topology/testutil"
 	"github.com/m3db/m3/src/dbnode/ts"
+	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3x/checked"
 	"github.com/m3db/m3x/context"
 	"github.com/m3db/m3x/ident"
@@ -306,19 +308,35 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 
 			// Determine which shards we need to bootstrap (based on the randomly
 			// generated data)
-			allShards := map[uint32]bool{}
+			var (
+				allShardsMap   = map[uint32]bool{}
+				allShardsSlice = []uint32{}
+			)
 			for _, write := range input.writes {
-				allShards[write.series.Shard] = true
+				shard := write.series.Shard
+				if _, ok := allShardsMap[shard]; !ok {
+					allShardsSlice = append(allShardsSlice, shard)
+				}
+				allShardsMap[shard] = true
 			}
 
 			// Assign the previously-determined bootstrap range to each known shard
 			shardTimeRanges := result.ShardTimeRanges{}
-			for shard := range allShards {
+			for shard := range allShardsMap {
 				shardTimeRanges[shard] = ranges
 			}
 
 			// Perform the bootstrap
-			runOpts := testDefaultRunOpts
+			var (
+				initialTopoState = topotestutils.SourceAvailableHosts{
+					topotestutils.SourceAvailableHost{
+						Name:        topotestutils.SelfID,
+						Shards:      allShardsSlice,
+						ShardStates: shard.Available,
+					},
+				}.TopologyState(1)
+				runOpts = testDefaultRunOpts.SetInitialTopologyState(initialTopoState)
+			)
 			dataResult, err := source.BootstrapData(nsMeta, shardTimeRanges, runOpts)
 			if err != nil {
 				return false, err
@@ -341,7 +359,7 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 				return false, err
 			}
 
-			indexResult, err := source.BootstrapIndex(nsMeta, shardTimeRanges, testDefaultRunOpts)
+			indexResult, err := source.BootstrapIndex(nsMeta, shardTimeRanges, runOpts)
 			if err != nil {
 				return false, err
 			}

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
-	topotestutils "github.com/m3db/m3/src/dbnode/topology/testutil"
+	tu "github.com/m3db/m3/src/dbnode/topology/testutil"
 	"github.com/m3db/m3cluster/shard"
 	xtime "github.com/m3db/m3x/time"
 
@@ -57,16 +57,16 @@ func TestAvailableData(t *testing.T) {
 
 	testCases := []struct {
 		title                             string
-		hosts                             topotestutils.SourceAvailableHosts
+		hosts                             tu.SourceAvailableHosts
 		majorityReplicas                  int
 		shardsTimeRangesToBootstrap       result.ShardTimeRanges
 		expectedAvailableShardsTimeRanges result.ShardTimeRanges
 	}{
 		{
 			title: "Single node - Shard initializing",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
@@ -77,9 +77,9 @@ func TestAvailableData(t *testing.T) {
 		},
 		{
 			title: "Single node - Shard unknown",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Unknown,
 				},
@@ -90,9 +90,9 @@ func TestAvailableData(t *testing.T) {
 		},
 		{
 			title: "Single node - Shard leaving",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Leaving,
 				},
@@ -103,9 +103,9 @@ func TestAvailableData(t *testing.T) {
 		},
 		{
 			title: "Single node - Shard available",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
@@ -116,13 +116,13 @@ func TestAvailableData(t *testing.T) {
 		},
 		{
 			title: "Multi node - Origin available",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
@@ -134,13 +134,13 @@ func TestAvailableData(t *testing.T) {
 		},
 		{
 			title: "Multi node - Origin not available",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
@@ -29,6 +29,7 @@ import (
 	topotestutils "github.com/m3db/m3/src/dbnode/topology/testutil"
 	"github.com/m3db/m3cluster/shard"
 	xtime "github.com/m3db/m3x/time"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/types.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/types.go
@@ -30,10 +30,10 @@ type Options interface {
 	// Validate validates the options
 	Validate() error
 
-	// SetResultOptions sets the instrumentation options
+	// SetResultOptions sets the result options
 	SetResultOptions(value result.Options) Options
 
-	// ResultOptions returns the instrumentation options
+	// ResultOptions returns the result options
 	ResultOptions() result.Options
 
 	// SetCommitLogOptions sets the commit log options

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -724,8 +724,8 @@ func (s *peersSource) peerAvailability(
 			default:
 				// TODO(rartoul): Make this a hard error once we refactor the interface to support
 				// returning errors.
-				panic(
-					fmt.Sprintf("encountered unknown shard state: %s", shardState.String()))
+				s.log.Errorf("unknown shard state: %v", shardState)
+				return result.ShardTimeRanges{}
 			}
 		}
 	}

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -710,17 +710,17 @@ func (s *peersSource) peerAvailability(
 			shardState := hostShardState.ShardState
 
 			switch shardState {
-			// Skip cases - We cannot bootstrap from this host
+			// Don't want to peer bootstrap from a node that has not yet completely
+			// taken ownership of the shard.
 			case shard.Initializing:
-				// Don't want to peer bootstrap from a node that has not yet completely
-				// taken ownership of the shard.
-			case shard.Unknown:
 				// Success cases - We can bootstrap from this host, which is enough to
 				// mark this shard as bootstrappable.
 			case shard.Leaving:
 				fallthrough
 			case shard.Available:
 				shardPeers.numAvailablePeers++
+			case shard.Unknown:
+				fallthrough
 			default:
 				// TODO(rartoul): Make this a hard error once we refactor the interface to support
 				// returning errors.

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -722,6 +722,8 @@ func (s *peersSource) peerAvailability(
 			case shard.Available:
 				shardPeers.numAvailablePeers++
 			default:
+				// TODO(rartoul): Make this a hard error once we refactor the interface to support
+				// returning errors.
 				panic(
 					fmt.Sprintf("encountered unknown shard state: %s", shardState.String()))
 			}

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -27,7 +27,7 @@ import (
 	m3dbruntime "github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
-	topotestutils "github.com/m3db/m3/src/dbnode/topology/testutil"
+	tu "github.com/m3db/m3/src/dbnode/topology/testutil"
 	"github.com/m3db/m3cluster/shard"
 	xtime "github.com/m3db/m3x/time"
 
@@ -65,7 +65,7 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 
 	testCases := []struct {
 		title                             string
-		hosts                             topotestutils.SourceAvailableHosts
+		hosts                             tu.SourceAvailableHosts
 		majorityReplicas                  int
 		bootstrapReadConsistency          topology.ReadConsistencyLevel
 		shardsTimeRangesToBootstrap       result.ShardTimeRanges
@@ -73,9 +73,9 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 	}{
 		{
 			title: "Returns empty if only self is available",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
@@ -87,18 +87,18 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 		},
 		{
 			title: "Returns empty if all other peers initializing/unknown",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Unknown,
@@ -111,18 +111,18 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 		},
 		{
 			title: "Returns success if consistency can be met (available/leaving)",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Leaving,
@@ -134,18 +134,18 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 		},
 		{
 			title: "Skips shards that were not in the topology at start",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Available,
@@ -158,18 +158,18 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 		},
 		{
 			title: "Returns empty if consistency can not be met",
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Available,

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -35,6 +35,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	notSelfID1 = "not-self1"
+	notSelfID2 = "not-self2"
+)
+
 func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -89,12 +94,12 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 					ShardStates: shard.Available,
 				},
 				topotestutils.SourceAvailableHost{
-					Name:        "other1",
+					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
 				topotestutils.SourceAvailableHost{
-					Name:        "other2",
+					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Unknown,
 				},
@@ -113,12 +118,12 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 					ShardStates: shard.Initializing,
 				},
 				topotestutils.SourceAvailableHost{
-					Name:        "other1",
+					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
 				topotestutils.SourceAvailableHost{
-					Name:        "other2",
+					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Leaving,
 				},
@@ -136,12 +141,12 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 					ShardStates: shard.Initializing,
 				},
 				topotestutils.SourceAvailableHost{
-					Name:        "other1",
+					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
 				topotestutils.SourceAvailableHost{
-					Name:        "other2",
+					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
@@ -160,12 +165,12 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 					ShardStates: shard.Initializing,
 				},
 				topotestutils.SourceAvailableHost{
-					Name:        "other1",
+					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
 				topotestutils.SourceAvailableHost{
-					Name:        "other2",
+					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
@@ -42,18 +42,6 @@ func NewOptions() Options {
 	return &options{}
 }
 
-func (o *options) Validate() error {
-	if o.iOpts == nil {
-		return errInstrumentOptsNotSet
-	}
-
-	if o.resultOpts == nil {
-		return errResultOptsNotSet
-	}
-
-	return nil
-}
-
 func (o *options) SetResultOptions(value result.Options) Options {
 	opts := *o
 	opts.resultOpts = value

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
@@ -37,6 +37,7 @@ type options struct {
 	iOpts      instrument.Options
 }
 
+// NewOptions creates a new Options.
 func NewOptions() Options {
 	return &options{}
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
@@ -23,15 +23,18 @@ package uninitialized
 import (
 	"errors"
 
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3x/instrument"
 )
 
 var (
 	errInstrumentOptsNotSet = errors.New("instrument options not set")
+	errResultOptsNotSet     = errors.New("result options not set")
 )
 
 type options struct {
-	iOpts instrument.Options
+	resultOpts result.Options
+	iOpts      instrument.Options
 }
 
 func NewOptions() Options {
@@ -43,7 +46,21 @@ func (o *options) Validate() error {
 		return errInstrumentOptsNotSet
 	}
 
+	if o.resultOpts == nil {
+		return errResultOptsNotSet
+	}
+
 	return nil
+}
+
+func (o *options) SetResultOptions(value result.Options) Options {
+	opts := *o
+	opts.resultOpts = value
+	return &opts
+}
+
+func (o *options) ResultOptions() result.Options {
+	return o.resultOpts
 }
 
 func (o *options) SetInstrumentOptions(value instrument.Options) Options {

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
@@ -21,15 +21,8 @@
 package uninitialized
 
 import (
-	"errors"
-
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3x/instrument"
-)
-
-var (
-	errInstrumentOptsNotSet = errors.New("instrument options not set")
-	errResultOptsNotSet     = errors.New("result options not set")
 )
 
 type options struct {

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package uninitialized
+
+import (
+	"errors"
+
+	"github.com/m3db/m3x/instrument"
+)
+
+var (
+	errInstrumentOptsNotSet = errors.New("instrument options not set")
+)
+
+type options struct {
+	iOpts instrument.Options
+}
+
+func NewOptions() Options {
+	return &options{}
+}
+
+func (o *options) Validate() error {
+	if o.iOpts == nil {
+		return errInstrumentOptsNotSet
+	}
+
+	return nil
+}
+
+func (o *options) SetInstrumentOptions(value instrument.Options) Options {
+	opts := *o
+	opts.iOpts = value
+	return &opts
+}
+
+func (o *options) InstrumentOptions() instrument.Options {
+	return o.iOpts
+}

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/options.go
@@ -39,7 +39,10 @@ type options struct {
 
 // NewOptions creates a new Options.
 func NewOptions() Options {
-	return &options{}
+	return &options{
+		resultOpts: result.NewOptions(),
+		iOpts:      instrument.NewOptions(),
+	}
 }
 
 func (o *options) SetResultOptions(value result.Options) Options {

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/provider.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/provider.go
@@ -40,15 +40,11 @@ type uninitializedTopologyBootstrapperProvider struct {
 func NewuninitializedTopologyBootstrapperProvider(
 	opts Options,
 	next bootstrap.BootstrapperProvider,
-) (bootstrap.BootstrapperProvider, error) {
-	if err := opts.Validate(); err != nil {
-		return nil, err
-	}
-
+) bootstrap.BootstrapperProvider {
 	return uninitializedTopologyBootstrapperProvider{
 		opts: opts,
 		next: next,
-	}, nil
+	}
 }
 
 func (p uninitializedTopologyBootstrapperProvider) Provide() (bootstrap.Bootstrapper, error) {

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/provider.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/provider.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package uninitialized
+
+import (
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
+)
+
+const (
+	// UninitializedBootstrapperName is the name of the uninitialized bootstrapper.
+	UninitializedBootstrapperName = "uninitialized"
+)
+
+type uninitializedBootstrapperProvider struct {
+	opts Options
+	next bootstrap.BootstrapperProvider
+}
+
+// NewUninitializedBootstrapperProvider creates a new uninitialized bootstrapper
+// provider.
+func NewUninitializedBootstrapperProvider(
+	opts Options,
+	next bootstrap.BootstrapperProvider,
+) (bootstrap.BootstrapperProvider, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+
+	return uninitializedBootstrapperProvider{
+		opts: opts,
+		next: next,
+	}, nil
+}
+
+func (p uninitializedBootstrapperProvider) Provide() (bootstrap.Bootstrapper, error) {
+	var (
+		src  = newUninitializedSource(p.opts)
+		b    = &uninitializedBootstrapper{}
+		next bootstrap.Bootstrapper
+		err  error
+	)
+
+	if p.next != nil {
+		next, err = p.next.Provide()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return bootstrapper.NewBaseBootstrapper(
+		b.String(), src, p.opts.ResultOptions(), next)
+}
+
+func (p uninitializedBootstrapperProvider) String() string {
+	return UninitializedBootstrapperName
+}
+
+type uninitializedBootstrapper struct {
+	bootstrap.Bootstrapper
+}
+
+func (*uninitializedBootstrapper) String() string {
+	return UninitializedBootstrapperName
+}

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/provider.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/provider.go
@@ -26,18 +26,18 @@ import (
 )
 
 const (
-	// UninitializedBootstrapperName is the name of the uninitialized bootstrapper.
-	UninitializedBootstrapperName = "uninitialized"
+	// UninitializedTopologyBootstrapperName is the name of the uninitialized bootstrapper.
+	UninitializedTopologyBootstrapperName = "uninitialized_topology"
 )
 
-type uninitializedBootstrapperProvider struct {
+type uninitializedTopologyBootstrapperProvider struct {
 	opts Options
 	next bootstrap.BootstrapperProvider
 }
 
-// NewUninitializedBootstrapperProvider creates a new uninitialized bootstrapper
+// NewuninitializedTopologyBootstrapperProvider creates a new uninitialized bootstrapper
 // provider.
-func NewUninitializedBootstrapperProvider(
+func NewuninitializedTopologyBootstrapperProvider(
 	opts Options,
 	next bootstrap.BootstrapperProvider,
 ) (bootstrap.BootstrapperProvider, error) {
@@ -45,16 +45,16 @@ func NewUninitializedBootstrapperProvider(
 		return nil, err
 	}
 
-	return uninitializedBootstrapperProvider{
+	return uninitializedTopologyBootstrapperProvider{
 		opts: opts,
 		next: next,
 	}, nil
 }
 
-func (p uninitializedBootstrapperProvider) Provide() (bootstrap.Bootstrapper, error) {
+func (p uninitializedTopologyBootstrapperProvider) Provide() (bootstrap.Bootstrapper, error) {
 	var (
-		src  = newUninitializedSource(p.opts)
-		b    = &uninitializedBootstrapper{}
+		src  = newTopologyUninitializedSource(p.opts)
+		b    = &uninitializedTopologyBootstrapper{}
 		next bootstrap.Bootstrapper
 		err  error
 	)
@@ -70,14 +70,14 @@ func (p uninitializedBootstrapperProvider) Provide() (bootstrap.Bootstrapper, er
 		b.String(), src, p.opts.ResultOptions(), next)
 }
 
-func (p uninitializedBootstrapperProvider) String() string {
-	return UninitializedBootstrapperName
+func (p uninitializedTopologyBootstrapperProvider) String() string {
+	return UninitializedTopologyBootstrapperName
 }
 
-type uninitializedBootstrapper struct {
+type uninitializedTopologyBootstrapper struct {
 	bootstrap.Bootstrapper
 }
 
-func (*uninitializedBootstrapper) String() string {
-	return UninitializedBootstrapperName
+func (*uninitializedTopologyBootstrapper) String() string {
+	return UninitializedTopologyBootstrapperName
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -109,6 +109,7 @@ func (s *uninitializedSource) availability(
 		// we end up with one extra node that is initializing which should be offset
 		// by the corresponding node that is leaving. I.E if numInitializing > 0
 		// BUT numLeaving >= numInitializing then it is still not a new namespace.
+		// See the TestUnitializedSourceAvailableDataAndAvailableIndex test for more details.
 		var (
 			numInitializing = 0
 			numLeaving      = 0

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -140,7 +140,17 @@ func (s *uninitializedSource) ReadData(
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
 ) (result.DataBootstrapResult, error) {
-	return result.NewDataBootstrapResult(), nil
+	var (
+		availability = s.availability(ns, shardsTimeRanges, runOpts)
+		missing      = shardsTimeRanges.Copy()
+	)
+	missing.Subtract(availability)
+
+	if missing.IsEmpty() {
+		return result.NewDataBootstrapResult(), nil
+	} else {
+		return missing.ToUnfulfilledDataResult(), nil
+	}
 }
 
 func (s *uninitializedSource) ReadIndex(
@@ -148,5 +158,15 @@ func (s *uninitializedSource) ReadIndex(
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
 ) (result.IndexBootstrapResult, error) {
-	return result.NewIndexBootstrapResult(), nil
+	var (
+		availability = s.availability(ns, shardsTimeRanges, runOpts)
+		missing      = shardsTimeRanges.Copy()
+	)
+	missing.Subtract(availability)
+
+	if missing.IsEmpty() {
+		return result.NewIndexBootstrapResult(), nil
+	} else {
+		return missing.ToUnfulfilledIndexResult(), nil
+	}
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -30,13 +30,15 @@ import (
 	"github.com/m3db/m3cluster/shard"
 )
 
-// The purpose of the unitializedSource is succeed bootstraps for any
+// The purpose of the unitializedSource is to succeed bootstraps for any
 // shard/time-ranges if the given shard/namespace combination has never
 // been completely initialized (is a new namespace). This is required for
 // allowing us to configure the bootstrappers such that the commitlog
 // bootstrapper can precede the peers bootstrapper and still suceed bootstraps
 // for brand new namespaces without permitting unintentional data loss by
 // putting the noop-all or noop-none bootstrappers at the end of the process.
+// Behavior is best understood by reading the test cases for the test:
+// TestUnitializedSourceAvailableDataAndAvailableIndex
 type uninitializedSource struct {
 	opts Options
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -148,9 +148,9 @@ func (s *uninitializedSource) ReadData(
 
 	if missing.IsEmpty() {
 		return result.NewDataBootstrapResult(), nil
-	} else {
-		return missing.ToUnfulfilledDataResult(), nil
 	}
+
+	return missing.ToUnfulfilledDataResult(), nil
 }
 
 func (s *uninitializedSource) ReadIndex(
@@ -166,7 +166,7 @@ func (s *uninitializedSource) ReadIndex(
 
 	if missing.IsEmpty() {
 		return result.NewIndexBootstrapResult(), nil
-	} else {
-		return missing.ToUnfulfilledIndexResult(), nil
 	}
+
+	return missing.ToUnfulfilledIndexResult(), nil
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -37,18 +37,18 @@ import (
 // putting the noop-all or noop-none bootstrappers at the end of the process.
 // Behavior is best understood by reading the test cases for the test:
 // TestUnitializedSourceAvailableDataAndAvailableIndex
-type uninitializedSource struct {
+type uninitializedTopologySource struct {
 	opts Options
 }
 
-// NewUninitializedSource creates a new uninitialized source.
-func newUninitializedSource(opts Options) bootstrap.Source {
-	return &uninitializedSource{
+// newTopologyUninitializedSource creates a new uninitialized source.
+func newTopologyUninitializedSource(opts Options) bootstrap.Source {
+	return &uninitializedTopologySource{
 		opts: opts,
 	}
 }
 
-func (s *uninitializedSource) Can(strategy bootstrap.Strategy) bool {
+func (s *uninitializedTopologySource) Can(strategy bootstrap.Strategy) bool {
 	switch strategy {
 	case bootstrap.BootstrapSequential:
 		return true
@@ -57,7 +57,7 @@ func (s *uninitializedSource) Can(strategy bootstrap.Strategy) bool {
 	return false
 }
 
-func (s *uninitializedSource) AvailableData(
+func (s *uninitializedTopologySource) AvailableData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
@@ -65,7 +65,7 @@ func (s *uninitializedSource) AvailableData(
 	return s.availability(ns, shardsTimeRanges, runOpts)
 }
 
-func (s *uninitializedSource) AvailableIndex(
+func (s *uninitializedTopologySource) AvailableIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
@@ -73,7 +73,7 @@ func (s *uninitializedSource) AvailableIndex(
 	return s.availability(ns, shardsTimeRanges, runOpts)
 }
 
-func (s *uninitializedSource) availability(
+func (s *uninitializedTopologySource) availability(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
@@ -135,7 +135,7 @@ func (s *uninitializedSource) availability(
 	return availableShardTimeRanges
 }
 
-func (s *uninitializedSource) ReadData(
+func (s *uninitializedTopologySource) ReadData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
@@ -153,7 +153,7 @@ func (s *uninitializedSource) ReadData(
 	return missing.ToUnfulfilledDataResult(), nil
 }
 
-func (s *uninitializedSource) ReadIndex(
+func (s *uninitializedTopologySource) ReadIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -34,7 +34,7 @@ import (
 // shard/time-ranges if the given shard/namespace combination has never
 // been completely initialized (is a new namespace). This is required for
 // allowing us to configure the bootstrappers such that the commitlog
-// bootstrapper can precede the peers bootstrapper and still suceed bootstraps
+// bootstrapper can precede the peers bootstrapper and still succeed bootstraps
 // for brand new namespaces without permitting unintentional data loss by
 // putting the noop-all or noop-none bootstrappers at the end of the process.
 // Behavior is best understood by reading the test cases for the test:

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -29,8 +29,8 @@ import (
 )
 
 // The purpose of the unitializedSource is to succeed bootstraps for any
-// shard/time-ranges if the given shard/namespace combination has never
-// been completely initialized (is a new namespace). This is required for
+// shard/time-ranges if the cluster they're associated with has never
+// been completely initialized (is a new cluster). This is required for
 // allowing us to configure the bootstrappers such that the commitlog
 // bootstrapper can precede the peers bootstrapper and still succeed bootstraps
 // for brand new namespaces without permitting unintentional data loss by

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -44,14 +44,10 @@ type uninitializedSource struct {
 }
 
 // NewUninitializedSource creates a new uninitialized source.
-func NewUninitializedSource(opts Options) (bootstrap.Source, error) {
-	if err := opts.Validate(); err != nil {
-		return nil, err
-	}
-
+func newUninitializedSource(opts Options) bootstrap.Source {
 	return &uninitializedSource{
 		opts: opts,
-	}, nil
+	}
 }
 
 func (s *uninitializedSource) Can(strategy bootstrap.Strategy) bool {

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -133,8 +133,8 @@ func (s *uninitializedSource) availability(
 			}
 		}
 
-		isNewNamespace := numInitializing-numLeaving > 0
-		if isNewNamespace {
+		shardHasEverBeenCompletelyInitialized := numInitializing-numLeaving > 0
+		if shardHasEverBeenCompletelyInitialized {
 			availableShardTimeRanges[shardIDUint] = shardsTimeRanges[shardIDUint]
 		}
 	}

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package uninitialized
+
+import (
+	"fmt"
+
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	"github.com/m3db/m3/src/dbnode/topology"
+	"github.com/m3db/m3cluster/shard"
+)
+
+// The purpose of the unitializedSource is succeed bootstraps for any
+// shard/time-ranges if the given shard/namespace combination has never
+// been completely initialized (is a new namespace). This is required for
+// allowing us to configure the bootstrappers such that the commitlog
+// bootstrapper can precede the peers bootstrapper and still suceed bootstraps
+// for brand new namespaces without permitting unintentional data loss by
+// putting the noop-all or noop-none bootstrappers at the end of the process.
+type uninitializedSource struct {
+	opts Options
+}
+
+// NewUninitializedSource creates a new uninitialized source.
+func NewUninitializedSource(opts Options) (bootstrap.Source, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &uninitializedSource{
+		opts: opts,
+	}, nil
+}
+
+func (s *uninitializedSource) Can(strategy bootstrap.Strategy) bool {
+	switch strategy {
+	case bootstrap.BootstrapSequential:
+		return true
+	}
+
+	return false
+}
+
+func (s *uninitializedSource) AvailableData(
+	ns namespace.Metadata,
+	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
+) result.ShardTimeRanges {
+	return s.availability(ns, shardsTimeRanges, runOpts)
+}
+
+func (s *uninitializedSource) AvailableIndex(
+	ns namespace.Metadata,
+	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
+) result.ShardTimeRanges {
+	return s.availability(ns, shardsTimeRanges, runOpts)
+}
+
+func (s *uninitializedSource) availability(
+	ns namespace.Metadata,
+	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
+) result.ShardTimeRanges {
+	var (
+		topoState                = runOpts.InitialTopologyState()
+		availableShardTimeRanges = result.ShardTimeRanges{}
+	)
+
+	for shardIDUint := range shardsTimeRanges {
+		shardID := topology.ShardID(shardIDUint)
+		hostShardStates, ok := topoState.ShardStates[shardID]
+		if !ok {
+			// This shard was not part of the topology when the bootstrapping
+			// process began.
+			continue
+		}
+
+		var (
+			numInitializing = 0
+			numLeaving      = 0
+		)
+		for _, hostState := range hostShardStates {
+			shardState := hostState.ShardState
+			switch shardState {
+			case shard.Initializing:
+				numInitializing++
+			case shard.Unknown:
+			case shard.Leaving:
+				numLeaving++
+			case shard.Available:
+			default:
+				// TODO(rartoul): Make this a hard error once we refactor the interface to support
+				// returning errors.
+				panic(fmt.Sprintf("unknown shard state: %v", shardState))
+			}
+		}
+
+		isNewNamespace := numInitializing-numLeaving > 0
+		if isNewNamespace {
+			availableShardTimeRanges[shardIDUint] = shardsTimeRanges[shardIDUint]
+		}
+	}
+
+	return availableShardTimeRanges
+}
+
+func (s *uninitializedSource) ReadData(
+	ns namespace.Metadata,
+	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
+) (result.DataBootstrapResult, error) {
+	return result.NewDataBootstrapResult(), nil
+}
+
+func (s *uninitializedSource) ReadIndex(
+	ns namespace.Metadata,
+	shardsTimeRanges result.ShardTimeRanges,
+	runOpts bootstrap.RunOptions,
+) (result.IndexBootstrapResult, error) {
+	return result.NewIndexBootstrapResult(), nil
+}

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -126,8 +126,8 @@ func (s *uninitializedSource) availability(
 			}
 		}
 
-		shardHasEverBeenCompletelyInitialized := numInitializing-numLeaving > 0
-		if shardHasEverBeenCompletelyInitialized {
+		shardHasNeverBeenCompletelyInitialized := numInitializing-numLeaving > 0
+		if shardHasNeverBeenCompletelyInitialized {
 			availableShardTimeRanges[shardIDUint] = shardsTimeRanges[shardIDUint]
 		}
 	}

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
@@ -1,0 +1,282 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package uninitialized
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	"github.com/m3db/m3/src/dbnode/topology"
+	topotestutils "github.com/m3db/m3/src/dbnode/topology/testutil"
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3x/ident"
+	"github.com/m3db/m3x/instrument"
+	xtime "github.com/m3db/m3x/time"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testNamespaceID    = ident.StringID("testnamespace")
+	testDefaultRunOpts = bootstrap.NewRunOptions()
+	notSelfID1         = "not-self-1"
+	notSelfID2         = "not-self-2"
+	notSelfID3         = "not-self-3"
+)
+
+func TestUnitializedSourceAvailableDataAndAvailableIndex(t *testing.T) {
+	var (
+		blockSize                  = 2 * time.Hour
+		shards                     = []uint32{0, 1, 2, 3}
+		blockStart                 = time.Now().Truncate(blockSize)
+		shardTimeRangesToBootstrap = result.ShardTimeRanges{}
+		bootstrapRanges            = xtime.Ranges{}.AddRange(xtime.Range{
+			Start: blockStart,
+			End:   blockStart.Add(blockSize),
+		})
+	)
+	nsMetadata, err := namespace.NewMetadata(testNamespaceID, namespace.NewOptions())
+	require.NoError(t, err)
+
+	for _, shard := range shards {
+		shardTimeRangesToBootstrap[shard] = bootstrapRanges
+	}
+
+	testCases := []struct {
+		title                             string
+		majorityReplicas                  int
+		hosts                             topotestutils.SourceAvailableHosts
+		bootstrapReadConsistency          topology.ReadConsistencyLevel
+		shardsTimeRangesToBootstrap       result.ShardTimeRanges
+		expectedAvailableShardsTimeRanges result.ShardTimeRanges
+	}{
+		// Snould return that it can bootstrap everything because
+		// it's a new namespace.
+		{
+			title:            "Single node - Shard initializing",
+			majorityReplicas: 1,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Initializing,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: shardTimeRangesToBootstrap,
+		},
+		// Snould return that it can't bootstrap anything because we don't
+		// know how to handle unknown shard states.
+		{
+			title:            "Single node - Shard unknown",
+			majorityReplicas: 1,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Unknown,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: result.ShardTimeRanges{},
+		},
+		// Snould return that it can't bootstrap anything because it's not
+		// a new namespace.
+		{
+			title:            "Single node - Shard leaving",
+			majorityReplicas: 1,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Leaving,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: result.ShardTimeRanges{},
+		},
+		// Snould return that it can't bootstrap anything because it's not
+		// a new namespace.
+		{
+			title:            "Single node - Shard available",
+			majorityReplicas: 1,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: result.ShardTimeRanges{},
+		},
+		// Snould return that it can bootstrap everything because
+		// it's a new namespace.
+		{
+			title:            "Multi node - Brand new namespace (all nodes initializing)",
+			majorityReplicas: 2,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Initializing,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID1,
+					Shards:      shards,
+					ShardStates: shard.Initializing,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID2,
+					Shards:      shards,
+					ShardStates: shard.Initializing,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: shardTimeRangesToBootstrap,
+		},
+		// Snould return that it can bootstrap everything because
+		// it's a new namespace (one of the nodes hasn't completed
+		// initializing yet.)
+		{
+			title:            "Multi node - Recently created namespace (one node still initializing)",
+			majorityReplicas: 2,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Initializing,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID1,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID2,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: shardTimeRangesToBootstrap,
+		},
+		// Snould return that it can't bootstrap anything because it's not
+		// a new namespace.
+		{
+			title:            "Multi node - Initialized namespace (no nodes initializing)",
+			majorityReplicas: 2,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID1,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID2,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: result.ShardTimeRanges{},
+		},
+		// Snould return that it can't bootstrap anything because it's not
+		// a new namespace, we're just doing a node replace.
+		{
+			title:            "Multi node - Node replace (one node leaving, one initializing)",
+			majorityReplicas: 2,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID1,
+					Shards:      shards,
+					ShardStates: shard.Leaving,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID2,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID3,
+					Shards:      shards,
+					ShardStates: shard.Initializing,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: result.ShardTimeRanges{},
+		},
+		// Snould return that it can't bootstrap anything because we don't
+		// know how to interpret the unknown host.
+		{
+			title:            "Multi node - One node unknown",
+			majorityReplicas: 2,
+			hosts: []topotestutils.SourceAvailableHost{
+				topotestutils.SourceAvailableHost{
+					Name:        topotestutils.SelfID,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID1,
+					Shards:      shards,
+					ShardStates: shard.Available,
+				},
+				topotestutils.SourceAvailableHost{
+					Name:        notSelfID2,
+					Shards:      shards,
+					ShardStates: shard.Unknown,
+				},
+			},
+			shardsTimeRangesToBootstrap:       shardTimeRangesToBootstrap,
+			expectedAvailableShardsTimeRanges: result.ShardTimeRanges{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+
+			srcOpts := NewOptions().SetInstrumentOptions(instrument.NewOptions())
+			src, err := NewUninitializedSource(srcOpts)
+			require.NoError(t, err)
+
+			runOpts := testDefaultRunOpts.SetInitialTopologyState(tc.hosts.TopologyState(tc.majorityReplicas))
+			dataRes := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+
+			require.Equal(t, tc.expectedAvailableShardsTimeRanges, dataRes)
+
+			indexRes := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+			require.Equal(t, tc.expectedAvailableShardsTimeRanges, indexRes)
+		})
+	}
+}

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
@@ -266,16 +266,15 @@ func TestUnitializedSourceAvailableDataAndAvailableIndex(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
 
-			srcOpts := NewOptions().SetInstrumentOptions(instrument.NewOptions())
-			src, err := NewUninitializedSource(srcOpts)
-			require.NoError(t, err)
-
-			runOpts := testDefaultRunOpts.SetInitialTopologyState(tc.hosts.TopologyState(tc.majorityReplicas))
-			dataRes := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+			var (
+				srcOpts  = NewOptions().SetInstrumentOptions(instrument.NewOptions())
+				src      = newUninitializedSource(srcOpts)
+				runOpts  = testDefaultRunOpts.SetInitialTopologyState(tc.hosts.TopologyState(tc.majorityReplicas))
+				dataRes  = src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+				indexRes = src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+			)
 
 			require.Equal(t, tc.expectedAvailableShardsTimeRanges, dataRes)
-
-			indexRes := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
 			require.Equal(t, tc.expectedAvailableShardsTimeRanges, indexRes)
 		})
 	}

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
-	topotestutils "github.com/m3db/m3/src/dbnode/topology/testutil"
+	tu "github.com/m3db/m3/src/dbnode/topology/testutil"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
@@ -65,7 +65,7 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 	testCases := []struct {
 		title                             string
 		majorityReplicas                  int
-		hosts                             topotestutils.SourceAvailableHosts
+		hosts                             tu.SourceAvailableHosts
 		shardsTimeRangesToBootstrap       result.ShardTimeRanges
 		expectedAvailableShardsTimeRanges result.ShardTimeRanges
 	}{
@@ -74,9 +74,9 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Single node - Shard initializing",
 			majorityReplicas: 1,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
@@ -89,9 +89,9 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Single node - Shard unknown",
 			majorityReplicas: 1,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Unknown,
 				},
@@ -104,9 +104,9 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Single node - Shard leaving",
 			majorityReplicas: 1,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Leaving,
 				},
@@ -119,9 +119,9 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Single node - Shard available",
 			majorityReplicas: 1,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
@@ -134,18 +134,18 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Multi node - Brand new namespace (all nodes initializing)",
 			majorityReplicas: 2,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
@@ -160,18 +160,18 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Multi node - Recently created namespace (one node still initializing)",
 			majorityReplicas: 2,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Available,
@@ -185,18 +185,18 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Multi node - Initialized namespace (no nodes initializing)",
 			majorityReplicas: 2,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Available,
@@ -210,23 +210,23 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Multi node - Node replace (one node leaving, one initializing)",
 			majorityReplicas: 2,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Leaving,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID3,
 					Shards:      shards,
 					ShardStates: shard.Initializing,
@@ -240,18 +240,18 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 		{
 			title:            "Multi node - One node unknown",
 			majorityReplicas: 2,
-			hosts: []topotestutils.SourceAvailableHost{
-				topotestutils.SourceAvailableHost{
-					Name:        topotestutils.SelfID,
+			hosts: []tu.SourceAvailableHost{
+				tu.SourceAvailableHost{
+					Name:        tu.SelfID,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID1,
 					Shards:      shards,
 					ShardStates: shard.Available,
 				},
-				topotestutils.SourceAvailableHost{
+				tu.SourceAvailableHost{
 					Name:        notSelfID2,
 					Shards:      shards,
 					ShardStates: shard.Unknown,

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
-	"github.com/m3db/m3/src/dbnode/topology"
 	topotestutils "github.com/m3db/m3/src/dbnode/topology/testutil"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/instrument"
 	xtime "github.com/m3db/m3x/time"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,7 +66,6 @@ func TestUnitializedSourceAvailableDataAndAvailableIndex(t *testing.T) {
 		title                             string
 		majorityReplicas                  int
 		hosts                             topotestutils.SourceAvailableHosts
-		bootstrapReadConsistency          topology.ReadConsistencyLevel
 		shardsTimeRangesToBootstrap       result.ShardTimeRanges
 		expectedAvailableShardsTimeRanges result.ShardTimeRanges
 	}{

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
@@ -44,7 +44,7 @@ var (
 	notSelfID3         = "not-self-3"
 )
 
-func TestUnitializedSourceAvailableDataAndAvailableIndex(t *testing.T) {
+func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 	var (
 		blockSize                  = 2 * time.Hour
 		shards                     = []uint32{0, 1, 2, 3}
@@ -267,7 +267,7 @@ func TestUnitializedSourceAvailableDataAndAvailableIndex(t *testing.T) {
 
 			var (
 				srcOpts                 = NewOptions().SetInstrumentOptions(instrument.NewOptions())
-				src                     = newUninitializedSource(srcOpts)
+				src                     = newTopologyUninitializedSource(srcOpts)
 				runOpts                 = testDefaultRunOpts.SetInitialTopologyState(tc.hosts.TopologyState(tc.majorityReplicas))
 				dataAvailabilityResult  = src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
 				indexAvailabilityResult = src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/types.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/types.go
@@ -27,18 +27,18 @@ import (
 
 // Options is the options interface for the uninitialized source.
 type Options interface {
+	// Validate validates the options are correct.
+	Validate() error
+
 	// SetResultOptions sets the result options
 	SetResultOptions(value result.Options) Options
 
 	// ResultOptions returns the result options
 	ResultOptions() result.Options
 
-	// Return the instrument options.
-	InstrumentOptions() instrument.Options
-
 	// Set the instrument options.
 	SetInstrumentOptions(value instrument.Options) Options
 
-	// Validate validates the options are correct.
-	Validate() error
+	// Return the instrument options.
+	InstrumentOptions() instrument.Options
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/types.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/types.go
@@ -27,9 +27,6 @@ import (
 
 // Options is the options interface for the uninitialized source.
 type Options interface {
-	// Validate validates the options are correct.
-	Validate() error
-
 	// SetResultOptions sets the result options
 	SetResultOptions(value result.Options) Options
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/types.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/types.go
@@ -20,10 +20,19 @@
 
 package uninitialized
 
-import "github.com/m3db/m3x/instrument"
+import (
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	"github.com/m3db/m3x/instrument"
+)
 
 // Options is the options interface for the uninitialized source.
 type Options interface {
+	// SetResultOptions sets the result options
+	SetResultOptions(value result.Options) Options
+
+	// ResultOptions returns the result options
+	ResultOptions() result.Options
+
 	// Return the instrument options.
 	InstrumentOptions() instrument.Options
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/types.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/types.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package uninitialized
+
+import "github.com/m3db/m3x/instrument"
+
+// Options is the options interface for the uninitialized source.
+type Options interface {
+	// Return the instrument options.
+	InstrumentOptions() instrument.Options
+
+	// Set the instrument options.
+	SetInstrumentOptions(value instrument.Options) Options
+
+	// Validate validates the options are correct.
+	Validate() error
+}

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -132,7 +132,7 @@ func (b *bootstrapProcessProvider) newInitialTopologyState() (*topology.StateSna
 				topologyState.ShardStates[shardID] = existing
 			}
 
-			hostID := topology.HostID(hostShardSet.Host().String())
+			hostID := topology.HostID(hostShardSet.Host().ID())
 			existing[hostID] = topology.HostShardState{
 				Host:       hostShardSet.Host(),
 				ShardState: currShard.State(),

--- a/src/dbnode/storage/bootstrap/result/result_data_test.go
+++ b/src/dbnode/storage/bootstrap/result/result_data_test.go
@@ -363,7 +363,7 @@ func TestShardTimeRangesCopy(t *testing.T) {
 	assert.True(t, str.Equal(copied))
 }
 
-func TestShardTimeRangesToUnfulfilledResult(t *testing.T) {
+func TestShardTimeRangesToUnfulfilledDataResult(t *testing.T) {
 	str := ShardTimeRanges{
 		0: xtime.NewRanges(xtime.Range{
 			Start: time.Now(),
@@ -374,7 +374,7 @@ func TestShardTimeRangesToUnfulfilledResult(t *testing.T) {
 			End:   time.Now().Add(4 * time.Minute),
 		}),
 	}
-	r := str.ToUnfulfilledResult()
+	r := str.ToUnfulfilledDataResult()
 	assert.Equal(t, 0, len(r.ShardResults()))
 	assert.True(t, r.Unfulfilled().Equal(str))
 }

--- a/src/dbnode/storage/bootstrap/result/result_index_test.go
+++ b/src/dbnode/storage/bootstrap/result/result_index_test.go
@@ -135,6 +135,22 @@ func TestIndexResultAdd(t *testing.T) {
 	require.Equal(t, testRanges, results.Unfulfilled())
 }
 
+func TestShardTimeRangesToUnfulfilledIndexResult(t *testing.T) {
+	str := ShardTimeRanges{
+		0: xtime.NewRanges(xtime.Range{
+			Start: time.Now(),
+			End:   time.Now().Add(time.Minute),
+		}),
+		1: xtime.NewRanges(xtime.Range{
+			Start: time.Now().Add(3 * time.Minute),
+			End:   time.Now().Add(4 * time.Minute),
+		}),
+	}
+	r := str.ToUnfulfilledIndexResult()
+	assert.Equal(t, 0, len(r.IndexResults()))
+	assert.True(t, r.Unfulfilled().Equal(str))
+}
+
 func TestIndexResulsMarkFulfilled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/src/dbnode/storage/bootstrap/result/shard_ranges.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges.go
@@ -99,13 +99,21 @@ func (r ShardTimeRanges) AddRanges(other ShardTimeRanges) {
 	}
 }
 
-// ToUnfulfilledResult will return a result that is comprised of wholly
+// ToUnfulfilledDataResult will return a result that is comprised of wholly
 // unfufilled time ranges from the set of shard time ranges.
-func (r ShardTimeRanges) ToUnfulfilledResult() DataBootstrapResult {
+func (r ShardTimeRanges) ToUnfulfilledDataResult() DataBootstrapResult {
 	result := NewDataBootstrapResult()
 	for shard, ranges := range r {
 		result.Add(shard, nil, ranges)
 	}
+	return result
+}
+
+// ToUnfulfilledIndexResult will return a result that is comprised of wholly
+// unfufilled time ranges from the set of shard time ranges.
+func (r ShardTimeRanges) ToUnfulfilledIndexResult() IndexBootstrapResult {
+	result := NewIndexBootstrapResult()
+	result.SetUnfulfilled(r)
 	return result
 }
 

--- a/src/dbnode/topology/testutil/topology.go
+++ b/src/dbnode/topology/testutil/topology.go
@@ -29,6 +29,7 @@ import (
 )
 
 const (
+	// SelfID is the string used to represent the ID of the origin node.
 	SelfID = "self"
 )
 

--- a/src/query/benchmark/benchmarker/main/m3dbnode-local-config.yaml
+++ b/src/query/benchmark/benchmarker/main/m3dbnode-local-config.yaml
@@ -51,7 +51,7 @@ bootstrap:
       - filesystem
       - commitlog
       - peers
-      - uninitialized
+      - uninitialized_topology
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/benchmarker/main/m3dbnode-local-config.yaml
+++ b/src/query/benchmark/benchmarker/main/m3dbnode-local-config.yaml
@@ -50,6 +50,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - uninitialized
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/benchmarker/main/m3dbnode-local-config.yaml
+++ b/src/query/benchmark/benchmarker/main/m3dbnode-local-config.yaml
@@ -50,6 +50,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - peers
       - uninitialized
   fs:
       numProcessorsPerCPU: 0.125

--- a/src/query/benchmark/configs/m3db_config.yaml
+++ b/src/query/benchmark/configs/m3db_config.yaml
@@ -50,7 +50,7 @@ bootstrap:
         - filesystem
         - commitlog
         - peers
-        - uninitialized
+        - uninitialized_topology
     fs:
         numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/configs/m3db_config.yaml
+++ b/src/query/benchmark/configs/m3db_config.yaml
@@ -49,6 +49,7 @@ bootstrap:
     bootstrappers:
         - filesystem
         - commitlog
+        - peers
         - uninitialized
     fs:
         numProcessorsPerCPU: 0.125

--- a/src/query/benchmark/configs/m3db_config.yaml
+++ b/src/query/benchmark/configs/m3db_config.yaml
@@ -49,6 +49,7 @@ bootstrap:
     bootstrappers:
         - filesystem
         - commitlog
+        - uninitialized
     fs:
         numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server1-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server1-config.yaml
@@ -48,6 +48,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - peers
       - uninitialized
   fs:
       numProcessorsPerCPU: 0.125

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server1-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server1-config.yaml
@@ -49,7 +49,7 @@ bootstrap:
       - filesystem
       - commitlog
       - peers
-      - uninitialized
+      - uninitialized_topology
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server1-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server1-config.yaml
@@ -48,6 +48,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - uninitialized
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server2-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server2-config.yaml
@@ -48,6 +48,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - peers
       - uninitialized
   fs:
       numProcessorsPerCPU: 0.125

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server2-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server2-config.yaml
@@ -49,7 +49,7 @@ bootstrap:
       - filesystem
       - commitlog
       - peers
-      - uninitialized
+      - uninitialized_topology
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server2-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server2-config.yaml
@@ -48,6 +48,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - uninitialized
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server3-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server3-config.yaml
@@ -48,6 +48,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - peers
       - uninitialized
   fs:
       numProcessorsPerCPU: 0.125

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server3-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server3-config.yaml
@@ -49,7 +49,7 @@ bootstrap:
       - filesystem
       - commitlog
       - peers
-      - uninitialized
+      - uninitialized_topology
   fs:
       numProcessorsPerCPU: 0.125
 

--- a/src/query/benchmark/configs/multi_node_setup/m3dbnode-server3-config.yaml
+++ b/src/query/benchmark/configs/multi_node_setup/m3dbnode-server3-config.yaml
@@ -48,6 +48,7 @@ bootstrap:
   bootstrappers:
       - filesystem
       - commitlog
+      - uninitialized
   fs:
       numProcessorsPerCPU: 0.125
 


### PR DESCRIPTION
- [X] Add a new "uninitialized" bootstrapper which can be added to the end of the bootstrapping process and will only succeed bootstraps for uninitialized topologies
- [X] Add logic to the commit log bootstrapper to only announce that it can succeed a bootstrap if the requested shard is marked as "Available" for itself in the topology
- [X] General refactoring for code sharing
- [X] Update example config files to use bootstrappers: filesystem,commitlog,peers,uninitialized

I also tested the following flows on the test cluster (with bootstrapping configuration filesystem,commitlog,peers,uninitialized):

- [X] Turn off all nodes, create new topology, create new namespace,  turn on all nodes and make sure they're able to start
- [X] Do a node remove and make sure bootstrap succeeds
- [X] Do a node add and make sure bootstrap succeeds
- [X] Roll the entire cluster and make sure each node is able to bootstrap

We will need to address #900 in a separate P.R