### PR TITLE
Only use signal channel if running embedded

### DIFF
--- a/src/query/functions/temporal/functions_test.go
+++ b/src/query/functions/temporal/functions_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/executor/transform"
+	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/parser"
 	"github.com/m3db/m3/src/query/test"
 	"github.com/m3db/m3/src/query/test/executor"
@@ -167,7 +167,7 @@ func testTemporalFunc(t *testing.T, testCases []testCase) {
 
 			original := values[0][0]
 			values[0][0] = math.NaN()
-			block1 := test.NewBlockFromValues(block.Bounds{
+			block1 := test.NewBlockFromValues(models.Bounds{
 				Start:    bounds.Start.Add(-2 * bounds.Duration),
 				Duration: bounds.Duration,
 				StepSize: bounds.StepSize,
@@ -184,7 +184,7 @@ func testTemporalFunc(t *testing.T, testCases []testCase) {
 			_, exists = bNode.cache.get(boundStart.Add(-1 * bounds.Duration))
 			assert.False(t, exists, "block cached")
 
-			block2 := test.NewBlockFromValues(block.Bounds{
+			block2 := test.NewBlockFromValues(models.Bounds{
 				Start:    bounds.Start.Add(-1 * bounds.Duration),
 				Duration: bounds.Duration,
 				StepSize: bounds.StepSize,

--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -203,9 +203,7 @@ func Run(runOpts RunOptions) {
 
 	var interruptErr error
 	if runOpts.DBConfig != nil {
-		select {
-		case interruptErr = <-interruptCh:
-		}
+		interruptErr = <-interruptCh
 	} else {
 		// Only use this if running standalone, as otherwise it will
 		// obfuscate signal channel for the db


### PR DESCRIPTION
Fixes an issue where m3 can hang if stopped during initialization