### PR TITLE
Timeout topology watch and return better error messages for missing topology / namespaces

### DIFF
--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -332,8 +332,6 @@ db:
       service: null
       static: null
       seedNodes: null
-      namespaceResolutionTimeout: 0s
-      topologyResolutionTimeout: 0s
     writeConsistencyLevel: 2
     readConsistencyLevel: 2
     connectConsistencyLevel: 0
@@ -577,8 +575,6 @@ db:
         trustedCaFile: ""
         clientCertAuth: false
         autoTls: false
-    namespaceResolutionTimeout: 0s
-    topologyResolutionTimeout: 0s
   hashing:
     seed: 42
   writeNewSeriesAsync: true

--- a/src/dbnode/environment/config.go
+++ b/src/dbnode/environment/config.go
@@ -130,7 +130,9 @@ func (c Configuration) Configure(cfgParams ConfigurationParameters) (ConfigureRe
 func (c Configuration) configureDynamic(cfgParams ConfigurationParameters) (ConfigureResults, error) {
 	configSvcClientOpts := c.Service.NewOptions().
 		SetInstrumentOptions(cfgParams.InstrumentOpts).
-		SetServicesOptions(services.NewOptions())
+		// Set timeout to zero so it will wait indefinitely for the
+		// initial value.
+		SetServicesOptions(services.NewOptions().SetInitTimeout(0))
 	configSvcClient, err := etcdclient.NewConfigServiceClient(configSvcClientOpts)
 	if err != nil {
 		err = fmt.Errorf("could not create m3cluster client: %v", err)

--- a/src/dbnode/environment/config.go
+++ b/src/dbnode/environment/config.go
@@ -23,7 +23,6 @@ package environment
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/m3db/m3/src/dbnode/kvconfig"
 	"github.com/m3db/m3/src/dbnode/sharding"
@@ -36,10 +35,6 @@ import (
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3x/instrument"
-)
-
-const (
-	defaultSDTimeout = time.Duration(0) // Wait indefinitely by default
 )
 
 var (

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -403,7 +403,7 @@ func Run(runOpts RunOptions) {
 
 	topo, err := envCfg.TopologyInitializer.Init()
 	if err != nil {
-		logger.Fatalf("could not initialize m3db topology: %v. make sure a topology has been set", err)
+		logger.Fatalf("could not initialize m3db topology: %v", err)
 	}
 
 	m3dbClient, err := cfg.Client.NewAdminClient(

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -80,9 +80,8 @@ import (
 )
 
 const (
-	bootstrapConfigInitTimeout            = 10 * time.Second
-	serverGracefulCloseTimeout            = 10 * time.Second
-	defaultDynamicConfigResolutionTimeout = time.Minute
+	bootstrapConfigInitTimeout = 10 * time.Second
+	serverGracefulCloseTimeout = 10 * time.Second
 )
 
 // RunOptions provides options for running the server
@@ -377,15 +376,9 @@ func Run(runOpts RunOptions) {
 	if cfg.EnvironmentConfig.Static == nil {
 		logger.Info("creating dynamic config service client with m3cluster")
 
-		dynamicConfigResolutionTimeout := cfg.EnvironmentConfig.ResolutionTime
-		if dynamicConfigResolutionTimeout <= 0 {
-			dynamicConfigResolutionTimeout = defaultDynamicConfigResolutionTimeout
-		}
-
 		envCfg, err = cfg.EnvironmentConfig.Configure(environment.ConfigurationParameters{
-			InstrumentOpts:    iopts,
-			HashingSeed:       cfg.Hashing.Seed,
-			ResolutionTimeout: dynamicConfigResolutionTimeout,
+			InstrumentOpts: iopts,
+			HashingSeed:    cfg.Hashing.Seed,
 		})
 		if err != nil {
 			logger.Fatalf("could not initialize dynamic config: %v", err)

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -166,7 +166,7 @@ func NewDatabase(
 	logger.Info("creating namespaces watch")
 	nsReg, err := nsInit.Init()
 	if err != nil {
-		return nil, fmt.Errorf("database: namespace initialized failed: %v. make sure a namespace has been set")
+		return nil, err
 	}
 
 	// get a namespace watch

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -166,7 +166,7 @@ func NewDatabase(
 	logger.Info("creating namespaces watch")
 	nsReg, err := nsInit.Init()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("database: namespace initialized failed: %v. make sure a namespace has been set")
 	}
 
 	// get a namespace watch

--- a/src/dbnode/storage/namespace/dynamic.go
+++ b/src/dbnode/storage/namespace/dynamic.go
@@ -34,7 +34,6 @@ import (
 )
 
 var (
-	errInitTimeOut           = errors.New("timed out waiting for initial value")
 	errRegistryAlreadyClosed = errors.New("registry already closed")
 	errInvalidRegistry       = errors.New("could not parse latest value from config service")
 )

--- a/src/dbnode/storage/namespace/dynamic_options.go
+++ b/src/dbnode/storage/namespace/dynamic_options.go
@@ -97,13 +97,3 @@ func (o *dynamicOpts) SetNamespaceRegistryKey(k string) DynamicOptions {
 func (o *dynamicOpts) NamespaceRegistryKey() string {
 	return o.nsRegistryKey
 }
-
-func (o *dynamicOpts) SetInitTimeout(value time.Duration) DynamicOptions {
-	opts := *o
-	opts.initTimeout = value
-	return &opts
-}
-
-func (o *dynamicOpts) InitTimeout() time.Duration {
-	return o.initTimeout
-}

--- a/src/dbnode/storage/namespace/dynamic_test.go
+++ b/src/dbnode/storage/namespace/dynamic_test.go
@@ -54,7 +54,6 @@ func newTestOpts(t *testing.T, ctrl *gomock.Controller, watchable kv.ValueWatcha
 			instrument.NewOptions().
 				SetReportInterval(10 * time.Millisecond).
 				SetMetricsScope(ts)).
-		SetInitTimeout(100 * time.Millisecond).
 		SetConfigServiceClient(mockCSClient)
 
 	return opts

--- a/src/dbnode/storage/namespace/dynamic_test.go
+++ b/src/dbnode/storage/namespace/dynamic_test.go
@@ -77,20 +77,6 @@ func currentVersionMetrics(opts DynamicOptions) float64 {
 	return g.Value()
 }
 
-func TestInitializerTimeout(t *testing.T) {
-	defer leaktest.CheckTimeout(t, time.Second)()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	w := newTestWatchable(t, nil)
-	opts := newTestOpts(t, ctrl, w)
-	init := NewDynamicInitializer(opts)
-	_, err := init.Init()
-	require.Error(t, err)
-	require.Equal(t, errInitTimeOut, err)
-}
-
 func TestInitializerNoTimeout(t *testing.T) {
 	defer leaktest.CheckTimeout(t, time.Second)()
 

--- a/src/dbnode/storage/namespace/namespace_mock.go
+++ b/src/dbnode/storage/namespace/namespace_mock.go
@@ -738,27 +738,3 @@ func (m *MockDynamicOptions) NamespaceRegistryKey() string {
 func (mr *MockDynamicOptionsMockRecorder) NamespaceRegistryKey() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceRegistryKey", reflect.TypeOf((*MockDynamicOptions)(nil).NamespaceRegistryKey))
 }
-
-// SetInitTimeout mocks base method
-func (m *MockDynamicOptions) SetInitTimeout(value time.Duration) DynamicOptions {
-	ret := m.ctrl.Call(m, "SetInitTimeout", value)
-	ret0, _ := ret[0].(DynamicOptions)
-	return ret0
-}
-
-// SetInitTimeout indicates an expected call of SetInitTimeout
-func (mr *MockDynamicOptionsMockRecorder) SetInitTimeout(value interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInitTimeout", reflect.TypeOf((*MockDynamicOptions)(nil).SetInitTimeout), value)
-}
-
-// InitTimeout mocks base method
-func (m *MockDynamicOptions) InitTimeout() time.Duration {
-	ret := m.ctrl.Call(m, "InitTimeout")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// InitTimeout indicates an expected call of InitTimeout
-func (mr *MockDynamicOptionsMockRecorder) InitTimeout() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitTimeout", reflect.TypeOf((*MockDynamicOptions)(nil).InitTimeout))
-}

--- a/src/dbnode/storage/namespace/types.go
+++ b/src/dbnode/storage/namespace/types.go
@@ -182,10 +182,4 @@ type DynamicOptions interface {
 	// NamespaceRegistryKey returns the kv-store key used for the
 	// NamespaceRegistry
 	NamespaceRegistryKey() string
-
-	// SetInitTimeout sets the waiting time for dynamic topology to be initialized
-	SetInitTimeout(value time.Duration) DynamicOptions
-
-	// InitTimeout returns the waiting time for dynamic topology to be initialized
-	InitTimeout() time.Duration
 }

--- a/src/dbnode/topology/dynamic.go
+++ b/src/dbnode/topology/dynamic.go
@@ -90,18 +90,15 @@ func newDynamicTopology(opts DynamicOptions) (DynamicTopology, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Watch will wait for an initial value so we don't need to do that
+	// in this function.
 	watch, err := services.Watch(opts.ServiceID(), opts.QueryOptions())
 	if err != nil {
 		return nil, err
 	}
 
 	logger := opts.InstrumentOptions().Logger()
-	if err = waitOnInit(watch, opts.InitTimeout()); err != nil {
-		logger.Errorf("dynamic topology initialization timed out in %s: %v",
-			opts.InitTimeout().String(), err)
-		return nil, err
-	}
-
 	m, err := getMapFromUpdate(watch.Get(), opts.HashGen())
 	if err != nil {
 		logger.Errorf("dynamic topology received invalid initial value: %v",

--- a/src/dbnode/topology/dynamic.go
+++ b/src/dbnode/topology/dynamic.go
@@ -33,7 +33,6 @@ import (
 )
 
 var (
-	errInitTimeOut               = errors.New("timed out waiting for initial value")
 	errInvalidService            = errors.New("service topology is invalid")
 	errUnexpectedShard           = errors.New("shard is unexpected")
 	errMissingShard              = errors.New("shard is missing")

--- a/src/dbnode/topology/dynamic.go
+++ b/src/dbnode/topology/dynamic.go
@@ -23,7 +23,6 @@ package topology
 import (
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3cluster/placement"
@@ -183,19 +182,6 @@ func (t *dynamicTopology) MarkShardsAvailable(
 		return err
 	}
 	return ps.MarkShardsAvailable(instanceID, shardIDs...)
-}
-
-func waitOnInit(w services.Watch, d time.Duration) error {
-	if d <= 0 {
-		<-w.C() // Wait for the first placement indefinitely
-		return nil
-	}
-	select {
-	case <-w.C():
-		return nil
-	case <-time.After(d):
-		return errInitTimeOut
-	}
 }
 
 func getMapFromUpdate(data interface{}, hashGen sharding.HashGen) (Map, error) {

--- a/src/dbnode/topology/dynamic.go
+++ b/src/dbnode/topology/dynamic.go
@@ -91,14 +91,17 @@ func newDynamicTopology(opts DynamicOptions) (DynamicTopology, error) {
 		return nil, err
 	}
 
+	logger := opts.InstrumentOptions().Logger()
+	logger.Info(`waiting for dynamic topology initialization.
+		If this takes a long time, make sure that a topology / placement is configured`)
 	// Watch will wait for an initial value so we don't need to do that
 	// in this function.
 	watch, err := services.Watch(opts.ServiceID(), opts.QueryOptions())
 	if err != nil {
 		return nil, err
 	}
+	logger.Info("initial topology / placement value received")
 
-	logger := opts.InstrumentOptions().Logger()
 	m, err := getMapFromUpdate(watch.Get(), opts.HashGen())
 	if err != nil {
 		logger.Errorf("dynamic topology received invalid initial value: %v",

--- a/src/dbnode/topology/dynamic.go
+++ b/src/dbnode/topology/dynamic.go
@@ -93,12 +93,11 @@ func newDynamicTopology(opts DynamicOptions) (DynamicTopology, error) {
 	logger := opts.InstrumentOptions().Logger()
 	logger.Info(`waiting for dynamic topology initialization.
 		If this takes a long time, make sure that a topology / placement is configured`)
-	// Watch will wait for an initial value so we don't need to do that
-	// in this function.
 	watch, err := services.Watch(opts.ServiceID(), opts.QueryOptions())
 	if err != nil {
 		return nil, err
 	}
+	<-watch.C()
 	logger.Info("initial topology / placement value received")
 
 	m, err := getMapFromUpdate(watch.Get(), opts.HashGen())

--- a/src/dbnode/topology/dynamic_test.go
+++ b/src/dbnode/topology/dynamic_test.go
@@ -54,16 +54,6 @@ func testFinish(ctrl *gomock.Controller, watch *testWatch) {
 	ctrl.Finish()
 }
 
-func TestInitTimeout(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	opts, w := testSetup(ctrl)
-	defer testFinish(ctrl, w)
-
-	topo, err := newDynamicTopology(opts)
-	assert.Equal(t, errInitTimeOut, err)
-	assert.Nil(t, topo)
-}
-
 func TestInitNoTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	opts, w := testSetup(ctrl)

--- a/src/dbnode/topology/dynamic_test.go
+++ b/src/dbnode/topology/dynamic_test.go
@@ -59,7 +59,7 @@ func TestInitTimeout(t *testing.T) {
 	opts, w := testSetup(ctrl)
 	defer testFinish(ctrl, w)
 
-	topo, err := newDynamicTopology(opts.SetInitTimeout(10 * time.Millisecond))
+	topo, err := newDynamicTopology(opts)
 	assert.Equal(t, errInitTimeOut, err)
 	assert.Nil(t, topo)
 }

--- a/src/dbnode/topology/options.go
+++ b/src/dbnode/topology/options.go
@@ -194,15 +194,6 @@ func (o *dynamicOptions) InstrumentOptions() instrument.Options {
 	return o.instrumentOptions
 }
 
-func (o *dynamicOptions) SetInitTimeout(value time.Duration) DynamicOptions {
-	o.initTimeout = value
-	return o
-}
-
-func (o *dynamicOptions) InitTimeout() time.Duration {
-	return o.initTimeout
-}
-
 func (o *dynamicOptions) SetHashGen(h sharding.HashGen) DynamicOptions {
 	o.hashGen = h
 	return o

--- a/src/dbnode/topology/topology_mock.go
+++ b/src/dbnode/topology/topology_mock.go
@@ -26,7 +26,6 @@ package topology
 
 import (
 	"reflect"
-	"time"
 
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3cluster/client"
@@ -788,30 +787,6 @@ func (m *MockDynamicOptions) InstrumentOptions() instrument.Options {
 // InstrumentOptions indicates an expected call of InstrumentOptions
 func (mr *MockDynamicOptionsMockRecorder) InstrumentOptions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstrumentOptions", reflect.TypeOf((*MockDynamicOptions)(nil).InstrumentOptions))
-}
-
-// SetInitTimeout mocks base method
-func (m *MockDynamicOptions) SetInitTimeout(value time.Duration) DynamicOptions {
-	ret := m.ctrl.Call(m, "SetInitTimeout", value)
-	ret0, _ := ret[0].(DynamicOptions)
-	return ret0
-}
-
-// SetInitTimeout indicates an expected call of SetInitTimeout
-func (mr *MockDynamicOptionsMockRecorder) SetInitTimeout(value interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInitTimeout", reflect.TypeOf((*MockDynamicOptions)(nil).SetInitTimeout), value)
-}
-
-// InitTimeout mocks base method
-func (m *MockDynamicOptions) InitTimeout() time.Duration {
-	ret := m.ctrl.Call(m, "InitTimeout")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// InitTimeout indicates an expected call of InitTimeout
-func (mr *MockDynamicOptionsMockRecorder) InitTimeout() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitTimeout", reflect.TypeOf((*MockDynamicOptions)(nil).InitTimeout))
 }
 
 // SetHashGen mocks base method

--- a/src/dbnode/topology/types.go
+++ b/src/dbnode/topology/types.go
@@ -21,8 +21,6 @@
 package topology
 
 import (
-	"time"
-
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/services"
@@ -204,12 +202,6 @@ type DynamicOptions interface {
 
 	// InstrumentOptions returns the instrumentation options
 	InstrumentOptions() instrument.Options
-
-	// SetInitTimeout sets the waiting time for dynamic topology to be initialized
-	SetInitTimeout(value time.Duration) DynamicOptions
-
-	// InitTimeout returns the waiting time for dynamic topology to be initialized
-	InitTimeout() time.Duration
 
 	// SetHashGen sets the HashGen function
 	SetHashGen(h sharding.HashGen) DynamicOptions


### PR DESCRIPTION
We weren't passing a timeout properly to the ServiceClient so:

```golang
watch, err := services.Watch(opts.ServiceID(), opts.QueryOptions())
```

would hang forever if there was no topology.

In addition, in the case where there is no topology or namespace the error message is cryptic (timeout) when it could be slightly more helpful