### PR TITLE
Refactor peers source to not emit error logs when it should not

### DIFF
--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -37,6 +37,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3cluster/shard"
 	"github.com/m3db/m3x/context"
+	"github.com/m3db/m3x/instrument"
 	xlog "github.com/m3db/m3x/log"
 	xsync "github.com/m3db/m3x/sync"
 	xtime "github.com/m3db/m3x/time"
@@ -484,49 +485,44 @@ func (s *peersSource) flush(
 		}
 	}
 
-	if seriesCachePolicy != series.CacheAll && seriesCachePolicy != series.CacheAllMetadata {
-		// TODO: We need this right now because nodes with older versions of M3DB will return an extra
-		// block when requesting bootstrapped blocks. Once all the clusters have been upgraded we can
-		// remove this code.
-		for _, entry := range shardResult.AllSeries().Iter() {
-			s := entry.Value()
-			bl, ok := s.Blocks.BlockAt(tr.End)
-			if !ok {
-				continue
-			}
-			s.Blocks.RemoveBlockAt(tr.End)
-			bl.Close()
+	if seriesCachePolicy == series.CacheAll ||
+		seriesCachePolicy == series.CacheAllMetadata ||
+		persistConfig.FileSetType == persist.FileSetSnapshotType {
+		// In all three of these cases we still need to keep all of the metadata in memory
+		// so we can return early.
+		return nil
+	}
+
+	// If we're not going to keep all of the data, or at least all of the metadata in memory
+	// then we don't want to keep these series in the shard result. If we leave them in, then
+	// they will all get loaded into the shard object, and then immediately evicted on the next
+	// tick which causes unnecessary memory pressure.
+	numSeriesTriedToRemoveWithRemainingBlocks := 0
+	for _, entry := range shardResult.AllSeries().Iter() {
+		series := entry.Value()
+		numBlocksRemaining := len(series.Blocks.AllBlocks())
+		// Should never happen since we removed all the block in the previous loop and fetching
+		// bootstrap blocks should always be exclusive on the end side.
+		if numBlocksRemaining > 0 {
+			numSeriesTriedToRemoveWithRemainingBlocks++
+			continue
 		}
 
-		// If we're not going to keep all of the data, or at least all of the metadata in memory
-		// then we don't want to keep these series in the shard result. If we leave them in, then
-		// they will all get loaded into the shard object, and then immediately evicted on the next
-		// tick which causes unnecessary memory pressure.
-		numSeriesTriedToRemoveWithRemainingBlocks := 0
-		for _, entry := range shardResult.AllSeries().Iter() {
-			series := entry.Value()
-			numBlocksRemaining := len(series.Blocks.AllBlocks())
-			// Should never happen since we removed all the block in the previous loop and fetching
-			// bootstrap blocks should always be exclusive on the end side.
-			if numBlocksRemaining > 0 {
-				numSeriesTriedToRemoveWithRemainingBlocks++
-				continue
-			}
-
-			shardResult.RemoveSeries(series.ID)
-			series.Blocks.Close()
-			// Safe to finalize these IDs and Tags because the prepared object was the only other thing
-			// using them, and it has been closed.
-			series.ID.Finalize()
-			series.Tags.Finalize()
-		}
-		if numSeriesTriedToRemoveWithRemainingBlocks > 0 {
-			s.log.WithFields(
+		shardResult.RemoveSeries(series.ID)
+		series.Blocks.Close()
+		// Safe to finalize these IDs and Tags because the prepared object was the only other thing
+		// using them, and it has been closed.
+		series.ID.Finalize()
+		series.Tags.Finalize()
+	}
+	if numSeriesTriedToRemoveWithRemainingBlocks > 0 {
+		iOpts := s.opts.ResultOptions().InstrumentOptions()
+		instrument.EmitInvariantViolationAndGetLogger(iOpts).
+			WithFields(
 				xlog.NewField("start", tr.Start.Unix()),
 				xlog.NewField("end", tr.End.Unix()),
 				xlog.NewField("numTimes", numSeriesTriedToRemoveWithRemainingBlocks),
 			).Error("error tried to remove series that still has blocks")
-		}
 	}
 
 	return nil


### PR DESCRIPTION
A recent change to the peers bootstrapper source caused it to begin emitting error logs when it should not. The reason it was emitting errors was because normally when we perform an incremental flush, we then remove all the series and blocks from the bootstrap result so that they don't get loaded into memory for no reason (increasing memory pressure).

Now that we've added the concept of a "snapshot" flush, the peers bootstrapper source needs to be aware that it should not remove series/data from memory when its doing an incremental flush that is of type snapshot, because the node is still expecting all that data to be returned for the active block. The existing code detected that the series that it was trying to remove still had data blocks in them, so it emitted an error log instead of removing them. 

Correct behavior of this functionality is already tested in a combination of unit and integration tests, and all the tests passed because the defensive code made the bootstrapper do the right thing anyways, but emit an error log.

This P.R refactors the code so that the error logs will not be emitted when they should not be, upgrades the existing error messages to InvariantViolated, and leaves the existing tests intact.

I also went ahead and removed some dead code that was left behind from a previous migration and is no longer required.