### PR TITLE
Set namespace and ID as NoFinalize

### DIFF
--- a/src/query/storage/m3/cluster.go
+++ b/src/query/storage/m3/cluster.go
@@ -290,8 +290,12 @@ func newUnaggregatedClusterNamespace(
 	if err := def.Validate(); err != nil {
 		return nil, err
 	}
+
+	ns := def.NamespaceID
+	// Set namespace to NoFinalize to avoid cloning it in write operations
+	ns.NoFinalize()
 	return &clusterNamespace{
-		namespaceID: def.NamespaceID,
+		namespaceID: ns,
 		options: ClusterNamespaceOptions{
 			attributes: storage.Attributes{
 				MetricsType: storage.UnaggregatedMetricsType,
@@ -308,8 +312,12 @@ func newAggregatedClusterNamespace(
 	if err := def.Validate(); err != nil {
 		return nil, err
 	}
+
+	ns := def.NamespaceID
+	// Set namespace to NoFinalize to avoid cloning it in write operations
+	ns.NoFinalize()
 	return &clusterNamespace{
-		namespaceID: def.NamespaceID,
+		namespaceID: ns,
 		options: ClusterNamespaceOptions{
 			attributes: storage.Attributes{
 				MetricsType: storage.AggregatedMetricsType,

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -257,6 +257,8 @@ func (s *m3storage) Write(
 	id := query.Tags.ID()
 	// TODO: Consider caching id -> identID
 	identID := ident.StringID(id)
+	// Set id to NoFinalize to avoid cloning it in write operations
+	identID.NoFinalize()
 	common := &writeRequestCommon{
 		store:       s,
 		annotation:  query.Annotation,


### PR DESCRIPTION
This allows the session to avoid cloning these on the WriteTagged
operation, which will save two allocations for each datapoint