### PR TITLE
Use dynamic $__interval variable for query step

### DIFF
--- a/integrations/grafana/m3db_dashboard.json
+++ b/integrations/grafana/m3db_dashboard.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1538144350249,
+  "iteration": 1538146205773,
   "links": [],
   "panels": [
     {
@@ -588,7 +588,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": " sum(rate(commitlog_writes_success{instance=~\"$instance\"}[$step]))",
+          "expr": " sum(rate(commitlog_writes_success{instance=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -677,7 +677,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(dbshard_insert_queue_inserts{instance=~\"$instance\"}[$step])) by (pending_write)",
+          "expr": "sum(rate(dbshard_insert_queue_inserts{instance=~\"$instance\"}[$__interval])) by (pending_write)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1094,7 +1094,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(service_writeTaggedBatchRaw_success{instance=~\"$instance\"}[$step]))",
+          "expr": "sum(rate(service_writeTaggedBatchRaw_success{instance=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1104,7 +1104,7 @@
           "textEditor": true
         },
         {
-          "expr": "sum(rate(service_writeTaggedBatchRaw_errors{instance=~\"$instance\"}[$step]))",
+          "expr": "sum(rate(service_writeTaggedBatchRaw_errors{instance=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1114,7 +1114,7 @@
           "textEditor": true
         },
         {
-          "expr": "sum(rate(service_fetchTaggedBatchRaw_success{instance=~\"$instance\"}[$step]))",
+          "expr": "sum(rate(service_fetchTaggedBatchRaw_success{instance=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1124,7 +1124,7 @@
           "textEditor": true
         },
         {
-          "expr": "sum(rate(service_fetchTaggedBatchRaw_errors{instance=~\"$instance\"}[$step]))",
+          "expr": "sum(rate(service_fetchTaggedBatchRaw_errors{instance=~\"$instance\"}[$__interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1400,7 +1400,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[$step])",
+          "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[$__interval])",
           "format": "time_series",
           "intervalFactor": 1,
           "key": 0.7090064740553321,
@@ -2487,7 +2487,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(database_tick_made_expired_blocks{instance=~\"$instance\"}[$step])",
+              "expr": "rate(database_tick_made_expired_blocks{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.12716494400774314,
@@ -2495,21 +2495,21 @@
               "refId": "A"
             },
             {
-              "expr": "rate(database_tick_made_unwired_blocks{instance=~\"$instance\"}[$step])",
+              "expr": "rate(database_tick_made_unwired_blocks{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "madeUnwiredBlocks-{{instance}}",
               "refId": "B"
             },
             {
-              "expr": "rate(database_tick_merged_out_of_order_blocks{instance=~\"$instance\"}[$step])",
+              "expr": "rate(database_tick_merged_out_of_order_blocks{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "mergedOutOfOrderBlocks-{{instance}}",
               "refId": "C"
             },
             {
-              "expr": "rate(database_tick_made_wired_blocks{instance=~\"$instance\"}[$step])",
+              "expr": "rate(database_tick_made_wired_blocks{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "madeWiredBlocks-{{instance}}",
@@ -2594,7 +2594,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(database_series_encoder_created{instance=~\"$instance\"}[$step])",
+              "expr": "rate(database_series_encoder_created{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.12716494400774314,
@@ -2786,7 +2786,7 @@
               "refId": "A"
             },
             {
-              "expr": "rate(wired_list_evicted{instance=~\"$instance\"}[$step])",
+              "expr": "rate(wired_list_evicted{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "B"
@@ -3157,7 +3157,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(database_write_tagged_success{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_write_tagged_success{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3167,7 +3167,7 @@
               "textEditor": true
             },
             {
-              "expr": "sum(rate(database_write_tagged_errors{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_write_tagged_errors{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.8767351594065642,
@@ -3175,7 +3175,7 @@
               "refId": "A"
             },
             {
-              "expr": "sum(rate(database_write_success{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_write_success{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.8767351594065642,
@@ -3183,7 +3183,7 @@
               "refId": "B"
             },
             {
-              "expr": "sum(rate(database_write_errors{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_write_errors{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.8767351594065642,
@@ -3270,7 +3270,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(database_read_tagged_success{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_read_tagged_success{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3280,7 +3280,7 @@
               "textEditor": true
             },
             {
-              "expr": "sum(rate(database_read_tagged_errors{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_read_tagged_errors{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.8767351594065642,
@@ -3288,7 +3288,7 @@
               "refId": "A"
             },
             {
-              "expr": "sum(rate(database_read_success{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_read_success{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.8767351594065642,
@@ -3296,7 +3296,7 @@
               "refId": "B"
             },
             {
-              "expr": "sum(rate(database_reads_errors{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_reads_errors{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.8767351594065642,
@@ -3383,7 +3383,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(database_queryIDs_success{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_queryIDs_success{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3393,7 +3393,7 @@
               "textEditor": true
             },
             {
-              "expr": "sum(rate(database_queryIDs_errors{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(rate(database_queryIDs_errors{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "hide": true,
               "intervalFactor": 1,
@@ -3481,7 +3481,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(database_flush_success{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(increase(database_flush_success{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3491,7 +3491,7 @@
               "textEditor": true
             },
             {
-              "expr": "sum(increase(database_flush_errors{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(increase(database_flush_errors{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3580,7 +3580,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(increase(database_index_flush_success{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(increase(database_index_flush_success{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -3590,7 +3590,7 @@
               "textEditor": true
             },
             {
-              "expr": "sum(increase(database_index_flush_errors{instance=~\"$instance\"}[$step])) by (namespace)",
+              "expr": "sum(increase(database_index_flush_errors{instance=~\"$instance\"}[$__interval])) by (namespace)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{namespace}}_index_flush_errors",
@@ -3949,7 +3949,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_metadata_peers_batch_call{instance=~\"$instance\"}[$step])) by (instance)",
+              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_metadata_peers_batch_call{instance=~\"$instance\"}[$__interval])) by (instance)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.8052472520531426,
@@ -4035,7 +4035,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_metadata_peers_received{instance=~\"$instance\"}[$step])) by (host)",
+              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_metadata_peers_received{instance=~\"$instance\"}[$__interval])) by (host)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.359145903986988,
@@ -4121,7 +4121,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_metadata_peers_peer_retry{instance=~\"$instance\"}[$step])) by (instance)",
+              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_metadata_peers_peer_retry{instance=~\"$instance\"}[$__interval])) by (instance)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.359145903986988,
@@ -4222,7 +4222,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(service_overload_rejected{instance=~\"$instance\"}[$step])",
+              "expr": "rate(service_overload_rejected{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.05455062296227564,
@@ -4414,7 +4414,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_block_success{instance=~\"$instance\"}[$step])) by (instance)",
+              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_block_success{instance=~\"$instance\"}[$__interval])) by (instance)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.4195302108331671,
@@ -4500,7 +4500,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_block_error{instance=~\"$instance\"}[$step])) by (instance)",
+              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_block_error{instance=~\"$instance\"}[$__interval])) by (instance)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.7411861401478703,
@@ -4586,7 +4586,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_block_full_retry{instance=~\"$instance\"}[$step])) by (instance)",
+              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_block_full_retry{instance=~\"$instance\"}[$__interval])) by (instance)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.3848186046051656,
@@ -4672,7 +4672,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_block_final_error{instance=~\"$instance\"}[$step])) by (instance)",
+              "expr": "sum(rate(m3dbclient_stream_from_peers_fetch_block_final_error{instance=~\"$instance\"}[$__interval])) by (instance)",
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.3848186046051656,
@@ -5163,14 +5163,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(dbindex_insert_queue_index_queue_num_pending{instance=~\"$instance\"}[$step])",
+              "expr": "rate(dbindex_insert_queue_index_queue_num_pending{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
               "refId": "A"
             },
             {
-              "expr": "rate(dbindex_index_error{instance=~\"$instance\"}[$step])",
+              "expr": "rate(dbindex_index_error{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "B"
@@ -5690,13 +5690,13 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "increase(database_tick_index_num_blocks_evicted{instance=~\"$instance\"}[$step])",
+              "expr": "increase(database_tick_index_num_blocks_evicted{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
             },
             {
-              "expr": "increase(database_tick_index_num_blocks_sealed{instance=~\"$instance\"}[$step])",
+              "expr": "increase(database_tick_index_num_blocks_sealed{instance=~\"$instance\"}[$__interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "B"
@@ -5748,7 +5748,7 @@
       "type": "row"
     }
   ],
-  "refresh": false,
+  "refresh": "1m",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
@@ -5863,43 +5863,6 @@
       },
       {
         "allValue": null,
-        "current": {
-          "selected": true,
-          "text": "30s",
-          "value": "30s"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "step",
-        "multi": false,
-        "name": "step",
-        "options": [
-          {
-            "selected": true,
-            "text": "30s",
-            "value": "30s"
-          },
-          {
-            "selected": false,
-            "text": "1m",
-            "value": "1m"
-          },
-          {
-            "selected": false,
-            "text": "5m",
-            "value": "5m"
-          },
-          {
-            "selected": false,
-            "text": "10m",
-            "value": "10m"
-          }
-        ],
-        "query": "30s,1m,5m,10m",
-        "type": "custom"
-      },
-      {
-        "allValue": null,
         "current": {},
         "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
@@ -5953,5 +5916,5 @@
   "timezone": "browser",
   "title": "M3DB Node Details",
   "uid": "99SFck0iz",
-  "version": 4
+  "version": 8
 }


### PR DESCRIPTION
This fix uses `$__interval` variable to calculate query step. It won't go below 2*scrape interval, so you will always get a graph, but it will try to pick the best query step given the selected time range and width of the graphs.

More info on http://docs.grafana.org/reference/templating/#the-interval-variable