### PR TITLE
Fix _redirects file

### DIFF
--- a/m3db.io/_redirects
+++ b/m3db.io/_redirects
@@ -1,1 +1,2 @@
-https://docs.m3db.io/* http://m3db.github.io/m3/:splat 200
+https://m3metrics.io/* https://m3db.io/:splat 301!
+https://m3db.netlify.com/* https://m3db.io/:splat 301!


### PR DESCRIPTION
Have redirects from our other domains to `m3db.io`. Docs will have to be served via Netlify [branch subdomains](https://www.netlify.com/docs/custom-domains/#branch-subdomains) in a different PR.
