### PR TITLE
[m3nsch] agent: add dbclient to config; dockerize

### DIFF
--- a/docker/m3nsch/Dockerfile
+++ b/docker/m3nsch/Dockerfile
@@ -1,0 +1,25 @@
+# stage 1: build
+FROM golang:1.10-alpine AS builder
+LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
+
+# Install Glide
+RUN apk add --update glide git make bash
+
+# Add source code
+RUN mkdir -p /go/src/github.com/m3db/m3
+ADD . /go/src/github.com/m3db/m3
+
+# Build m3nsch binary
+RUN cd /go/src/github.com/m3db/m3/ && \
+    git submodule update --init      && \
+    make m3nsch_server-linux-amd64 && \
+    make m3nsch_client-linux-amd64
+
+# stage 2: lightweight "release"
+FROM alpine:latest
+LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
+
+COPY --from=builder /go/src/github.com/m3db/m3/bin/m3nsch_server /bin/
+COPY --from=builder /go/src/github.com/m3db/m3/bin/m3nsch_client /bin/
+
+ENTRYPOINT [ "/bin/m3nsch_server" ]

--- a/src/cmd/services/m3nsch_server/config/config.go
+++ b/src/cmd/services/m3nsch_server/config/config.go
@@ -21,15 +21,17 @@
 package config
 
 import (
+	"github.com/m3db/m3/src/dbnode/client"
 	xconfig "github.com/m3db/m3x/config"
 	"github.com/m3db/m3x/instrument"
 )
 
 // Configuration represents the knobs available to configure a m3nsch_server
 type Configuration struct {
-	Server  ServerConfiguration             `yaml:"server"`
-	M3nsch  M3nschConfiguration             `yaml:"m3nsch" validate:"nonzero"`
-	Metrics instrument.MetricsConfiguration `yaml:"metrics" validate:"nonzero"`
+	Server   ServerConfiguration             `yaml:"server"`
+	M3nsch   M3nschConfiguration             `yaml:"m3nsch" validate:"nonzero"`
+	Metrics  instrument.MetricsConfiguration `yaml:"metrics" validate:"nonzero"`
+	DBClient client.Configuration            `yaml:"dbClient"`
 }
 
 // ServerConfiguration represents the knobs available to configure server properties


### PR DESCRIPTION
This updates the config for `m3nsch_server` to allow configuring the db
client. Additionally a `Dockerfile` for m3nsch is included that will by
default start the server but also include the client binary.