### PR TITLE
Significantly improve performance of FetchResultToPromResult and helper functions

### DIFF
--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -188,15 +188,15 @@ func TagsToPromLabels(tags models.Tags) []*prompb.Label {
 // SeriesToPromSamples series datapoints to prometheus samples
 func SeriesToPromSamples(series *ts.Series) []*prompb.Sample {
 	var (
-		seriesLen = series.Len()
-		values    = series.Values()
+		seriesLen  = series.Len()
+		values     = series.Values()
+		datapoints = values.Datapoints()
 		// Perform bulk allocation upfront then convert to pointers afterwards
 		// to reduce total number of allocations. See BenchmarkFetchResultToPromResult
 		// if modifying.
 		samples = make([]prompb.Sample, 0, seriesLen)
 	)
-	for i := 0; i < seriesLen; i++ {
-		dp := values.DatapointAt(i)
+	for _, dp := range datapoints {
 		samples = append(samples, prompb.Sample{
 			Timestamp: TimeToTimestamp(dp.Timestamp),
 			Value:     dp.Value,

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -140,9 +140,9 @@ func TimeToTimestamp(timestamp time.Time) int64 {
 }
 
 // FetchResultToPromResult converts fetch results from M3 to Prometheus result.
-// TODO(rartoul): Ideally we would pool all of these intermediary datastructures,
-// but right now its hooked into generated code so accomplishing that would be
-// non-trivial.
+// TODO(rartoul): We should pool all of these intermediary datastructures, or
+// at least the []*prompb.Sample (as thats the most heavily allocated object)
+// since we have full control over the lifecycle.
 func FetchResultToPromResult(result *FetchResult) *prompb.QueryResult {
 	// Perform bulk allocation upfront then convert to pointers afterwards
 	// to reduce total number of allocations. See BenchmarkFetchResultToPromResult

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -139,7 +139,10 @@ func TimeToTimestamp(timestamp time.Time) int64 {
 	return timestamp.UnixNano() / int64(time.Millisecond)
 }
 
-// FetchResultToPromResult converts fetch results from M3 to Prometheus result
+// FetchResultToPromResult converts fetch results from M3 to Prometheus result.
+// TODO(rartoul): Ideally we would pool all of these intermediary datastructures,
+// but right now its hooked into generated code so accomplishing that would be
+// non-trivial.
 func FetchResultToPromResult(result *FetchResult) *prompb.QueryResult {
 	// Perform bulk allocation upfront then convert to pointers afterwards
 	// to reduce total number of allocations. See BenchmarkFetchResultToPromResult
@@ -160,14 +163,14 @@ func FetchResultToPromResult(result *FetchResult) *prompb.QueryResult {
 	}
 }
 
-// SeriesToPromTS converts a series to prometheus timeseries
+// SeriesToPromTS converts a series to prometheus timeseries.
 func SeriesToPromTS(series *ts.Series) prompb.TimeSeries {
 	labels := TagsToPromLabels(series.Tags)
 	samples := SeriesToPromSamples(series)
 	return prompb.TimeSeries{Labels: labels, Samples: samples}
 }
 
-// TagsToPromLabels converts tags to prometheus labels
+// TagsToPromLabels converts tags to prometheus labels.TagsToPromLabels.
 func TagsToPromLabels(tags models.Tags) []*prompb.Label {
 	// Perform bulk allocation upfront then convert to pointers afterwards
 	// to reduce total number of allocations. See BenchmarkFetchResultToPromResult
@@ -185,7 +188,7 @@ func TagsToPromLabels(tags models.Tags) []*prompb.Label {
 	return labelsPointers
 }
 
-// SeriesToPromSamples series datapoints to prometheus samples
+// SeriesToPromSamples series datapoints to prometheus samples.SeriesToPromSamples.
 func SeriesToPromSamples(series *ts.Series) []*prompb.Sample {
 	var (
 		seriesLen  = series.Len()

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -170,7 +170,7 @@ func SeriesToPromTS(series *ts.Series) prompb.TimeSeries {
 	return prompb.TimeSeries{Labels: labels, Samples: samples}
 }
 
-// TagsToPromLabels converts tags to prometheus labels.TagsToPromLabels.
+// TagsToPromLabels converts tags to prometheus labels.
 func TagsToPromLabels(tags models.Tags) []*prompb.Label {
 	// Perform bulk allocation upfront then convert to pointers afterwards
 	// to reduce total number of allocations. See BenchmarkFetchResultToPromResult

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -235,6 +235,7 @@ var (
 	benchResult *prompb.QueryResult
 )
 
+// BenchmarkFetchResultToPromResult-8   	     100	  10563444 ns/op	25368543 B/op	    4443 allocs/op
 func BenchmarkFetchResultToPromResult(b *testing.B) {
 	var (
 		numSeries              = 1000

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3/src/query/generated/proto/prompb"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/test/seriesiter"
+	"github.com/m3db/m3/src/query/ts"
 	"github.com/m3db/m3x/ident"
 	"github.com/m3db/m3x/pool"
 	xsync "github.com/m3db/m3x/sync"
@@ -227,5 +228,47 @@ func TestPromReadQueryToM3(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+var (
+	benchResult *prompb.QueryResult
+)
+
+func BenchmarkFetchResultToPromResult(b *testing.B) {
+	var (
+		numSeries              = 1000
+		numDatapointsPerSeries = 1000
+		numTagsPerSeries       = 10
+		fr                     = &FetchResult{
+			SeriesList: make(ts.SeriesList, 0, numSeries),
+		}
+	)
+
+	for i := 0; i < numSeries; i++ {
+		values := make(ts.Datapoints, 0, numDatapointsPerSeries)
+		for i := 0; i < numDatapointsPerSeries; i++ {
+			values = append(values, ts.Datapoint{
+				Timestamp: time.Time{},
+				Value:     float64(i),
+			})
+		}
+
+		tags := make(models.Tags, 0, numTagsPerSeries)
+		for i := 0; i < numTagsPerSeries; i++ {
+			tags = append(tags, models.Tag{
+				Name:  fmt.Sprintf("name-%d", i),
+				Value: fmt.Sprintf("value-%d", i),
+			})
+		}
+
+		series := ts.NewSeries(
+			fmt.Sprintf("series-%d", i), values, tags)
+
+		fr.SeriesList = append(fr.SeriesList, series)
+	}
+
+	for i := 0; i < b.N; i++ {
+		benchResult = FetchResultToPromResult(fr)
 	}
 }

--- a/src/query/ts/values.go
+++ b/src/query/ts/values.go
@@ -46,6 +46,9 @@ type Values interface {
 	// DatapointAt returns the datapoint at the nth element
 	DatapointAt(n int) Datapoint
 
+	// Datapoints returns all the datapoints
+	Datapoints() []Datapoint
+
 	// AlignToBounds returns values aligned to the start time and duration
 	AlignToBounds(bounds models.Bounds) []Datapoints
 }
@@ -67,6 +70,9 @@ func (d Datapoints) ValueAt(n int) float64 { return d[n].Value }
 
 // DatapointAt returns the value at the nth element.
 func (d Datapoints) DatapointAt(n int) Datapoint { return d[n] }
+
+// Datapoints returns all the datapoints.
+func (d Datapoints) Datapoints() []Datapoint { return d }
 
 // Values returns the values representation.
 func (d Datapoints) Values() []float64 {
@@ -136,6 +142,13 @@ func (b *fixedResolutionValues) DatapointAt(point int) Datapoint {
 		Timestamp: b.StartTimeForStep(point),
 		Value:     b.ValueAt(point),
 	}
+}
+func (b *fixedResolutionValues) Datapoints() []Datapoint {
+	datapoints := make([]Datapoint, 0, len(b.values))
+	for i := range b.values {
+		datapoints = append(datapoints, b.DatapointAt(i))
+	}
+	return datapoints
 }
 
 // AlignToBounds returns values aligned to given bounds.


### PR DESCRIPTION
<img width="1822" alt="screen shot 2018-10-02 at 9 57 09 am" src="https://user-images.githubusercontent.com/9171254/46353188-96c12800-c629-11e8-8979-c32048df9de7.png">
<img width="516" alt="screen shot 2018-10-02 at 9 57 13 am" src="https://user-images.githubusercontent.com/9171254/46353196-9a54af00-c629-11e8-9d14-b8f25d3b3f4c.png">

Before
```
BenchmarkFetchResultToPromResult-8   	      30	  34556216 ns/op	25773633 B/op	 1014479 allocs/op
```

After
```
BenchmarkFetchResultToPromResult-8   	     100	  10563444 ns/op	25368543 B/op	    4443 allocs/op
```