### PR TITLE
Backfill changelog and add developers guide for updating CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,56 @@
 Changelog
 =========
 
+# 0.4.6 (unreleased)
+
+# 0.4.5 (2018-09-24)
+
+- FIX **DB** Index data race in FST Segment reads (#938)
+
+# 0.4.4 (2018-09-21)
+
+- **DB:** Use commit log bootstrapper before peers bootstrapper (#894)
+- **Query:** Add more PromQL functions (irate, temporal functions, etc) (#872, #897)
+- **Coordinator:** Add downsampling to all configured namespaces by default (#890)
+- **DB:** By default use upsert behavior for datapoints written to mutable series (#876)
+- PERF **DB:** Various performance updates (#889, #903)
+
+# 0.4.3 (2018-09-05)
+
+- **Query:** Make compatible with Grafana Prometheus data source (#871, #877)
+- FIX **DB:** Fix index correctness for multi-segment reads (#883)
+- PERF **DB:** Index performance improvements (#880)
+
+# 0.4.2 (2018-08-30)
+
+- FIX **DB:** Remove native pooling and remove possibility of it being used by any components (#870)
+- FIX **DB:** Fix LRU series cache locking during very high throughput (#862)
+
+# 0.4.1 (2018-08-27)
+
+- FIX **Coordinator:** Add support for negated match and regexp Prometheus remote read queries (#858)
+
+# 0.4.0 (2018-08-09)
+
+- **Coordinator:** Add downsampling capabilities (#796)
+- **Query:** Add dedicated m3query service for serving PromQL and other supported query languages (#817)
+- **DB:** Add commit log snapshotting support to significantly reduce disk space usage by removing the majority of uncompressed commit logs on a database node and speed up bootstrap time (#757) (#802)
+
+- **Coordinator:** Add downsampling capabilities (#796)
+- **Query:** Add dedicated m3query service for serving PromQL and other supported query languages (#817)
+- **DB:** Add commit log snapshotting support to significantly reduce disk space usage by removing the majority of uncompressed commit logs on a database node and speed up bootstrap time (#757) (#802)
+
+# 0.3.0 (2018-07-19)
+
+- **Coordinator:** Add m3coordinator Dockerfile and update Prometheus test to use standalone coordinator (#792)
+- **Coordinator:** Add rudimentary multi-cluster support for m3coordinator (#785)
+- **DB:** Fix documentation for single node walkthrough (#795)
+
+# 0.2.0 (2018-05-26)
+
+- **Coordinator:** Build dedicated m3coordinator binary for release binaries
+
+# 0.1.0 (2018-05-24)
+
+- **DB:** Reverse indexing
+- **Coordinator:** Prometheus remote read/write support

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -2,10 +2,11 @@
 
 ## Running the M3 stack locally
 
-Follow the instructions in `/scripts/development/m3_stack/README.md`
+Follow the instructions in `./scripts/development/m3_stack/README.md`
 
 ## Testing Changes
-M3DB has an extensive (and ever increasing) set of tests to ensure we are able to validate changes. More notes about the various testing strategies we employ can be found in `TESTING.md`. An unfortunate consequence of the number of tests is running the test suite takes too long on a developer's laptop. Here's the workflow most developers employ to be productive. Note: take this as a suggestion of something that works for some people, not as a directive. Do what makes you enjoy the development process most, including disregarding this suggestion!
+
+M3 has an extensive, and ever increasing, set of tests to ensure we are able to validate changes. More notes about the various testing strategies we employ can be found in `TESTING.md`. An unfortunate consequence of the number of tests is running the test suite takes too long on a developer's laptop. Here's the workflow most developers employ to be productive. Note: take this as a suggestion of something that works for some people, not as a directive. Do what makes you enjoy the development process most, including disregarding this suggestion!
 
 Once you have identified a change you want to make, and gathered consensus by talking to some devs, go ahead and make a branch with the changes. To test your changes:
 
@@ -40,6 +41,25 @@ $ go test  -tags big ./services/m3dbnode/main -run TestIndexEnabledServer -v
 
 (5) Polish up the PR, ensure CI signs off, and coverage increases. Then ping someone to take a look and get feedback!
 
+## Adding a Changelog
+
+When you open a PR, if you have made are making a significant change you must also update the contents of `CHANGELOG.md` with a description of the changes and the PR number.  You will not know the PR number ahead of time so this must be added as a subsequent commit to an open PR.
+
+The format of the change should be:
+```
+- TYPE **COMPONENT:** Description (#PR_NUMBER)
+```
+
+The `TYPE` should be ommitted if it is a feature.  If it is not a feature it should be one of: `FIX`, `PERF`.  New types of changes should be added to this document before used if they cannot be categorized by the existing types.
+
+Here is an example of an additiong to the pending changelog:
+
+```
+# 0.4.5 (unreleased)
+
+- FIX **DB** Index data race in FST Segment reads (#938)
+```
+
 ## Building the Docs
 
 The `docs` folder contains our documentation in Markdown files. These Markdown files are built into a static site using
@@ -57,7 +77,7 @@ make docs-serve
 make docs-deploy
 ```
 
-## M3DB Website
-The [M3DB website](https://m3db.io/) is hosted via netlify. It is configured to run `make site-build` and then serving the contents of the `/m3db.io` directory. The site is built and republished every time
-there is a push to master.
+## M3 Website
 
+The [M3 website](https://m3db.io/) is hosted with Netlify. It is configured to run `make site-build` and then serving the contents of the `/m3db.io` directory. The site is built and republished every time
+there is a push to master.


### PR DESCRIPTION
With a backfill on the changelog, we should aim to add notes for unreleased versions as they are added to the stack of pending release changes.