### PR TITLE
[coordinator] placement: add+remove fully atomic

### DIFF
--- a/src/query/api/v1/handler/placement/common.go
+++ b/src/query/api/v1/handler/placement/common.go
@@ -147,9 +147,6 @@ func RegisterRoutes(r *mux.Router, client clusterclient.Client, cfg config.Confi
 func validateAllAvailable(p placement.Placement) error {
 	badInsts := []string{}
 	for _, inst := range p.Instances() {
-		if inst.Shards().NumShards() == 0 {
-			continue
-		}
 		if !inst.IsAvailable() {
 			badInsts = append(badInsts, inst.ID())
 		}

--- a/src/query/api/v1/handler/placement/common.go
+++ b/src/query/api/v1/handler/placement/common.go
@@ -29,6 +29,7 @@ import (
 	clusterclient "github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/generated/proto/placementpb"
 	"github.com/m3db/m3cluster/placement"
+	"github.com/m3db/m3cluster/placement/algo"
 	"github.com/m3db/m3cluster/services"
 	"github.com/m3db/m3cluster/shard"
 
@@ -60,9 +61,17 @@ type Handler struct {
 
 // Service gets a placement service from m3cluster client
 func Service(clusterClient clusterclient.Client, headers http.Header) (placement.Service, error) {
+	ps, _, err := ServiceWithAlgo(clusterClient, headers)
+	return ps, err
+}
+
+// ServiceWithAlgo gets a placement service from m3cluster client and
+// additionally returns an algorithm instance for callers that need fine-grained
+// control over placement updates.
+func ServiceWithAlgo(clusterClient clusterclient.Client, headers http.Header) (placement.Service, placement.Algorithm, error) {
 	cs, err := clusterClient.Services(services.NewOverrideOptions())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	serviceName := DefaultServiceName
@@ -85,12 +94,16 @@ func Service(clusterClient clusterclient.Client, headers http.Header) (placement
 		SetEnvironment(serviceEnvironment).
 		SetZone(serviceZone)
 
-	ps, err := cs.PlacementService(sid, placement.NewOptions().SetValidZone(serviceZone))
+	pOpts := placement.NewOptions().SetValidZone(serviceZone)
+
+	ps, err := cs.PlacementService(sid, pOpts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return ps, nil
+	alg := algo.NewAlgorithm(pOpts)
+
+	return ps, alg, nil
 }
 
 // ConvertInstancesProto converts a slice of protobuf `Instance`s to `placement.Instance`s
@@ -129,4 +142,22 @@ func RegisterRoutes(r *mux.Router, client clusterclient.Client, cfg config.Confi
 	r.HandleFunc(DeleteAllURL, logged(NewDeleteAllHandler(client, cfg)).ServeHTTP).Methods(DeleteAllHTTPMethod)
 	r.HandleFunc(AddURL, logged(NewAddHandler(client, cfg)).ServeHTTP).Methods(AddHTTPMethod)
 	r.HandleFunc(DeleteURL, logged(NewDeleteHandler(client, cfg)).ServeHTTP).Methods(DeleteHTTPMethod)
+}
+
+func validateAllAvailable(p placement.Placement) error {
+	badInsts := []string{}
+	for _, inst := range p.Instances() {
+		if inst.Shards().NumShards() == 0 {
+			continue
+		}
+		if !inst.IsAvailable() {
+			badInsts = append(badInsts, inst.ID())
+		}
+	}
+	if len(badInsts) > 0 {
+		return unsafeAddError{
+			hosts: strings.Join(badInsts, ","),
+		}
+	}
+	return nil
 }

--- a/src/query/api/v1/handler/placement/common_test.go
+++ b/src/query/api/v1/handler/placement/common_test.go
@@ -242,11 +242,6 @@ func TestValidateAllAvailable(t *testing.T) {
 	p := placement.NewPlacement()
 	assert.NoError(t, validateAllAvailable(p))
 
-	p = p.SetInstances([]placement.Instance{
-		placement.NewInstance().SetID("C"),
-	})
-	assert.NoError(t, validateAllAvailable(p))
-
 	p = newAvailPlacement()
 	assert.NoError(t, validateAllAvailable(p))
 

--- a/src/query/api/v1/handler/placement/common_test.go
+++ b/src/query/api/v1/handler/placement/common_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3cluster/generated/proto/placementpb"
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/services"
+	"github.com/m3db/m3cluster/shard"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -49,9 +50,10 @@ func TestPlacementService(t *testing.T) {
 	mockClient.EXPECT().Services(gomock.Not(nil)).Return(mockServices, nil)
 	mockServices.EXPECT().PlacementService(gomock.Not(nil), gomock.Not(nil)).Return(mockPlacementService, nil)
 
-	placementService, err := Service(mockClient, http.Header{})
+	placementService, algo, err := ServiceWithAlgo(mockClient, http.Header{})
 	assert.NoError(t, err)
 	assert.NotNil(t, placementService)
+	assert.NotNil(t, algo)
 
 	// Test Services returns error
 	mockClient.EXPECT().Services(gomock.Not(nil)).Return(nil, errors.New("dummy service error"))
@@ -216,4 +218,38 @@ func TestConvertInstancesProto(t *testing.T) {
 		},
 	})
 	require.EqualError(t, err, "invalid proto shard state")
+}
+
+func newPlacement(state shard.State) placement.Placement {
+	shards := shard.NewShards([]shard.Shard{
+		shard.NewShard(1).SetState(state),
+	})
+
+	instA := placement.NewInstance().SetShards(shards).SetID("A")
+	instB := placement.NewInstance().SetShards(shards).SetID("B")
+	return placement.NewPlacement().SetInstances([]placement.Instance{instA, instB})
+}
+
+func newInitPlacement() placement.Placement {
+	return newPlacement(shard.Initializing)
+}
+
+func newAvailPlacement() placement.Placement {
+	return newPlacement(shard.Available)
+}
+
+func TestValidateAllAvailable(t *testing.T) {
+	p := placement.NewPlacement()
+	assert.NoError(t, validateAllAvailable(p))
+
+	p = p.SetInstances([]placement.Instance{
+		placement.NewInstance().SetID("C"),
+	})
+	assert.NoError(t, validateAllAvailable(p))
+
+	p = newAvailPlacement()
+	assert.NoError(t, validateAllAvailable(p))
+
+	p = newInitPlacement()
+	assert.Error(t, validateAllAvailable(p))
 }


### PR DESCRIPTION
I realized that even with the change to make adds "safe" by default,
there could still be a race. That is, the placement that all shards were
validated as AVAILABLE for could not be the present placement by the
time `AddInstances` was called.

This changes placement adds/removes to use the placement algorithm to
construct the new placement, and perform a `CheckAndSet` with the old
placement.

Additionally, this implements "safe" adds in the delete handler as well.