### PR TITLE
Add a m3msg server for ingestion

### DIFF
--- a/src/cmd/services/m3coordinator/server/m3msg/config.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/config.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package m3msg
 
 import (

--- a/src/cmd/services/m3coordinator/server/m3msg/config.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/config.go
@@ -1,0 +1,87 @@
+package m3msg
+
+import (
+	"github.com/m3db/m3metrics/encoding/msgpack"
+	"github.com/m3db/m3msg/consumer"
+	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/server"
+)
+
+// Configuration configs the m3msg server.
+type Configuration struct {
+	// Server configs the server.
+	Server server.Configuration `yaml:"server"`
+
+	// Handler configs the handler.
+	Handler handlerConfiguration `yaml:"handler"`
+
+	// Consumer configs the consumer.
+	Consumer consumer.Configuration `yaml:"consumer"`
+}
+
+// NewServer creates a new server.
+func (c Configuration) NewServer(
+	writeFn WriteFn,
+	iOpts instrument.Options,
+) (server.Server, error) {
+	scope := iOpts.MetricsScope().Tagged(map[string]string{"server": "m3msg"})
+	hOpts := c.Handler.NewOptions(
+		writeFn,
+		iOpts.SetMetricsScope(scope.Tagged(map[string]string{
+			"handler": "msgpack",
+		})),
+	)
+	msgpackHandler, err := newHandler(hOpts)
+	if err != nil {
+		return nil, err
+	}
+	return c.Server.NewServer(
+		consumer.NewHandler(
+			msgpackHandler.Handle,
+			c.Consumer.NewOptions(
+				iOpts.SetMetricsScope(scope.Tagged(map[string]string{
+					"component": "consumer",
+				})),
+			),
+		),
+		iOpts.SetMetricsScope(scope),
+	), nil
+}
+
+type handlerConfiguration struct {
+	// Msgpack configs the msgpack iterator.
+	Msgpack MsgpackIteratorConfiguration `yaml:"msgpack"`
+}
+
+// NewOptions creates handler options.
+func (c handlerConfiguration) NewOptions(
+	writeFn WriteFn,
+	iOpts instrument.Options,
+) Options {
+	return Options{
+		WriteFn:                   writeFn,
+		InstrumentOptions:         iOpts,
+		AggregatedIteratorOptions: c.Msgpack.NewOptions(),
+	}
+}
+
+// MsgpackIteratorConfiguration configs the msgpack iterator.
+type MsgpackIteratorConfiguration struct {
+	// Whether to ignore encoded data streams whose version is higher than the current known version.
+	IgnoreHigherVersion *bool `yaml:"ignoreHigherVersion"`
+
+	// Reader buffer size.
+	ReaderBufferSize *int `yaml:"readerBufferSize"`
+}
+
+// NewOptions creates a new msgpack aggregated iterator options.
+func (c MsgpackIteratorConfiguration) NewOptions() msgpack.AggregatedIteratorOptions {
+	opts := msgpack.NewAggregatedIteratorOptions()
+	if c.IgnoreHigherVersion != nil {
+		opts = opts.SetIgnoreHigherVersion(*c.IgnoreHigherVersion)
+	}
+	if c.ReaderBufferSize != nil {
+		opts = opts.SetReaderBufferSize(*c.ReaderBufferSize)
+	}
+	return opts
+}

--- a/src/cmd/services/m3coordinator/server/m3msg/handler.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/handler.go
@@ -1,0 +1,135 @@
+package m3msg
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/m3db/m3metrics/encoding/msgpack"
+	"github.com/m3db/m3msg/consumer"
+	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/log"
+
+	"github.com/uber-go/tally"
+)
+
+// Options for the ingest handler.
+type Options struct {
+	InstrumentOptions         instrument.Options
+	WriteFn                   WriteFn
+	AggregatedIteratorOptions msgpack.AggregatedIteratorOptions
+}
+
+type handlerMetrics struct {
+	messageReadError                tally.Counter
+	metricAccepted                  tally.Counter
+	droppedMetricMsgpackDecodeError tally.Counter
+	droppedMetricDecodeMalformed    tally.Counter
+}
+
+func newHandlerMetrics(scope tally.Scope) handlerMetrics {
+	messageScope := scope.SubScope("metric")
+	return handlerMetrics{
+		messageReadError: scope.Counter("message-read-error"),
+		metricAccepted:   messageScope.Counter("accepted"),
+		droppedMetricMsgpackDecodeError: messageScope.Tagged(map[string]string{
+			"reason": "msgpack-decode-error",
+		}).Counter("dropped"),
+		droppedMetricDecodeMalformed: messageScope.Tagged(map[string]string{
+			"reason": "decode-malformed",
+		}).Counter("dropped"),
+	}
+}
+
+type handler struct {
+	writeFn      WriteFn
+	iteratorOpts msgpack.AggregatedIteratorOptions
+	logger       log.Logger
+	m            handlerMetrics
+}
+
+func newHandler(opts Options) (*handler, error) {
+	return &handler{
+		writeFn:      opts.WriteFn,
+		iteratorOpts: opts.AggregatedIteratorOptions,
+		logger:       opts.InstrumentOptions.Logger(),
+		m:            newHandlerMetrics(opts.InstrumentOptions.MetricsScope()),
+	}, nil
+}
+
+func (h *handler) Handle(c consumer.Consumer) {
+	h.newPerConsumerHandler().handle(c)
+}
+
+func (h *handler) newPerConsumerHandler() *perConsumerHandler {
+	return &perConsumerHandler{
+		writeFn: h.writeFn,
+		logger:  h.logger,
+		m:       h.m,
+		it:      msgpack.NewAggregatedIterator(nil, h.iteratorOpts),
+		r:       bytes.NewReader(nil),
+	}
+}
+
+type perConsumerHandler struct {
+	// Per server variables, shared across consumers/connections.
+	writeFn WriteFn
+	logger  log.Logger
+	m       handlerMetrics
+
+	// Per consumer/connection variables.
+	it msgpack.AggregatedIterator
+	r  *bytes.Reader
+}
+
+func (h *perConsumerHandler) handle(c consumer.Consumer) {
+	var (
+		msgErr error
+		msg    consumer.Message
+	)
+	for {
+		msg, msgErr = c.Message()
+		if msgErr != nil {
+			break
+		}
+
+		h.processMessage(msg)
+	}
+	if msgErr != nil && msgErr != io.EOF {
+		h.logger.WithFields(log.NewErrField(msgErr)).Errorf("could not read message from consumer")
+		h.m.messageReadError.Inc(1)
+	}
+	c.Close()
+	h.it.Close()
+}
+
+func (h *perConsumerHandler) processMessage(
+	msg consumer.Message,
+) {
+	r := NewRefCountedCallback(msg)
+	r.incRef()
+
+	// Decode the bytes in the message.
+	h.r.Reset(msg.Bytes())
+	h.it.Reset(h.r)
+	for h.it.Next() {
+		raw, sp, _ := h.it.Value()
+		m, err := raw.Metric()
+		if err != nil {
+			h.logger.WithFields(log.NewErrField(err)).Error("invalid raw metric")
+			h.m.droppedMetricDecodeMalformed.Inc(1)
+			continue
+		}
+
+		h.m.metricAccepted.Inc(1)
+
+		// TODO: Consider incrementing a wait group for each write and wait on
+		// shut down to reduce the number of messages being retried by m3msg.
+		r.incRef()
+		h.writeFn(m.ID, m.TimeNanos, m.Value, sp, r)
+	}
+	r.decRef()
+	if err := h.it.Err(); err != nil && err != io.EOF {
+		h.logger.WithFields(log.NewErrField(h.it.Err())).Errorf("could not decode msg %s", msg.Bytes())
+		h.m.droppedMetricMsgpackDecodeError.Inc(1)
+	}
+}

--- a/src/cmd/services/m3coordinator/server/m3msg/handler.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/handler.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package m3msg
 
 import (

--- a/src/cmd/services/m3coordinator/server/m3msg/handler_test.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/handler_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package m3msg
 
 import (

--- a/src/cmd/services/m3coordinator/server/m3msg/handler_test.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/handler_test.go
@@ -74,9 +74,8 @@ func TestM3msgServerHandlerWithMultipleMetricsPerMessage(t *testing.T) {
 type mockWriter struct {
 	sync.Mutex
 
-	m       map[string]payload
-	enabled bool
-	n       int
+	m map[string]payload
+	n int
 }
 
 func (m *mockWriter) write(

--- a/src/cmd/services/m3coordinator/server/m3msg/handler_test.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/handler_test.go
@@ -1,0 +1,114 @@
+package m3msg
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/m3db/m3metrics/encoding/msgpack"
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/metric/id"
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3msg/consumer"
+	"github.com/m3db/m3msg/generated/proto/msgpb"
+	"github.com/m3db/m3msg/protocol/proto"
+	"github.com/m3db/m3x/instrument"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	validStoragePolicy = policy.MustParseStoragePolicy("1m:40d")
+)
+
+func TestM3msgServerHandlerWithMultipleMetricsPerMessage(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	m := &mockWriter{m: make(map[string]payload)}
+	hOpts := Options{
+		WriteFn:           m.write,
+		InstrumentOptions: instrument.NewOptions(),
+	}
+	handler, err := newHandler(hOpts)
+	require.NoError(t, err)
+	sOpts := consumer.NewServerOptions().
+		SetConsumerOptions(
+			consumer.NewOptions().
+				SetAckBufferSize(1).
+				SetConnectionWriteBufferSize(1),
+		).
+		SetConsumeFn(handler.Handle)
+	s := consumer.NewServer("a", sOpts)
+	s.Serve(l)
+
+	encoder := msgpack.NewAggregatedEncoder(msgpack.NewPooledBufferedEncoder(nil))
+	chunkedMetricWithPolicy := aggregated.ChunkedMetricWithStoragePolicy{
+		ChunkedMetric: aggregated.ChunkedMetric{
+			ChunkedID: id.ChunkedID{
+				Data: []byte("stats.sjc1.gauges.m3+some-name+dc=sjc1,env=production,service=foo,type=gauge"),
+			},
+			TimeNanos: 1000,
+			Value:     1,
+		},
+		StoragePolicy: validStoragePolicy,
+	}
+	require.NoError(t, encoder.EncodeChunkedMetricWithStoragePolicyAndEncodeTime(chunkedMetricWithPolicy, 2000))
+	require.NoError(t, encoder.EncodeChunkedMetricWithStoragePolicyAndEncodeTime(chunkedMetricWithPolicy, 3000))
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	require.NoError(t, err)
+	enc := proto.NewEncoder(sOpts.ConsumerOptions().EncoderOptions())
+	dec := proto.NewDecoder(conn, sOpts.ConsumerOptions().DecoderOptions())
+	require.NoError(t, enc.Encode(&msgpb.Message{
+		Value: encoder.Encoder().Bytes(),
+	}))
+	_, err = conn.Write(enc.Bytes())
+	require.NoError(t, err)
+
+	var a msgpb.Ack
+	require.NoError(t, dec.Decode(&a))
+	require.Equal(t, 2, m.ingested())
+}
+
+type mockWriter struct {
+	sync.Mutex
+
+	m       map[string]payload
+	enabled bool
+	n       int
+}
+
+func (m *mockWriter) write(
+	name []byte,
+	metricTime int64,
+	value float64,
+	sp policy.StoragePolicy,
+	callbackable *RefCountedCallback,
+) {
+	m.Lock()
+	m.n++
+	payload := payload{
+		id:         string(name),
+		metricTime: metricTime,
+		value:      value,
+		sp:         sp,
+	}
+	m.m[payload.id] = payload
+	m.Unlock()
+	callbackable.Callback(OnSuccess)
+}
+
+func (m *mockWriter) ingested() int {
+	m.Lock()
+	defer m.Unlock()
+
+	return m.n
+}
+
+type payload struct {
+	id         string
+	metricTime int64
+	value      float64
+	sp         policy.StoragePolicy
+}

--- a/src/cmd/services/m3coordinator/server/m3msg/types.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/types.go
@@ -1,0 +1,66 @@
+package m3msg
+
+import (
+	"sync/atomic"
+
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3msg/consumer"
+)
+
+// WriteFn is the function that writes a metric.
+type WriteFn func(
+	id []byte,
+	metricTimeNanos int64,
+	value float64,
+	sp policy.StoragePolicy,
+	callback *RefCountedCallback,
+)
+
+// CallbackType defines the type for the callback.
+type CallbackType int
+
+// Supported CallbackTypes.
+const (
+	OnError CallbackType = iota
+	OnSuccess
+)
+
+// RefCountedCallback wraps a message with a reference count, the message will
+// be acked once the reference count decrements to zero.
+type RefCountedCallback struct {
+	ref int32
+	msg consumer.Message
+}
+
+// NewRefCountedCallback creates a RefCountedCallback.
+func NewRefCountedCallback(msg consumer.Message) *RefCountedCallback {
+	return &RefCountedCallback{
+		ref: 0,
+		msg: msg,
+	}
+}
+
+// incRef increments the ref count.
+func (r *RefCountedCallback) incRef() {
+	atomic.AddInt32(&r.ref, 1)
+}
+
+// decRef decrements the ref count. If the reference count became zero after
+// the call, the message will be acked.
+func (r *RefCountedCallback) decRef() {
+	ref := atomic.AddInt32(&r.ref, -1)
+	if ref == 0 {
+		r.msg.Ack()
+		return
+	}
+	if ref < 0 {
+		panic("invalid ref count")
+	}
+}
+
+// Callback performs the callback.
+func (r *RefCountedCallback) Callback(t CallbackType) {
+	if t == OnSuccess {
+		r.decRef()
+	}
+}

--- a/src/cmd/services/m3coordinator/server/m3msg/types.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/types.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package m3msg
 
 import (

--- a/src/cmd/services/m3coordinator/server/m3msg/types.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/types.go
@@ -41,8 +41,12 @@ type CallbackType int
 
 // Supported CallbackTypes.
 const (
-	OnError CallbackType = iota
-	OnSuccess
+	// OnSuccess will mark the call as success.
+	OnSuccess CallbackType = iota
+	// OnNonRetriableError will mark the call as errored but not retriable.
+	OnNonRetriableError
+	// OnRetriableError will mark the call as errored and should be retried.
+	OnRetriableError
 )
 
 // RefCountedCallback wraps a message with a reference count, the message will
@@ -80,7 +84,8 @@ func (r *RefCountedCallback) decRef() {
 
 // Callback performs the callback.
 func (r *RefCountedCallback) Callback(t CallbackType) {
-	if t == OnSuccess {
+	switch t {
+	case OnSuccess, OnNonRetriableError:
 		r.decRef()
 	}
 }


### PR DESCRIPTION
Part 1 for the ingestion change in M3coordinator. 
This diff adds a m3msg server which decodes traffic from m3msg consumer into metrics and takes in a WriteFn to write those metrics.

Part 2 will be implementing a storage based ingester to fulfill the WriteFn.