### PR TITLE
Add metrics for engine to track all processing.

### DIFF
--- a/src/query/api/v1/handler/prometheus/native/read_test.go
+++ b/src/query/api/v1/handler/prometheus/native/read_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 func TestPromRead(t *testing.T) {
@@ -47,7 +48,7 @@ func TestPromRead(t *testing.T) {
 	mockStorage.SetFetchBlocksResult(block.Result{Blocks: []block.Block{b}}, nil)
 
 	promRead := &PromReadHandler{
-		engine:  executor.NewEngine(mockStorage),
+		engine:  executor.NewEngine(mockStorage, tally.NewTestScope("test", nil)),
 		tagOpts: models.NewTagOptions(),
 	}
 

--- a/src/query/api/v1/httpd/handler_test.go
+++ b/src/query/api/v1/httpd/handler_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/remote"
 	"github.com/m3db/m3/src/query/executor"
 	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/test/m3"
 	"github.com/m3db/m3/src/query/util/logging"
 
@@ -46,6 +47,11 @@ func makeTagOptions() models.TagOptions {
 	return models.NewTagOptions().SetMetricName([]byte("some_name"))
 }
 
+func setupHandler(store storage.Storage) (*Handler, error) {
+	return NewHandler(store, makeTagOptions(), nil, executor.NewEngine(store, tally.NewTestScope("test", nil)), nil, nil,
+		config.Configuration{}, nil, tally.NewTestScope("", nil))
+}
+
 func TestPromRemoteReadGet(t *testing.T) {
 	logging.InitWithCores(nil)
 
@@ -54,8 +60,7 @@ func TestPromRemoteReadGet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storage, _ := m3.NewStorageAndSession(t, ctrl)
 
-	h, err := NewHandler(storage, makeTagOptions(), nil, executor.NewEngine(storage), nil, nil,
-		config.Configuration{}, nil, tally.NewTestScope("", nil))
+	h, err := setupHandler(storage)
 	require.NoError(t, err, "unable to setup handler")
 	err = h.RegisterRoutes()
 	require.NoError(t, err, "unable to register routes")
@@ -71,8 +76,7 @@ func TestPromRemoteReadPost(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storage, _ := m3.NewStorageAndSession(t, ctrl)
 
-	h, err := NewHandler(storage, makeTagOptions(), nil, executor.NewEngine(storage), nil, nil,
-		config.Configuration{}, nil, tally.NewTestScope("", nil))
+	h, err := setupHandler(storage)
 	require.NoError(t, err, "unable to setup handler")
 	err = h.RegisterRoutes()
 	require.NoError(t, err, "unable to register routes")
@@ -88,8 +92,7 @@ func TestPromNativeReadGet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storage, _ := m3.NewStorageAndSession(t, ctrl)
 
-	h, err := NewHandler(storage, makeTagOptions(), nil, executor.NewEngine(storage), nil,
-		nil, config.Configuration{}, nil, tally.NewTestScope("", nil))
+	h, err := setupHandler(storage)
 	require.NoError(t, err, "unable to setup handler")
 	h.RegisterRoutes()
 	h.Router.ServeHTTP(res, req)
@@ -104,8 +107,7 @@ func TestPromNativeReadPost(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storage, _ := m3.NewStorageAndSession(t, ctrl)
 
-	h, err := NewHandler(storage, makeTagOptions(), nil, executor.NewEngine(storage),
-		nil, nil, config.Configuration{}, nil, tally.NewTestScope("", nil))
+	h, err := setupHandler(storage)
 	require.NoError(t, err, "unable to setup handler")
 	h.RegisterRoutes()
 	h.Router.ServeHTTP(res, req)
@@ -120,8 +122,7 @@ func TestJSONWritePost(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storage, _ := m3.NewStorageAndSession(t, ctrl)
 
-	h, err := NewHandler(storage, makeTagOptions(), nil, executor.NewEngine(storage),
-		nil, nil, config.Configuration{}, nil, tally.NewTestScope("", nil))
+	h, err := setupHandler(storage)
 	require.NoError(t, err, "unable to setup handler")
 	h.RegisterRoutes()
 	h.Router.ServeHTTP(res, req)
@@ -136,8 +137,7 @@ func TestRoutesGet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storage, _ := m3.NewStorageAndSession(t, ctrl)
 
-	h, err := NewHandler(storage, makeTagOptions(), nil, executor.NewEngine(storage),
-		nil, nil, config.Configuration{}, nil, tally.NewTestScope("", nil))
+	h, err := setupHandler(storage)
 	require.NoError(t, err, "unable to setup handler")
 	h.RegisterRoutes()
 	h.Router.ServeHTTP(res, req)
@@ -169,8 +169,7 @@ func TestHealthGet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	storage, _ := m3.NewStorageAndSession(t, ctrl)
 
-	h, err := NewHandler(storage, makeTagOptions(), nil, executor.NewEngine(storage),
-		nil, nil, config.Configuration{}, nil, tally.NewTestScope("", nil))
+	h, err := setupHandler(storage)
 	require.NoError(t, err, "unable to setup handler")
 	h.RegisterRoutes()
 

--- a/src/query/executor/engine.go
+++ b/src/query/executor/engine.go
@@ -136,21 +136,21 @@ func (e *Engine) Execute(ctx context.Context, query *storage.FetchQuery, opts *E
 func (e *Engine) ExecuteExpr(ctx context.Context, parser parser.Parser, opts *EngineOptions, params models.RequestParams, results chan Query) {
 	defer close(results)
 
-	req, reqCtx := newRequest(ctx, e, params)
+	req := newRequest(e, params)
 	defer req.finish()
-	nodes, edges, err := req.compile(reqCtx, parser)
+	nodes, edges, err := req.compile(ctx, parser)
 	if err != nil {
 		results <- Query{Err: err}
 		return
 	}
 
-	pp, err := req.plan(reqCtx, nodes, edges)
+	pp, err := req.plan(ctx, nodes, edges)
 	if err != nil {
 		results <- Query{Err: err}
 		return
 	}
 
-	state, err := req.execute(reqCtx, pp)
+	state, err := req.execute(ctx, pp)
 	// free up resources
 	if err != nil {
 		results <- Query{Err: err}
@@ -159,7 +159,7 @@ func (e *Engine) ExecuteExpr(ctx context.Context, parser parser.Parser, opts *En
 
 	result := state.resultNode
 	results <- Query{Result: result}
-	if err := state.Execute(reqCtx); err != nil {
+	if err := state.Execute(ctx); err != nil {
 		result.abort(err)
 	} else {
 		result.done()

--- a/src/query/executor/engine.go
+++ b/src/query/executor/engine.go
@@ -22,21 +22,20 @@ package executor
 
 import (
 	"context"
+	"time"
 
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/parser"
-	"github.com/m3db/m3/src/query/plan"
 	"github.com/m3db/m3/src/query/storage"
-	"github.com/m3db/m3/src/query/util/logging"
 
-	"go.uber.org/zap"
+	"github.com/uber-go/tally"
 )
 
 // Engine executes a Query.
 type Engine struct {
 	// Used for tracking running queries.
 	tracker *Tracker
-	Stats   *QueryStatistics
+	metrics *engineMetrics
 	store   storage.Storage
 }
 
@@ -53,20 +52,58 @@ type Query struct {
 }
 
 // NewEngine returns a new instance of QueryExecutor.
-func NewEngine(store storage.Storage) *Engine {
+func NewEngine(store storage.Storage, scope tally.Scope) *Engine {
 	return &Engine{
 		tracker: NewTracker(),
-		Stats:   &QueryStatistics{},
+		metrics: newEngineMetrics(scope),
 		store:   store,
 	}
 }
 
-// QueryStatistics keeps statistics related to the QueryExecutor.
-type QueryStatistics struct {
-	ActiveQueries          int64
-	ExecutedQueries        int64
-	FinishedQueries        int64
-	QueryExecutionDuration int64
+type engineMetrics struct {
+	all       *counterWithDecrement
+	compiling *counterWithDecrement
+	planning  *counterWithDecrement
+	executing *counterWithDecrement
+
+	activeHist    tally.Histogram
+	compilingHist tally.Histogram
+	planningHist  tally.Histogram
+	executingHist tally.Histogram
+}
+
+type counterWithDecrement struct {
+	start tally.Counter
+	end   tally.Counter
+}
+
+func (c *counterWithDecrement) Inc() {
+	c.start.Inc(1)
+}
+
+func (c *counterWithDecrement) Dec() {
+	c.end.Inc(1)
+}
+
+func newCounterWithDecrement(scope tally.Scope) *counterWithDecrement {
+	return &counterWithDecrement{
+		start: scope.Counter("start"),
+		end:   scope.Counter("end"),
+	}
+}
+
+func newEngineMetrics(scope tally.Scope) *engineMetrics {
+	durationBuckets := tally.MustMakeExponentialDurationBuckets(time.Millisecond, 10, 5)
+	return &engineMetrics{
+		all:           newCounterWithDecrement(scope.SubScope(all.String())),
+		compiling:     newCounterWithDecrement(scope.SubScope(compiling.String())),
+		planning:      newCounterWithDecrement(scope.SubScope(planning.String())),
+		executing:     newCounterWithDecrement(scope.SubScope(executing.String())),
+		activeHist:    scope.Histogram(all.durationString(), durationBuckets),
+		compilingHist: scope.Histogram(compiling.durationString(), durationBuckets),
+		planningHist:  scope.Histogram(planning.durationString(), durationBuckets),
+		executingHist: scope.Histogram(executing.durationString(), durationBuckets),
+	}
 }
 
 // Execute runs the query and closes the results channel once done
@@ -99,46 +136,30 @@ func (e *Engine) Execute(ctx context.Context, query *storage.FetchQuery, opts *E
 func (e *Engine) ExecuteExpr(ctx context.Context, parser parser.Parser, opts *EngineOptions, params models.RequestParams, results chan Query) {
 	defer close(results)
 
-	nodes, edges, err := parser.DAG()
+	req, reqCtx := newRequest(ctx, e, params)
+	defer req.finish()
+	nodes, edges, err := req.compile(reqCtx, parser)
 	if err != nil {
 		results <- Query{Err: err}
 		return
 	}
 
-	lp, err := plan.NewLogicalPlan(nodes, edges)
+	pp, err := req.plan(reqCtx, nodes, edges)
 	if err != nil {
 		results <- Query{Err: err}
 		return
 	}
 
-	if params.Debug {
-		logging.WithContext(ctx).Info("logical plan", zap.String("plan", lp.String()))
-	}
-
-	pp, err := plan.NewPhysicalPlan(lp, e.store, params)
-	if err != nil {
-		results <- Query{Err: err}
-		return
-	}
-
-	if params.Debug {
-		logging.WithContext(ctx).Info("physical plan", zap.String("plan", pp.String()))
-	}
-
-	state, err := GenerateExecutionState(pp, e.store)
+	state, err := req.execute(reqCtx, pp)
 	// free up resources
 	if err != nil {
 		results <- Query{Err: err}
 		return
 	}
 
-	if params.Debug {
-		logging.WithContext(ctx).Info("execution state", zap.String("state", state.String()))
-	}
-
 	result := state.resultNode
 	results <- Query{Result: result}
-	if err := state.Execute(ctx); err != nil {
+	if err := state.Execute(reqCtx); err != nil {
 		result.abort(err)
 	} else {
 		result.done()

--- a/src/query/executor/engine_test.go
+++ b/src/query/executor/engine_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
 )
 
 func TestExecute(t *testing.T) {
@@ -44,7 +45,7 @@ func TestExecute(t *testing.T) {
 	results := make(chan *storage.QueryResult)
 	closing := make(chan bool)
 
-	engine := NewEngine(store)
+	engine := NewEngine(store, tally.NewTestScope("test", nil))
 	go engine.Execute(context.TODO(), &storage.FetchQuery{}, &EngineOptions{}, closing, results)
 	<-results
 	assert.Equal(t, len(engine.tracker.queries), 1)

--- a/src/query/executor/request.go
+++ b/src/query/executor/request.go
@@ -28,10 +28,10 @@ import (
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/parser"
 	"github.com/m3db/m3/src/query/plan"
+	"github.com/m3db/m3/src/query/util/logging"
 
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 // State is the request state.
@@ -70,101 +70,101 @@ type Request struct {
 	parentSpan *span
 }
 
-func newRequest(ctx context.Context, engine *Engine, params models.RequestParams) (*Request, context.Context) {
-	parentSpan, parentCtx := startSpan(ctx, all, engine.metrics.activeHist, engine.metrics.all)
+func newRequest(engine *Engine, params models.RequestParams) *Request {
+	parentSpan := startSpan(engine.metrics.activeHist, engine.metrics.all)
 	r := &Request{engine: engine, params: params, parentSpan: parentSpan}
-	return r, parentCtx
+	return r
 
 }
 
 func (r *Request) compile(ctx context.Context, parser parser.Parser) (parser.Nodes, parser.Edges, error) {
-	sp, _ := startSpan(ctx, compiling, r.engine.metrics.compilingHist, r.engine.metrics.compiling)
-	defer sp.finish()
+	sp := startSpan(r.engine.metrics.compilingHist, r.engine.metrics.compiling)
 	// TODO: Change DAG interface to take in a context
 	nodes, edges, err := parser.DAG()
 	if err != nil {
+		sp.finish(err)
 		return nil, nil, err
 	}
 
 	if r.params.Debug {
-		sp.s.LogFields(log.Object("nodes", nodes), log.Object("edges", edges), log.String("message", "compiling dag"))
+		logging.WithContext(ctx).Info("compiling dag", zap.Any("nodes", nodes), zap.Any("edges", edges))
 	}
 
+	sp.finish(nil)
 	return nodes, edges, nil
 }
 
 func (r *Request) plan(ctx context.Context, nodes parser.Nodes, edges parser.Edges) (plan.PhysicalPlan, error) {
-	sp, _ := startSpan(ctx, planning, r.engine.metrics.planningHist, r.engine.metrics.planning)
-	defer sp.finish()
+	sp := startSpan(r.engine.metrics.planningHist, r.engine.metrics.planning)
 	lp, err := plan.NewLogicalPlan(nodes, edges)
 	if err != nil {
+		sp.finish(err)
 		return plan.PhysicalPlan{}, err
 	}
 
 	if r.params.Debug {
-		sp.s.LogFields(log.Object("plan", lp.String()), log.String("message", "logical plan"))
+		logging.WithContext(ctx).Info("logical plan", zap.String("plan", lp.String()))
 	}
 
 	pp, err := plan.NewPhysicalPlan(lp, r.engine.store, r.params)
 	if err != nil {
+		sp.finish(err)
 		return plan.PhysicalPlan{}, err
 	}
 
 	if r.params.Debug {
-		sp.s.LogFields(log.String("plan", pp.String()), log.String("message", "physical plan"))
+		logging.WithContext(ctx).Info("physical plan", zap.String("plan", pp.String()))
 	}
 
+	sp.finish(nil)
 	return pp, nil
 }
 
 func (r *Request) execute(ctx context.Context, pp plan.PhysicalPlan) (*ExecutionState, error) {
-	sp, _ := startSpan(ctx, executing, r.engine.metrics.executingHist, r.engine.metrics.executing)
-	defer sp.finish()
+	sp := startSpan(r.engine.metrics.executingHist, r.engine.metrics.executing)
 	state, err := GenerateExecutionState(pp, r.engine.store)
 	// free up resources
 	if err != nil {
+		sp.finish(err)
 		return nil, err
 	}
 
 	if r.params.Debug {
-		sp.s.LogFields(log.String("state", state.String()), log.String("message", "execution state"))
+		logging.WithContext(ctx).Info("execution state", zap.String("state", state.String()))
 	}
 
+	sp.finish(nil)
 	return state, nil
 }
 
 func (r *Request) finish() {
-	r.parentSpan.finish()
+	r.parentSpan.finish(nil)
 }
 
 // span is a simple wrapper around opentracing.Span in order to
 // get access to the duration of the span for metrics reporting.
 type span struct {
-	s            opentracing.Span
 	start        time.Time
-	duration     time.Duration
 	durationHist tally.Histogram
 	counter      *counterWithDecrement
 }
 
-func startSpan(ctx context.Context, state State, durationHist tally.Histogram, counter *counterWithDecrement) (*span, context.Context) {
+func startSpan(durationHist tally.Histogram, counter *counterWithDecrement) *span {
 	now := time.Now()
-	s, sctx := opentracing.StartSpanFromContext(ctx, state.String(), opentracing.StartTime(now))
 	counter.Inc()
 	return &span{
-		s:            s,
 		durationHist: durationHist,
 		start:        now,
 		counter:      counter,
-	}, sctx
+	}
 }
 
-func (s *span) finish() {
-	now := time.Now()
-	s.duration = now.Sub(s.start)
-	s.s.FinishWithOptions(opentracing.FinishOptions{
-		FinishTime: now,
-	})
-	s.durationHist.RecordDuration(s.duration)
+func (s *span) finish(err error) {
 	s.counter.Dec()
+	// Don't record duration for error cases
+	if err == nil {
+		now := time.Now()
+		duration := now.Sub(s.start)
+		s.durationHist.RecordDuration(duration)
+	}
 }

--- a/src/query/executor/request.go
+++ b/src/query/executor/request.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/parser"
+	"github.com/m3db/m3/src/query/plan"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"github.com/uber-go/tally"
+)
+
+// State is the request state.
+type State int
+
+const (
+	compiling State = iota
+	planning
+	executing
+	all
+)
+
+func (s State) String() string {
+	switch s {
+	case compiling:
+		return "compiling"
+	case planning:
+		return "planning"
+	case executing:
+		return "executing"
+	case all:
+		return "all"
+	default:
+		return "unknown"
+	}
+}
+
+func (s State) durationString() string {
+	return fmt.Sprint("%s_duration_seconds", s)
+}
+
+// Request represents a single request.
+type Request struct {
+	engine     *Engine
+	params     models.RequestParams
+	parentSpan *span
+}
+
+func newRequest(ctx context.Context, engine *Engine, params models.RequestParams) (*Request, context.Context) {
+	parentSpan, parentCtx := startSpan(ctx, all, engine.metrics.activeHist, engine.metrics.all)
+	r := &Request{engine: engine, params: params, parentSpan: parentSpan}
+	return r, parentCtx
+
+}
+
+func (r *Request) compile(ctx context.Context, parser parser.Parser) (parser.Nodes, parser.Edges, error) {
+	sp, _ := startSpan(ctx, compiling, r.engine.metrics.compilingHist, r.engine.metrics.compiling)
+	defer sp.finish()
+	// TODO: Change DAG interface to take in a context
+	nodes, edges, err := parser.DAG()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if r.params.Debug {
+		sp.s.LogFields(log.Object("nodes", nodes), log.Object("edges", edges), log.String("message", "compiling dag"))
+	}
+
+	return nodes, edges, nil
+}
+
+func (r *Request) plan(ctx context.Context, nodes parser.Nodes, edges parser.Edges) (plan.PhysicalPlan, error) {
+	sp, _ := startSpan(ctx, planning, r.engine.metrics.planningHist, r.engine.metrics.planning)
+	defer sp.finish()
+	lp, err := plan.NewLogicalPlan(nodes, edges)
+	if err != nil {
+		return plan.PhysicalPlan{}, err
+	}
+
+	if r.params.Debug {
+		sp.s.LogFields(log.Object("plan", lp.String()), log.String("message", "logical plan"))
+	}
+
+	pp, err := plan.NewPhysicalPlan(lp, r.engine.store, r.params)
+	if err != nil {
+		return plan.PhysicalPlan{}, err
+	}
+
+	if r.params.Debug {
+		sp.s.LogFields(log.String("plan", pp.String()), log.String("message", "physical plan"))
+	}
+
+	return pp, nil
+}
+
+func (r *Request) execute(ctx context.Context, pp plan.PhysicalPlan) (*ExecutionState, error) {
+	sp, _ := startSpan(ctx, executing, r.engine.metrics.executingHist, r.engine.metrics.executing)
+	defer sp.finish()
+	state, err := GenerateExecutionState(pp, r.engine.store)
+	// free up resources
+	if err != nil {
+		return nil, err
+	}
+
+	if r.params.Debug {
+		sp.s.LogFields(log.String("state", state.String()), log.String("message", "execution state"))
+	}
+
+	return state, nil
+}
+
+func (r *Request) finish() {
+	r.parentSpan.finish()
+}
+
+// span is a simple wrapper around opentracing.Span in order to
+// get access to the duration of the span for metrics reporting.
+type span struct {
+	s            opentracing.Span
+	start        time.Time
+	duration     time.Duration
+	durationHist tally.Histogram
+	counter      *counterWithDecrement
+}
+
+func startSpan(ctx context.Context, state State, durationHist tally.Histogram, counter *counterWithDecrement) (*span, context.Context) {
+	now := time.Now()
+	s, sctx := opentracing.StartSpanFromContext(ctx, state.String(), opentracing.StartTime(now))
+	counter.Inc()
+	return &span{
+		s:            s,
+		durationHist: durationHist,
+		start:        now,
+		counter:      counter,
+	}, sctx
+}
+
+func (s *span) finish() {
+	now := time.Now()
+	s.duration = now.Sub(s.start)
+	s.s.FinishWithOptions(opentracing.FinishOptions{
+		FinishTime: now,
+	})
+	s.durationHist.RecordDuration(s.duration)
+	s.counter.Dec()
+}

--- a/src/query/executor/request.go
+++ b/src/query/executor/request.go
@@ -60,7 +60,7 @@ func (s State) String() string {
 }
 
 func (s State) durationString() string {
-	return fmt.Sprint("%s_duration_seconds", s)
+	return fmt.Sprintf("%s_duration_seconds", s)
 }
 
 // Request represents a single request.

--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -203,7 +203,7 @@ func Run(runOpts RunOptions) {
 		defer cleanup()
 	}
 
-	engine := executor.NewEngine(backendStorage)
+	engine := executor.NewEngine(backendStorage, scope.SubScope("engine"))
 
 	handler, err := httpd.NewHandler(backendStorage, tagOptions, downsampler, engine,
 		m3dbClusters, clusterClient, cfg, runOpts.DBConfig, scope)


### PR DESCRIPTION
Tested with following targets:
    - targets: ['localhost:9090','docker.for.mac.localhost:7203']
