### PR TITLE
Skip flaky importorder bug

### DIFF
--- a/.excludemetalint
+++ b/.excludemetalint
@@ -7,4 +7,4 @@ mocks/
 vendor/
 src/m3ninx/x/bytes/slice_arraypool_gen.go
 src/m3ninx/index/segment/mem/ids_map_gen.go
-src/aggregator/integration/data.go
+src/aggregator/integration/integration_data.go


### PR DESCRIPTION
Skipping file causing CI flakiness. Can revert once https://github.com/m3db/build-tools/issues/27 is addressed