### PR TITLE
Add ActiveLogs() API to commitlog and use it in the CleanupManager

### DIFF
--- a/docs/m3db/architecture/engine.md
+++ b/docs/m3db/architecture/engine.md
@@ -181,7 +181,7 @@ The ticking process runs continously in the background and is responsible for a 
 
 #### Merging all encoders
 
-M3TSZ is designed for compressing time series data in which each datapoint has a timestamp that is larger than the last encoded datapoint. For monitoring workloads this works very well because every subsequent datapoint is almost always larger than the previous one. However, real world systems are messy and occasionally out of order writes will be received. When this happens, M3DB will allocate a new encoder for the out of order datapoints. The multiple encoders need to be merged before flushing the data to disk, but to prevent huge memory spikes during the flushing process we continuously merge out of order encoders in the background.
+M3TSZ is designed for compressing time series data in which each datapoint has a timestamp that is larger than the last encoded datapoint. For monitoring workloads this works very well because every subsequent datapoint is almost always chronologically after the previous one. However, real world systems are messy and occasionally out of order writes will be received. When this happens, M3DB will allocate a new encoder for the out of order datapoints. The multiple encoders need to be merged before flushing the data to disk, but to prevent huge memory spikes during the flushing process we continuously merge out of order encoders in the background.
 
 #### Removing expired / flushed series and blocks from memory
 

--- a/docs/m3db/architecture/engine.md
+++ b/docs/m3db/architecture/engine.md
@@ -181,7 +181,7 @@ The ticking process runs continously in the background and is responsible for a 
 
 #### Merging all encoders
 
-M3TSZ is designed for compressing time series data in which each datapoint has a timestamp that is larger than the last encoded datapoint. For monitoring workloads this works very well because every subsequent datapoint is almost always larger than the previous one. However, real world systems are messy and occassionally out of order writes will be received. When this happens, M3DB will allocate a new encoder for the out of order datapoints. The multiple encoders need to be merged before flushing the data to disk, but to prevent huge memory spikes during the flushing process we continuously merge out of order encoders in the background.
+M3TSZ is designed for compressing time series data in which each datapoint has a timestamp that is larger than the last encoded datapoint. For monitoring workloads this works very well because every subsequent datapoint is almost always larger than the previous one. However, real world systems are messy and occasionally out of order writes will be received. When this happens, M3DB will allocate a new encoder for the out of order datapoints. The multiple encoders need to be merged before flushing the data to disk, but to prevent huge memory spikes during the flushing process we continuously merge out of order encoders in the background.
 
 #### Removing expired / flushed series and blocks from memory
 

--- a/src/dbnode/integration/disk_cleanup_multi_ns_test.go
+++ b/src/dbnode/integration/disk_cleanup_multi_ns_test.go
@@ -154,6 +154,16 @@ func TestDiskCleanupMultipleNamespace(t *testing.T) {
 	// Move now forward by 12 hours, and see if the expected files have been deleted
 	testSetup.setNowFn(end)
 
+	// This isn't great, but right now the commitlog will only ever rotate when writes
+	// are received, so we need to issue a write after changing the time to force the
+	// commitlog rotation. This won't be required once we tie commitlog rotation into
+	// the snapshotting process.
+	testSetup.writeBatch(testNamespaces[0], generate.Block(generate.BlockConfig{
+		IDs:       []string{"foo"},
+		NumPoints: 1,
+		Start:     end,
+	}))
+
 	// Check if expected files have been deleted
 	log.Infof("waiting until data is cleaned up")
 	waitTimeout := 60 * time.Second

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -175,11 +175,10 @@ func (l *commitLog) Open() error {
 
 	// Open the buffered commit log writer
 	l.writerState.Lock()
+	defer l.writerState.Unlock()
 	if err := l.openWriterWithLock(l.nowFn()); err != nil {
-		l.writerState.Unlock()
 		return err
 	}
-	l.writerState.Unlock()
 
 	// Flush the info header to ensure we can write to disk
 	if err := l.writerState.writer.Flush(); err != nil {

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -267,7 +267,7 @@ func (l *commitLog) write() {
 	// is guaranteed to still be present), but it does need to acquire an exclusive lock when the writer
 	// is opened, closed, or set to nil (any operation that could change the pointer value of
 	// writerState.writer or writerState.activeFile). In other words, this function can be thought of
-	// as having an implied read lock at all times that is occassionally upgraded to an exclusive lock
+	// as having an implied read lock at all times that is occasionally upgraded to an exclusive lock
 	// for the purpose of mutating the writerState.
 	for write := range l.writes {
 		// For writes requiring acks add to pending acks

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -70,7 +70,7 @@ type commitLog struct {
 	closeErr chan error
 
 	// TODO(r): replace buffered channel with concurrent striped
-	// circular buffer to avoid central write lock contention
+	// circular buffer to avoid central write lock contention.
 	writes chan commitLogWrite
 
 	opts  Options

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -180,8 +180,9 @@ func (l *commitLog) Open() error {
 		return err
 	}
 
-	// Flush the info header to ensure we can write to disk
-	if err := l.writerState.writer.Flush(); err != nil {
+	// Sync the info header to ensure we can write to disk and make sure that we can at least
+	// read the info about the commitlog file later.
+	if err := l.writerState.writer.Sync(); err != nil {
 		return err
 	}
 
@@ -276,6 +277,8 @@ func (l *commitLog) write() {
 		}
 
 		if write.valueType == flushValueType {
+			// TODO(rartoul): Consider replacing this with a call to Sync() once we have time to do
+			// benchmarking.
 			l.writerState.writer.Flush()
 			continue
 		}

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -294,13 +294,6 @@ func (l *commitLog) flushEvery(interval time.Duration) {
 }
 
 func (l *commitLog) write() {
-	// This loop is the only part of the commit log that is allowed to modify (open, close, set to nil)
-	// the writer. As a result, it does not need to synchronize itself when it is using the writer (it
-	// is guaranteed to still be present), but it does need to acquire an exclusive lock when the writer
-	// is opened, closed, or set to nil (any operation that could change the pointer value of
-	// writerState.writer or writerState.activeFile). In other words, this function can be thought of
-	// as having an implied read lock at all times that is occasionally upgraded to an exclusive lock
-	// for the purpose of mutating the writerState.
 	for write := range l.writes {
 		// For writes requiring acks add to pending acks
 		if write.valueType == writeValueType && write.completionFn != nil {

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -231,7 +231,7 @@ func (l *commitLog) Open() error {
 
 	// Sync the info header to ensure we can write to disk and make sure that we can at least
 	// read the info about the commitlog file later.
-	if err := l.writerState.writer.Sync(); err != nil {
+	if err := l.writerState.writer.Flush(true); err != nil {
 		return err
 	}
 
@@ -335,12 +335,7 @@ func (l *commitLog) flushEvery(interval time.Duration) {
 func (l *commitLog) write() {
 	for write := range l.writes {
 		if write.eventType == flushEventType {
-			// TODO(rartoul): This should probably be replaced with a call to Sync() as the expectation
-			// is that the commitlog will actually FSync the data at regular intervals, whereas Flush
-			// just ensures that the writers buffer flushes to the chunkWriter (creating a new chunk), but
-			// does not guarantee that the O.S isn't still buffering the data. Leaving as is for now as making
-			// this change will require extensive benchmarking in production clusters.
-			l.writerState.writer.Flush()
+			l.writerState.writer.Flush(false)
 			continue
 		}
 

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -81,8 +81,6 @@ type commitLog struct {
 	// being accessed.
 	closeErr chan error
 
-	// TODO(r): replace buffered channel with concurrent striped
-	// circular buffer to avoid central write lock contention.
 	writes          chan commitLogWrite
 	pendingFlushFns []completionFn
 

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -41,8 +41,6 @@ var (
 
 	errCommitLogClosed = errors.New("commit log is closed")
 
-	errCommitLogAlreadyOpen = errors.New("commit log is already open")
-
 	timeZero = time.Time{}
 )
 

--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -246,11 +246,7 @@ func (l *commitLog) ActiveLogs() ([]File, error) {
 	l.writes <- commitLogWrite{
 		valueType: activeLogsValueType,
 		completionFn: func(f File, e error) {
-			if e != nil {
-				err = e
-				return
-			}
-
+			err = e
 			file = f
 			wg.Done()
 		},

--- a/src/dbnode/persist/fs/commitlog/commit_log_conc_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_conc_test.go
@@ -1,0 +1,95 @@
+// +build big
+//
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package commitlog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/ts"
+	"github.com/m3db/m3x/context"
+	xtime "github.com/m3db/m3x/time"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitLogActiveLogsConcurrency(t *testing.T) {
+	opts, _ := newTestOptions(t, overrides{
+		strategy: StrategyWriteBehind,
+	})
+	opts = opts.SetBlockSize(1 * time.Millisecond)
+	defer cleanup(t, opts)
+
+	var (
+		doneCh    = make(chan struct{})
+		commitLog = newTestCommitLog(t, opts)
+	)
+
+	// One goroutine continuously writing
+	go func() {
+		for {
+			select {
+			case <-doneCh:
+				return
+			default:
+				time.Sleep(time.Millisecond)
+				err := commitLog.Write(
+					context.NewContext(),
+					testSeries(0, "foo.bar", testTags1, 127),
+					ts.Datapoint{},
+					xtime.Second,
+					nil)
+				if err == errCommitLogClosed {
+					return
+				}
+				if err != nil {
+					panic(err)
+				}
+			}
+		}
+	}()
+
+	// One goroutine continuously checking active logs
+	go func() {
+		var (
+			lastSeenFile string
+			numFilesSeen int
+		)
+		for numFilesSeen < 10 {
+			time.Sleep(100 * time.Millisecond)
+			logs, err := commitLog.ActiveLogs()
+			if err != nil {
+				panic(err)
+			}
+			require.Equal(t, 1, len(logs))
+			if logs[0].FilePath != lastSeenFile {
+				lastSeenFile = logs[0].FilePath
+				numFilesSeen++
+			}
+		}
+		close(doneCh)
+	}()
+
+	<-doneCh
+
+	require.NoError(t, commitLog.Close())
+}

--- a/src/dbnode/persist/fs/commitlog/commit_log_conc_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_conc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3x/context"
 	xtime "github.com/m3db/m3x/time"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/src/dbnode/persist/fs/commitlog/commit_log_conc_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_conc_test.go
@@ -62,6 +62,9 @@ func TestCommitLogActiveLogsConcurrency(t *testing.T) {
 				if err == errCommitLogClosed {
 					return
 				}
+				if err == ErrCommitLogQueueFull {
+					continue
+				}
 				if err != nil {
 					panic(err)
 				}

--- a/src/dbnode/persist/fs/commitlog/commit_log_mock.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_mock.go
@@ -99,6 +99,19 @@ func (mr *MockCommitLogMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockCommitLog)(nil).Close))
 }
 
+// ActiveLogs mocks base method
+func (m *MockCommitLog) ActiveLogs() ([]File, error) {
+	ret := m.ctrl.Call(m, "ActiveLogs")
+	ret0, _ := ret[0].([]File)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ActiveLogs indicates an expected call of ActiveLogs
+func (mr *MockCommitLogMockRecorder) ActiveLogs() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActiveLogs", reflect.TypeOf((*MockCommitLog)(nil).ActiveLogs))
+}
+
 // MockIterator is a mock of Iterator interface
 type MockIterator struct {
 	ctrl     *gomock.Controller

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -384,7 +384,7 @@ func TestReadCommitLogMissingMetadata(t *testing.T) {
 	// Replace bitset in writer with one that configurably returns true or false
 	// depending on the series
 	commitLog := newTestCommitLog(t, opts)
-	writer := commitLog.writer.(*writer)
+	writer := commitLog.writerState.writer.(*writer)
 
 	bitSet := bitset.NewBitSet(0)
 
@@ -754,10 +754,10 @@ func TestCommitLogFailOnOpenError(t *testing.T) {
 	wg := setupCloseOnFail(t, commitLog)
 
 	func() {
-		commitLog.RLock()
-		defer commitLog.RUnlock()
+		commitLog.writerState.Lock()
+		defer commitLog.writerState.Unlock()
 		// Expire the writer so it requires a new open
-		commitLog.writerExpireAt = timeZero
+		commitLog.writerState.writerExpireAt = timeZero
 	}()
 
 	writes := []testWrite{

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -856,6 +856,7 @@ func TestCommitLogActiveLogs(t *testing.T) {
 }
 
 func TestCommitLogActiveLogsConcurrency(t *testing.T) {
+	t.Skip()
 	opts, _ := newTestOptions(t, overrides{
 		strategy: StrategyWriteBehind,
 	})

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -285,7 +285,7 @@ func flushUntilDone(l *commitLog, wg *sync.WaitGroup) {
 	blockWg.Add(1)
 	go func() {
 		for atomic.LoadUint64(&done) == 0 {
-			l.writes <- commitLogWrite{valueType: flushValueType}
+			l.writes <- commitLogWrite{eventType: flushEventType}
 			time.Sleep(time.Millisecond)
 		}
 		blockWg.Done()

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -835,7 +835,18 @@ func TestCommitLogActiveLogs(t *testing.T) {
 	defer cleanup(t, opts)
 
 	commitLog := newTestCommitLog(t, opts)
-	commitLog.Open()
+
+	writer := newMockCommitLogWriter()
+	writer.flushFn = func() error {
+		return nil
+	}
+	commitLog.newCommitLogWriterFn = func(
+		_ flushFn,
+		_ Options,
+	) commitLogWriter {
+		return writer
+	}
+
 	logs, err := commitLog.ActiveLogs()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(logs))

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -913,7 +913,6 @@ func TestCommitLogActiveLogsConcurrency(t *testing.T) {
 			}
 			require.Equal(t, 1, len(logs))
 			if logs[0].FilePath != lastSeenFile {
-				fmt.Println(logs[0].FilePath)
 				lastSeenFile = logs[0].FilePath
 				numFilesSeen++
 			}

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -762,8 +762,6 @@ func TestCommitLogFailOnOpenError(t *testing.T) {
 	wg := setupCloseOnFail(t, commitLog)
 
 	func() {
-		commitLog.writerState.Lock()
-		defer commitLog.writerState.Unlock()
 		// Expire the writer so it requires a new open
 		commitLog.writerState.writerExpireAt = timeZero
 	}()

--- a/src/dbnode/persist/fs/commitlog/read_write_prop_test.go
+++ b/src/dbnode/persist/fs/commitlog/read_write_prop_test.go
@@ -610,3 +610,7 @@ func (c *corruptingChunkWriter) close() error {
 func (c *corruptingChunkWriter) isOpen() bool {
 	return c.chunkWriter.isOpen()
 }
+
+func (c *corruptingChunkWriter) sync() error {
+	return c.chunkWriter.sync()
+}

--- a/src/dbnode/persist/fs/commitlog/read_write_prop_test.go
+++ b/src/dbnode/persist/fs/commitlog/read_write_prop_test.go
@@ -1,3 +1,4 @@
+// +build big
 //
 // Copyright (c) 2018 Uber Technologies, Inc.
 //

--- a/src/dbnode/persist/fs/commitlog/types.go
+++ b/src/dbnode/persist/fs/commitlog/types.go
@@ -64,6 +64,9 @@ type CommitLog interface {
 
 	// Close the commit log
 	Close() error
+
+	// ActiveLogs returns a slice of the active commitlogs.
+	ActiveLogs() ([]File, error)
 }
 
 // Iterator provides an iterator for commit logs

--- a/src/dbnode/persist/fs/commitlog/writer.go
+++ b/src/dbnode/persist/fs/commitlog/writer.go
@@ -65,7 +65,7 @@ var (
 
 type commitLogWriter interface {
 	// Open opens the commit log for writing data
-	Open(start time.Time, duration time.Duration) error
+	Open(start time.Time, duration time.Duration) (File, error)
 
 	// Write will write an entry in the commit log for a given series
 	Write(
@@ -133,19 +133,19 @@ func newCommitLogWriter(
 	}
 }
 
-func (w *writer) Open(start time.Time, duration time.Duration) error {
+func (w *writer) Open(start time.Time, duration time.Duration) (File, error) {
 	if w.isOpen() {
-		return errCommitLogWriterAlreadyOpen
+		return File{}, errCommitLogWriterAlreadyOpen
 	}
 
 	commitLogsDir := fs.CommitLogsDirPath(w.filePathPrefix)
 	if err := os.MkdirAll(commitLogsDir, w.newDirectoryMode); err != nil {
-		return err
+		return File{}, err
 	}
 
 	filePath, index, err := fs.NextCommitLogsFile(w.filePathPrefix, start)
 	if err != nil {
-		return err
+		return File{}, err
 	}
 	logInfo := schema.LogInfo{
 		Start:    start.UnixNano(),
@@ -154,23 +154,28 @@ func (w *writer) Open(start time.Time, duration time.Duration) error {
 	}
 	w.logEncoder.Reset()
 	if err := w.logEncoder.EncodeLogInfo(logInfo); err != nil {
-		return err
+		return File{}, err
 	}
 	fd, err := fs.OpenWritable(filePath, w.newFileMode)
 	if err != nil {
-		return err
+		return File{}, err
 	}
 
 	w.chunkWriter.reset(fd)
 	w.buffer.Reset(w.chunkWriter)
 	if err := w.write(w.logEncoder.Bytes()); err != nil {
 		w.Close()
-		return err
+		return File{}, err
 	}
 
 	w.start = start
 	w.duration = duration
-	return nil
+	return File{
+		FilePath: filePath,
+		Start:    start,
+		Duration: duration,
+		Index:    int64(index),
+	}, nil
 }
 
 func (w *writer) isOpen() bool {

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -310,8 +310,8 @@ func (m *cleanupManager) commitLogTimes(t time.Time) ([]commitLogFileWithErrorAn
 	//
 	// If we call ActiveLogs first then it will return time3. Next, the commit log file rotates, and
 	// after that we call commitLogFilesFn which returns: [time1, time2, time3, time4]. In this scenario
-	// we would be allowed to commitlog files 1,2, and 4 which is not the desired behavior. Instead, we
-	// list the commitlogs on disk first (which returns time1, time2, and time3) and *then* check what
+	// we would be allowed to delete commitlog files 1,2, and 4 which is not the desired behavior. Instead,
+	// we list the commitlogs on disk first (which returns time1, time2, and time3) and *then* check what
 	// the active file is. If the commitlog has not rotated, then ActiveLogs() will return time3 which
 	// we will correctly avoid deleting, and if the commitlog has rotated, then ActiveLogs() will return
 	// time4 which we wouldn't consider deleting anyways because it wasn't returned from the first call

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -80,14 +80,14 @@ func newCleanupManagerMetrics(scope tally.Scope) cleanupManagerMetrics {
 }
 
 func newCleanupManager(
-	database database, activeLogs activeCommitlogs, scope tally.Scope) databaseCleanupManager {
+	database database, scope tally.Scope) databaseCleanupManager {
 	opts := database.Options()
 	filePathPrefix := opts.CommitLogOptions().FilesystemOptions().FilePathPrefix()
 	commitLogsDir := fs.CommitLogsDirPath(filePathPrefix)
 
 	return &cleanupManager{
-		database:         database,
-		activeCommitlogs: activeLogs,
+		database: database,
+		// activeCommitlogs: activeLogs,
 
 		opts:                        opts,
 		nowFn:                       opts.ClockOptions().NowFn(),

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -80,14 +80,14 @@ func newCleanupManagerMetrics(scope tally.Scope) cleanupManagerMetrics {
 }
 
 func newCleanupManager(
-	database database, scope tally.Scope) databaseCleanupManager {
+	database database, activeLogs activeCommitlogs, scope tally.Scope) databaseCleanupManager {
 	opts := database.Options()
 	filePathPrefix := opts.CommitLogOptions().FilesystemOptions().FilePathPrefix()
 	commitLogsDir := fs.CommitLogsDirPath(filePathPrefix)
 
 	return &cleanupManager{
-		database: database,
-		// activeCommitlogs: activeLogs,
+		database:         database,
+		activeCommitlogs: activeLogs,
 
 		opts:                        opts,
 		nowFn:                       opts.ClockOptions().NowFn(),

--- a/src/dbnode/storage/cleanup_prop_test.go
+++ b/src/dbnode/storage/cleanup_prop_test.go
@@ -60,7 +60,7 @@ func newPropTestCleanupMgr(
 	db.EXPECT().Options().Return(opts).AnyTimes()
 	db.EXPECT().GetOwnedNamespaces().Return(ns, nil).AnyTimes()
 	scope := tally.NoopScope
-	cmIface := newCleanupManager(db, scope)
+	cmIface := newCleanupManager(db, newNoopFakeActiveLogs(), scope)
 	cm := cmIface.(*cleanupManager)
 
 	var (

--- a/src/dbnode/storage/cleanup_test.go
+++ b/src/dbnode/storage/cleanup_test.go
@@ -68,7 +68,7 @@ func TestCleanupManagerCleanup(t *testing.T) {
 	}
 	db := newMockdatabase(ctrl, namespaces...)
 	db.EXPECT().GetOwnedNamespaces().Return(namespaces, nil).AnyTimes()
-	mgr := newCleanupManager(db, tally.NoopScope).(*cleanupManager)
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 	mgr.opts = mgr.opts.SetCommitLogOptions(
 		mgr.opts.CommitLogOptions().
 			SetBlockSize(rOpts.BlockSize()))
@@ -116,7 +116,7 @@ func TestCleanupManagerNamespaceCleanup(t *testing.T) {
 	db := newMockdatabase(ctrl, ns)
 	db.EXPECT().GetOwnedNamespaces().Return(nses, nil).AnyTimes()
 
-	mgr := newCleanupManager(db, tally.NoopScope).(*cleanupManager)
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 	idx.EXPECT().CleanupExpiredFileSets(ts).Return(nil)
 	require.NoError(t, mgr.Cleanup(ts))
 }
@@ -140,7 +140,7 @@ func TestCleanupManagerDoesntNeedCleanup(t *testing.T) {
 	}
 	db := newMockdatabase(ctrl, namespaces...)
 	db.EXPECT().GetOwnedNamespaces().Return(namespaces, nil).AnyTimes()
-	mgr := newCleanupManager(db, tally.NoopScope).(*cleanupManager)
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 	mgr.opts = mgr.opts.SetCommitLogOptions(
 		mgr.opts.CommitLogOptions().
 			SetBlockSize(rOpts.BlockSize()))
@@ -175,7 +175,7 @@ func TestCleanupDataAndSnapshotFileSetFiles(t *testing.T) {
 
 	db := newMockdatabase(ctrl, namespaces...)
 	db.EXPECT().GetOwnedNamespaces().Return(namespaces, nil).AnyTimes()
-	mgr := newCleanupManager(db, tally.NoopScope).(*cleanupManager)
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 
 	require.NoError(t, mgr.Cleanup(ts))
 }
@@ -204,7 +204,7 @@ func TestDeleteInactiveDataAndSnapshotFileSetFiles(t *testing.T) {
 
 	db := newMockdatabase(ctrl, namespaces...)
 	db.EXPECT().GetOwnedNamespaces().Return(namespaces, nil).AnyTimes()
-	mgr := newCleanupManager(db, tally.NoopScope).(*cleanupManager)
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 
 	deleteInactiveDirectoriesCalls := []deleteInactiveDirectoriesCall{}
 	deleteInactiveDirectoriesFn := func(parentDirPath string, activeDirNames []string) error {
@@ -257,7 +257,7 @@ func TestCleanupManagerPropagatesGetOwnedNamespacesError(t *testing.T) {
 	db.EXPECT().Terminate().Return(nil)
 	db.EXPECT().GetOwnedNamespaces().Return(nil, errDatabaseIsClosed).AnyTimes()
 
-	mgr := newCleanupManager(db, tally.NoopScope).(*cleanupManager)
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 	require.NoError(t, db.Open())
 	require.NoError(t, db.Terminate())
 
@@ -436,7 +436,7 @@ func newCleanupManagerCommitLogTimesTest(t *testing.T, ctrl *gomock.Controller) 
 	ns.EXPECT().Options().Return(no).AnyTimes()
 
 	db := newMockdatabase(ctrl, ns)
-	mgr := newCleanupManager(db, tally.NoopScope).(*cleanupManager)
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 
 	mgr.opts = mgr.opts.SetCommitLogOptions(
 		mgr.opts.CommitLogOptions().
@@ -465,7 +465,7 @@ func newCleanupManagerCommitLogTimesTestMultiNS(
 	ns2.EXPECT().Options().Return(no).AnyTimes()
 
 	db := newMockdatabase(ctrl, ns1, ns2)
-	mgr := newCleanupManager(db, tally.NoopScope).(*cleanupManager)
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 
 	mgr.opts = mgr.opts.SetCommitLogOptions(
 		mgr.opts.CommitLogOptions().
@@ -743,4 +743,22 @@ func TestCleanupManagerDeletesCorruptCommitLogFiles(t *testing.T) {
 	filesToCleanup, err := mgr.commitLogTimes(currentTime)
 	require.NoError(t, err)
 	require.True(t, containsCorrupt(filesToCleanup, path))
+}
+
+type fakeActiveLogs struct {
+	activeLogs []commitlog.File
+}
+
+func (f fakeActiveLogs) ActiveLogs() ([]commitlog.File, error) {
+	return f.activeLogs, nil
+}
+
+func newNoopFakeActiveLogs() fakeActiveLogs {
+	return newFakeActiveLogs(nil)
+}
+
+func newFakeActiveLogs(activeLogs []commitlog.File) fakeActiveLogs {
+	return fakeActiveLogs{
+		activeLogs: activeLogs,
+	}
 }

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -188,7 +188,8 @@ func NewDatabase(
 		return nil, err
 	}
 
-	mediator, err := newMediator(d, opts.SetInstrumentOptions(databaseIOpts))
+	mediator, err := newMediator(
+		d, commitLog, opts.SetInstrumentOptions(databaseIOpts))
 	if err != nil {
 		return nil, err
 	}

--- a/src/dbnode/storage/fs.go
+++ b/src/dbnode/storage/fs.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	xlog "github.com/m3db/m3x/log"
 )
 
@@ -69,6 +70,7 @@ type fileSystemManager struct {
 
 func newFileSystemManager(
 	database database,
+	commitlog commitlog.CommitLog,
 	opts Options,
 ) databaseFileSystemManager {
 	instrumentOpts := opts.InstrumentOptions()

--- a/src/dbnode/storage/fs.go
+++ b/src/dbnode/storage/fs.go
@@ -70,13 +70,13 @@ type fileSystemManager struct {
 
 func newFileSystemManager(
 	database database,
-	commitlog commitlog.CommitLog,
+	commitLog commitlog.CommitLog,
 	opts Options,
 ) databaseFileSystemManager {
 	instrumentOpts := opts.InstrumentOptions()
 	scope := instrumentOpts.MetricsScope().SubScope("fs")
 	fm := newFlushManager(database, scope)
-	cm := newCleanupManager(database, scope)
+	cm := newCleanupManager(database, commitLog, scope)
 
 	return &fileSystemManager{
 		databaseFlushManager:   fm,

--- a/src/dbnode/storage/fs_test.go
+++ b/src/dbnode/storage/fs_test.go
@@ -34,7 +34,7 @@ func TestFileSystemManagerShouldRunDuringBootstrap(t *testing.T) {
 	defer ctrl.Finish()
 
 	database := newMockdatabase(ctrl)
-	fsm := newFileSystemManager(database, testDatabaseOptions())
+	fsm := newFileSystemManager(database, nil, testDatabaseOptions())
 	mgr := fsm.(*fileSystemManager)
 
 	database.EXPECT().IsBootstrapped().Return(false)
@@ -48,7 +48,7 @@ func TestFileSystemManagerShouldRunWhileRunning(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := newMockdatabase(ctrl)
-	fsm := newFileSystemManager(database, testDatabaseOptions())
+	fsm := newFileSystemManager(database, nil, testDatabaseOptions())
 	mgr := fsm.(*fileSystemManager)
 	database.EXPECT().IsBootstrapped().Return(true)
 	require.True(t, mgr.shouldRunWithLock())
@@ -60,7 +60,7 @@ func TestFileSystemManagerShouldRunEnableDisable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := newMockdatabase(ctrl)
-	fsm := newFileSystemManager(database, testDatabaseOptions())
+	fsm := newFileSystemManager(database, nil, testDatabaseOptions())
 	mgr := fsm.(*fileSystemManager)
 	database.EXPECT().IsBootstrapped().Return(true).AnyTimes()
 	require.True(t, mgr.shouldRunWithLock())
@@ -78,7 +78,7 @@ func TestFileSystemManagerRun(t *testing.T) {
 
 	fm := NewMockdatabaseFlushManager(ctrl)
 	cm := NewMockdatabaseCleanupManager(ctrl)
-	fsm := newFileSystemManager(database, testDatabaseOptions())
+	fsm := newFileSystemManager(database, nil, testDatabaseOptions())
 	mgr := fsm.(*fileSystemManager)
 	mgr.databaseFlushManager = fm
 	mgr.databaseCleanupManager = cm

--- a/src/dbnode/storage/mediator.go
+++ b/src/dbnode/storage/mediator.go
@@ -82,8 +82,8 @@ type mediator struct {
 
 func newMediator(database database, commitlog commitlog.CommitLog, opts Options) (databaseMediator, error) {
 	scope := opts.InstrumentOptions().MetricsScope()
-	d := &mediator
-		database:  database,
+	d := &mediator{
+		database: database,
 		opts:     opts,
 		nowFn:    opts.ClockOptions().NowFn(),
 		sleepFn:  time.Sleep,

--- a/src/dbnode/storage/mediator.go
+++ b/src/dbnode/storage/mediator.go
@@ -92,7 +92,7 @@ func newMediator(database database, commitlog commitlog.CommitLog, opts Options)
 		closedCh: make(chan struct{}),
 	}
 
-	fsm := newFileSystemManager(database, opts)
+	fsm := newFileSystemManager(database, commitlog, opts)
 	d.databaseFileSystemManager = fsm
 
 	d.databaseRepairer = newNoopDatabaseRepairer()

--- a/src/dbnode/storage/mediator.go
+++ b/src/dbnode/storage/mediator.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/clock"
+	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 
 	"github.com/uber-go/tally"
 )
@@ -79,10 +80,10 @@ type mediator struct {
 	closedCh chan struct{}
 }
 
-func newMediator(database database, opts Options) (databaseMediator, error) {
+func newMediator(database database, commitlog commitlog.CommitLog, opts Options) (databaseMediator, error) {
 	scope := opts.InstrumentOptions().MetricsScope()
-	d := &mediator{
-		database: database,
+	d := &mediator
+		database:  database,
 		opts:     opts,
 		nowFn:    opts.ClockOptions().NowFn(),
 		sleepFn:  time.Sleep,

--- a/src/dbnode/storage/mediator_test.go
+++ b/src/dbnode/storage/mediator_test.go
@@ -44,7 +44,7 @@ func TestDatabaseMediatorOpenClose(t *testing.T) {
 	db.EXPECT().Options().Return(opts).AnyTimes()
 	db.EXPECT().GetOwnedNamespaces().Return(nil, nil).AnyTimes()
 	db.EXPECT().BootstrapState().Return(DatabaseBootstrapState{}).AnyTimes()
-	m, err := newMediator(db, opts)
+	m, err := newMediator(db, nil, opts)
 	require.NoError(t, err)
 
 	require.Equal(t, errMediatorNotOpen, m.Close())
@@ -70,7 +70,7 @@ func TestDatabaseMediatorDisableFileOps(t *testing.T) {
 
 	db := NewMockdatabase(ctrl)
 	db.EXPECT().Options().Return(opts).AnyTimes()
-	med, err := newMediator(db, opts)
+	med, err := newMediator(db, nil, opts)
 	require.NoError(t, err)
 
 	m := med.(*mediator)


### PR DESCRIPTION
This P.R allows us to distinguish between corrupt commitlogs and active commitlogs (which sometimes look corrupt because the header info hasn't been flushed yet), allowing us to delete corrupt commitlog files safely.