### PR TITLE
Rename grafana image in docker-compose to force build at least once

### DIFF
--- a/scripts/development/m3_stack/docker-compose.yml
+++ b/scripts/development/m3_stack/docker-compose.yml
@@ -96,6 +96,6 @@ services:
       - "0.0.0.0:3000:3000"
     networks:
       - backend
-    image: grafana/grafana:latest
+    image: m3grafana:latest
 networks:
   backend:


### PR DESCRIPTION
We were previously calling the grafana image in the docker-compose file the same as the canonical image which meant that docker-compose would not build it and default graphs / sources would not be copied into the image. Renaming it forces the image to be built at least once so users of the command always get default dashboards / sources.