### PR TITLE
Fix Matcher string method to use non-pointer receiver

### DIFF
--- a/src/query/models/matcher.go
+++ b/src/query/models/matcher.go
@@ -61,12 +61,12 @@ func NewMatcher(t MatchType, n, v []byte) (Matcher, error) {
 	return m, nil
 }
 
-func (m *Matcher) String() string {
+func (m Matcher) String() string {
 	return fmt.Sprintf("%s%s%q", m.Name, m.Type, m.Value)
 }
 
 // Matches returns whether the matcher matches the given string value.
-func (m *Matcher) Matches(s []byte) bool {
+func (m Matcher) Matches(s []byte) bool {
 	switch m.Type {
 	case MatchEqual:
 		return bytes.Equal(s, m.Value)

--- a/src/query/models/matcher_test.go
+++ b/src/query/models/matcher_test.go
@@ -21,6 +21,7 @@
 package models
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,6 +97,14 @@ func TestMatcher(t *testing.T) {
 	for _, test := range tests {
 		assert.Equal(t, test.match, test.matcher.Matches([]byte(test.value)))
 	}
+}
+
+func TestMatcher_String(t *testing.T) {
+	m := newMatcher(t, MatchEqual, "foo")
+	m.Name = []byte(`key`)
+
+	assert.Equal(t,  `key="foo"`, fmt.Sprintf("%s", m))
+	assert.Equal(t,  `key="foo"`, fmt.Sprintf("%s", &m))
 }
 
 func TestMatchType(t *testing.T) {


### PR DESCRIPTION
The teeniest of fixes here. I noticed that the plan printed by debug=true included some not very useful byte arrays. Turns out that's because `Matcher.String()` was defined on `*Matcher`, and we always use `Matcher`.

Before:

```
2018-10-18T15:03:54.267-0400	INFO	logical plan	{"rqID": "67a88734-6c10-4f09-991a-6f94306c7fb4", "plan": "Plan steps: map[0:Parents: [], Children: [], Transform: ID: 0, Op: type: fetch. name: prometheus_tsdb_wal_corruptions_total, range: 0s, offset: 0s, matchers: [{= [106 111 98] [112 114 111 109 101 116 104 101 117 115] <nil>} {= [95 95 110 97 109 101 95 95] [112 114 111 109 101 116 104 101 117 115 95 116 115 100 98 95 119 97 108 95 99 111 114 114 117 112 116 105 111 110 115 95 116 111 116 97 108] <nil>}]], Pipeline: [0]"}
```

After:
```
2018-10-18T15:06:20.084-0400	INFO	logical plan	{"rqID": "e1cbdd9a-8eb4-4cbc-871b-de832a3075a6", "plan": "Plan steps: map[0:Parents: [], Children: [], Transform: ID: 0, Op: type: fetch. name: prometheus_tsdb_wal_corruptions_total, range: 0s, offset: 0s, matchers: [job=\"prometheus\" __name__=\"prometheus_tsdb_wal_corruptions_total\"]], Pipeline: [0]"}
```
FWIW `String` will now also get called for `*Matcher`, since `Printf` follows pointers.