### PR TITLE
Use a default pool size of 10 in development for query

### DIFF
--- a/src/query/README.md
+++ b/src/query/README.md
@@ -46,7 +46,7 @@ Build m3coordinator binary:
 
 Run m3coordinator binary:
 
-    $ ./bin/m3coordinator --config.file docker/coordinator.yml
+    $ ./bin/m3coordinator -f src/query/config/m3query-dev-etcd.yml
 
 Run Prometheus Docker image:
 

--- a/src/query/config/m3query-dev-etcd.yml
+++ b/src/query/config/m3query-dev-etcd.yml
@@ -1,0 +1,62 @@
+# m3query configuration for local development setup. Mostly the same as m3query-local-etcd.yml, but using fewer
+# resources (threads primarily).
+
+listenAddress:
+  type: "config"
+  value: "0.0.0.0:7201"
+
+metrics:
+  scope:
+    prefix: "coordinator"
+  prometheus:
+    handlerPath: /metrics
+    listenAddress: 0.0.0.0:7203 # until https://github.com/m3db/m3/issues/682 is resolved
+  sanitization: prometheus
+  samplingRate: 1.0
+  extended: none
+
+clusters:
+  - namespaces:
+      - namespace: default
+        type: unaggregated
+        retention: 48h
+    client:
+      config:
+        service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+            - zone: embedded
+              endpoints:
+                - 127.0.0.1:2379
+        seedNodes:
+          initialCluster:
+            - hostID: m3db_local
+              endpoint: http://127.0.0.1:2380
+      writeConsistencyLevel: majority
+      readConsistencyLevel: unstrict_majority
+      writeTimeout: 10s
+      fetchTimeout: 15s
+      connectTimeout: 20s
+      writeRetry:
+        initialBackoff: 500ms
+        backoffFactor: 3
+        maxRetries: 2
+        jitter: true
+      fetchRetry:
+        initialBackoff: 500ms
+        backoffFactor: 2
+        maxRetries: 3
+        jitter: true
+      backgroundHealthCheckFailLimit: 4
+      backgroundHealthCheckFailThrottleFactor: 0.5
+
+readWorkerPoolPolicy:
+  grow: false
+  size: 10
+
+writeWorkerPoolPolicy:
+  grow: false
+  size: 10


### PR DESCRIPTION
Another small tweak--I found that when I got panics running locally, the stack trace was huge due to the large number of goroutines we had spawned. Most of them were from the `readWorkerPool` and `writeWorkerPool` in query, since default config gives you 4096 threads. I added config to the local query config to shrink this down to a starting size of 10, which is much more manageable.

Let me know if I should propagate that through some of the other config files as well.