### PR TITLE
[Aggregator Client] Drain queue asynchronously when closing writer

### DIFF
--- a/src/aggregator/client/queue.go
+++ b/src/aggregator/client/queue.go
@@ -101,7 +101,7 @@ type instanceQueue interface {
 	// Enqueue enqueues a data buffer.
 	Enqueue(buf protobuf.Buffer) error
 
-	// Close closes the queue.
+	// Close closes the queue, it blocks until the queue is drained.
 	Close() error
 }
 

--- a/src/aggregator/client/writer.go
+++ b/src/aggregator/client/writer.go
@@ -148,18 +148,18 @@ func (w *writer) Close() error {
 	}
 	w.closed = true
 
-	err := w.flushWithLock()
-	if err != nil {
-		w.metrics.flushErrors.Inc(1)
-		w.log.Errorf("error flushing writer, %v", err)
-	}
 	go func() {
+		if err := w.flushWithLock(); err != nil {
+			w.metrics.flushErrors.Inc(1)
+			w.log.Errorf("error flushing writer, %v", err)
+		}
 		if err := w.queue.Close(); err != nil {
+			w.metrics.queueCloseErrors.Inc(1)
 			w.log.Errorf("error closing queue, %v", err)
 		}
 	}()
 
-	return err
+	return nil
 }
 
 func (w *writer) encodeWithLock(
@@ -436,18 +436,20 @@ const (
 )
 
 type writerMetrics struct {
-	buffersEnqueued tally.Counter
-	encodeErrors    tally.Counter
-	enqueueErrors   tally.Counter
-	flushErrors     tally.Counter
+	buffersEnqueued  tally.Counter
+	encodeErrors     tally.Counter
+	enqueueErrors    tally.Counter
+	flushErrors      tally.Counter
+	queueCloseErrors tally.Counter
 }
 
 func newWriterMetrics(s tally.Scope) writerMetrics {
 	return writerMetrics{
-		buffersEnqueued: s.Tagged(map[string]string{actionTag: "enqueued"}).Counter(buffersMetric),
-		encodeErrors:    s.Tagged(map[string]string{actionTag: "encode-error"}).Counter(buffersMetric),
-		enqueueErrors:   s.Tagged(map[string]string{actionTag: "enqueue-error"}).Counter(buffersMetric),
-		flushErrors:     s.Tagged(map[string]string{actionTag: "flush-error"}).Counter(buffersMetric),
+		buffersEnqueued:  s.Tagged(map[string]string{actionTag: "enqueued"}).Counter(buffersMetric),
+		encodeErrors:     s.Tagged(map[string]string{actionTag: "encode-error"}).Counter(buffersMetric),
+		enqueueErrors:    s.Tagged(map[string]string{actionTag: "enqueue-error"}).Counter(buffersMetric),
+		flushErrors:      s.Tagged(map[string]string{actionTag: "flush-error"}).Counter(buffersMetric),
+		queueCloseErrors: s.Tagged(map[string]string{actionTag: "queue-close-error"}).Counter(buffersMetric),
 	}
 }
 

--- a/src/aggregator/client/writer.go
+++ b/src/aggregator/client/writer.go
@@ -464,5 +464,8 @@ func newRefCountedWriter(instance placement.Instance, opts Options) *refCountedW
 }
 
 func (rcWriter *refCountedWriter) Close() {
+	// NB: closing the writer needs to be done asynchronously because it may
+	// be called by writer manager while holding a lock that blocks any writes
+	// from proceeding.
 	go rcWriter.instanceWriter.Close() // nolint: errcheck
 }

--- a/src/aggregator/client/writer_test.go
+++ b/src/aggregator/client/writer_test.go
@@ -30,7 +30,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/m3db/m3/src/metrics/encoding"
 	"github.com/m3db/m3/src/metrics/encoding/migration"
@@ -40,7 +39,6 @@ import (
 	"github.com/m3db/m3/src/metrics/metric/aggregated"
 	"github.com/m3db/m3/src/metrics/metric/id"
 	"github.com/m3db/m3/src/metrics/metric/unaggregated"
-	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
 
 	"github.com/golang/mock/gomock"
@@ -754,28 +752,6 @@ func TestWriterCloseAlreadyClosed(t *testing.T) {
 	w := newInstanceWriter(testPlacementInstance, testOptions()).(*writer)
 	w.closed = true
 	require.Equal(t, errInstanceWriterClosed, w.Close())
-}
-
-func TestWriterCloseNotBlockingOnDraining(t *testing.T) {
-	var (
-		opts = testOptions().SetInstanceQueueSize(200)
-		w    = newInstanceWriter(testPlacementInstance, opts).(*writer)
-	)
-	w.queue.(*queue).writeFn = func([]byte) error {
-		time.Sleep(time.Second)
-		return nil
-	}
-	data := []byte("foo")
-	for i := 0; i < opts.InstanceQueueSize(); i++ {
-		require.NoError(t, w.queue.Enqueue(testNewBuffer(data)))
-	}
-
-	go w.Close()
-	require.True(t, clock.WaitUntil(func() bool {
-		w.Lock()
-		defer w.Unlock()
-		return w.closed
-	}, 10*time.Second))
 }
 
 func TestWriterCloseSuccess(t *testing.T) {


### PR DESCRIPTION
Currently closing a writer is blocked on draining the queue within it. When the size of the queue is large, it could take a long time for it to drain. Which would cause the writer close to take a long time.

On the other hand the writer manager needs to close the writer with a lock when an instance is removed from the placement. A delayed writer close could block writes from acquiring the lock.

This changes changes the `RemoveInstance` behavior to synchronously remove the writer from its map and calls `writer.Close()` asynchronously.