### PR TITLE
Set wasRetrievedFromDisk properly

### DIFF
--- a/src/dbnode/client/fetch_state_leakcheckpool_gen_test.go
+++ b/src/dbnode/client/fetch_state_leakcheckpool_gen_test.go
@@ -26,8 +26,11 @@ package client
 
 import (
 	"fmt"
+
 	"runtime/debug"
+
 	"sync"
+
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/src/dbnode/client/fetch_tagged_attempt_leakcheckpool_gen_test.go
+++ b/src/dbnode/client/fetch_tagged_attempt_leakcheckpool_gen_test.go
@@ -26,8 +26,11 @@ package client
 
 import (
 	"fmt"
+
 	"runtime/debug"
+
 	"sync"
+
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/src/dbnode/client/fetch_tagged_op_leakcheckpool_gen_test.go
+++ b/src/dbnode/client/fetch_tagged_op_leakcheckpool_gen_test.go
@@ -26,8 +26,11 @@ package client
 
 import (
 	"fmt"
+
 	"runtime/debug"
+
 	"sync"
+
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/src/dbnode/storage/block/block.go
+++ b/src/dbnode/storage/block/block.go
@@ -265,6 +265,7 @@ func (b *dbBlock) ResetFromDisk(start time.Time, blockSize time.Duration, segmen
 	// resetSegmentWithLock sets seriesID to nil
 	b.resetSegmentWithLock(segment)
 	b.seriesID = id
+	b.wasRetrievedFromDisk = true
 }
 
 func (b *dbBlock) streamWithRLock(ctx context.Context) (xio.BlockReader, error) {

--- a/src/dbnode/storage/block/block_test.go
+++ b/src/dbnode/storage/block/block_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3x/ident"
+
 	"github.com/m3db/m3/src/dbnode/digest"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
@@ -677,4 +679,22 @@ func TestDatabaseSeriesBlocksReset(t *testing.T) {
 	require.Equal(t, 0, len(blocks.elems))
 	require.True(t, blocks.min.Equal(time.Time{}))
 	require.True(t, blocks.max.Equal(time.Time{}))
+}
+
+func TestBlockResetFromDisk(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	bl := testDatabaseBlock(ctrl)
+	now := time.Now()
+	blockSize := 2 * time.Hour
+	id := ident.StringID("testID")
+	segment := ts.Segment{}
+	bl.ResetFromDisk(now, blockSize, segment, id)
+
+	assert.True(t, now.Equal(bl.StartTime()))
+	assert.Equal(t, blockSize, bl.BlockSize())
+	assert.Equal(t, segment, bl.segment)
+	assert.Equal(t, id, bl.seriesID)
+	assert.True(t, bl.WasRetrievedFromDisk())
 }

--- a/src/dbnode/storage/block/block_test.go
+++ b/src/dbnode/storage/block/block_test.go
@@ -25,14 +25,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3x/ident"
-
 	"github.com/m3db/m3/src/dbnode/digest"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	"github.com/m3db/m3x/context"
+	"github.com/m3db/m3x/ident"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/golang/mock/gomock"


### PR DESCRIPTION
Prior to being [removing the CacheAllMetadata policy](https://github.com/m3db/m3/pull/1110/files#diff-8605e9ad35bdfdb5c194ed171978939dL206), this used to be set in the `OnRetrieveBlock` function. Properly set it here.