### PR TITLE
Reduce noise from multi errors by returning last

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e18d8ec10bc3e1cefa5c87365838c7c97ba003d552733931b5e4b9a2515d4235
-updated: 2018-10-23T16:48:16.261449-04:00
+hash: 760468137d3b67dc5978441265e564f5afe9f526fb4c556464eb3a4505df8dbc
+updated: 2018-11-14T14:03:59.559765-05:00
 imports:
 - name: github.com/apache/thrift
   version: c2fb1c4e8c931d22617bebb0bf388cb4d5e6fcff
@@ -219,7 +219,7 @@ imports:
 - name: github.com/m3db/bloom
   version: 47fe1193cdb900de7193d1f3d26ea9b2cbf6fb31
 - name: github.com/m3db/m3x
-  version: 943173a151c8a6b2da1f93f814c27c4e4a1e2050
+  version: 4f657299af578e9aa28c557075c7307d4b756378
   vcs: git
   subpackages:
   - checked
@@ -296,7 +296,7 @@ imports:
 - name: github.com/pborman/uuid
   version: adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1
 - name: github.com/pelletier/go-buffruneio
-  version: de1592c34d9c6055a32fc9ebe2b3ee50ca468ebe
+  version: e2f66f8164ca709d4c21e815860afd2024e9b894
 - name: github.com/pelletier/go-toml
   version: 3b00596b2e9ee541bbd72dc50cc0c60e2b46c69c
 - name: github.com/philhofer/fwd
@@ -385,7 +385,7 @@ imports:
   - require
   - suite
 - name: github.com/tinylib/msgp
-  version: f65876d3ea05943d6613bca6b8ed391843044bd4
+  version: 53e4ad1e134ee9b42a7add28ca77177ab17983b3
   subpackages:
   - msgp
 - name: github.com/uber-go/atomic

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e18d8ec10bc3e1cefa5c87365838c7c97ba003d552733931b5e4b9a2515d4235
-updated: 2018-10-23T16:48:16.261449-04:00
+hash: 760468137d3b67dc5978441265e564f5afe9f526fb4c556464eb3a4505df8dbc
+updated: 2018-11-13T10:43:49.169139-05:00
 imports:
 - name: github.com/apache/thrift
   version: c2fb1c4e8c931d22617bebb0bf388cb4d5e6fcff
@@ -219,7 +219,7 @@ imports:
 - name: github.com/m3db/bloom
   version: 47fe1193cdb900de7193d1f3d26ea9b2cbf6fb31
 - name: github.com/m3db/m3x
-  version: 943173a151c8a6b2da1f93f814c27c4e4a1e2050
+  version: 4f657299af578e9aa28c557075c7307d4b756378
   vcs: git
   subpackages:
   - checked
@@ -296,7 +296,7 @@ imports:
 - name: github.com/pborman/uuid
   version: adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1
 - name: github.com/pelletier/go-buffruneio
-  version: de1592c34d9c6055a32fc9ebe2b3ee50ca468ebe
+  version: e2f66f8164ca709d4c21e815860afd2024e9b894
 - name: github.com/pelletier/go-toml
   version: 3b00596b2e9ee541bbd72dc50cc0c60e2b46c69c
 - name: github.com/philhofer/fwd
@@ -385,7 +385,7 @@ imports:
   - require
   - suite
 - name: github.com/tinylib/msgp
-  version: f65876d3ea05943d6613bca6b8ed391843044bd4
+  version: 53e4ad1e134ee9b42a7add28ca77177ab17983b3
   subpackages:
   - msgp
 - name: github.com/uber-go/atomic

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 760468137d3b67dc5978441265e564f5afe9f526fb4c556464eb3a4505df8dbc
-updated: 2018-11-13T10:43:49.169139-05:00
+hash: e18d8ec10bc3e1cefa5c87365838c7c97ba003d552733931b5e4b9a2515d4235
+updated: 2018-10-23T16:48:16.261449-04:00
 imports:
 - name: github.com/apache/thrift
   version: c2fb1c4e8c931d22617bebb0bf388cb4d5e6fcff
@@ -219,7 +219,7 @@ imports:
 - name: github.com/m3db/bloom
   version: 47fe1193cdb900de7193d1f3d26ea9b2cbf6fb31
 - name: github.com/m3db/m3x
-  version: 4f657299af578e9aa28c557075c7307d4b756378
+  version: 943173a151c8a6b2da1f93f814c27c4e4a1e2050
   vcs: git
   subpackages:
   - checked
@@ -296,7 +296,7 @@ imports:
 - name: github.com/pborman/uuid
   version: adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1
 - name: github.com/pelletier/go-buffruneio
-  version: e2f66f8164ca709d4c21e815860afd2024e9b894
+  version: de1592c34d9c6055a32fc9ebe2b3ee50ca468ebe
 - name: github.com/pelletier/go-toml
   version: 3b00596b2e9ee541bbd72dc50cc0c60e2b46c69c
 - name: github.com/philhofer/fwd
@@ -385,7 +385,7 @@ imports:
   - require
   - suite
 - name: github.com/tinylib/msgp
-  version: 53e4ad1e134ee9b42a7add28ca77177ab17983b3
+  version: f65876d3ea05943d6613bca6b8ed391843044bd4
   subpackages:
   - msgp
 - name: github.com/uber-go/atomic

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/m3db/m3
 import:
   - package: github.com/m3db/m3x
-    version: 943173a151c8a6b2da1f93f814c27c4e4a1e2050
+    version: 4f657299af578e9aa28c557075c7307d4b756378
     vcs: git
     subpackages:
       - checked

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -191,8 +191,7 @@ func (h *PromWriteHandler) writeUnaggregated(
 	}
 
 	wg.Wait()
-
-	return multiErr.FinalError()
+	return multiErr.LastError()
 }
 
 func (h *PromWriteHandler) writeAggregated(
@@ -224,6 +223,5 @@ func (h *PromWriteHandler) writeAggregated(
 	}
 
 	metricsAppender.Finalize()
-
-	return multiErr.FinalError()
+	return multiErr.LastError()
 }

--- a/src/query/models/matcher_test.go
+++ b/src/query/models/matcher_test.go
@@ -21,7 +21,6 @@
 package models
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,8 +102,8 @@ func TestMatcher_String(t *testing.T) {
 	m := newMatcher(t, MatchEqual, "foo")
 	m.Name = []byte(`key`)
 
-	assert.Equal(t,  `key="foo"`, fmt.Sprintf("%s", m))
-	assert.Equal(t,  `key="foo"`, fmt.Sprintf("%s", &m))
+	assert.Equal(t, `key="foo"`, m.String())
+	assert.Equal(t, `key="foo"`, (&m).String())
 }
 
 func TestMatchType(t *testing.T) {

--- a/src/query/storage/m3/cluster.go
+++ b/src/query/storage/m3/cluster.go
@@ -295,7 +295,7 @@ func (c *clusters) Close() error {
 
 	wg.Wait()
 
-	return syncMultiErrs.finalError()
+	return syncMultiErrs.lastError()
 }
 
 type clusterNamespace struct {
@@ -373,8 +373,11 @@ func (errs *syncMultiErrs) add(err error) {
 	errs.Unlock()
 }
 
-func (errs *syncMultiErrs) finalError() error {
+func (errs *syncMultiErrs) lastError() error {
 	errs.Lock()
 	defer errs.Unlock()
-	return errs.multiErr.FinalError()
+	// TODO: consider taking a debug param when building a syncMultiErrs
+	// which would determine wether to return only the last error message
+	// or the consolidated list of errors.
+	return errs.multiErr.LastError()
 }

--- a/src/query/storage/m3/multi_fetch_result.go
+++ b/src/query/storage/m3/multi_fetch_result.go
@@ -99,7 +99,7 @@ func (r *multiResult) FinalResult() (encoding.SeriesIterators, error) {
 	r.Lock()
 	defer r.Unlock()
 
-	err := r.err.FinalError()
+	err := r.err.LastError()
 	if err != nil {
 		return nil, err
 	}

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -212,7 +212,7 @@ func (s *m3storage) FetchTags(
 	}
 
 	wg.Wait()
-	if err := result.err.FinalError(); err != nil {
+	if err := result.err.LastError(); err != nil {
 		return nil, err
 	}
 	return result.result, nil
@@ -308,7 +308,7 @@ func (s *m3storage) Write(
 	}
 
 	wg.Wait()
-	return multiErr.finalError()
+	return multiErr.lastError()
 }
 
 func (s *m3storage) Type() storage.Type {


### PR DESCRIPTION
Previously, was returning the concatenated error messages for all
errors seen, which got very noisy if a single failure was causing each
request to error. Now returns only last error if any seen.