### PR TITLE
remove time logging on the prom/remote/write endpoint

### DIFF
--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -124,12 +124,11 @@ func (h *Handler) RegisterRoutes() error {
 		return err
 	}
 
-	h.Router.HandleFunc(
-		remote.PromReadURL,
+	h.Router.HandleFunc(remote.PromReadURL,
 		logged(promRemoteReadHandler).ServeHTTP,
 	).Methods(remote.PromReadHTTPMethod)
 	h.Router.HandleFunc(remote.PromWriteURL,
-		logged(promRemoteWriteHandler).ServeHTTP,
+		promRemoteWriteHandler.ServeHTTP,
 	).Methods(remote.PromWriteHTTPMethod)
 	h.Router.HandleFunc(native.PromReadURL,
 		logged(native.NewPromReadHandler(h.engine, h.tagOptions, &h.config.Limits)).ServeHTTP,


### PR DESCRIPTION
The logging currently kicks in with force if there's any issues with m3, but we can get all the information from `prometheus_remote_storage_sent_batch_duration_seconds_bucket` in prometheus, so removing the loggging cuts down on noise and potential side effects in case of issues.