### PR TITLE
Improve how M3DB handles data durability during topology changes

### DIFF
--- a/scripts/development/m3_stack/start_m3.sh
+++ b/scripts/development/m3_stack/start_m3.sh
@@ -148,7 +148,7 @@ echo "Validating topology"
 [ "$(curl -sSf localhost:7201/api/v1/placement | jq .placement.instances.m3db_seed.id)" == '"m3db_seed"' ]
 echo "Done validating topology"
 
-echo "Sleeping until shards are marked as available"
+echo "Waiting until shards are marked as available"
 ATTEMPTS=10 TIMEOUT=1 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | grep -c INITIALIZING)" -eq 0 ]'
 

--- a/scripts/development/m3_stack/start_m3.sh
+++ b/scripts/development/m3_stack/start_m3.sh
@@ -2,6 +2,8 @@
 
 set -xe
 
+source $GOPATH/src/github.com/m3db/m3/scripts/docker-integration-tests/common.sh
+
 DOCKER_ARGS="-d --renew-anon-volumes"
 if [[ "$FORCE_BUILD" = true ]] ; then
     DOCKER_ARGS="--build -d --renew-anon-volumes"
@@ -145,6 +147,10 @@ fi
 echo "Validating topology"
 [ "$(curl -sSf localhost:7201/api/v1/placement | jq .placement.instances.m3db_seed.id)" == '"m3db_seed"' ]
 echo "Done validating topology"
+
+echo "Sleeping until shards are marked as available"
+ATTEMPTS=10 TIMEOUT=1 retry_with_backoff  \
+  '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | grep -c INITIALIZING)" -eq 0 ]'
 
 if [[ "$AGGREGATOR_PIPELINE" = true ]]; then
     curl -vvvsSf -X POST localhost:7201/api/v1/services/m3aggregator/placement/init -d '{

--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -103,7 +103,7 @@ echo "Sleep until bootstrapped"
 ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
 
-echo "Sleep until shards are marked as available"
+echo "Waiting until shards are marked as available"
 ATTEMPTS=10 TIMEOUT=1 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | grep -c INITIALIZING)" -eq 0 ]'
 

--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -103,6 +103,10 @@ echo "Sleep until bootstrapped"
 ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
 
+echo "Sleep until shards are marked as available"
+ATTEMPTS=10 TIMEOUT=1 retry_with_backoff  \
+  '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | grep -c INITIALIZING)" -eq 0 ]'
+
 echo "Start Prometheus containers"
 docker-compose -f ${COMPOSE_FILE} up -d prometheus01
 

--- a/scripts/docker-integration-tests/simple/test.sh
+++ b/scripts/docker-integration-tests/simple/test.sh
@@ -81,7 +81,7 @@ echo "Sleep until bootstrapped"
 ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
 
-echo "Sleep until shards are marked as available"
+echo "Waiting until shards are marked as available"
 ATTEMPTS=10 TIMEOUT=1 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | grep -c INITIALIZING)" -eq 0 ]'
 

--- a/scripts/docker-integration-tests/simple/test.sh
+++ b/scripts/docker-integration-tests/simple/test.sh
@@ -81,6 +81,10 @@ echo "Sleep until bootstrapped"
 ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
 
+echo "Sleep until shards are marked as available"
+ATTEMPTS=10 TIMEOUT=1 retry_with_backoff  \
+  '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | grep -c INITIALIZING)" -eq 0 ]'
+
 echo "Write data"
 curl -vvvsS -X POST 0.0.0.0:9003/writetagged -d '{
   "namespace": "default",

--- a/scripts/docker-integration-tests/simple/test.sh
+++ b/scripts/docker-integration-tests/simple/test.sh
@@ -35,7 +35,7 @@ curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/namespace -d '{
     "flushEnabled": true,
     "writesToCommitLog": true,
     "cleanupEnabled": true,
-    "snapshotEnabled": false,
+    "snapshotEnabled": true,
     "repairEnabled": false,
     "retentionOptions": {
       "retentionPeriodNanos": 172800000000000,

--- a/src/dbnode/client/errors.go
+++ b/src/dbnode/client/errors.go
@@ -29,7 +29,7 @@ import (
 	xerrors "github.com/m3db/m3x/errors"
 )
 
-// IsInternalServerError determines if the error is an internal server error
+// IsInternalServerError determines if the error is an internal server error.
 func IsInternalServerError(err error) bool {
 	for err != nil {
 		if e, ok := err.(*rpc.Error); ok && tterrors.IsInternalError(e) {
@@ -40,7 +40,7 @@ func IsInternalServerError(err error) bool {
 	return false
 }
 
-// IsBadRequestError determines if the error is a bad request error
+// IsBadRequestError determines if the error is a bad request error.
 func IsBadRequestError(err error) bool {
 	for err != nil {
 		if e, ok := err.(*rpc.Error); ok && tterrors.IsBadRequestError(e) {
@@ -52,6 +52,12 @@ func IsBadRequestError(err error) bool {
 		err = xerrors.InnerError(err)
 	}
 	return false
+}
+
+// IsConsistencyResultError determines if the error is a consistency result error.
+func IsConsistencyResultError(err error) bool {
+	_, ok := err.(consistencyResultErr)
+	return ok
 }
 
 // NumResponded returns how many nodes responded for a given error

--- a/src/dbnode/integration/cluster_add_one_node_test.go
+++ b/src/dbnode/integration/cluster_add_one_node_test.go
@@ -218,6 +218,12 @@ func testClusterAddOneNode(t *testing.T, verifyCommitlogCanBootstrapAfterNodeJoi
 	waitUntilHasBootstrappedShardsExactly(setups[1].db, testutil.Uint32Range(midShard+1, maxShard))
 
 	log.Debug("waiting for shards to be marked initialized")
+	for _, setup := range setups {
+		// Move time forward slightly so the database can determine that a snapshot
+		// has started and completed since the topology change. See
+		// Database.IsBootstrappedAndDurable method for more information.
+		setup.setNowFn(now.Add(time.Second))
+	}
 	allMarkedAvailable := func(
 		fakePlacementService fake.M3ClusterPlacementService,
 		instanceID string,

--- a/src/dbnode/integration/cluster_add_one_node_test.go
+++ b/src/dbnode/integration/cluster_add_one_node_test.go
@@ -23,7 +23,6 @@
 package integration
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -300,10 +299,7 @@ func testClusterAddOneNode(t *testing.T, verifyCommitlogCanBootstrapAfterNodeJoi
 
 	// Verify in-memory data match what we expect
 	for i := range setups {
-		ok := verifySeriesMaps(t, setups[i], namesp.ID(), expectedSeriesMaps[i])
-		if !ok {
-			fmt.Println("bad for: ", i)
-		}
+		verifySeriesMaps(t, setups[i], namesp.ID(), expectedSeriesMaps[i])
 	}
 
 	if verifyCommitlogCanBootstrapAfterNodeJoin {

--- a/src/dbnode/integration/cluster_add_one_node_test.go
+++ b/src/dbnode/integration/cluster_add_one_node_test.go
@@ -57,7 +57,7 @@ func testClusterAddOneNode(t *testing.T, verifyCommitlogCanBootstrapAfterNodeJoi
 		t.SkipNow()
 	}
 
-	// Test setups
+	// Test setups.
 	log := xlog.SimpleLogger
 
 	namesp, err := namespace.NewMetadata(testNamespaces[0],
@@ -121,7 +121,7 @@ func testClusterAddOneNode(t *testing.T, verifyCommitlogCanBootstrapAfterNodeJoi
 	setups, closeFn := newDefaultBootstrappableTestSetups(t, opts, setupOpts)
 	defer closeFn()
 
-	// Write test data for first node
+	// Write test data for first node.
 	topo, err := topoInit.Init()
 	require.NoError(t, err)
 	ids := []idShard{}
@@ -150,7 +150,7 @@ func testClusterAddOneNode(t *testing.T, verifyCommitlogCanBootstrapAfterNodeJoi
 	}
 
 	for _, id := range ids {
-		// Verify IDs will map to halves of the shard space
+		// Verify IDs will map to halves of the shard space.
 		require.Equal(t, id.shard, shardSet.Lookup(ident.StringID(id.str)))
 	}
 
@@ -163,7 +163,7 @@ func testClusterAddOneNode(t *testing.T, verifyCommitlogCanBootstrapAfterNodeJoi
 	err = writeTestDataToDisk(namesp, setups[0], seriesMaps)
 	require.NoError(t, err)
 
-	// Prepare verification of data on nodes
+	// Prepare verification of data on nodes.
 	expectedSeriesMaps := make([]map[xtime.UnixNano]generate.SeriesBlock, 2)
 	expectedSeriesIDs := make([]map[string]struct{}, 2)
 	for i := range expectedSeriesMaps {
@@ -195,15 +195,23 @@ func testClusterAddOneNode(t *testing.T, verifyCommitlogCanBootstrapAfterNodeJoi
 	require.Equal(t, 2, len(expectedSeriesIDs[0]))
 	require.Equal(t, 1, len(expectedSeriesIDs[1]))
 
-	// Start the first server with filesystem bootstrapper
+	// Start the first server with filesystem bootstrapper.
 	require.NoError(t, setups[0].startServer())
 
 	// Start the last server with peers and filesystem bootstrappers, no shards
-	// are assigned at first
+	// are assigned at first.
 	require.NoError(t, setups[1].startServer())
 	log.Debug("servers are now up")
 
-	// Bootstrap the new shards
+	// Stop the servers on test completion.
+	defer func() {
+		setups.parallel(func(s *testSetup) {
+			require.NoError(t, s.stopServer())
+		})
+		log.Debug("servers are now down")
+	}()
+
+	// Bootstrap the new shards.
 	log.Debug("resharding to initialize shards on second node")
 	svc.SetInstances(instances.add)
 	svcs.NotifyServiceUpdate("m3db")

--- a/src/dbnode/integration/options.go
+++ b/src/dbnode/integration/options.go
@@ -57,6 +57,9 @@ const (
 	// defaultTickMinimumInterval is the default minimum tick interval.
 	defaultTickMinimumInterval = 1 * time.Second
 
+	// defaultMinimimumSnapshotInterval is the default minimum snapshot interval.
+	defaultMinimimumSnapshotInterval = 1 * time.Second
+
 	// defaultUseTChannelClientForReading determines whether we use the tchannel client for reading by default.
 	defaultUseTChannelClientForReading = true
 
@@ -325,6 +328,7 @@ func newTestOptions(t *testing.T) testOptions {
 		writeConsistencyLevel:          defaultWriteConsistencyLevel,
 		numShards:                      defaultNumShards,
 		maxWiredBlocks:                 defaultMaxWiredBlocks,
+		minimumSnapshotInterval:        defaultMinimimumSnapshotInterval,
 		useTChannelClientForReading:    defaultUseTChannelClientForReading,
 		useTChannelClientForWriting:    defaultUseTChannelClientForWriting,
 		useTChannelClientForTruncation: defaultUseTChannelClientForTruncation,

--- a/src/dbnode/integration/options.go
+++ b/src/dbnode/integration/options.go
@@ -267,7 +267,7 @@ type testOptions interface {
 	// SetMinimumSnapshotInterval sets the minimum interval between snapshots.
 	SetMinimumSnapshotInterval(value time.Duration) testOptions
 
-	// MinimumSnapshotInterval returns the minimum interval between snapshots
+	// MinimumSnapshotInterval returns the minimum interval between snapshots.
 	MinimumSnapshotInterval() time.Duration
 }
 

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -225,6 +225,7 @@ func newTestSetup(t *testing.T, opts testOptions, fsOpts fs.Options) (*testSetup
 		}
 	}
 
+	fmt.Println(filePathPrefix)
 	if fsOpts == nil {
 		fsOpts = fs.NewOptions().
 			SetFilePathPrefix(filePathPrefix)

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -225,7 +225,6 @@ func newTestSetup(t *testing.T, opts testOptions, fsOpts fs.Options) (*testSetup
 		}
 	}
 
-	fmt.Println(filePathPrefix)
 	if fsOpts == nil {
 		fsOpts = fs.NewOptions().
 			SetFilePathPrefix(filePathPrefix)

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -447,12 +447,12 @@ func (ts *testSetup) startServer() error {
 
 	topo, err := ts.topoInit.Init()
 	if err != nil {
-		return err
+		return fmt.Errorf("error initializing topology: %v", err)
 	}
 
 	topoWatch, err := topo.Watch()
 	if err != nil {
-		return err
+		return fmt.Errorf("error watching topology: %v", err)
 	}
 
 	ts.db, err = cluster.NewDatabase(ts.hostID, topo, topoWatch, ts.storageOpts)

--- a/src/dbnode/runtime/runtime_options.go
+++ b/src/dbnode/runtime/runtime_options.go
@@ -48,7 +48,7 @@ const (
 	defaultWriteNewSeriesLimitPerShardPerSecond = 0
 	defaultTickSeriesBatchSize                  = 512
 	defaultTickPerSeriesSleepDuration           = 100 * time.Microsecond
-	defaultTickMinimumInterval                  = time.Minute
+	defaultTickMinimumInterval                  = 5 * time.Second
 	defaultMaxWiredBlocks                       = uint(1 << 18) // 262,144
 )
 

--- a/src/dbnode/runtime/runtime_options.go
+++ b/src/dbnode/runtime/runtime_options.go
@@ -48,7 +48,7 @@ const (
 	defaultWriteNewSeriesLimitPerShardPerSecond = 0
 	defaultTickSeriesBatchSize                  = 512
 	defaultTickPerSeriesSleepDuration           = 100 * time.Microsecond
-	defaultTickMinimumInterval                  = 5 * time.Second
+	defaultTickMinimumInterval                  = 10 * time.Second
 	defaultMaxWiredBlocks                       = uint(1 << 18) // 262,144
 )
 

--- a/src/dbnode/storage/bootstrap.go
+++ b/src/dbnode/storage/bootstrap.go
@@ -23,6 +23,7 @@ package storage
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
@@ -58,15 +59,16 @@ var (
 type bootstrapManager struct {
 	sync.RWMutex
 
-	database        database
-	mediator        databaseMediator
-	opts            Options
-	log             xlog.Logger
-	nowFn           clock.NowFn
-	processProvider bootstrap.ProcessProvider
-	state           BootstrapState
-	hasPending      bool
-	status          tally.Gauge
+	database                    database
+	mediator                    databaseMediator
+	opts                        Options
+	log                         xlog.Logger
+	nowFn                       clock.NowFn
+	processProvider             bootstrap.ProcessProvider
+	state                       BootstrapState
+	hasPending                  bool
+	status                      tally.Gauge
+	lastBootstrapCompletionTime time.Time
 }
 
 func newBootstrapManager(
@@ -91,6 +93,10 @@ func (m *bootstrapManager) IsBootstrapped() bool {
 	state := m.state
 	m.RUnlock()
 	return state == Bootstrapped
+}
+
+func (m *bootstrapManager) LastBootstrapCompletionTime() (time.Time, bool) {
+	return m.lastBootstrapCompletionTime, !m.lastBootstrapCompletionTime.IsZero()
 }
 
 func (m *bootstrapManager) Bootstrap() error {
@@ -148,6 +154,7 @@ func (m *bootstrapManager) Bootstrap() error {
 	// on its own course so that the load of ticking and flushing is more spread out
 	// across the cluster.
 
+	m.lastBootstrapCompletionTime = m.nowFn()
 	return multiErr.FinalError()
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -112,7 +112,7 @@ func (s *peersSource) ReadData(
 		persistConfig     = opts.PersistConfig()
 	)
 	if persistConfig.Enabled &&
-		(seriesCachePolicy == series.CacheAll || seriesCachePolicy == series.CacheLRU) &&
+		(seriesCachePolicy == series.CacheRecentlyRead || seriesCachePolicy == series.CacheLRU) &&
 		persistConfig.FileSetType == persist.FileSetFlushType {
 		retrieverMgr := s.opts.DatabaseBlockRetrieverManager()
 		persistManager := s.opts.PersistManager()

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -371,11 +371,24 @@ func (s *peersSource) flush(
 			"tried to flush with unexpected fileset type: %v", persistConfig.FileSetType)
 	}
 
+	seriesCachePolicy := s.opts.ResultOptions().SeriesCachePolicy()
+	if seriesCachePolicy == series.CacheAll {
+		// Should never happen.
+		iOpts := s.opts.ResultOptions().InstrumentOptions()
+		instrument.EmitAndLogInvariantViolation(iOpts, func(l xlog.Logger) {
+			l.WithFields(
+				xlog.NewField("namespace", nsMetadata.ID().String()),
+				xlog.NewField("cachePolicy", series.CacheAll),
+			).Error("error tried to persist data in peers bootstrapper with invalid cache policy")
+		})
+		return instrument.InvariantErrorf(
+			"tried to persist data in peers bootstrapper with invalid cache policy: %v", series.CacheAll)
+	}
+
 	var (
-		ropts             = nsMetadata.Options().RetentionOptions()
-		blockSize         = ropts.BlockSize()
-		tmpCtx            = context.NewContext()
-		seriesCachePolicy = s.opts.ResultOptions().SeriesCachePolicy()
+		ropts     = nsMetadata.Options().RetentionOptions()
+		blockSize = ropts.BlockSize()
+		tmpCtx    = context.NewContext()
 	)
 
 	for start := tr.Start; start.Before(tr.End); start = start.Add(blockSize) {
@@ -460,43 +473,37 @@ func (s *peersSource) flush(
 		}
 	}
 
-	// We only want to retain the series metadata if we're using the CacheAll caching policy
-	// because we're expected to cache everything in memory in that case.
-	shouldRetainSeriesMetadata := seriesCachePolicy == series.CacheAll
-
-	if !shouldRetainSeriesMetadata {
-		// If we're not going to keep all of the data, or at least all of the metadata in memory
-		// then we don't want to keep these series in the shard result. If we leave them in, then
-		// they will all get loaded into the shard object, and then immediately evicted on the next
-		// tick which causes unnecessary memory pressure.
-		numSeriesTriedToRemoveWithRemainingBlocks := 0
-		for _, entry := range shardResult.AllSeries().Iter() {
-			series := entry.Value()
-			numBlocksRemaining := len(series.Blocks.AllBlocks())
-			// Should never happen since we removed all the block in the previous loop and fetching
-			// bootstrap blocks should always be exclusive on the end side.
-			if numBlocksRemaining > 0 {
-				numSeriesTriedToRemoveWithRemainingBlocks++
-				continue
-			}
-
-			shardResult.RemoveSeries(series.ID)
-			series.Blocks.Close()
-			// Safe to finalize these IDs and Tags because the prepared object was the only other thing
-			// using them, and it has been closed.
-			series.ID.Finalize()
-			series.Tags.Finalize()
+	// Since we've persisted the data to disk, we don't want to keep all the series in the shard
+	// result. Otherwise if we leave them in, then they will all get loaded into the shard object,
+	// and then immediately evicted on the next tick which causes unnecessary memory pressure
+	// during peer bootstrapping.
+	numSeriesTriedToRemoveWithRemainingBlocks := 0
+	for _, entry := range shardResult.AllSeries().Iter() {
+		series := entry.Value()
+		numBlocksRemaining := len(series.Blocks.AllBlocks())
+		// Should never happen since we removed all the block in the previous loop and fetching
+		// bootstrap blocks should always be exclusive on the end side.
+		if numBlocksRemaining > 0 {
+			numSeriesTriedToRemoveWithRemainingBlocks++
+			continue
 		}
-		if numSeriesTriedToRemoveWithRemainingBlocks > 0 {
-			iOpts := s.opts.ResultOptions().InstrumentOptions()
-			instrument.EmitAndLogInvariantViolation(iOpts, func(l xlog.Logger) {
-				l.WithFields(
-					xlog.NewField("start", tr.Start.Unix()),
-					xlog.NewField("end", tr.End.Unix()),
-					xlog.NewField("numTimes", numSeriesTriedToRemoveWithRemainingBlocks),
-				).Error("error tried to remove series that still has blocks")
-			})
-		}
+
+		shardResult.RemoveSeries(series.ID)
+		series.Blocks.Close()
+		// Safe to finalize these IDs and Tags because the prepared object was the only other thing
+		// using them, and it has been closed.
+		series.ID.Finalize()
+		series.Tags.Finalize()
+	}
+	if numSeriesTriedToRemoveWithRemainingBlocks > 0 {
+		iOpts := s.opts.ResultOptions().InstrumentOptions()
+		instrument.EmitAndLogInvariantViolation(iOpts, func(l xlog.Logger) {
+			l.WithFields(
+				xlog.NewField("start", tr.Start.Unix()),
+				xlog.NewField("end", tr.End.Unix()),
+				xlog.NewField("numTimes", numSeriesTriedToRemoveWithRemainingBlocks),
+			).Error("error tried to remove series that still has blocks")
+		})
 	}
 
 	return nil

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -453,7 +453,7 @@ func (s *peersSource) flush(
 			}
 
 			// Now that we've persisted the data to disk, we can finalize the block,
-			// as there is no need to keep it in memory. We do this here becasue it
+			// as there is no need to keep it in memory. We do this here because it
 			// is better to do this as we loop to make blocks return to the pool earlier
 			// than all at once the end of this flush cycle.
 			s.Blocks.RemoveBlockAt(start)

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
@@ -233,6 +233,7 @@ func TestPeersSourceReturnsFulfilledAndUnfulfilled(t *testing.T) {
 func TestPeersSourceRunWithPersist(t *testing.T) {
 	for _, cachePolicy := range []series.CachePolicy{
 		series.CacheRecentlyRead,
+		series.CacheLRU,
 	} {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -296,7 +296,6 @@ func (d *clusterDB) analyzeAndReportShardStates() {
 		}
 	}
 
-	fmt.Println("checkign durability")
 	if !d.IsBootstrappedAndDurable() {
 		return
 	}

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -296,9 +296,9 @@ func (d *clusterDB) analyzeAndReportShardStates() {
 		}
 	}
 
-	// TODO(rartoul): Make sure the database has durably persisted everything
-	// since the last change.
-	// d.IsBootstrappedAndDurable()
+	if !d.IsBootstrappedAndDurable() {
+		return
+	}
 
 	var markAvailable []uint32
 	for id := range d.initializing {

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -190,7 +190,6 @@ func (d *clusterDB) activeTopologyWatch() {
 		for {
 			select {
 			case <-ticker.C:
-				fmt.Println("ticking")
 				d.analyzeAndReportShardStates()
 			case <-reportClosingCh:
 				ticker.Stop()

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -296,6 +296,7 @@ func (d *clusterDB) analyzeAndReportShardStates() {
 		}
 	}
 
+	fmt.Println("checkign durability")
 	if !d.IsBootstrappedAndDurable() {
 		return
 	}

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -289,7 +289,7 @@ func (d *clusterDB) analyzeAndReportShardStates() {
 
 	// Count if initializing shards have bootstrapped in all namespaces. This
 	// check is redundant with the database check above, but we do it for
-	// posterity just to make sure everthing is in the correct state.
+	// posterity just to make sure everything is in the correct state.
 	namespaces := d.Database.Namespaces()
 	for _, n := range namespaces {
 		for _, s := range n.Shards() {

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -272,7 +272,7 @@ func (d *clusterDB) analyzeAndReportShardStates() {
 	// To mark any initializing shards as available we need a
 	// dynamic topology, check if we have one and if not we will report
 	// that shards are initialzing and that we do not have a dynamic
-	// topology to mark them as available
+	// topology to mark them as available.
 	topo, ok := d.topo.(topology.DynamicTopology)
 	if !ok {
 		err := fmt.Errorf("topology constructed is not a dynamic topology")

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -280,7 +280,9 @@ func (d *clusterDB) analyzeAndReportShardStates() {
 		return
 	}
 
-	// Count if initializing shards have bootstrapped in all namespaces
+	// Count if initializing shards have bootstrapped in all namespaces. This
+	// check is redundant with the database check below, but we do it for
+	// posterity.
 	namespaces := d.Database.Namespaces()
 	for _, n := range namespaces {
 		for _, s := range n.Shards() {
@@ -293,6 +295,10 @@ func (d *clusterDB) analyzeAndReportShardStates() {
 			d.bootstrapCount[s.ID()]++
 		}
 	}
+
+	// TODO(rartoul): Make sure the database has durably persisted everything
+	// since the last change.
+	// d.IsBootstrappedAndDurable()
 
 	var markAvailable []uint32
 	for id := range d.initializing {

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -190,6 +190,7 @@ func (d *clusterDB) activeTopologyWatch() {
 		for {
 			select {
 			case <-ticker.C:
+				fmt.Println("ticking")
 				d.analyzeAndReportShardStates()
 			case <-reportClosingCh:
 				ticker.Stop()

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -309,7 +309,7 @@ func (d *clusterDB) analyzeAndReportShardStates() {
 
 		// Mark this shard as available
 		if markAvailable == nil {
-			// Defer allocation until needed, alloc as much as could be required
+			// Defer allocation until needed, alloc as much as could be required.
 			markAvailable = make([]uint32, 0, len(d.initializing))
 		}
 		markAvailable = append(markAvailable, id)

--- a/src/dbnode/storage/cluster/database_test.go
+++ b/src/dbnode/storage/cluster/database_test.go
@@ -187,7 +187,7 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 	// Allow the process to proceed by simulating the situation where the
 	// database has had sufficient time to make itself completely bootstrapped
 	// as well as durable.
-	mockStorageDB.EXPECT().IsBootstrappedAndDurable().Return(true).AnyTimes()
+	mockStorageDB.EXPECT().IsBootstrappedAndDurable().Return(true)
 
 	// Enqueue the update.
 	viewsCh <- testutil.NewTopologyView(1, updatedView)

--- a/src/dbnode/storage/cluster/database_test.go
+++ b/src/dbnode/storage/cluster/database_test.go
@@ -89,6 +89,7 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockStorageDB, restore := mockNewStorageDatabase(ctrl)
+	mockStorageDB.EXPECT().Open().Return(nil)
 	defer restore()
 
 	viewsCh := make(chan testutil.TopologyView, 64)
@@ -104,29 +105,28 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 	db, err := newTestDatabase(t, "testhost0", topoInit)
 	require.NoError(t, err)
 
-	// Now open the cluster database
-	mockStorageDB.EXPECT().Open().Return(nil)
+	// Now open the cluster database.
 	err = db.Open()
 	require.NoError(t, err)
 
-	// Reshard by taking a leaving host's shards
+	// Reshard by taking a leaving host's shards.
 	updatedView := map[string][]shard.Shard{
 		"testhost0": append(sharding.NewShards([]uint32{0, 1}, shard.Available),
 			sharding.NewShards([]uint32{2, 3}, shard.Initializing)...),
 		"testhost1": sharding.NewShards([]uint32{2, 3}, shard.Leaving),
 	}
 
-	// Expect the assign shards call
+	// Expect the assign shards call.
 	mockStorageDB.EXPECT().AssignShardSet(gomock.Any()).Do(
 		func(shardSet sharding.ShardSet) {
-			// Ensure updated shard set is as expected
+			// Ensure updated shard set is as expected.
 			assert.Equal(t, 4, len(shardSet.AllIDs()))
 			values := updatedView["testhost0"]
 			hostShardSet, _ := sharding.NewShardSet(values, shardSet.HashFn())
 			assert.Equal(t, hostShardSet.AllIDs(), shardSet.AllIDs())
 		})
 
-	// Expect the namespaces query from report shard state background query
+	// Expect the namespaces query from report shard state background query.
 	mockShards := []*storage.MockShard{
 		storage.NewMockShard(ctrl),
 		storage.NewMockShard(ctrl),
@@ -136,8 +136,8 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 	for i, s := range mockShards {
 		s.EXPECT().ID().Return(uint32(i)).AnyTimes()
 	}
-	mockShards[2].EXPECT().IsBootstrapped().Return(true)
-	mockShards[3].EXPECT().IsBootstrapped().Return(true)
+	mockShards[2].EXPECT().IsBootstrapped().Return(true).AnyTimes()
+	mockShards[3].EXPECT().IsBootstrapped().Return(true).AnyTimes()
 
 	var expectShards []storage.Shard
 	for _, s := range mockShards {
@@ -145,10 +145,10 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 	}
 
 	mockNamespace := storage.NewMockNamespace(ctrl)
-	mockNamespace.EXPECT().Shards().Return(expectShards)
+	mockNamespace.EXPECT().Shards().Return(expectShards).AnyTimes()
 
 	expectNamespaces := []storage.Namespace{mockNamespace}
-	mockStorageDB.EXPECT().Namespaces().Return(expectNamespaces)
+	mockStorageDB.EXPECT().Namespaces().Return(expectNamespaces).AnyTimes()
 
 	needsMarkAvailable := struct {
 		sync.Mutex
@@ -174,13 +174,22 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 		}
 	}
 
-	// Could be batched together, or could be called one by one
+	// Could be batched together, or could be called one by one.
 	props.topology.EXPECT().
 		MarkShardsAvailable("testhost0", gomock.Any()).
 		Do(onMarkShardsAvailable).
 		AnyTimes()
 
-	// Enqueue the update
+	// Simulate the case where the database isn't bootstrapped and durable
+	// yet (due to a snapshot not having run yet.)
+	mockStorageDB.EXPECT().IsBootstrappedAndDurable().Return(false)
+
+	// Allow the process to proceed by simulating the situation where the
+	// database has had sufficient time to make itself completely bootstrapped
+	// as well as durable.
+	mockStorageDB.EXPECT().IsBootstrappedAndDurable().Return(true).AnyTimes()
+
+	// Enqueue the update.
 	viewsCh <- testutil.NewTopologyView(1, updatedView)
 
 	// Wait for the update to propagate, consume the first notification
@@ -190,7 +199,7 @@ func TestDatabaseMarksShardAsAvailableOnReshard(t *testing.T) {
 		<-props.propogateViewsCh
 	}
 
-	// Wait for shards to be marked available
+	// Wait for shards to be marked available.
 	wg.Wait()
 
 	mockStorageDB.EXPECT().Close().Return(nil)

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -826,9 +826,10 @@ func (d *db) IsBootstrappedAndDurable() bool {
 			xlog.NewField("lastReceivedNewShards", d.lastReceivedNewShards),
 		).Debugf(
 			"not bootstrapped and durable because: has not snapshotted post bootstrap and/or has not bootstrapped since receiving new shards")
+		return false
 	}
 
-	return isBootstrappedAndDurable
+	return true
 }
 
 func (d *db) Repair() error {

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -156,23 +156,26 @@ func NewDatabase(
 		return nil, err
 	}
 
-	iopts := opts.InstrumentOptions()
-	scope := iopts.MetricsScope().SubScope("database")
-	logger := iopts.Logger()
+	var (
+		iopts  = opts.InstrumentOptions()
+		scope  = iopts.MetricsScope().SubScope("database")
+		logger = iopts.Logger()
+		nowFn  = opts.ClockOptions().NowFn()
+	)
 
 	d := &db{
-		opts:           opts,
-		nowFn:          opts.ClockOptions().NowFn(),
-		shardSet:       shardSet,
-		namespaces:     newDatabaseNamespacesMap(databaseNamespacesMapOptions{}),
-		commitLog:      commitLog,
-		scope:          scope,
-		metrics:        newDatabaseMetrics(scope),
-		log:            logger,
-		errors:         xcounter.NewFrequencyCounter(opts.ErrorCounterOptions()),
-		errWindow:      opts.ErrorWindowForLoad(),
-		errThreshold:   opts.ErrorThresholdForLoad(),
-		writeBatchPool: opts.WriteBatchPool(),
+		opts:               opts,
+		nowFn:              nowFn,
+		shardSet:           shardSet,
+		shardSetAssignedAt: nowFn(),
+		namespaces:         newDatabaseNamespacesMap(databaseNamespacesMapOptions{}),
+		commitLog:          commitLog,
+		scope:              scope,
+		metrics:            newDatabaseMetrics(scope),
+		log:                logger,
+		errors:             xcounter.NewFrequencyCounter(opts.ErrorCounterOptions()),
+		errWindow:          opts.ErrorWindowForLoad(),
+		errThreshold:       opts.ErrorThresholdForLoad(),
 	}
 
 	databaseIOpts := iopts.SetMetricsScope(scope)

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -749,11 +749,11 @@ func (d *db) IsBootstrapped() bool {
 func (d *db) IsBootstrappedAndDurable() bool {
 	isBootstrapped := d.mediator.IsBootstrapped()
 
-	lastSnapshot, ok := d.mediator.LastSuccessfulSnapshotStartTime()
+	lastSnapshotStartTime, ok := d.mediator.LastSuccessfulSnapshotStartTime()
 	if !ok {
 		return false
 	}
-	isDurable := lastSnapshot.After(d.shardSetAssignedAt)
+	isDurable := lastSnapshotStartTime.After(d.shardSetAssignedAt)
 
 	return isBootstrapped && isDurable
 }

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -801,8 +801,13 @@ func (d *db) IsBootstrappedAndDurable() bool {
 		return false
 	}
 
-	return lastSnapshotStartTime.After(lastBootstrapCompletionTime) &&
-		lastBootstrapCompletionTime.After(d.lastReceivedNewShards)
+	var (
+		hasSnapshottedPostBootstrap            = lastSnapshotStartTime.After(lastBootstrapCompletionTime)
+		hasBootstrappedSinceReceivingNewShards = lastBootstrapCompletionTime.After(d.lastReceivedNewShards) ||
+			lastBootstrapCompletionTime.Equal(d.lastReceivedNewShards)
+	)
+	return hasSnapshottedPostBootstrap &&
+		hasBootstrappedSinceReceivingNewShards
 }
 
 func (d *db) Repair() error {

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -93,9 +93,8 @@ type db struct {
 	created    uint64
 	bootstraps int
 
-	shardSet             sharding.ShardSet
-	shardSetAssignedAt   time.Time
-	bootstrapCompletedAt time.Time
+	shardSet           sharding.ShardSet
+	shardSetAssignedAt time.Time
 
 	scope   tally.Scope
 	metrics databaseMetrics

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -748,14 +748,16 @@ func (d *db) IsBootstrapped() bool {
 
 func (d *db) IsBootstrappedAndDurable() bool {
 	isBootstrapped := d.mediator.IsBootstrapped()
+	if !isBootstrapped {
+		return false
+	}
 
 	lastSnapshotStartTime, ok := d.mediator.LastSuccessfulSnapshotStartTime()
 	if !ok {
 		return false
 	}
-	isDurable := lastSnapshotStartTime.After(d.shardSetAssignedAt)
 
-	return isBootstrapped && isDurable
+	return lastSnapshotStartTime.After(d.shardSetAssignedAt)
 }
 
 func (d *db) Repair() error {

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -747,6 +747,14 @@ func (d *db) IsBootstrapped() bool {
 	return d.mediator.IsBootstrapped()
 }
 
+// IsBootstrappedAndDurable should only return true if the following conditonsa are met:
+//    1. The database is bootstrapped.
+//    2. The last successful snapshot began AFTER the last bootstrap completed.
+//
+// Those two conditions should be sufficient to ensure that after a placement change, the
+// node will be able to bootstrap any and all data from its local disk, however, for posterity
+// we also perform the following check:
+//     3. The last bootstrap completed AFTER the shardset was last assigned.
 func (d *db) IsBootstrappedAndDurable() bool {
 	isBootstrapped := d.mediator.IsBootstrapped()
 	if !isBootstrapped {

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -386,7 +386,7 @@ func (d *db) queueBootstrapWithLock() {
 	// database when it receives an initial topology (as well as topology changes) without
 	// triggering a bootstrap until an external call initiates a bootstrap with an initial
 	// call to Bootstrap(). After that initial bootstrap, the clustered database will keep
-	// the non-clustered database bootstrapped by assign it shardsets which will trigger new
+	// the non-clustered database bootstrapped by assigning it shardsets which will trigger new
 	// bootstraps since d.bootstraps > 0 will be true.
 	if d.bootstraps > 0 {
 		// NB(r): Trigger another bootstrap, if already bootstrapping this will

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -176,6 +176,7 @@ func NewDatabase(
 		errors:             xcounter.NewFrequencyCounter(opts.ErrorCounterOptions()),
 		errWindow:          opts.ErrorWindowForLoad(),
 		errThreshold:       opts.ErrorThresholdForLoad(),
+		writeBatchPool:     opts.WriteBatchPool(),
 	}
 
 	databaseIOpts := iopts.SetMetricsScope(scope)

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -749,7 +749,7 @@ func (d *db) IsBootstrapped() bool {
 	return d.mediator.IsBootstrapped()
 }
 
-// IsBootstrappedAndDurable should only return true if the following conditonsa are met:
+// IsBootstrappedAndDurable should only return true if the following conditions are met:
 //    1. The database is bootstrapped.
 //    2. The last successful snapshot began AFTER the last bootstrap completed.
 //

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -753,7 +753,7 @@ func (d *db) IsBootstrapped() bool {
 //    1. The database is bootstrapped.
 //    2. The last successful snapshot began AFTER the last bootstrap completed.
 //
-// Those two conditions should be sufficient to ensure that after a placement change, the
+// Those two conditions should be sufficient to ensure that after a placement change the
 // node will be able to bootstrap any and all data from its local disk, however, for posterity
 // we also perform the following check:
 //     3. The last bootstrap completed AFTER the shardset was last assigned.

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -364,7 +364,7 @@ func (d *db) AssignShardSet(shardSet sharding.ShardSet) {
 	d.Lock()
 	defer d.Unlock()
 
-	receivedNewShards := d.hasReceivedNewShards(shardSet)
+	receivedNewShards := d.hasReceivedNewShardsWithLock(shardSet)
 
 	d.shardSet = shardSet
 	if receivedNewShards {
@@ -379,10 +379,10 @@ func (d *db) AssignShardSet(shardSet sharding.ShardSet) {
 	d.queueBootstrapWithLock()
 }
 
-func (d *db) hasReceivedNewShards(incoming sharding.ShardSet) bool {
+func (d *db) hasReceivedNewShardsWithLock(incoming sharding.ShardSet) bool {
 	var (
 		existing    = d.shardSet
-		existingSet = map[uint32]struct{}{}
+		existingSet = make(map[uint32]struct{}, len(existing.AllIDs()))
 	)
 
 	for _, shard := range existing.AllIDs() {

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -757,6 +757,8 @@ func (d *db) IsBootstrappedAndDurable() bool {
 		return false
 	}
 
+	fmt.Println("lastSnapshotStartTime: ", lastSnapshotStartTime)
+	fmt.Println("shardSetAssignedAt: ", d.shardSetAssignedAt)
 	return lastSnapshotStartTime.After(d.shardSetAssignedAt)
 }
 

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -807,7 +807,7 @@ func (d *db) IsBootstrappedAndDurable() bool {
 			xlog.NewField("lastBootstrapCompletionTime", lastBootstrapCompletionTime),
 			xlog.NewField("lastSnapshotStartTime", lastSnapshotStartTime),
 		).Debugf(
-			"not bootstrapped and durable because: no last bootstrap completion time")
+			"not bootstrapped and durable because: no last snapshot start time")
 		return false
 	}
 
@@ -825,7 +825,7 @@ func (d *db) IsBootstrappedAndDurable() bool {
 			xlog.NewField("lastSnapshotStartTime", lastSnapshotStartTime),
 			xlog.NewField("lastReceivedNewShards", d.lastReceivedNewShards),
 		).Debugf(
-			"not bootstrapped and durable because: no last bootstrap completion time")
+			"not bootstrapped and durable because: has not snapshotted post bootstrap and/or has not bootstrapped since receiving new shards")
 	}
 
 	return isBootstrappedAndDurable

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -984,39 +984,4 @@ func TestDatabaseIsBootstrappedAndDurable(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, d.IsBootstrappedAndDurable())
 		})
 	}
-
-	// // Not BootstrappedAndDurable if not bootstrapped.
-	// mediator.EXPECT().IsBootstrapped().Return(false)
-	// assert.False(t, d.IsBootstrappedAndDurable())
-
-	// // Not BootstrappedAndDurable if no last bootstrap completion time.
-	// mediator.EXPECT().IsBootstrapped().Return(true)
-	// mediator.EXPECT().LastBootstrapCompletionTime().Return(time.Time{}, false)
-	// assert.False(t, d.IsBootstrappedAndDurable())
-
-	// var (
-	// 	now                     = time.Now()
-	// 	bootstrapCompletionTime = now.Add(time.Second)
-	// )
-	// d.shardSetAssignedAt = now
-
-	// // Not BootstrappedAndDurable if no last successful snapshot start time.
-	// mediator.EXPECT().IsBootstrapped().Return(true)
-	// mediator.EXPECT().LastBootstrapCompletionTime().Return(bootstrapCompletionTime, true)
-	// mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(time.Time{}, false)
-	// assert.False(t, d.IsBootstrappedAndDurable())
-
-	// // Not BootstrappedAndDurable if last successful snapshot start time
-	// // is not after bootstrap completion time.
-	// mediator.EXPECT().IsBootstrapped().Return(true)
-	// mediator.EXPECT().LastBootstrapCompletionTime().Return(bootstrapCompletionTime, true)
-	// mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(bootstrapCompletionTime, true)
-	// assert.False(t, d.IsBootstrappedAndDurable())
-
-	// // BootstrappedAndDurable because its bootstrapped and one complete snapshot has
-	// // finished that also started AFTER the last shardset was assigned.
-	// d.shardSetAssignedAt = now
-	// mediator.EXPECT().IsBootstrapped().Return(true)
-	// mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(now.Add(time.Second), true)
-	// assert.True(t, d.IsBootstrappedAndDurable())
 }

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -962,7 +962,7 @@ func TestDatabaseIsBootstrappedAndDurable(t *testing.T) {
 			isBootstrapped:                  validIsBootstrapped,
 			lastBootstrapCompletionTime:     validLastBootstrapCompletionTime,
 			lastSuccessfulSnapshotStartTime: validLastSuccessfulSnapshotStartTime,
-			shardSetAssignedAt:              validLastBootstrapCompletionTime,
+			shardSetAssignedAt:              validLastBootstrapCompletionTime.Add(-time.Second),
 			expectedResult:                  false,
 		},
 		{

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -425,20 +425,16 @@ func TestDatabaseAssignShardSetDoesNotUpdateLastReceivedNewShardsIfNoNewShards(t
 	ns = append(ns, dbAddNewMockNamespace(ctrl, d, "testns1"))
 	ns = append(ns, dbAddNewMockNamespace(ctrl, d, "testns2"))
 
-	shards := append(sharding.NewShards([]uint32{0, 1}, shard.Available))
-	shardSet, err := sharding.NewShardSet(shards, nil)
-	require.NoError(t, err)
-
 	var wg sync.WaitGroup
 	wg.Add(len(ns))
 	for _, n := range ns {
-		n.EXPECT().AssignShardSet(shardSet).Do(func(_ sharding.ShardSet) {
+		n.EXPECT().AssignShardSet(d.shardSet).Do(func(_ sharding.ShardSet) {
 			wg.Done()
 		})
 	}
 
 	t1 := d.lastReceivedNewShards
-	d.AssignShardSet(shardSet)
+	d.AssignShardSet(d.shardSet)
 	require.True(t, d.lastReceivedNewShards.Equal(t1))
 
 	wg.Wait()

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -958,11 +958,11 @@ func TestDatabaseIsBootstrappedAndDurable(t *testing.T) {
 			expectedResult:                  false,
 		},
 		{
-			title:                           "False if last bootstrap completion time is not after shardset assigned at time",
+			title:                           "False if last bootstrap completion time is not after/equal shardset assigned at time",
 			isBootstrapped:                  validIsBootstrapped,
 			lastBootstrapCompletionTime:     validLastBootstrapCompletionTime,
 			lastSuccessfulSnapshotStartTime: validLastSuccessfulSnapshotStartTime,
-			shardSetAssignedAt:              validLastBootstrapCompletionTime.Add(-time.Second),
+			shardSetAssignedAt:              validLastBootstrapCompletionTime.Add(time.Second),
 			expectedResult:                  false,
 		},
 		{

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -850,3 +850,40 @@ func TestDatabaseBootstrapState(t *testing.T) {
 		},
 	}, dbBootstrapState)
 }
+
+func TestDatabaseIsBootstrapped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	d, mapCh, _ := newTestDatabase(t, ctrl, Bootstrapped)
+	defer func() {
+		close(mapCh)
+	}()
+
+	mediator := NewMockdatabaseMediator(ctrl)
+	mediator.EXPECT().IsBootstrapped().Return(true)
+	mediator.EXPECT().IsBootstrapped().Return(false)
+	d.mediator = mediator
+
+	assert.True(t, d.IsBootstrapped())
+	assert.False(t, d.IsBootstrapped())
+}
+
+func TestDatabaseIsBootstrappedAndDurable(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	d, mapCh, _ := newTestDatabase(t, ctrl, Bootstrapped)
+	defer func() {
+		close(mapCh)
+	}()
+
+	mediator := NewMockdatabaseMediator(ctrl)
+	d.mediator = mediator
+
+	mediator.EXPECT().IsBootstrapped().Return(false)
+	assert.False(t, d.IsBootstrappedAndDurable())
+
+	mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(false)
+	// assert.False(t, d.IsBootstrapped())
+}

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -895,13 +895,13 @@ func TestDatabaseIsBootstrappedAndDurable(t *testing.T) {
 	now := time.Now()
 	d.shardSetAssignedAt = now
 	mediator.EXPECT().IsBootstrapped().Return(true)
-	mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(now, false)
+	mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(now, true)
 	assert.False(t, d.IsBootstrappedAndDurable())
 
 	// BootstrappedAndDurable because its bootstrapped and one complete snapshot has
 	// finished that also started AFTER the last shardset was assigned.
 	d.shardSetAssignedAt = now
 	mediator.EXPECT().IsBootstrapped().Return(true)
-	mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(now.Add(time.Second), false)
-	assert.False(t, d.IsBootstrappedAndDurable())
+	mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(now.Add(time.Second), true)
+	assert.True(t, d.IsBootstrappedAndDurable())
 }

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -873,35 +873,150 @@ func TestDatabaseIsBootstrappedAndDurable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	d, mapCh, _ := newTestDatabase(t, ctrl, Bootstrapped)
-	defer func() {
-		close(mapCh)
-	}()
+	var (
+		validIsBootstrapped                  = true
+		validShardSetAssignedAt              = time.Now()
+		validLastBootstrapCompletionTime     = validShardSetAssignedAt.Add(time.Second)
+		validLastSuccessfulSnapshotStartTime = validLastBootstrapCompletionTime.Add(time.Second)
+	)
+	testCases := []struct {
+		title                           string
+		isBootstrapped                  bool
+		lastBootstrapCompletionTime     time.Time
+		lastSuccessfulSnapshotStartTime time.Time
+		shardSetAssignedAt              time.Time
+		expectedResult                  bool
+	}{
+		{
+			title:                           "False is not bootstrapped",
+			isBootstrapped:                  false,
+			lastBootstrapCompletionTime:     validLastBootstrapCompletionTime,
+			lastSuccessfulSnapshotStartTime: validLastSuccessfulSnapshotStartTime,
+			shardSetAssignedAt:              validShardSetAssignedAt,
+			expectedResult:                  false,
+		},
+		{
+			title:                           "False if no last bootstrap completion time",
+			isBootstrapped:                  validIsBootstrapped,
+			lastBootstrapCompletionTime:     time.Time{},
+			lastSuccessfulSnapshotStartTime: validLastSuccessfulSnapshotStartTime,
+			shardSetAssignedAt:              validShardSetAssignedAt,
+			expectedResult:                  false,
+		},
+		{
+			title:                           "False if no last successful snapshot start time",
+			isBootstrapped:                  validIsBootstrapped,
+			lastBootstrapCompletionTime:     validLastBootstrapCompletionTime,
+			lastSuccessfulSnapshotStartTime: time.Time{},
+			shardSetAssignedAt:              validShardSetAssignedAt,
+			expectedResult:                  false,
+		},
+		{
+			title:                           "False if last snapshot start is not after last bootstrap completion time",
+			isBootstrapped:                  validIsBootstrapped,
+			lastBootstrapCompletionTime:     validLastBootstrapCompletionTime,
+			lastSuccessfulSnapshotStartTime: validLastBootstrapCompletionTime,
+			shardSetAssignedAt:              validShardSetAssignedAt,
+			expectedResult:                  false,
+		},
+		{
+			title:                           "False if last bootstrap completion time is not after shardset assigned at time",
+			isBootstrapped:                  validIsBootstrapped,
+			lastBootstrapCompletionTime:     validLastBootstrapCompletionTime,
+			lastSuccessfulSnapshotStartTime: validLastBootstrapCompletionTime,
+			shardSetAssignedAt:              validLastBootstrapCompletionTime,
+			expectedResult:                  false,
+		},
+		{
+			title:                           "False if last bootstrap completion time is not after shardset assigned at time",
+			isBootstrapped:                  validIsBootstrapped,
+			lastBootstrapCompletionTime:     validLastBootstrapCompletionTime,
+			lastSuccessfulSnapshotStartTime: validLastSuccessfulSnapshotStartTime,
+			shardSetAssignedAt:              validLastBootstrapCompletionTime,
+			expectedResult:                  false,
+		},
+		{
+			title:                           "True if all conditions are met",
+			isBootstrapped:                  validIsBootstrapped,
+			lastBootstrapCompletionTime:     validLastBootstrapCompletionTime,
+			lastSuccessfulSnapshotStartTime: validLastSuccessfulSnapshotStartTime,
+			shardSetAssignedAt:              validShardSetAssignedAt,
+			expectedResult:                  true,
+		},
+	}
 
-	mediator := NewMockdatabaseMediator(ctrl)
-	d.mediator = mediator
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			d, mapCh, _ := newTestDatabase(t, ctrl, Bootstrapped)
+			defer func() {
+				close(mapCh)
+			}()
 
-	// Not BootstrappedAndDurable if not bootstrapped.
-	mediator.EXPECT().IsBootstrapped().Return(false)
-	assert.False(t, d.IsBootstrappedAndDurable())
+			mediator := NewMockdatabaseMediator(ctrl)
+			d.mediator = mediator
+			d.shardSetAssignedAt = tc.shardSetAssignedAt
 
-	// Not BootstrappedAndDurable if no last successful snapshot start time.
-	mediator.EXPECT().IsBootstrapped().Return(true)
-	mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(time.Time{}, false)
-	assert.False(t, d.IsBootstrappedAndDurable())
+			mediator.EXPECT().IsBootstrapped().Return(tc.isBootstrapped)
+			if !tc.isBootstrapped {
+				assert.Equal(t, tc.expectedResult, d.IsBootstrappedAndDurable())
+				// Early return because other mock calls will not get called.
+				return
+			}
 
-	// Not BootstrappedAndDurable if last successful snapshot start time
-	// is not after last time shardset was assigned.
-	now := time.Now()
-	d.shardSetAssignedAt = now
-	mediator.EXPECT().IsBootstrapped().Return(true)
-	mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(now, true)
-	assert.False(t, d.IsBootstrappedAndDurable())
+			if tc.lastBootstrapCompletionTime.IsZero() {
+				mediator.EXPECT().LastBootstrapCompletionTime().Return(time.Time{}, false)
+				assert.Equal(t, tc.expectedResult, d.IsBootstrappedAndDurable())
+				// Early return because other mock calls will not get called.
+				return
+			}
 
-	// BootstrappedAndDurable because its bootstrapped and one complete snapshot has
-	// finished that also started AFTER the last shardset was assigned.
-	d.shardSetAssignedAt = now
-	mediator.EXPECT().IsBootstrapped().Return(true)
-	mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(now.Add(time.Second), true)
-	assert.True(t, d.IsBootstrappedAndDurable())
+			mediator.EXPECT().LastBootstrapCompletionTime().Return(tc.lastBootstrapCompletionTime, true)
+
+			if tc.lastSuccessfulSnapshotStartTime.IsZero() {
+				mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(time.Time{}, false)
+				assert.Equal(t, tc.expectedResult, d.IsBootstrappedAndDurable())
+				// Early return because other mock calls will not get called.
+				return
+			}
+
+			mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(tc.lastSuccessfulSnapshotStartTime, true)
+
+			assert.Equal(t, tc.expectedResult, d.IsBootstrappedAndDurable())
+		})
+	}
+
+	// // Not BootstrappedAndDurable if not bootstrapped.
+	// mediator.EXPECT().IsBootstrapped().Return(false)
+	// assert.False(t, d.IsBootstrappedAndDurable())
+
+	// // Not BootstrappedAndDurable if no last bootstrap completion time.
+	// mediator.EXPECT().IsBootstrapped().Return(true)
+	// mediator.EXPECT().LastBootstrapCompletionTime().Return(time.Time{}, false)
+	// assert.False(t, d.IsBootstrappedAndDurable())
+
+	// var (
+	// 	now                     = time.Now()
+	// 	bootstrapCompletionTime = now.Add(time.Second)
+	// )
+	// d.shardSetAssignedAt = now
+
+	// // Not BootstrappedAndDurable if no last successful snapshot start time.
+	// mediator.EXPECT().IsBootstrapped().Return(true)
+	// mediator.EXPECT().LastBootstrapCompletionTime().Return(bootstrapCompletionTime, true)
+	// mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(time.Time{}, false)
+	// assert.False(t, d.IsBootstrappedAndDurable())
+
+	// // Not BootstrappedAndDurable if last successful snapshot start time
+	// // is not after bootstrap completion time.
+	// mediator.EXPECT().IsBootstrapped().Return(true)
+	// mediator.EXPECT().LastBootstrapCompletionTime().Return(bootstrapCompletionTime, true)
+	// mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(bootstrapCompletionTime, true)
+	// assert.False(t, d.IsBootstrappedAndDurable())
+
+	// // BootstrappedAndDurable because its bootstrapped and one complete snapshot has
+	// // finished that also started AFTER the last shardset was assigned.
+	// d.shardSetAssignedAt = now
+	// mediator.EXPECT().IsBootstrapped().Return(true)
+	// mediator.EXPECT().LastSuccessfulSnapshotStartTime().Return(now.Add(time.Second), true)
+	// assert.True(t, d.IsBootstrappedAndDurable())
 }

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -954,7 +954,7 @@ func TestDatabaseIsBootstrappedAndDurable(t *testing.T) {
 
 			mediator := NewMockdatabaseMediator(ctrl)
 			d.mediator = mediator
-			d.shardSetAssignedAt = tc.shardSetAssignedAt
+			d.lastReceivedNewShards = tc.shardSetAssignedAt
 
 			mediator.EXPECT().IsBootstrapped().Return(tc.isBootstrapped)
 			if !tc.isBootstrapped {

--- a/src/dbnode/storage/flush.go
+++ b/src/dbnode/storage/flush.go
@@ -168,6 +168,7 @@ func (m *flushManager) Flush(
 	multiErr = multiErr.Add(flush.DoneData())
 
 	if multiErr.NumErrors() == 0 {
+		fmt.Println("done snapshotting!")
 		m.lastSuccessfulSnapshotStartTime = tickStart
 	}
 

--- a/src/dbnode/storage/flush.go
+++ b/src/dbnode/storage/flush.go
@@ -133,6 +133,11 @@ func (m *flushManager) Flush(
 		multiErr = multiErr.Add(m.flushNamespaceWithTimes(ns, shardBootstrapTimes, flushTimes, flush))
 	}
 
+	// NB(rartoul): We need to make decisions about whether to snapshot or not as an
+	// all-or-nothing decision, we can't decide on a namespace-by-namespace or
+	// shard-by-shard basis because the model we're moving towards is that once a snapshot
+	// has completed, then all data that had been received by the dbnode up until the
+	// snapshot "start time" has been persisted durably.
 	shouldSnapshot := tickStart.Sub(m.lastSuccessfulSnapshotStartTime) > m.opts.MinimumSnapshotInterval()
 	if shouldSnapshot {
 		m.setState(flushManagerSnapshotInProgress)

--- a/src/dbnode/storage/flush.go
+++ b/src/dbnode/storage/flush.go
@@ -138,7 +138,7 @@ func (m *flushManager) Flush(
 	// shard-by-shard basis because the model we're moving towards is that once a snapshot
 	// has completed, then all data that had been received by the dbnode up until the
 	// snapshot "start time" has been persisted durably.
-	shouldSnapshot := tickStart.Sub(m.lastSuccessfulSnapshotStartTime) > m.opts.MinimumSnapshotInterval()
+	shouldSnapshot := tickStart.Sub(m.lastSuccessfulSnapshotStartTime) >= m.opts.MinimumSnapshotInterval()
 	if shouldSnapshot {
 		m.setState(flushManagerSnapshotInProgress)
 		maxBlocksSnapshottedByNamespace := 0

--- a/src/dbnode/storage/flush_test.go
+++ b/src/dbnode/storage/flush_test.go
@@ -354,7 +354,7 @@ func TestFlushManagerFlushSnapshot(t *testing.T) {
 	)
 
 	// Haven't snapshotted yet.
-	lastSuccessfulSnapshot, ok := fm.LastSuccessfulSnapshotStartTime()
+	_, ok := fm.LastSuccessfulSnapshotStartTime()
 	require.False(t, ok)
 
 	for _, ns := range []*MockdatabaseNamespace{ns1, ns2} {

--- a/src/dbnode/storage/flush_test.go
+++ b/src/dbnode/storage/flush_test.go
@@ -348,8 +348,14 @@ func TestFlushManagerFlushSnapshot(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	fm, ns1, ns2 := newMultipleFlushManagerNeedsFlush(t, ctrl)
-	now := time.Now()
+	var (
+		fm, ns1, ns2 = newMultipleFlushManagerNeedsFlush(t, ctrl)
+		now          = time.Now()
+	)
+
+	// Haven't snapshotted yet.
+	lastSuccessfulSnapshot, ok := fm.LastSuccessfulSnapshotStartTime()
+	require.False(t, ok)
 
 	for _, ns := range []*MockdatabaseNamespace{ns1, ns2} {
 		rOpts := ns.Options().RetentionOptions()
@@ -381,6 +387,10 @@ func TestFlushManagerFlushSnapshot(t *testing.T) {
 		},
 	}
 	require.NoError(t, fm.Flush(now, bootstrapStates))
+
+	lastSuccessfulSnapshot, ok = fm.LastSuccessfulSnapshotStartTime()
+	require.True(t, ok)
+	require.Equal(t, now, lastSuccessfulSnapshot)
 }
 
 type timesInOrder []time.Time

--- a/src/dbnode/storage/flush_test.go
+++ b/src/dbnode/storage/flush_test.go
@@ -393,6 +393,45 @@ func TestFlushManagerFlushSnapshot(t *testing.T) {
 	require.Equal(t, now, lastSuccessfulSnapshot)
 }
 
+func TestFlushManagerFlushSnapshotHonorsMinimumInterval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		fm, ns1, ns2 = newMultipleFlushManagerNeedsFlush(t, ctrl)
+		now          = time.Now()
+	)
+	fm.lastSuccessfulSnapshotStartTime = now
+
+	for _, ns := range []*MockdatabaseNamespace{ns1, ns2} {
+		// Expect flushes but not snapshots.
+		var (
+			rOpts     = ns.Options().RetentionOptions()
+			blockSize = rOpts.BlockSize()
+			start     = retention.FlushTimeStart(ns.Options().RetentionOptions(), now)
+			flushEnd  = retention.FlushTimeEnd(ns.Options().RetentionOptions(), now)
+			num       = numIntervals(start, flushEnd, blockSize)
+		)
+
+		for i := 0; i < num; i++ {
+			st := start.Add(time.Duration(i) * blockSize)
+			ns.EXPECT().NeedsFlush(st, st).Return(false)
+		}
+	}
+
+	bootstrapStates := DatabaseBootstrapState{
+		NamespaceBootstrapStates: map[string]ShardBootstrapStates{
+			ns1.ID().String(): ShardBootstrapStates{},
+			ns2.ID().String(): ShardBootstrapStates{},
+		},
+	}
+	require.NoError(t, fm.Flush(now, bootstrapStates))
+
+	lastSuccessfulSnapshot, ok := fm.LastSuccessfulSnapshotStartTime()
+	require.True(t, ok)
+	require.Equal(t, now, lastSuccessfulSnapshot)
+}
+
 type timesInOrder []time.Time
 
 func (a timesInOrder) Len() int           { return len(a) }

--- a/src/dbnode/storage/flush_test.go
+++ b/src/dbnode/storage/flush_test.go
@@ -388,7 +388,7 @@ func TestFlushManagerFlushSnapshot(t *testing.T) {
 	}
 	require.NoError(t, fm.Flush(now, bootstrapStates))
 
-	lastSuccessfulSnapshot, ok = fm.LastSuccessfulSnapshotStartTime()
+	lastSuccessfulSnapshot, ok := fm.LastSuccessfulSnapshotStartTime()
 	require.True(t, ok)
 	require.Equal(t, now, lastSuccessfulSnapshot)
 }

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -902,18 +902,13 @@ func (n *dbNamespace) Snapshot(
 	multiErr := xerrors.NewMultiError()
 	shards := n.GetOwnedShards()
 	for _, shard := range shards {
-		isSnapshotting, lastSuccessfulSnapshot := shard.SnapshotState()
+		isSnapshotting, _ := shard.SnapshotState()
 		if isSnapshotting {
 			// Should never happen because snapshots should never overlap
 			// each other (controlled by loop in flush manager)
 			n.log.
 				WithFields(xlog.NewField("shard", shard.ID())).
 				Errorf("[invariant violated] tried to snapshot shard that is already snapshotting")
-			continue
-		}
-
-		if snapshotTime.Sub(lastSuccessfulSnapshot) < n.opts.MinimumSnapshotInterval() {
-			// Skip if not enough time has elapsed since the previous snapshot
 			continue
 		}
 

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -885,7 +885,6 @@ func (n *dbNamespace) Snapshot(
 	// NB(rartoul): This value can be used for emitting metrics, but should not be used
 	// for business logic.
 	callStart := n.nowFn()
-	panic("yolo")
 
 	n.RLock()
 	if n.bootstrapState != Bootstrapped {
@@ -931,7 +930,6 @@ func (n *dbNamespace) Snapshot(
 			continue
 		}
 
-		fmt.Println("SNAPSHOTTING")
 		err := shard.Snapshot(blockStart, snapshotTime, flush)
 		if err != nil {
 			detailedErr := fmt.Errorf("shard %d failed to snapshot: %v", shard.ID(), err)

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -885,6 +885,7 @@ func (n *dbNamespace) Snapshot(
 	// NB(rartoul): This value can be used for emitting metrics, but should not be used
 	// for business logic.
 	callStart := n.nowFn()
+	panic("yolo")
 
 	n.RLock()
 	if n.bootstrapState != Bootstrapped {
@@ -930,6 +931,7 @@ func (n *dbNamespace) Snapshot(
 			continue
 		}
 
+		fmt.Println("SNAPSHOTTING")
 		err := shard.Snapshot(blockStart, snapshotTime, flush)
 		if err != nil {
 			detailedErr := fmt.Errorf("shard %d failed to snapshot: %v", shard.ID(), err)

--- a/src/dbnode/storage/namespace/options.go
+++ b/src/dbnode/storage/namespace/options.go
@@ -27,22 +27,22 @@ import (
 )
 
 const (
-	// Namespace requires bootstrapping by default
+	// Namespace requires bootstrapping by default.
 	defaultBootstrapEnabled = true
 
-	// Namespace requires flushing by default
+	// Namespace requires flushing by default.
 	defaultFlushEnabled = true
 
-	// Namespace requires snapshotting disabled by default
+	// Namespace requires snapshotting disabled by default.
 	defaultSnapshotEnabled = true
 
-	// Namespace writes go to commit logs by default
+	// Namespace writes go to commit logs by default.
 	defaultWritesToCommitLog = true
 
-	// Namespace requires fileset/snapshot cleanup by default
+	// Namespace requires fileset/snapshot cleanup by default.
 	defaultCleanupEnabled = true
 
-	// Namespace requires repair disabled by default
+	// Namespace requires repair disabled by default.
 	defaultRepairEnabled = false
 )
 

--- a/src/dbnode/storage/namespace/options.go
+++ b/src/dbnode/storage/namespace/options.go
@@ -34,7 +34,7 @@ const (
 	defaultFlushEnabled = true
 
 	// Namespace requires snapshotting disabled by default
-	defaultSnapshotEnabled = false
+	defaultSnapshotEnabled = true
 
 	// Namespace writes go to commit logs by default
 	defaultWritesToCommitLog = true

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -441,30 +441,6 @@ func TestNamespaceSnapshotNotBootstrapped(t *testing.T) {
 	require.Equal(t, errNamespaceNotBootstrapped, ns.Snapshot(blockStart, blockStart, nil, nil))
 }
 
-func TestNamespaceSnapshotNotEnoughTimeSinceLastSnapshot(t *testing.T) {
-	shardMethodResults := []snapshotTestCase{
-		snapshotTestCase{
-			isSnapshotting:                false,
-			expectSnapshot:                false,
-			shardBootstrapStateBeforeTick: Bootstrapped,
-			lastSnapshotTime: func(curr time.Time, blockSize time.Duration) time.Time {
-				return curr
-			},
-			shardSnapshotErr: nil,
-		},
-		snapshotTestCase{
-			isSnapshotting:                false,
-			expectSnapshot:                true,
-			shardBootstrapStateBeforeTick: Bootstrapped,
-			lastSnapshotTime: func(curr time.Time, blockSize time.Duration) time.Time {
-				return curr.Add(-2 * defaultMinSnapshotInterval)
-			},
-			shardSnapshotErr: nil,
-		},
-	}
-	require.NoError(t, testSnapshotWithShardSnapshotErrs(t, shardMethodResults))
-}
-
 func TestNamespaceSnapshotShardIsSnapshotting(t *testing.T) {
 	shardMethodResults := []snapshotTestCase{
 		snapshotTestCase{

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -71,7 +71,7 @@ const (
 	defaultIndexingEnabled = false
 
 	// defaultMinSnapshotInterval is the default minimum interval that must elapse between snapshots
-	defaultMinSnapshotInterval = 5 * time.Second
+	defaultMinSnapshotInterval = 10 * time.Second
 )
 
 var (

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -52,33 +52,33 @@ import (
 )
 
 const (
-	// defaultBytesPoolBucketCapacity is the default bytes buffer capacity for the default bytes pool bucket
+	// defaultBytesPoolBucketCapacity is the default bytes buffer capacity for the default bytes pool bucket.
 	defaultBytesPoolBucketCapacity = 256
 
-	// defaultBytesPoolBucketCount is the default count of elements for the default bytes pool bucket
+	// defaultBytesPoolBucketCount is the default count of elements for the default bytes pool bucket.
 	defaultBytesPoolBucketCount = 4096
 
-	// defaultRepairEnabled enables repair by default
+	// defaultRepairEnabled enables repair by default.
 	defaultRepairEnabled = true
 
-	// defaultErrorWindowForLoad is the default error window for evaluating server load
+	// defaultErrorWindowForLoad is the default error window for evaluating server load.
 	defaultErrorWindowForLoad = 10 * time.Second
 
-	// defaultErrorThresholdForLoad is the default error threshold for considering server overloaded
+	// defaultErrorThresholdForLoad is the default error threshold for considering server overloaded.
 	defaultErrorThresholdForLoad = 1000
 
-	// defaultIndexingEnabled disables indexing by default
+	// defaultIndexingEnabled disables indexing by default.
 	defaultIndexingEnabled = false
 
-	// defaultMinSnapshotInterval is the default minimum interval that must elapse between snapshots
+	// defaultMinSnapshotInterval is the default minimum interval that must elapse between snapshots.
 	defaultMinSnapshotInterval = 10 * time.Second
 )
 
 var (
-	// defaultBootstrapProcessProvider is the default bootstrap provider for the database
+	// defaultBootstrapProcessProvider is the default bootstrap provider for the database.
 	defaultBootstrapProcessProvider = bootstrap.NewNoOpProcessProvider()
 
-	// defaultPoolOptions are the pool options used by default
+	// defaultPoolOptions are the pool options used by default.
 	defaultPoolOptions pool.ObjectPoolOptions
 
 	timeZero time.Time

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -71,7 +71,7 @@ const (
 	defaultIndexingEnabled = false
 
 	// defaultMinSnapshotInterval is the default minimum interval that must elapse between snapshots
-	defaultMinSnapshotInterval = time.Minute
+	defaultMinSnapshotInterval = 5 * time.Second
 )
 
 var (

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -344,6 +344,18 @@ func (mr *MockDatabaseMockRecorder) IsBootstrapped() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBootstrapped", reflect.TypeOf((*MockDatabase)(nil).IsBootstrapped))
 }
 
+// IsBootstrappedAndDurable mocks base method
+func (m *MockDatabase) IsBootstrappedAndDurable() bool {
+	ret := m.ctrl.Call(m, "IsBootstrappedAndDurable")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsBootstrappedAndDurable indicates an expected call of IsBootstrappedAndDurable
+func (mr *MockDatabaseMockRecorder) IsBootstrappedAndDurable() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBootstrappedAndDurable", reflect.TypeOf((*MockDatabase)(nil).IsBootstrappedAndDurable))
+}
+
 // IsOverloaded mocks base method
 func (m *MockDatabase) IsOverloaded() bool {
 	ret := m.ctrl.Call(m, "IsOverloaded")
@@ -647,6 +659,18 @@ func (m *Mockdatabase) IsBootstrapped() bool {
 // IsBootstrapped indicates an expected call of IsBootstrapped
 func (mr *MockdatabaseMockRecorder) IsBootstrapped() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBootstrapped", reflect.TypeOf((*Mockdatabase)(nil).IsBootstrapped))
+}
+
+// IsBootstrappedAndDurable mocks base method
+func (m *Mockdatabase) IsBootstrappedAndDurable() bool {
+	ret := m.ctrl.Call(m, "IsBootstrappedAndDurable")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsBootstrappedAndDurable indicates an expected call of IsBootstrappedAndDurable
+func (mr *MockdatabaseMockRecorder) IsBootstrappedAndDurable() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBootstrappedAndDurable", reflect.TypeOf((*Mockdatabase)(nil).IsBootstrappedAndDurable))
 }
 
 // IsOverloaded mocks base method
@@ -1670,6 +1694,19 @@ func (mr *MockdatabaseBootstrapManagerMockRecorder) IsBootstrapped() *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBootstrapped", reflect.TypeOf((*MockdatabaseBootstrapManager)(nil).IsBootstrapped))
 }
 
+// LastBootstrapCompletionTime mocks base method
+func (m *MockdatabaseBootstrapManager) LastBootstrapCompletionTime() (time.Time, bool) {
+	ret := m.ctrl.Call(m, "LastBootstrapCompletionTime")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// LastBootstrapCompletionTime indicates an expected call of LastBootstrapCompletionTime
+func (mr *MockdatabaseBootstrapManagerMockRecorder) LastBootstrapCompletionTime() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastBootstrapCompletionTime", reflect.TypeOf((*MockdatabaseBootstrapManager)(nil).LastBootstrapCompletionTime))
+}
+
 // Bootstrap mocks base method
 func (m *MockdatabaseBootstrapManager) Bootstrap() error {
 	ret := m.ctrl.Call(m, "Bootstrap")
@@ -1725,6 +1762,19 @@ func (m *MockdatabaseFlushManager) Flush(tickStart time.Time, dbBootstrapStateAt
 // Flush indicates an expected call of Flush
 func (mr *MockdatabaseFlushManagerMockRecorder) Flush(tickStart, dbBootstrapStateAtTickStart interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockdatabaseFlushManager)(nil).Flush), tickStart, dbBootstrapStateAtTickStart)
+}
+
+// LastSuccessfulSnapshotStartTime mocks base method
+func (m *MockdatabaseFlushManager) LastSuccessfulSnapshotStartTime() (time.Time, bool) {
+	ret := m.ctrl.Call(m, "LastSuccessfulSnapshotStartTime")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// LastSuccessfulSnapshotStartTime indicates an expected call of LastSuccessfulSnapshotStartTime
+func (mr *MockdatabaseFlushManagerMockRecorder) LastSuccessfulSnapshotStartTime() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastSuccessfulSnapshotStartTime", reflect.TypeOf((*MockdatabaseFlushManager)(nil).LastSuccessfulSnapshotStartTime))
 }
 
 // Report mocks base method
@@ -1885,6 +1935,19 @@ func (m *MockdatabaseFileSystemManager) Report() {
 // Report indicates an expected call of Report
 func (mr *MockdatabaseFileSystemManagerMockRecorder) Report() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockdatabaseFileSystemManager)(nil).Report))
+}
+
+// LastSuccessfulSnapshotStartTime mocks base method
+func (m *MockdatabaseFileSystemManager) LastSuccessfulSnapshotStartTime() (time.Time, bool) {
+	ret := m.ctrl.Call(m, "LastSuccessfulSnapshotStartTime")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// LastSuccessfulSnapshotStartTime indicates an expected call of LastSuccessfulSnapshotStartTime
+func (mr *MockdatabaseFileSystemManagerMockRecorder) LastSuccessfulSnapshotStartTime() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastSuccessfulSnapshotStartTime", reflect.TypeOf((*MockdatabaseFileSystemManager)(nil).LastSuccessfulSnapshotStartTime))
 }
 
 // MockdatabaseShardRepairer is a mock of databaseShardRepairer interface
@@ -2082,6 +2145,19 @@ func (mr *MockdatabaseMediatorMockRecorder) IsBootstrapped() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBootstrapped", reflect.TypeOf((*MockdatabaseMediator)(nil).IsBootstrapped))
 }
 
+// LastBootstrapCompletionTime mocks base method
+func (m *MockdatabaseMediator) LastBootstrapCompletionTime() (time.Time, bool) {
+	ret := m.ctrl.Call(m, "LastBootstrapCompletionTime")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// LastBootstrapCompletionTime indicates an expected call of LastBootstrapCompletionTime
+func (mr *MockdatabaseMediatorMockRecorder) LastBootstrapCompletionTime() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastBootstrapCompletionTime", reflect.TypeOf((*MockdatabaseMediator)(nil).LastBootstrapCompletionTime))
+}
+
 // Bootstrap mocks base method
 func (m *MockdatabaseMediator) Bootstrap() error {
 	ret := m.ctrl.Call(m, "Bootstrap")
@@ -2158,6 +2234,19 @@ func (m *MockdatabaseMediator) Report() {
 // Report indicates an expected call of Report
 func (mr *MockdatabaseMediatorMockRecorder) Report() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockdatabaseMediator)(nil).Report))
+}
+
+// LastSuccessfulSnapshotStartTime mocks base method
+func (m *MockdatabaseMediator) LastSuccessfulSnapshotStartTime() (time.Time, bool) {
+	ret := m.ctrl.Call(m, "LastSuccessfulSnapshotStartTime")
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// LastSuccessfulSnapshotStartTime indicates an expected call of LastSuccessfulSnapshotStartTime
+func (mr *MockdatabaseMediatorMockRecorder) LastSuccessfulSnapshotStartTime() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastSuccessfulSnapshotStartTime", reflect.TypeOf((*MockdatabaseMediator)(nil).LastSuccessfulSnapshotStartTime))
 }
 
 // MockdatabaseNamespaceWatch is a mock of databaseNamespaceWatch interface

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -534,6 +534,10 @@ type databaseFlushManager interface {
 	// Flush flushes in-memory data to persistent storage.
 	Flush(tickStart time.Time, dbBootstrapStateAtTickStart DatabaseBootstrapState) error
 
+	// LastSuccessfulSnapshotStartTime returns the start time of the last successful snapshot,
+	// if any.
+	LastSuccessfulSnapshotStartTime() (time.Time, bool)
+
 	// Report reports runtime information
 	Report()
 }
@@ -576,6 +580,10 @@ type databaseFileSystemManager interface {
 
 	// Report reports runtime information
 	Report()
+
+	// LastSuccessfulSnapshotStartTime returns the start time of the last successful snapshot,
+	// if any.
+	LastSuccessfulSnapshotStartTime() (time.Time, bool)
 }
 
 // databaseShardRepairer repairs in-memory data for a shard
@@ -643,6 +651,10 @@ type databaseMediator interface {
 
 	// Report reports runtime information
 	Report()
+
+	// LastSuccessfulSnapshotStartTime returns the start time of the last successful snapshot,
+	// if any.
+	LastSuccessfulSnapshotStartTime() (time.Time, bool)
 }
 
 // databaseNamespaceWatch watches for namespace updates.

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -527,7 +527,7 @@ type databaseBootstrapManager interface {
 	// IsBootstrapped returns whether the database is already bootstrapped.
 	IsBootstrapped() bool
 
-	// LastBootstrapCompletionTime returns the last bootstrap compeltion time,
+	// LastBootstrapCompletionTime returns the last bootstrap completion time,
 	// if any.
 	LastBootstrapCompletionTime() (time.Time, bool)
 
@@ -640,7 +640,7 @@ type databaseMediator interface {
 	// IsBootstrapped returns whether the database is bootstrapped.
 	IsBootstrapped() bool
 
-	// LastBootstrapCompletionTime returns the last bootstrap compeltion time,
+	// LastBootstrapCompletionTime returns the last bootstrap completion time,
 	// if any.
 	LastBootstrapCompletionTime() (time.Time, bool)
 

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -175,7 +175,7 @@ type Database interface {
 	// IsBootstrapped determines whether the database is bootstrapped.
 	IsBootstrapped() bool
 
-	// IsBootstrappedAndDurable determines whether the database is bootstrapped,
+	// IsBootstrappedAndDurable determines whether the database is bootstrapped
 	// and durable, meaning that it could recover all data in memory using only
 	// the local disk.
 	IsBootstrappedAndDurable() bool

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -527,6 +527,10 @@ type databaseBootstrapManager interface {
 	// IsBootstrapped returns whether the database is already bootstrapped.
 	IsBootstrapped() bool
 
+	// LastBootstrapCompletionTime returns the last bootstrap compeltion time,
+	// if any.
+	LastBootstrapCompletionTime() (time.Time, bool)
+
 	// Bootstrap performs bootstrapping for all namespaces and shards owned.
 	Bootstrap() error
 
@@ -630,31 +634,35 @@ type databaseTickManager interface {
 
 // databaseMediator mediates actions among various database managers
 type databaseMediator interface {
-	// Open opens the mediator
+	// Open opens the mediator.
 	Open() error
 
-	// IsBootstrapped returns whether the database is bootstrapped
+	// IsBootstrapped returns whether the database is bootstrapped.
 	IsBootstrapped() bool
 
-	// Bootstrap bootstraps the database with file operations performed at the end
+	// LastBootstrapCompletionTime returns the last bootstrap compeltion time,
+	// if any.
+	LastBootstrapCompletionTime() (time.Time, bool)
+
+	// Bootstrap bootstraps the database with file operations performed at the end.
 	Bootstrap() error
 
-	// DisableFileOps disables file operations
+	// DisableFileOps disables file operations.
 	DisableFileOps()
 
-	// EnableFileOps enables file operations
+	// EnableFileOps enables file operations.
 	EnableFileOps()
 
-	// Tick performs a tick
+	// Tick performs a tick.
 	Tick(runType runType, forceType forceType) error
 
-	// Repair repairs the database
+	// Repair repairs the database.
 	Repair() error
 
-	// Close closes the mediator
+	// Close closes the mediator.
 	Close() error
 
-	// Report reports runtime information
+	// Report reports runtime information.
 	Report()
 
 	// LastSuccessfulSnapshotStartTime returns the start time of the last successful snapshot,

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -175,6 +175,11 @@ type Database interface {
 	// IsBootstrapped determines whether the database is bootstrapped.
 	IsBootstrapped() bool
 
+	// IsBootstrappedAndDurable determines whether the database is bootstrapped,
+	// and durable, meaning that it could recover all data in memory using only
+	// the local disk.
+	IsBootstrappedAndDurable() bool
+
 	// IsOverloaded determines whether the database is overloaded
 	IsOverloaded() bool
 

--- a/src/query/api/v1/handler/database/create_test.go
+++ b/src/query/api/v1/handler/database/create_test.go
@@ -136,7 +136,7 @@ func TestLocalType(t *testing.T) {
 							"blockDataExpiry": true,
 							"blockDataExpiryAfterNotAccessPeriodNanos": "300000000000"
 						},
-						"snapshotEnabled": false,
+						"snapshotEnabled": true,
 						"indexOptions": {
 							"enabled": true,
 							"blockSizeNanos": "3600000000000"
@@ -237,7 +237,7 @@ func TestLocalWithBlockSizeNanos(t *testing.T) {
 							"blockDataExpiry": true,
 							"blockDataExpiryAfterNotAccessPeriodNanos": "300000000000"
 						},
-						"snapshotEnabled": false,
+						"snapshotEnabled": true,
 						"indexOptions": {
 							"enabled": true,
 							"blockSizeNanos": "10800000000000"
@@ -341,7 +341,7 @@ func TestLocalWithBlockSizeExpectedSeriesDatapointsPerHour(t *testing.T) {
 							"blockDataExpiry": true,
 							"blockDataExpiryAfterNotAccessPeriodNanos": "300000000000"
 						},
-						"snapshotEnabled": false,
+						"snapshotEnabled": true,
 						"indexOptions": {
 							"enabled": true,
 							"blockSizeNanos": "%d"
@@ -452,7 +452,7 @@ func TestClusterTypeHosts(t *testing.T) {
 							"blockDataExpiry": true,
 							"blockDataExpiryAfterNotAccessPeriodNanos": "300000000000"
 						},
-						"snapshotEnabled": false,
+						"snapshotEnabled": true,
 						"indexOptions": {
 							"enabled": true,
 							"blockSizeNanos": "3600000000000"
@@ -573,7 +573,7 @@ func TestClusterTypeHostsWithIsolationGroup(t *testing.T) {
 							"blockDataExpiry": true,
 							"blockDataExpiryAfterNotAccessPeriodNanos": "300000000000"
 						},
-						"snapshotEnabled": false,
+						"snapshotEnabled": true,
 						"indexOptions": {
 							"enabled": true,
 							"blockSizeNanos": "3600000000000"

--- a/src/query/api/v1/handler/namespace/add_test.go
+++ b/src/query/api/v1/handler/namespace/add_test.go
@@ -82,7 +82,7 @@ func TestNamespaceAddHandler(t *testing.T) {
                 "blockDataExpiry": true,
                 "blockDataExpiryAfterNotAccessPeriodNanos": 300000000000
               },
-              "snapshotEnabled": false,
+              "snapshotEnabled": true,
               "indexOptions": {
                 "enabled": true,
                 "blockSizeNanos": 7200000000000
@@ -101,5 +101,5 @@ func TestNamespaceAddHandler(t *testing.T) {
 	resp = w.Result()
 	body, _ = ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "{\"registry\":{\"namespaces\":{\"testNamespace\":{\"bootstrapEnabled\":true,\"flushEnabled\":true,\"writesToCommitLog\":true,\"cleanupEnabled\":true,\"repairEnabled\":true,\"retentionOptions\":{\"retentionPeriodNanos\":\"172800000000000\",\"blockSizeNanos\":\"7200000000000\",\"bufferFutureNanos\":\"600000000000\",\"bufferPastNanos\":\"600000000000\",\"blockDataExpiry\":true,\"blockDataExpiryAfterNotAccessPeriodNanos\":\"300000000000\"},\"snapshotEnabled\":false,\"indexOptions\":{\"enabled\":true,\"blockSizeNanos\":\"7200000000000\"}}}}}", string(body))
+	assert.Equal(t, "{\"registry\":{\"namespaces\":{\"testNamespace\":{\"bootstrapEnabled\":true,\"flushEnabled\":true,\"writesToCommitLog\":true,\"cleanupEnabled\":true,\"repairEnabled\":true,\"retentionOptions\":{\"retentionPeriodNanos\":\"172800000000000\",\"blockSizeNanos\":\"7200000000000\",\"bufferFutureNanos\":\"600000000000\",\"bufferPastNanos\":\"600000000000\",\"blockDataExpiry\":true,\"blockDataExpiryAfterNotAccessPeriodNanos\":\"300000000000\"},\"snapshotEnabled\":true,\"indexOptions\":{\"enabled\":true,\"blockSizeNanos\":\"7200000000000\"}}}}}", string(body))
 }

--- a/src/query/api/v1/handler/namespace/get_test.go
+++ b/src/query/api/v1/handler/namespace/get_test.go
@@ -82,6 +82,7 @@ func TestNamespaceGetHandler(t *testing.T) {
 			"test": &nsproto.NamespaceOptions{
 				BootstrapEnabled:  true,
 				FlushEnabled:      true,
+				SnapshotEnabled:   true,
 				WritesToCommitLog: true,
 				CleanupEnabled:    false,
 				RepairEnabled:     false,
@@ -106,5 +107,5 @@ func TestNamespaceGetHandler(t *testing.T) {
 	resp = w.Result()
 	body, _ = ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, "{\"registry\":{\"namespaces\":{\"test\":{\"bootstrapEnabled\":true,\"flushEnabled\":true,\"writesToCommitLog\":true,\"cleanupEnabled\":false,\"repairEnabled\":false,\"retentionOptions\":{\"retentionPeriodNanos\":\"172800000000000\",\"blockSizeNanos\":\"7200000000000\",\"bufferFutureNanos\":\"600000000000\",\"bufferPastNanos\":\"600000000000\",\"blockDataExpiry\":true,\"blockDataExpiryAfterNotAccessPeriodNanos\":\"3600000000000\"},\"snapshotEnabled\":false,\"indexOptions\":null}}}}", string(body))
+	assert.Equal(t, "{\"registry\":{\"namespaces\":{\"test\":{\"bootstrapEnabled\":true,\"flushEnabled\":true,\"writesToCommitLog\":true,\"cleanupEnabled\":false,\"repairEnabled\":false,\"retentionOptions\":{\"retentionPeriodNanos\":\"172800000000000\",\"blockSizeNanos\":\"7200000000000\",\"bufferFutureNanos\":\"600000000000\",\"bufferPastNanos\":\"600000000000\",\"blockDataExpiry\":true,\"blockDataExpiryAfterNotAccessPeriodNanos\":\"3600000000000\"},\"snapshotEnabled\":true,\"indexOptions\":null}}}}", string(body))
 }


### PR DESCRIPTION
Previously, M3DB implemented durability during topology changes by forcing the peers bootstrapper to write out a snapshot file for any *mutable* data that was streamed in from a peer. This ensured that if the node crashed after the topology change, the commitlog bootstrapper could restore all the data the node was expected to have.

We're currently trying to move M3DB to a model where every set of snapshot files indicates that all the data that had been received by the node up until the beginning of the snapshot could be recovered from a combination of the data files, snapshot files, and commitlog files. The existing implementation clashes with that idea because it was writing out individual snapshot files that were not tied to any large snapshot process.

As a result, this P.R modifies M3DB to eschew writing out snapshot files for mutable data in the peers bootstrapper, and instead it prevents the clustered database from marking shards as available until the last successful snapshot began AFTER the last bootstrap completed and all bootstrapping for the topology change has completed. This is a much simpler model that is robust against future changes to the database.