### PR TITLE
[ci] remove dependency on docker CI base image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,12 +28,14 @@ steps:
     plugins:
       docker-compose#v2.5.1:
         run: app
+        workdir: /go/src/github.com/m3db/m3
     <<: *common
   - name: "Big Unit"
     command: make clean install-vendor test-ci-big-unit
     plugins:
       docker-compose#v2.5.1:
         run: app
+        workdir: /go/src/github.com/m3db/m3
     <<: *common
   - name: "Integration (:docker:), Services, Tools, Metalint"
     command: make install-vendor metalint docker-integration-test tools services
@@ -50,6 +52,7 @@ steps:
     plugins:
       docker-compose#v2.5.1:
         run: app
+        workdir: /go/src/github.com/m3db/m3
     <<: *common
   - name: "Integration (dbnode LRU) %n"
     parallelism: 2
@@ -57,6 +60,7 @@ steps:
     plugins:
       docker-compose#v2.5.1:
         run: app
+        workdir: /go/src/github.com/m3db/m3
     <<: *common
   - label: "Integration (collector, aggregator, m3em, cluster, msg, metrics) %n"
     parallelism: 2
@@ -64,11 +68,13 @@ steps:
     plugins:
       docker-compose#v2.5.1:
         run: app
+        workdir: /go/src/github.com/m3db/m3
     <<: *common
   - label: "FOSSA license scan"
     command: make clean install-vendor fossa
     plugins:
       docker-compose#v2.5.1:
         run: app
+        workdir: /go/src/github.com/m3db/m3
         env:
           - FOSSA_API_KEY

--- a/.buildkite/scripts/Dockerfile
+++ b/.buildkite/scripts/Dockerfile
@@ -1,9 +1,0 @@
-# Built artifacts maintained externally at https://quay.io/repository/m3db/ci-base
-
-# Base image required for CI.
-# We seal the version of Golang to get hermetic builds.
-FROM golang:1.10.4-stretch
-LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
-
-RUN mkdir -p /go/src/github.com/m3db/m3
-WORKDIR /go/src/github.com/m3db/m3

--- a/.buildkite/scripts/adhoc_build.sh
+++ b/.buildkite/scripts/adhoc_build.sh
@@ -24,7 +24,7 @@ function build() {
   fi
 
   if [[ "$action" == "list" ]]; then
-    curl -H "$auth" "${url}/builds"
+    curl -sSf -H "$auth" "${url}/builds"
     return
   fi
 

--- a/.buildkite/scripts/adhoc_build.sh
+++ b/.buildkite/scripts/adhoc_build.sh
@@ -15,6 +15,11 @@ function usage() {
 }
 
 function build() {
+  if [[ -z "$BUILDKITE_CLI_TOKEN" ]]; then
+    echo "BUILDKITE_CLI_TOKEN must be set"
+    exit 1
+  fi
+
   local action=$1
   local url="https://api.buildkite.com/v2/organizations/m3/pipelines/m3-monorepo-ci"
   local auth="Authorization: Bearer $BUILDKITE_CLI_TOKEN"

--- a/.buildkite/scripts/adhoc_build.sh
+++ b/.buildkite/scripts/adhoc_build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Script to run adhoc buildkite builds for the given branch. Useful for running
+# CI tests against branches that may not yet be ready for a PR. See
+# https://buildkite.com/docs/apis/rest-api#authentication for more info on
+# buildkite tokens. To take full advantage of this script your token will need
+# `read_builds` and `write_builds` scopes. The script expects a working
+# installation of jq.
+
+function usage() {
+  echo "build.sh <build|list>"
+  exit 1
+}
+
+function build() {
+  local action=$1
+  local url="https://api.buildkite.com/v2/organizations/m3/pipelines/m3-monorepo-ci"
+  local auth="Authorization: Bearer $BUILDKITE_CLI_TOKEN"
+
+  if [[ "$action" != "build" && "$action" != "list" ]]; then
+    usage
+  fi
+
+  if [[ "$action" == "list" ]]; then
+    curl -H "$auth" "${url}/builds"
+    return
+  fi
+
+  # action == build
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD)
+
+  local data
+  data=$(cat <<EOF
+    {
+      "branch": "${branch}",
+      "message": "$(whoami) adhoc build",
+      "commit": "HEAD",
+      "ignore_pipeline_branch_filters": true,
+      "clean_checkout": true
+    }
+EOF
+  )
+
+  curl -sSf -X POST -H "$auth" "${url}/builds" -d "$data" | jq -r .web_url
+}
+
+build "$*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 app:
-  image: quay.io/m3db/ci-base:latest
+  image: golang:1.10.4-stretch
   volumes:
     - .:/go/src/github.com/m3db/m3
     - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent


### PR DESCRIPTION
Our dockerized CI tests currently run based off the `ci-base` image,
which is just a golang image with our directory in it. This is somewhat
inefficient as we have to bump another docker image if we want to change
the test harness.

This modifies the buildkite builds to use a similar pattern we've used
in other repos, which is to base directly off the golang image and add
the workdir via docker-compose configs.

Additionally, a script is included for creating buildkite builds in an
adhoc manner. The URL referenced in the script is publicly
reconstructable just by looking at any PR on the monorepo, so we're not
exposing any info.