### PR TITLE
Use solely Pilosa roaring bitmaps in m3ninx to avoid expensive unmarshalling

### DIFF
--- a/src/m3ninx/index/segment/fst/segment.go
+++ b/src/m3ninx/index/segment/fst/segment.go
@@ -371,7 +371,10 @@ func (r *fsSegment) MatchAll() (postings.MutableList, error) {
 	}
 
 	pl := r.opts.PostingsListPool().Get()
-	pl.AddRange(r.startInclusive, r.endExclusive)
+	err := pl.AddRange(r.startInclusive, r.endExclusive)
+	if err != nil {
+		return nil, err
+	}
 
 	return pl, nil
 }
@@ -417,7 +420,7 @@ func (r *fsSegment) retrievePostingsListWithRLock(postingsOffset uint64) (postin
 		return nil, fmt.Errorf("unable to retrieve postings data: %v", err)
 	}
 
-	return pilosa.Unmarshal(postingsBytes, roaring.NewPostingsList)
+	return pilosa.Unmarshal(postingsBytes)
 }
 
 func (r *fsSegment) retrieveTermsFSTWithRLock(field []byte) (*vellum.FST, bool, error) {

--- a/src/m3ninx/index/segment/mem/concurrent_postings_map.go
+++ b/src/m3ninx/index/segment/mem/concurrent_postings_map.go
@@ -44,7 +44,7 @@ func newConcurrentPostingsMap(opts Options) *concurrentPostingsMap {
 }
 
 // Add adds the provided `id` to the postings.List backing `key`.
-func (m *concurrentPostingsMap) Add(key []byte, id postings.ID) {
+func (m *concurrentPostingsMap) Add(key []byte, id postings.ID) error {
 	// Try read lock to see if we already have a postings list for the given value.
 	m.RLock()
 	p, ok := m.postingsMap.Get(key)
@@ -52,8 +52,7 @@ func (m *concurrentPostingsMap) Add(key []byte, id postings.ID) {
 
 	// We have a postings list, insert the ID and move on.
 	if ok {
-		p.Insert(id)
-		return
+		return p.Insert(id)
 	}
 
 	// A corresponding postings list doesn't exist, time to acquire write lock.
@@ -63,8 +62,7 @@ func (m *concurrentPostingsMap) Add(key []byte, id postings.ID) {
 	// Check if the corresponding postings list has been created since we released lock.
 	if ok {
 		m.Unlock()
-		p.Insert(id)
-		return
+		return p.Insert(id)
 	}
 
 	// Create a new posting list for the term, and insert into fieldValues.
@@ -74,7 +72,7 @@ func (m *concurrentPostingsMap) Add(key []byte, id postings.ID) {
 		NoFinalizeKey: true,
 	})
 	m.Unlock()
-	p.Insert(id)
+	return p.Insert(id)
 }
 
 // Keys returns the keys known to the map.

--- a/src/m3ninx/index/segment/mem/reader.go
+++ b/src/m3ninx/index/segment/mem/reader.go
@@ -99,7 +99,10 @@ func (r *reader) MatchAll() (postings.MutableList, error) {
 	}
 
 	pl := r.plPool.Get()
-	pl.AddRange(r.limits.startInclusive, r.limits.endExclusive)
+	err := pl.AddRange(r.limits.startInclusive, r.limits.endExclusive)
+	if err != nil {
+		return nil, err
+	}
 	return pl, nil
 }
 

--- a/src/m3ninx/index/segment/mem/reader_test.go
+++ b/src/m3ninx/index/segment/mem/reader_test.go
@@ -41,9 +41,9 @@ func TestReaderMatchExact(t *testing.T) {
 
 	name, value := []byte("apple"), []byte("red")
 	postingsList := roaring.NewPostingsList()
-	postingsList.Insert(postings.ID(42))
-	postingsList.Insert(postings.ID(50))
-	postingsList.Insert(postings.ID(57))
+	require.NoError(t, postingsList.Insert(postings.ID(42)))
+	require.NoError(t, postingsList.Insert(postings.ID(50)))
+	require.NoError(t, postingsList.Insert(postings.ID(57)))
 
 	segment := NewMockReadableSegment(mockCtrl)
 	gomock.InOrder(
@@ -68,9 +68,9 @@ func TestReaderMatchRegex(t *testing.T) {
 	name, regexp := []byte("apple"), []byte("r.*")
 	compiled := re.MustCompile(string(regexp))
 	postingsList := roaring.NewPostingsList()
-	postingsList.Insert(postings.ID(42))
-	postingsList.Insert(postings.ID(50))
-	postingsList.Insert(postings.ID(57))
+	require.NoError(t, postingsList.Insert(postings.ID(42)))
+	require.NoError(t, postingsList.Insert(postings.ID(50)))
+	require.NoError(t, postingsList.Insert(postings.ID(57)))
 
 	segment := NewMockReadableSegment(mockCtrl)
 	gomock.InOrder(
@@ -95,11 +95,11 @@ func TestReaderMatchAll(t *testing.T) {
 	)
 
 	postingsList := roaring.NewPostingsList()
-	postingsList.Insert(postings.ID(42))
-	postingsList.Insert(postings.ID(43))
-	postingsList.Insert(postings.ID(44))
-	postingsList.Insert(postings.ID(45))
-	postingsList.Insert(postings.ID(46))
+	require.NoError(t, postingsList.Insert(postings.ID(42)))
+	require.NoError(t, postingsList.Insert(postings.ID(43)))
+	require.NoError(t, postingsList.Insert(postings.ID(44)))
+	require.NoError(t, postingsList.Insert(postings.ID(45)))
+	require.NoError(t, postingsList.Insert(postings.ID(46)))
 
 	reader := newReader(nil, readerDocRange{minID, maxID}, postings.NewPool(nil, roaring.NewPostingsList))
 
@@ -141,9 +141,9 @@ func TestReaderDocs(t *testing.T) {
 	)
 
 	postingsList := roaring.NewPostingsList()
-	postingsList.Insert(postings.ID(42))
-	postingsList.Insert(postings.ID(47))
-	postingsList.Insert(postings.ID(57)) // IDs past maxID should be ignored.
+	require.NoError(t, postingsList.Insert(postings.ID(42)))
+	require.NoError(t, postingsList.Insert(postings.ID(47)))
+	require.NoError(t, postingsList.Insert(postings.ID(57))) // IDs past maxID should be ignored.
 
 	reader := newReader(segment, readerDocRange{0, maxID}, postings.NewPool(nil, roaring.NewPostingsList))
 

--- a/src/m3ninx/index/segment/mem/terms_dict.go
+++ b/src/m3ninx/index/segment/mem/terms_dict.go
@@ -47,9 +47,9 @@ func newTermsDict(opts Options) termsDictionary {
 	return dict
 }
 
-func (d *termsDict) Insert(field doc.Field, id postings.ID) {
+func (d *termsDict) Insert(field doc.Field, id postings.ID) error {
 	postingsMap := d.getOrAddName(field.Name)
-	postingsMap.Add(field.Value, id)
+	return postingsMap.Add(field.Value, id)
 }
 
 func (d *termsDict) ContainsTerm(field, term []byte) bool {

--- a/src/m3ninx/index/segment/mem/types.go
+++ b/src/m3ninx/index/segment/mem/types.go
@@ -31,7 +31,7 @@ import (
 // termsDictionary is an internal interface for a mutable terms dictionary.
 type termsDictionary interface {
 	// Insert inserts the field with the given ID into the terms dictionary.
-	Insert(field doc.Field, id postings.ID)
+	Insert(field doc.Field, id postings.ID) error
 
 	// ContainsTerm returns a bool indicating whether the terms dictionary contains
 	// the given term.

--- a/src/m3ninx/postings/pilosa/codec.go
+++ b/src/m3ninx/postings/pilosa/codec.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 
 	"github.com/m3db/m3/src/m3ninx/postings"
+	idxroaring "github.com/m3db/m3/src/m3ninx/postings/roaring"
 
 	"github.com/pilosa/pilosa/roaring"
 )
@@ -82,12 +83,11 @@ func toPilosa(pl postings.List) (*roaring.Bitmap, error) {
 }
 
 // Unmarshal unmarshals the provided bytes into a postings.List.
-func Unmarshal(data []byte, allocFn postings.PoolAllocateFn) (postings.List, error) {
-	b := roaring.NewBitmap()
-	if err := b.UnmarshalBinary(data); err != nil {
+func Unmarshal(data []byte) (postings.List, error) {
+	bitmap := roaring.NewBitmap()
+	err := bitmap.UnmarshalBinary(data)
+	if err != nil {
 		return nil, err
 	}
-	pl := allocFn()
-	iter := NewIterator(b.Iterator())
-	return pl, pl.AddIterator(iter)
+	return idxroaring.NewPostingsListFromBitmap(bitmap), nil
 }

--- a/src/m3ninx/postings/pilosa/codec_test.go
+++ b/src/m3ninx/postings/pilosa/codec_test.go
@@ -31,13 +31,13 @@ import (
 
 func TestEncodeDecode(t *testing.T) {
 	b := roaring.NewPostingsList()
-	b.AddRange(postings.ID(1), postings.ID(1000))
+	require.NoError(t, b.AddRange(postings.ID(1), postings.ID(1000)))
 
 	e := NewEncoder()
 	bytes, err := e.Encode(b)
 	require.NoError(t, err)
 
-	unmarshaled, err := Unmarshal(bytes, roaring.NewPostingsList)
+	unmarshaled, err := Unmarshal(bytes)
 	require.NoError(t, err)
 
 	require.True(t, b.Equal(unmarshaled))

--- a/src/m3ninx/postings/postings_mock.go
+++ b/src/m3ninx/postings/postings_mock.go
@@ -77,19 +77,6 @@ func (mr *MockListMockRecorder) IsEmpty() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEmpty", reflect.TypeOf((*MockList)(nil).IsEmpty))
 }
 
-// Min mocks base method
-func (m *MockList) Min() (ID, error) {
-	ret := m.ctrl.Call(m, "Min")
-	ret0, _ := ret[0].(ID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Min indicates an expected call of Min
-func (mr *MockListMockRecorder) Min() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Min", reflect.TypeOf((*MockList)(nil).Min))
-}
-
 // Max mocks base method
 func (m *MockList) Max() (ID, error) {
 	ret := m.ctrl.Call(m, "Max")
@@ -198,19 +185,6 @@ func (mr *MockMutableListMockRecorder) IsEmpty() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEmpty", reflect.TypeOf((*MockMutableList)(nil).IsEmpty))
 }
 
-// Min mocks base method
-func (m *MockMutableList) Min() (ID, error) {
-	ret := m.ctrl.Call(m, "Min")
-	ret0, _ := ret[0].(ID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Min indicates an expected call of Min
-func (mr *MockMutableListMockRecorder) Min() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Min", reflect.TypeOf((*MockMutableList)(nil).Min))
-}
-
 // Max mocks base method
 func (m *MockMutableList) Max() (ID, error) {
 	ret := m.ctrl.Call(m, "Max")
@@ -273,8 +247,10 @@ func (mr *MockMutableListMockRecorder) Equal(other interface{}) *gomock.Call {
 }
 
 // Insert mocks base method
-func (m *MockMutableList) Insert(i ID) {
-	m.ctrl.Call(m, "Insert", i)
+func (m *MockMutableList) Insert(i ID) error {
+	ret := m.ctrl.Call(m, "Insert", i)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Insert indicates an expected call of Insert
@@ -331,8 +307,10 @@ func (mr *MockMutableListMockRecorder) AddIterator(iter interface{}) *gomock.Cal
 }
 
 // AddRange mocks base method
-func (m *MockMutableList) AddRange(min, max ID) {
-	m.ctrl.Call(m, "AddRange", min, max)
+func (m *MockMutableList) AddRange(min, max ID) error {
+	ret := m.ctrl.Call(m, "AddRange", min, max)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AddRange indicates an expected call of AddRange
@@ -341,8 +319,10 @@ func (mr *MockMutableListMockRecorder) AddRange(min, max interface{}) *gomock.Ca
 }
 
 // RemoveRange mocks base method
-func (m *MockMutableList) RemoveRange(min, max ID) {
-	m.ctrl.Call(m, "RemoveRange", min, max)
+func (m *MockMutableList) RemoveRange(min, max ID) error {
+	ret := m.ctrl.Call(m, "RemoveRange", min, max)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // RemoveRange indicates an expected call of RemoveRange

--- a/src/m3ninx/postings/roaring/roaring.go
+++ b/src/m3ninx/postings/roaring/roaring.go
@@ -82,7 +82,7 @@ func NewPostingsList() postings.MutableList {
 
 // NewPostingsListFromBitmap returns a new mutable postings list using an
 // existing roaring bitmap.
-func NewPostingsListFromBitmap(bitmap *roaring.Bitmap) postings.List {
+func NewPostingsListFromBitmap(bitmap *roaring.Bitmap) postings.MutableList {
 	return &postingsList{bitmap: bitmap}
 }
 

--- a/src/m3ninx/postings/roaring/roaring_test.go
+++ b/src/m3ninx/postings/roaring/roaring_test.go
@@ -37,9 +37,9 @@ func TestRoaringPostingsListEmpty(t *testing.T) {
 
 func TestRoaringPostingsListMax(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(42)
-	d.Insert(78)
-	d.Insert(103)
+	require.NoError(t, d.Insert(42))
+	require.NoError(t, d.Insert(78))
+	require.NoError(t, d.Insert(103))
 
 	max, err := d.Max()
 	require.NoError(t, err)
@@ -52,18 +52,18 @@ func TestRoaringPostingsListMax(t *testing.T) {
 
 func TestRoaringPostingsListInsert(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
+	require.NoError(t, d.Insert(1))
 	require.True(t, d.Contains(1))
 	require.Equal(t, 1, d.Len())
 	// Idempotency of inserts.
-	d.Insert(1)
+	require.NoError(t, d.Insert(1))
 	require.Equal(t, 1, d.Len())
 	require.True(t, d.Contains(1))
 }
 
 func TestRoaringPostingsListClone(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
+	require.NoError(t, d.Insert(1))
 	require.True(t, d.Contains(1))
 	require.Equal(t, 1, d.Len())
 
@@ -72,7 +72,7 @@ func TestRoaringPostingsListClone(t *testing.T) {
 	require.Equal(t, 1, c.Len())
 
 	// Ensure only clone is uniquely backed.
-	c.Insert(2)
+	require.NoError(t, c.Insert(2))
 	require.True(t, c.Contains(2))
 	require.Equal(t, 2, c.Len())
 	require.True(t, d.Contains(1))
@@ -81,15 +81,15 @@ func TestRoaringPostingsListClone(t *testing.T) {
 
 func TestRoaringPostingsListIntersect(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
+	require.NoError(t, d.Insert(1))
 	require.True(t, d.Contains(1))
 	require.Equal(t, 1, d.Len())
 
 	c := d.Clone()
 	require.True(t, c.Contains(1))
 
-	d.Insert(2)
-	c.Insert(3)
+	require.NoError(t, d.Insert(2))
+	require.NoError(t, c.Insert(3))
 
 	require.NoError(t, d.Intersect(c))
 	require.True(t, d.Contains(1))
@@ -101,15 +101,15 @@ func TestRoaringPostingsListIntersect(t *testing.T) {
 
 func TestRoaringPostingsListDifference(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
+	require.NoError(t, d.Insert(1))
 	require.True(t, d.Contains(1))
 	require.Equal(t, 1, d.Len())
 
 	c := d.Clone()
 	require.True(t, c.Contains(1))
 
-	d.Insert(2)
-	d.Insert(3)
+	require.NoError(t, d.Insert(2))
+	require.NoError(t, d.Insert(3))
 	require.NoError(t, d.Difference(c))
 
 	require.False(t, d.Contains(1))
@@ -122,14 +122,14 @@ func TestRoaringPostingsListDifference(t *testing.T) {
 
 func TestRoaringPostingsListUnion(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
+	require.NoError(t, d.Insert(1))
 	require.True(t, d.Contains(1))
 	require.Equal(t, 1, d.Len())
 
 	c := d.Clone()
 	require.True(t, c.Contains(1))
-	d.Insert(2)
-	c.Insert(3)
+	require.NoError(t, d.Insert(2))
+	require.NoError(t, c.Insert(3))
 
 	require.NoError(t, d.Union(c))
 	require.True(t, d.Contains(1))
@@ -143,9 +143,9 @@ func TestRoaringPostingsListUnion(t *testing.T) {
 
 func TestRoaringPostingsListAddRange(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
-	d.Insert(9)
-	d.AddRange(3, 5)
+	require.NoError(t, d.Insert(1))
+	require.NoError(t, d.Insert(9))
+	require.NoError(t, d.AddRange(3, 5))
 
 	require.Equal(t, 4, d.Len())
 	require.True(t, d.Contains(1))
@@ -158,13 +158,13 @@ func TestRoaringPostingsListAddRange(t *testing.T) {
 
 func TestRoaringPostingsListRemoveRange(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
-	d.Insert(2)
-	d.Insert(7)
-	d.Insert(8)
-	d.Insert(9)
+	require.NoError(t, d.Insert(1))
+	require.NoError(t, d.Insert(2))
+	require.NoError(t, d.Insert(7))
+	require.NoError(t, d.Insert(8))
+	require.NoError(t, d.Insert(9))
 
-	d.RemoveRange(2, 8)
+	require.NoError(t, d.RemoveRange(2, 8))
 	require.Equal(t, 3, d.Len())
 	require.True(t, d.Contains(1))
 	require.False(t, d.Contains(2))
@@ -175,7 +175,7 @@ func TestRoaringPostingsListRemoveRange(t *testing.T) {
 
 func TestRoaringPostingsListReset(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
+	require.NoError(t, d.Insert(1))
 	require.True(t, d.Contains(1))
 	require.Equal(t, 1, d.Len())
 	d.Reset()
@@ -185,8 +185,8 @@ func TestRoaringPostingsListReset(t *testing.T) {
 
 func TestRoaringPostingsListIter(t *testing.T) {
 	d := NewPostingsList()
-	d.Insert(1)
-	d.Insert(2)
+	require.NoError(t, d.Insert(1))
+	require.NoError(t, d.Insert(2))
 	require.Equal(t, 2, d.Len())
 
 	it := d.Iterator()
@@ -202,59 +202,33 @@ func TestRoaringPostingsListIter(t *testing.T) {
 	for id, ok := range found {
 		require.True(t, ok, id)
 	}
-}
-
-func TestRoaringPostingsListIterInsertAfter(t *testing.T) {
-	d := NewPostingsList()
-	d.Insert(1)
-	d.Insert(2)
-	require.Equal(t, 2, d.Len())
-
-	it := d.Iterator()
-	defer it.Close()
-	numElems := 0
-	d.Insert(3)
-	require.Equal(t, 3, d.Len())
-	found := map[postings.ID]bool{
-		1: false,
-		2: false,
-	}
-	for it.Next() {
-		found[it.Current()] = true
-		numElems++
-	}
-
-	for id, ok := range found {
-		require.True(t, ok, id)
-	}
-	require.Equal(t, 2, numElems)
 }
 
 func TestRoaringPostingsListEqualWithOtherRoaring(t *testing.T) {
 	first := NewPostingsList()
-	first.Insert(42)
-	first.Insert(44)
-	first.Insert(51)
+	require.NoError(t, first.Insert(42))
+	require.NoError(t, first.Insert(44))
+	require.NoError(t, first.Insert(51))
 
 	second := NewPostingsList()
-	second.Insert(42)
-	second.Insert(44)
-	second.Insert(51)
+	require.NoError(t, second.Insert(42))
+	require.NoError(t, second.Insert(44))
+	require.NoError(t, second.Insert(51))
 
 	require.True(t, first.Equal(second))
 }
 
 func TestRoaringPostingsListNotEqualWithOtherRoaring(t *testing.T) {
 	first := NewPostingsList()
-	first.Insert(42)
-	first.Insert(44)
-	first.Insert(51)
+	require.NoError(t, first.Insert(42))
+	require.NoError(t, first.Insert(44))
+	require.NoError(t, first.Insert(51))
 
 	second := NewPostingsList()
-	second.Insert(42)
-	second.Insert(44)
-	second.Insert(51)
-	second.Insert(53)
+	require.NoError(t, second.Insert(42))
+	require.NoError(t, second.Insert(44))
+	require.NoError(t, second.Insert(51))
+	require.NoError(t, second.Insert(53))
 
 	require.False(t, first.Equal(second))
 }
@@ -264,9 +238,9 @@ func TestRoaringPostingsListEqualWithOtherNonRoaring(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	first := NewPostingsList()
-	first.Insert(42)
-	first.Insert(44)
-	first.Insert(51)
+	require.NoError(t, first.Insert(42))
+	require.NoError(t, first.Insert(44))
+	require.NoError(t, first.Insert(51))
 
 	postingsIter := postings.NewMockIterator(mockCtrl)
 	gomock.InOrder(
@@ -292,9 +266,9 @@ func TestRoaringPostingsListNotEqualWithOtherNonRoaring(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	first := NewPostingsList()
-	first.Insert(42)
-	first.Insert(44)
-	first.Insert(51)
+	require.NoError(t, first.Insert(42))
+	require.NoError(t, first.Insert(44))
+	require.NoError(t, first.Insert(51))
 
 	postingsIter := postings.NewMockIterator(mockCtrl)
 	gomock.InOrder(

--- a/src/m3ninx/postings/roaring/roaring_test.go
+++ b/src/m3ninx/postings/roaring/roaring_test.go
@@ -50,21 +50,6 @@ func TestRoaringPostingsListMax(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRoaringPostingsListMin(t *testing.T) {
-	d := NewPostingsList()
-	d.Insert(42)
-	d.Insert(78)
-	d.Insert(103)
-
-	min, err := d.Min()
-	require.NoError(t, err)
-	require.Equal(t, postings.ID(42), min)
-
-	d = NewPostingsList()
-	_, err = d.Min()
-	require.Error(t, err)
-}
-
 func TestRoaringPostingsListInsert(t *testing.T) {
 	d := NewPostingsList()
 	d.Insert(1)

--- a/src/m3ninx/postings/types.go
+++ b/src/m3ninx/postings/types.go
@@ -52,9 +52,6 @@ type List interface {
 	// calculating the size of the postings list.
 	IsEmpty() bool
 
-	// Min returns the minimum ID in the postings list or an error if it is empty.
-	Min() (ID, error)
-
 	// Max returns the maximum ID in the postings list or an error if it is empty.
 	Max() (ID, error)
 
@@ -76,7 +73,7 @@ type MutableList interface {
 	List
 
 	// Insert inserts the given ID into the postings list.
-	Insert(i ID)
+	Insert(i ID) error
 
 	// Intersect updates this postings list in place to contain only those DocIDs which are
 	// in both this postings list and other.
@@ -94,10 +91,10 @@ type MutableList interface {
 	AddIterator(iter Iterator) error
 
 	// AddRange adds all IDs between [min, max) to this postings list.
-	AddRange(min, max ID)
+	AddRange(min, max ID) error
 
 	// RemoveRange removes all IDs between [min, max) from this postings list.
-	RemoveRange(min, max ID)
+	RemoveRange(min, max ID) error
 
 	// Reset resets the internal state of the postings list.
 	Reset()

--- a/src/m3ninx/search/executor/iterator_test.go
+++ b/src/m3ninx/search/executor/iterator_test.go
@@ -38,10 +38,10 @@ func TestIterator(t *testing.T) {
 
 	// Set up Searcher.
 	firstPL := roaring.NewPostingsList()
-	firstPL.Insert(42)
-	firstPL.Insert(47)
+	require.NoError(t, firstPL.Insert(42))
+	require.NoError(t, firstPL.Insert(47))
 	secondPL := roaring.NewPostingsList()
-	firstPL.Insert(67)
+	require.NoError(t, secondPL.Insert(67))
 
 	// Set up Readers.
 	docs := []doc.Document{

--- a/src/m3ninx/search/searcher/conjunction.go
+++ b/src/m3ninx/search/searcher/conjunction.go
@@ -56,7 +56,9 @@ func (s *conjunctionSearcher) Search(r index.Reader) (postings.List, error) {
 		if pl == nil {
 			pl = curr.Clone()
 		} else {
-			pl.Intersect(curr)
+			if err := pl.Intersect(curr); err != nil {
+				return nil, err
+			}
 		}
 
 		// We can break early if the interescted postings list is ever empty.
@@ -72,7 +74,9 @@ func (s *conjunctionSearcher) Search(r index.Reader) (postings.List, error) {
 		}
 
 		// TODO: Sort the iterators so that we take the set differences in order of decreasing size.
-		pl.Difference(curr)
+		if err := pl.Difference(curr); err != nil {
+			return nil, err
+		}
 
 		// We can break early if the interescted postings list is ever empty.
 		if pl.IsEmpty() {

--- a/src/m3ninx/search/searcher/conjunction_test.go
+++ b/src/m3ninx/search/searcher/conjunction_test.go
@@ -41,28 +41,28 @@ func TestConjunctionSearcher(t *testing.T) {
 
 	// First searcher.
 	firstPL1 := roaring.NewPostingsList()
-	firstPL1.Insert(postings.ID(42))
-	firstPL1.Insert(postings.ID(50))
+	require.NoError(t, firstPL1.Insert(postings.ID(42)))
+	require.NoError(t, firstPL1.Insert(postings.ID(50)))
 	firstPL2 := roaring.NewPostingsList()
-	firstPL2.Insert(postings.ID(64))
+	require.NoError(t, firstPL2.Insert(postings.ID(64)))
 	firstSearcher := search.NewMockSearcher(mockCtrl)
 
 	// Second searcher.
 	secondPL1 := roaring.NewPostingsList()
-	secondPL1.Insert(postings.ID(53))
-	secondPL1.Insert(postings.ID(50))
+	require.NoError(t, secondPL1.Insert(postings.ID(53)))
+	require.NoError(t, secondPL1.Insert(postings.ID(50)))
 	secondPL2 := roaring.NewPostingsList()
-	secondPL2.Insert(postings.ID(64))
-	secondPL2.Insert(postings.ID(72))
+	require.NoError(t, secondPL2.Insert(postings.ID(64)))
+	require.NoError(t, secondPL2.Insert(postings.ID(72)))
 	secondSearcher := search.NewMockSearcher(mockCtrl)
 
 	// Third searcher.
 	thirdPL1 := roaring.NewPostingsList()
-	thirdPL1.Insert(postings.ID(42))
-	thirdPL1.Insert(postings.ID(53))
+	require.NoError(t, thirdPL1.Insert(postings.ID(42)))
+	require.NoError(t, thirdPL1.Insert(postings.ID(53)))
 	thirdPL2 := roaring.NewPostingsList()
-	thirdPL2.Insert(postings.ID(64))
-	thirdPL2.Insert(postings.ID(89))
+	require.NoError(t, thirdPL2.Insert(postings.ID(64)))
+	require.NoError(t, thirdPL2.Insert(postings.ID(89)))
 	thirdSearcher := search.NewMockSearcher(mockCtrl)
 
 	gomock.InOrder(

--- a/src/m3ninx/search/searcher/disjunction_test.go
+++ b/src/m3ninx/search/searcher/disjunction_test.go
@@ -41,26 +41,26 @@ func TestDisjunctionSearcher(t *testing.T) {
 
 	// First searcher.
 	firstPL1 := roaring.NewPostingsList()
-	firstPL1.Insert(postings.ID(42))
-	firstPL1.Insert(postings.ID(50))
+	require.NoError(t, firstPL1.Insert(postings.ID(42)))
+	require.NoError(t, firstPL1.Insert(postings.ID(50)))
 	firstPL2 := roaring.NewPostingsList()
-	firstPL2.Insert(postings.ID(64))
+	require.NoError(t, firstPL2.Insert(postings.ID(64)))
 	firstSearcher := search.NewMockSearcher(mockCtrl)
 
 	// Second searcher.
 	secondPL1 := roaring.NewPostingsList()
-	secondPL1.Insert(postings.ID(53))
+	require.NoError(t, secondPL1.Insert(postings.ID(53)))
 	secondPL2 := roaring.NewPostingsList()
-	secondPL2.Insert(postings.ID(64))
-	secondPL2.Insert(postings.ID(72))
+	require.NoError(t, secondPL2.Insert(postings.ID(64)))
+	require.NoError(t, secondPL2.Insert(postings.ID(72)))
 	secondSearcher := search.NewMockSearcher(mockCtrl)
 
 	// Third searcher.
 	thirdPL1 := roaring.NewPostingsList()
-	thirdPL1.Insert(postings.ID(53))
+	require.NoError(t, thirdPL1.Insert(postings.ID(53)))
 	thirdPL2 := roaring.NewPostingsList()
-	thirdPL2.Insert(postings.ID(72))
-	thirdPL2.Insert(postings.ID(89))
+	require.NoError(t, thirdPL2.Insert(postings.ID(72)))
+	require.NoError(t, thirdPL2.Insert(postings.ID(89)))
 	thirdSearcher := search.NewMockSearcher(mockCtrl)
 
 	gomock.InOrder(

--- a/src/m3ninx/search/searcher/negation_test.go
+++ b/src/m3ninx/search/searcher/negation_test.go
@@ -38,22 +38,22 @@ func TestNegationSearcher(t *testing.T) {
 
 	// First reader.
 	readerFirstPL := roaring.NewPostingsList()
-	readerFirstPL.AddRange(postings.ID(42), postings.ID(48))
+	require.NoError(t, readerFirstPL.AddRange(postings.ID(42), postings.ID(48)))
 	firstReader := index.NewMockReader(mockCtrl)
 
 	// Second reader.
 	readerSecondPL := roaring.NewPostingsList()
-	readerSecondPL.AddRange(postings.ID(48), postings.ID(52))
+	require.NoError(t, readerSecondPL.AddRange(postings.ID(48), postings.ID(52)))
 	secondReader := index.NewMockReader(mockCtrl)
 
 	// Mock searcher.
 	searcherFirstPL := roaring.NewPostingsList()
-	searcherFirstPL.Insert(postings.ID(42))
-	searcherFirstPL.Insert(postings.ID(44))
-	searcherFirstPL.Insert(postings.ID(45))
+	require.NoError(t, searcherFirstPL.Insert(postings.ID(42)))
+	require.NoError(t, searcherFirstPL.Insert(postings.ID(44)))
+	require.NoError(t, searcherFirstPL.Insert(postings.ID(45)))
 	searcherSecondPL := roaring.NewPostingsList()
-	searcherSecondPL.Insert(postings.ID(51))
-	searcherSecondPL.Insert(postings.ID(52))
+	require.NoError(t, searcherSecondPL.Insert(postings.ID(51)))
+	require.NoError(t, searcherSecondPL.Insert(postings.ID(52)))
 	searcher := search.NewMockSearcher(mockCtrl)
 
 	gomock.InOrder(

--- a/src/m3ninx/search/searcher/regexp_test.go
+++ b/src/m3ninx/search/searcher/regexp_test.go
@@ -43,13 +43,13 @@ func TestRegexpSearcher(t *testing.T) {
 
 	// First reader.
 	firstPL := roaring.NewPostingsList()
-	firstPL.Insert(postings.ID(42))
-	firstPL.Insert(postings.ID(50))
+	require.NoError(t, firstPL.Insert(postings.ID(42)))
+	require.NoError(t, firstPL.Insert(postings.ID(50)))
 	firstReader := index.NewMockReader(mockCtrl)
 
 	// Second reader.
 	secondPL := roaring.NewPostingsList()
-	secondPL.Insert(postings.ID(57))
+	require.NoError(t, secondPL.Insert(postings.ID(57)))
 	secondReader := index.NewMockReader(mockCtrl)
 
 	gomock.InOrder(

--- a/src/m3ninx/search/searcher/term_test.go
+++ b/src/m3ninx/search/searcher/term_test.go
@@ -39,13 +39,13 @@ func TestTermSearcher(t *testing.T) {
 
 	// First reader.
 	firstPL := roaring.NewPostingsList()
-	firstPL.Insert(postings.ID(42))
-	firstPL.Insert(postings.ID(50))
+	require.NoError(t, firstPL.Insert(postings.ID(42)))
+	require.NoError(t, firstPL.Insert(postings.ID(50)))
 	firstReader := index.NewMockReader(mockCtrl)
 
 	// Second reader.
 	secondPL := roaring.NewPostingsList()
-	secondPL.Insert(postings.ID(57))
+	require.NoError(t, secondPL.Insert(postings.ID(57)))
 	secondReader := index.NewMockReader(mockCtrl)
 
 	gomock.InOrder(


### PR DESCRIPTION
Unmarshalling Pilosa bitmaps into the other RoaringBitmap library's bitmap was causing a ton of allocations.

Now that we solely use Pilosa bitmaps we entirely avoid the large allocations of copying the postings lists when searching FST segments with MatchTerm, MatchRegexp, etc.

Fixes #1192.