### PR TITLE
[coordinator] set cluster client w/ dbnode colo

### DIFF
--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -348,9 +348,15 @@ func newM3DBStorage(
 	if clusterClientCh != nil {
 		// Only use a cluster client if we are going to receive one, that
 		// way passing nil to httpd NewHandler disables the endpoints entirely
+		asyncDoneCh := make(chan struct{})
 		clusterClient = m3dbcluster.NewAsyncClient(func() (clusterclient.Client, error) {
 			return <-clusterClientCh, nil
-		}, nil)
+		}, asyncDoneCh)
+
+		if clusterManagementClient == nil {
+			<-asyncDoneCh
+			clusterManagementClient = clusterClient
+		}
 	}
 
 	var (


### PR DESCRIPTION
We were previously not setting the cluster client for the coordinator
when collocated with the dbnode.