### PR TITLE
[integration] docker: add test for coord+db colo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,9 +191,9 @@ docker-integration-test:
 	@./scripts/docker-integration-tests/simple/test.sh
 	docker ps
 	docker network ls
-	@./scripts/docker-integration-tests/prometheus/test.sh
-	docker ps
-	docker network ls
+	# @./scripts/docker-integration-tests/prometheus/test.sh
+	# docker ps
+	# docker network ls
 	@./scripts/docker-integration-tests/prometheus-colo/test.sh
 	docker ps
 	docker network ls

--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,10 @@ docs-deploy: docs-container
 .PHONY: docker-integration-test
 docker-integration-test:
 	@echo "--- Running Docker integration test"
-	@./scripts/docker-integration-tests/setup.sh
-	@./scripts/docker-integration-tests/simple/test.sh
-	docker ps
-	docker network ls
+	# @./scripts/docker-integration-tests/setup.sh
+	# @./scripts/docker-integration-tests/simple/test.sh
+	# docker ps
+	# docker network ls
 	# @./scripts/docker-integration-tests/prometheus/test.sh
 	# docker ps
 	# docker network ls

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ docs-deploy: docs-container
 .PHONY: docker-integration-test
 docker-integration-test:
 	@echo "--- Running Docker integration test"
-	# @./scripts/docker-integration-tests/setup.sh
+	@./scripts/docker-integration-tests/setup.sh
 	# @./scripts/docker-integration-tests/simple/test.sh
 	# docker ps
 	# docker network ls

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ docker-integration-test:
 	@./scripts/docker-integration-tests/setup.sh
 	@./scripts/docker-integration-tests/simple/test.sh
 	@./scripts/docker-integration-tests/prometheus/test.sh
+	@./scripts/docker-integration-tests/prometheus-colo/test.sh
 
 .PHONY: site-build
 site-build:

--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,14 @@ docker-integration-test:
 	@echo "--- Running Docker integration test"
 	@./scripts/docker-integration-tests/setup.sh
 	@./scripts/docker-integration-tests/simple/test.sh
+	docker ps
+	docker network ls
 	@./scripts/docker-integration-tests/prometheus/test.sh
+	docker ps
+	docker network ls
 	@./scripts/docker-integration-tests/prometheus-colo/test.sh
+	docker ps
+	docker network ls
 
 .PHONY: site-build
 site-build:

--- a/scripts/docker-integration-tests/prometheus-colo/docker-compose.yml
+++ b/scripts/docker-integration-tests/prometheus-colo/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.5"
+services:
+  dbnode-colo01:
+    expose:
+      - "9000-9004"
+      - "2379-2380"
+      - "7201"
+      - "7203"
+    ports:
+      - "0.0.0.0:9000-9004:9000-9004"
+      - "0.0.0.0:2379-2380:2379-2380"
+      - "0.0.0.0:7201:7201"
+      - "0.0.0.0:7203:7203"
+    networks:
+      - backend-colo
+    image: "m3dbnode_integration:${REVISION}"
+    volumes:
+      - ".:/etc/m3dbnode"
+  prometheus-colo01:
+    expose:
+      - "9090"
+    ports:
+      - "0.0.0.0:9090:9090"
+    networks:
+      - backend-colo
+    image: prom/prometheus:latest
+    volumes:
+      - "./:/etc/prometheus/"
+networks:
+  backend-colo:

--- a/scripts/docker-integration-tests/prometheus-colo/m3dbnode.yml
+++ b/scripts/docker-integration-tests/prometheus-colo/m3dbnode.yml
@@ -1,0 +1,250 @@
+coordinator:
+  listenAddress:
+    type: "config"
+    value: "0.0.0.0:7201"
+
+  metrics:
+    scope:
+      prefix: "coordinator"
+    prometheus:
+      handlerPath: /metrics
+      listenAddress: 0.0.0.0:7203 # until https://github.com/m3db/m3/issues/682 is resolved
+    sanitization: prometheus
+    samplingRate: 1.0
+    extended: none
+
+  clusters:
+  - namespaces:
+      - namespace: agg
+        type: aggregated
+        retention: 10h
+        resolution: 15s
+      - namespace: unagg
+        type: unaggregated
+        retention: 10m
+    client:
+      config:
+        service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+            - zone: embedded
+              endpoints:
+                - dbnode-colo01:2379
+      writeConsistencyLevel: majority
+      readConsistencyLevel: unstrict_majority
+      writeTimeout: 10s
+      fetchTimeout: 15s
+      connectTimeout: 20s
+      writeRetry:
+        initialBackoff: 500ms
+        backoffFactor: 3
+        maxRetries: 2
+        jitter: true
+      fetchRetry:
+        initialBackoff: 500ms
+        backoffFactor: 2
+        maxRetries: 3
+        jitter: true
+      backgroundHealthCheckFailLimit: 4
+      backgroundHealthCheckFailThrottleFactor: 0.5
+
+db:
+  logging:
+    level: info
+
+  metrics:
+    prometheus:
+      handlerPath: /metrics
+    sanitization: prometheus
+    samplingRate: 1.0
+    extended: detailed
+
+  listenAddress: 0.0.0.0:9000
+  clusterListenAddress: 0.0.0.0:9001
+  httpNodeListenAddress: 0.0.0.0:9002
+  httpClusterListenAddress: 0.0.0.0:9003
+  debugListenAddress: 0.0.0.0:9004
+
+  hostID:
+    resolver: config
+    value: m3db_local
+
+  client:
+    writeConsistencyLevel: majority
+    readConsistencyLevel: unstrict_majority
+    writeTimeout: 10s
+    fetchTimeout: 15s
+    connectTimeout: 20s
+    writeRetry:
+        initialBackoff: 500ms
+        backoffFactor: 3
+        maxRetries: 2
+        jitter: true
+    fetchRetry:
+        initialBackoff: 500ms
+        backoffFactor: 2
+        maxRetries: 3
+        jitter: true
+    backgroundHealthCheckFailLimit: 4
+    backgroundHealthCheckFailThrottleFactor: 0.5
+
+  gcPercentage: 100
+
+  writeNewSeriesAsync: true
+  writeNewSeriesLimitPerSecond: 1048576
+  writeNewSeriesBackoffDuration: 2ms
+
+  bootstrap:
+    bootstrappers:
+        - filesystem
+        - commitlog
+        - peers
+        - uninitialized_topology
+    fs:
+        numProcessorsPerCPU: 0.125
+
+  cache:
+    series:
+      policy: lru
+
+  commitlog:
+    flushMaxBytes: 524288
+    flushEvery: 1s
+    queue:
+        calculationType: fixed
+        size: 2097152
+    blockSize: 10m
+
+  fs:
+    filePathPrefix: /var/lib/m3db
+    writeBufferSize: 65536
+    dataReadBufferSize: 65536
+    infoReadBufferSize: 128
+    seekReadBufferSize: 4096
+    throughputLimitMbps: 100.0
+    throughputCheckEvery: 128
+
+  repair:
+    enabled: false
+    interval: 2h
+    offset: 30m
+    jitter: 1h
+    throttle: 2m
+    checkInterval: 1m
+
+  pooling:
+    blockAllocSize: 16
+    type: simple
+    seriesPool:
+        size: 262144
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    blockPool:
+        size: 262144
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    encoderPool:
+        size: 262144
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    closersPool:
+        size: 104857
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    contextPool:
+        size: 262144
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    segmentReaderPool:
+        size: 16384
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    iteratorPool:
+        size: 2048
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    fetchBlockMetadataResultsPool:
+        size: 65536
+        capacity: 32
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    fetchBlocksMetadataResultsPool:
+        size: 32
+        capacity: 4096
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    hostBlockMetadataSlicePool:
+        size: 131072
+        capacity: 3
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    blockMetadataPool:
+        size: 65536
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    blockMetadataSlicePool:
+        size: 65536
+        capacity: 32
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    blocksMetadataPool:
+        size: 65536
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    blocksMetadataSlicePool:
+        size: 32
+        capacity: 4096
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    identifierPool:
+        size: 262144
+        lowWatermark: 0.7
+        highWatermark: 1.0
+    bytesPool:
+        buckets:
+            - capacity: 16
+              size: 524288
+              lowWatermark: 0.7
+              highWatermark: 1.0
+            - capacity: 32
+              size: 262144
+              lowWatermark: 0.7
+              highWatermark: 1.0
+            - capacity: 64
+              size: 131072
+              lowWatermark: 0.7
+              highWatermark: 1.0
+            - capacity: 128
+              size: 65536
+              lowWatermark: 0.7
+              highWatermark: 1.0
+            - capacity: 256
+              size: 65536
+              lowWatermark: 0.7
+              highWatermark: 1.0
+            - capacity: 1440
+              size: 16384
+              lowWatermark: 0.7
+              highWatermark: 1.0
+            - capacity: 4096
+              size: 8192
+              lowWatermark: 0.7
+              highWatermark: 1.0
+
+  config:
+      service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+              - zone: embedded
+                endpoints:
+                    - 127.0.0.1:2379
+      seedNodes:
+          initialCluster:
+              - hostID: m3db_local
+                endpoint: http://127.0.0.1:2380

--- a/scripts/docker-integration-tests/prometheus-colo/prometheus.yml
+++ b/scripts/docker-integration-tests/prometheus-colo/prometheus.yml
@@ -1,0 +1,45 @@
+# my global config
+global:
+  external_labels:
+    role: "remote"
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'coordinator'
+    static_configs:
+      - targets: ['dbnode-colo01:7203']
+
+  - job_name: 'dbnode'
+    static_configs:
+      - targets: ['dbnode-colo01:9004']
+
+remote_read:
+  - url: http://dbnode-colo01:7201/api/v1/prom/remote/read
+
+remote_write:
+  - url: http://dbnode-colo01:7201/api/v1/prom/remote/write

--- a/scripts/docker-integration-tests/prometheus-colo/test.sh
+++ b/scripts/docker-integration-tests/prometheus-colo/test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -xe
+
+source $GOPATH/src/github.com/m3db/m3/scripts/docker-integration-tests/common.sh
+REVISION=$(git rev-parse HEAD)
+COMPOSE_FILE=$GOPATH/src/github.com/m3db/m3/scripts/docker-integration-tests/prometheus-colo/docker-compose.yml
+export REVISION
+
+echo "Run m3dbnode and m3coordinator containers"
+docker-compose -f ${COMPOSE_FILE} up -d dbnode-colo01
+
+# think of this as a defer func() in golang
+function defer {
+  docker-compose -f ${COMPOSE_FILE} down || echo "unable to shutdown containers" # CI fails to stop all containers sometimes
+}
+trap defer EXIT
+
+
+echo "Sleeping for a bit to ensure db up"
+sleep 15 # TODO Replace sleeps with logic to determine when to proceed
+
+echo "Adding namespace"
+curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/namespace -d '{
+  "name": "agg",
+  "options": {
+    "bootstrapEnabled": true,
+    "flushEnabled": true,
+    "writesToCommitLog": true,
+    "cleanupEnabled": true,
+    "snapshotEnabled": true,
+    "repairEnabled": false,
+    "retentionOptions": {
+      "retentionPeriodNanos": 172800000000000,
+      "blockSizeNanos": 7200000000000,
+      "bufferFutureNanos": 600000000000,
+      "bufferPastNanos": 600000000000,
+      "blockDataExpiry": true,
+      "blockDataExpiryAfterNotAccessPeriodNanos": 300000000000
+    },
+    "indexOptions": {
+      "enabled": true,
+      "blockSizeNanos": 7200000000000
+    }
+  }
+}'
+
+echo "Sleep until namespace is init'd"
+ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
+  '[ "$(curl -sSf 0.0.0.0:7201/api/v1/namespace | jq .registry.namespaces.agg.indexOptions.enabled)" == true ]'
+
+curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/namespace -d '{
+  "name": "unagg",
+  "options": {
+    "bootstrapEnabled": true,
+    "flushEnabled": true,
+    "writesToCommitLog": true,
+    "cleanupEnabled": true,
+    "snapshotEnabled": true,
+    "repairEnabled": false,
+    "retentionOptions": {
+      "retentionPeriodNanos": 172800000000000,
+      "blockSizeNanos": 7200000000000,
+      "bufferFutureNanos": 600000000000,
+      "bufferPastNanos": 600000000000,
+      "blockDataExpiry": true,
+      "blockDataExpiryAfterNotAccessPeriodNanos": 300000000000
+    },
+    "indexOptions": {
+      "enabled": true,
+      "blockSizeNanos": 7200000000000
+    }
+  }
+}'
+
+echo "Sleep until namespace is init'd"
+ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
+  '[ "$(curl -sSf 0.0.0.0:7201/api/v1/namespace | jq .registry.namespaces.unagg.indexOptions.enabled)" == true ]'
+
+echo "Placement initialization"
+curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/placement/init -d '{
+    "num_shards": 64,
+    "replication_factor": 1,
+    "instances": [
+        {
+            "id": "m3db_local",
+            "isolation_group": "rack-a",
+            "zone": "embedded",
+            "weight": 1024,
+            "endpoint": "dbnode-colo01:9000",
+            "hostname": "dbnode-colo01",
+            "port": 9000
+        }
+    ]
+}'
+
+echo "Sleep until placement is init'd"
+ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
+  '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | jq .placement.instances.m3db_local.id)" == \"m3db_local\" ]'
+
+echo "Sleep until bootstrapped"
+ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
+  '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
+
+echo "Start Prometheus containers"
+docker-compose -f ${COMPOSE_FILE} up -d prometheus-colo01
+
+# Ensure Prometheus can proxy a Prometheus query
+echo "Wait until the remote write endpoint generates and allows for data to be queried"
+ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
+  '[[ $(curl -sSf 0.0.0.0:9090/api/v1/query?query=prometheus_remote_storage_succeeded_samples_total | jq -r .data.result[].value[1]) -gt 100 ]]'
+
+# Make sure we're proxying writes to the unaggregated namespace
+echo "Wait until data begins being written to remote storage for the unaggregated namespace"
+ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
+  '[[ $(curl -sSf 0.0.0.0:9090/api/v1/query?query=database_write_tagged_success\\{namespace=\"unagg\"\\} | jq -r .data.result[0].value[1]) -gt 0 ]]'
+
+# Make sure we're proxying writes to the aggregated namespace
+echo "Wait until data begins being written to remote storage for the aggregated namespace"
+ATTEMPTS=10 TIMEOUT=2 retry_with_backoff  \
+  '[[ $(curl -sSf 0.0.0.0:9090/api/v1/query?query=database_write_tagged_success\\{namespace=\"agg\"\\} | jq -r .data.result[0].value[1]) -gt 0 ]]'


### PR DESCRIPTION
We unintentionally broke colo'd dbnode + coordinator downsampling in a
recent PR (#1205), but didn't catch it in tests. This adds an integration test
for such. We expect this PR to fail until pending async downsampling PR (#1206)
lands.

Verified that this 1) fails on master and 2) worked at `HEAD~2` prior to
breaking PR #1205.