### PR TITLE
Use a random test port in server_test.go

### DIFF
--- a/src/query/server/server_test.go
+++ b/src/query/server/server_test.go
@@ -47,10 +47,12 @@ import (
 	"google.golang.org/grpc"
 )
 
+var queryPort = 25123
+
 var configYAML = `
 listenAddress:
   type: "config"
-  value: "127.0.0.1:7201"
+  value: "127.0.0.1:25123"
 
 metrics:
   scope:
@@ -142,13 +144,13 @@ func TestRun(t *testing.T) {
 	}()
 
 	// Wait for server to come up
-	waitForServerHealthy(t, 7201)
+	waitForServerHealthy(t, queryPort)
 
 	// Send Prometheus write request
 	promReq := test.GeneratePromWriteRequest()
 	promReqBody := test.GeneratePromWriteRequestBody(t, promReq)
 	req, err := http.NewRequest(http.MethodPost,
-		"http://127.0.0.1:7201"+remote.PromWriteURL, promReqBody)
+		fmt.Sprintf("http://127.0.0.1:%d", queryPort)+remote.PromWriteURL, promReqBody)
 	require.NoError(t, err)
 
 	res, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
I noticed that my tests were failing locally while I had a query instance running, and tracked it down to this. Pretty small; just switches the port to a different fixed port. Random ephemeral would be ideal, but that would require passing a `net.Listener` through to `Run` as described [here](https://stackoverflow.com/questions/43424787/how-to-use-next-available-port-in-http-listenandserve), and it didn't seem worth it.