### PR TITLE
Use CORS middleware (etcd's implementation) instead of setting CORS headers on all requests

### DIFF
--- a/src/query/api/v1/handler/prometheus/native/complete_tags.go
+++ b/src/query/api/v1/handler/prometheus/native/complete_tags.go
@@ -59,7 +59,6 @@ func (h *CompleteTagsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	ctx := context.WithValue(r.Context(), handler.HeaderKey, r.Header)
 	logger := logging.WithContext(ctx)
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	query, rErr := prometheus.ParseTagCompletionParamsToQuery(r)
 	if rErr != nil {

--- a/src/query/api/v1/handler/prometheus/native/read.go
+++ b/src/query/api/v1/handler/prometheus/native/read.go
@@ -114,7 +114,6 @@ func (h *PromReadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: Support multiple result types
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	renderResultsJSON(w, result, params)
 }
 

--- a/src/query/api/v1/handler/prometheus/remote/tag_values.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values.go
@@ -65,7 +65,6 @@ func (h *TagValuesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := context.WithValue(r.Context(), handler.HeaderKey, r.Header)
 	logger := logging.WithContext(ctx)
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	query, err := prometheus.ParseTagValuesToQuery(r)
 	if err != nil {

--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -219,7 +219,7 @@ func Run(runOpts RunOptions) {
 		logger.Fatal("unable to get listen address", zap.Error(err))
 	}
 
-	srv := &http.Server{Addr: listenAddress, Handler: handler.Router}
+	srv := &http.Server{Addr: listenAddress, Handler: handler.Router()}
 	defer func() {
 		logger.Info("closing server")
 		if err := srv.Shutdown(ctx); err != nil {


### PR DESCRIPTION
Fixes #1135 . Currently, we set CORS headers manually in each request. This has middleware do that for us instead. I used etcd's implementation of this (github.com/coreos/etcd/pkg/cors), since it's good enough, simple, and already a dependency, but I could also switch to a dedicated package (e.g. [github.com/rs/cors](https://github.com/rs/cors) which would support a bit more config). 

No config right now; let me know if you want it. This middleware sets:

```
 Access-Control-Allow-Headers: accept, content-type, authorization
Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE
Access-Control-Allow-Origin: *
```
