### PR TITLE
Expose number of shards in producer

### DIFF
--- a/src/msg/producer/producer_mock.go
+++ b/src/msg/producer/producer_mock.go
@@ -146,6 +146,18 @@ func (mr *MockProducerMockRecorder) Init() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockProducer)(nil).Init))
 }
 
+// NumShards mocks base method
+func (m *MockProducer) NumShards() uint32 {
+	ret := m.ctrl.Call(m, "NumShards")
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+// NumShards indicates an expected call of NumShards
+func (mr *MockProducerMockRecorder) NumShards() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumShards", reflect.TypeOf((*MockProducer)(nil).NumShards))
+}
+
 // Produce mocks base method
 func (m *MockProducer) Produce(arg0 Message) error {
 	ret := m.ctrl.Call(m, "Produce", arg0)

--- a/src/msg/producer/types.go
+++ b/src/msg/producer/types.go
@@ -129,7 +129,7 @@ type Writer interface {
 	UnregisterFilter(sid services.ServiceID)
 
 	// NumShards returns the total number of shards of the topic the writer is
-	// writting to.
+	// writing to.
 	NumShards() uint32
 
 	// Init initializes a writer.

--- a/src/msg/producer/types.go
+++ b/src/msg/producer/types.go
@@ -72,6 +72,10 @@ type Producer interface {
 	// UnregisterFilter unregisters the filter of a consumer service.
 	UnregisterFilter(sid services.ServiceID)
 
+	// NumShards returns the total number of shards of the topic the producer is
+	// producing to.
+	NumShards() uint32
+
 	// Init initializes a producer.
 	Init() error
 
@@ -123,6 +127,10 @@ type Writer interface {
 
 	// UnregisterFilter unregisters the filter of a consumer service.
 	UnregisterFilter(sid services.ServiceID)
+
+	// NumShards returns the total number of shards of the topic the writer is
+	// writting to.
+	NumShards() uint32
 
 	// Init initializes a writer.
 	Init() error

--- a/src/msg/producer/writer/writer.go
+++ b/src/msg/producer/writer/writer.go
@@ -159,9 +159,10 @@ func (w *writer) process(update interface{}) error {
 	}
 	// We don't allow changing number of shards for topics, it will be
 	// prevented on topic service side, but also being defensive here as well.
-	if w.numShards != 0 && w.numShards != t.NumberOfShards() {
+	numShards := w.NumShards()
+	if numShards != 0 && numShards != t.NumberOfShards() {
 		w.m.topicUpdateError.Inc(1)
-		return fmt.Errorf("invalid topic update with %d shards, expecting %d", t.NumberOfShards(), w.numShards)
+		return fmt.Errorf("invalid topic update with %d shards, expecting %d", t.NumberOfShards(), numShards)
 	}
 	var (
 		iOpts                     = w.opts.InstrumentOptions()

--- a/src/msg/producer/writer/writer.go
+++ b/src/msg/producer/writer/writer.go
@@ -145,6 +145,10 @@ func (w *writer) Init() error {
 	return nil
 }
 
+func (w *writer) NumShards() uint32 {
+	return w.numShards
+}
+
 func (w *writer) process(update interface{}) error {
 	t := update.(topic.Topic)
 	if err := t.Validate(); err != nil {

--- a/src/msg/producer/writer/writer.go
+++ b/src/msg/producer/writer/writer.go
@@ -146,7 +146,10 @@ func (w *writer) Init() error {
 }
 
 func (w *writer) NumShards() uint32 {
-	return w.numShards
+	w.RLock()
+	n := w.numShards
+	w.RUnlock()
+	return n
 }
 
 func (w *writer) process(update interface{}) error {


### PR DESCRIPTION
Expose the total number of shards of the topic the producer is producing to. So users of the producer interface could shard traffic accordingly.