### PR TITLE
Honor namespace-level "WritesToCommitlog" configuration

### DIFF
--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -512,6 +512,10 @@ func (d *db) Write(
 		return err
 	}
 
+	if !n.Options().WritesToCommitLog() {
+		return nil
+	}
+
 	dp := ts.Datapoint{Timestamp: timestamp, Value: value}
 	return d.commitLog.Write(ctx, series, dp, unit, annotation)
 }
@@ -538,6 +542,10 @@ func (d *db) WriteTagged(
 	}
 	if err != nil {
 		return err
+	}
+
+	if !n.Options().WritesToCommitLog() {
+		return nil
 	}
 
 	dp := ts.Datapoint{Timestamp: timestamp, Value: value}
@@ -642,6 +650,10 @@ func (d *db) writeBatch(
 		// commitlog. Need to set the outcome in the error case so that the commitlog knows
 		// to skip this entry.
 		writes.SetOutcome(i, series, err)
+	}
+
+	if !n.Options().WritesToCommitLog() {
+		return nil
 	}
 
 	return d.commitLog.WriteBatch(ctx, writes)

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -610,6 +610,7 @@ func TestDatabaseNamespaceIndexFunctions(t *testing.T) {
 	ns.EXPECT().GetOwnedShards().Return([]databaseShard{}).AnyTimes()
 	ns.EXPECT().Tick(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	ns.EXPECT().BootstrapState().Return(ShardBootstrapStates{}).AnyTimes()
+	ns.EXPECT().Options().Return(namespace.NewOptions()).AnyTimes()
 	require.NoError(t, d.Open())
 
 	var (

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -747,14 +747,16 @@ func testDatabaseWriteBatch(t *testing.T, tagged bool, commitlogEnabled bool) {
 	}
 
 	ns := dbAddNewMockNamespace(ctrl, d, "testns")
+	nsOptions := namespace.NewOptions()
+	if !commitlogEnabled {
+		nsOptions = nsOptions.
+			SetWritesToCommitLog(false)
+	}
+
 	ns.EXPECT().GetOwnedShards().Return([]databaseShard{}).AnyTimes()
 	ns.EXPECT().Tick(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	ns.EXPECT().BootstrapState().Return(ShardBootstrapStates{}).AnyTimes()
-	if !commitlogEnabled {
-		nsOptions := namespace.NewOptions().
-			SetWritesToCommitLog(false)
-		ns.EXPECT().Options().Return(nsOptions).AnyTimes()
-	}
+	ns.EXPECT().Options().Return(nsOptions).AnyTimes()
 	ns.EXPECT().Close().Return(nil).Times(1)
 	require.NoError(t, d.Open())
 


### PR DESCRIPTION
Fixes a bug introduced in #1157 where we ignore the WritesToCommitlog flag on the namespace configuration