### PR TITLE
Auto-calculate reasonable values for WriteBatchPoolSize and return batches to the pool even if commitlog queue is full

### DIFF
--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -638,6 +638,13 @@ func (l *commitLog) writeWait(
 	if numEnqueued > l.maxQueueSize {
 		atomic.AddInt64(&l.numWritesInQueue, int64(-numToEnqueue))
 		l.closedState.RUnlock()
+
+		if write.writeBatch != nil {
+			// Make sure to finalize the write batch even though we didn't accept the writes
+			// so it can be returned to the pool.
+			write.writeBatch.Finalize()
+		}
+
 		return ErrCommitLogQueueFull
 	}
 
@@ -676,6 +683,13 @@ func (l *commitLog) writeBehind(
 	if numEnqueued > l.maxQueueSize {
 		atomic.AddInt64(&l.numWritesInQueue, int64(-numToEnqueue))
 		l.closedState.RUnlock()
+
+		if write.writeBatch != nil {
+			// Make sure to finalize the write batch even though we didn't accept the writes
+			// so it can be returned to the pool.
+			write.writeBatch.Finalize()
+		}
+
 		return ErrCommitLogQueueFull
 	}
 

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -984,14 +984,32 @@ func withEncodingAndPoolingOptions(
 
 	var writeBatchPoolInitialBatchSize *int
 	if policy.WriteBatchPool.InitialBatchSize != nil {
+		// Use config value if available.
 		writeBatchPoolInitialBatchSize = policy.WriteBatchPool.InitialBatchSize
+	} else {
+		// Otherwise use the default batch size that the client will use.
+		clientDefaultSize := client.DefaultWriteBatchSize
+		writeBatchPoolInitialBatchSize = &clientDefaultSize
 	}
+
 	var writeBatchPoolMaxBatchSize *int
 	if policy.WriteBatchPool.MaxBatchSize != nil {
 		writeBatchPoolMaxBatchSize = policy.WriteBatchPool.MaxBatchSize
 	}
+
+	writeBatchPoolPolicy := policy.WriteBatchPool.Pool
+	if writeBatchPoolPolicy.Size == 0 {
+		// If no value set, calculate a reasonabble value based on the commit log
+		// queue size. We base it off the commitlog queue size because we will
+		// want to be able to buffer at least one full commitlog queues worth of
+		// writes without allocating because these objects are very expensive to
+		// allocate.
+		commitlogQueueSize := opts.CommitLogOptions().BacklogQueueSize()
+		expectedBatchSize := *writeBatchPoolInitialBatchSize
+		writeBatchPoolPolicy.Size = commitlogQueueSize / expectedBatchSize
+	}
 	writeBatchPool := ts.NewWriteBatchPool(
-		poolOptions(policy.WriteBatchPool.Pool, scope.SubScope("write-batch-pool")),
+		poolOptions(writeBatchPoolPolicy, scope.SubScope("write-batch-pool")),
 		writeBatchPoolInitialBatchSize,
 		writeBatchPoolMaxBatchSize)
 


### PR DESCRIPTION
- [X] Auto-calculate WriteBatchPool size based on commitlog queue size
- [X] Return WriteBatch to pool even if commitlog queue is full
- [X] Fix db.IsOverloaded() calculations  