### PR TITLE
[query] Proof of concept of asynchronous block iterators

### DIFF
--- a/src/query/block/async_column_builder.go
+++ b/src/query/block/async_column_builder.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package block
+
+import (
+	"sync"
+)
+
+// asyncColumnBlockBuilder builds a block optimized for column iteration
+// in an asynchronous fashion.
+type asyncColumnBlockBuilder struct {
+	mu      sync.RWMutex
+	err     error
+	builder Builder
+}
+
+// NewAsyncColumnBlockBuilder creates a new asynchronous column block builder
+// that wraps the given builder with async operations.
+func NewAsyncColumnBlockBuilder(
+	builder Builder,
+) AsyncBuilder {
+	return &asyncColumnBlockBuilder{
+		builder: builder,
+	}
+}
+
+func (cb *asyncColumnBlockBuilder) AppendValue(idx int, value float64) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	if cb.err != nil {
+		return
+	}
+
+	cb.err = cb.builder.AppendValue(idx, value)
+}
+
+func (cb *asyncColumnBlockBuilder) AppendValues(
+	idx int,
+	values []float64,
+) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	if cb.err != nil {
+		return
+	}
+
+	cb.err = cb.builder.AppendValues(idx, values)
+}
+
+func (cb *asyncColumnBlockBuilder) AddCols(num int) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	if cb.err != nil {
+		return
+	}
+
+	cb.err = cb.builder.AddCols(num)
+}
+
+func (cb *asyncColumnBlockBuilder) Build() Block {
+	cb.mu.RLock()
+	defer cb.mu.RUnlock()
+	if cb.err != nil {
+		return nil
+	}
+
+	return cb.builder.Build()
+}
+
+func (cb *asyncColumnBlockBuilder) Error() error {
+	cb.mu.RLock()
+	err := cb.err
+	cb.mu.RUnlock()
+	return err
+}

--- a/src/query/block/async_types.go
+++ b/src/query/block/async_types.go
@@ -38,7 +38,7 @@ type AsyncBuilder interface {
 	Error() error
 }
 
-// AsyncBlock represents a group of series accross a time bound with async
+// AsyncBlock represents a group of series across a time bound with async
 // iterators.
 type AsyncBlock interface {
 	io.Closer

--- a/src/query/block/async_types.go
+++ b/src/query/block/async_types.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package block
+
+import (
+	"io"
+)
+
+// AsyncBuilder is an asynchronous block builder.
+type AsyncBuilder interface {
+	// AppendValue adds a value to a column at the given index.
+	AppendValue(idx int, value float64)
+	// AppendValues adds a slice of values to a column at the given index.
+	AppendValues(idx int, values []float64)
+	// Build builds the
+	Build() Block
+	// AddCols adds new columns to the builder.
+	AddCols(num int)
+	// Error returns any errors encountered during building.
+	Error() error
+}
+
+// AsyncBlock represents a group of series accross a time bound with async
+// iterators.
+type AsyncBlock interface {
+	io.Closer
+	// AsyncStepIter returns an async step iterator.
+	AsyncStepIter() (AsyncStepIter, error)
+}
+
+// StepCh is a channel that returns a step for asynchronously accessing steps.
+// type StepCh <-chan (Step)
+
+// IndexedStep combines a step with that step's intended index in the
+// created block.
+type IndexedStep struct {
+	Idx int
+	Step
+}
+
+// IndexedStepCh is a channel for asynchronously serving indexed steps.
+// type IndexedStepCh <-chan (IndexedStep)
+
+// AsyncStepIter iterates through a block vertically asynchronously.
+type AsyncStepIter interface {
+	Iterator
+	StepMetaIter
+	// Current returns the current step for the block.
+	Current() <-chan (Step)
+	// ValuesChannel returns a channel containing indexed steps for each value
+	// in this iterator.
+	ValuesChannel() <-chan (IndexedStep)
+	// Err returns any errors encountered during iteration.
+	Err() error
+}

--- a/src/query/block/async_types.go
+++ b/src/query/block/async_types.go
@@ -46,18 +46,12 @@ type AsyncBlock interface {
 	AsyncStepIter() (AsyncStepIter, error)
 }
 
-// StepCh is a channel that returns a step for asynchronously accessing steps.
-// type StepCh <-chan (Step)
-
 // IndexedStep combines a step with that step's intended index in the
 // created block.
 type IndexedStep struct {
 	Idx int
 	Step
 }
-
-// IndexedStepCh is a channel for asynchronously serving indexed steps.
-// type IndexedStepCh <-chan (IndexedStep)
 
 // AsyncStepIter iterates through a block vertically asynchronously.
 type AsyncStepIter interface {

--- a/src/query/block/column.go
+++ b/src/query/block/column.go
@@ -25,8 +25,8 @@ import (
 	"time"
 )
 
-// ColumnBlockBuilder builds a block optimized for column iteration
-type ColumnBlockBuilder struct {
+// columnBlockBuilder builds a block optimized for column iteration
+type columnBlockBuilder struct {
 	block *columnBlock
 }
 
@@ -161,7 +161,7 @@ func NewColStep(t time.Time, values []float64) Step {
 
 // NewColumnBlockBuilder creates a new column block builder
 func NewColumnBlockBuilder(meta Metadata, seriesMeta []SeriesMeta) Builder {
-	return ColumnBlockBuilder{
+	return columnBlockBuilder{
 		block: &columnBlock{
 			meta:       meta,
 			seriesMeta: seriesMeta,
@@ -169,8 +169,8 @@ func NewColumnBlockBuilder(meta Metadata, seriesMeta []SeriesMeta) Builder {
 	}
 }
 
-// AppendValue adds a value to a column at index
-func (cb ColumnBlockBuilder) AppendValue(idx int, value float64) error {
+// AppendValue adds a value to a column at index.
+func (cb columnBlockBuilder) AppendValue(idx int, value float64) error {
 	columns := cb.block.columns
 	if len(columns) <= idx {
 		return fmt.Errorf("idx out of range for append: %d", idx)
@@ -180,8 +180,8 @@ func (cb ColumnBlockBuilder) AppendValue(idx int, value float64) error {
 	return nil
 }
 
-// AppendValues adds a slice of values to a column at index
-func (cb ColumnBlockBuilder) AppendValues(idx int, values []float64) error {
+// AppendValues adds a slice of values to a column at index.
+func (cb columnBlockBuilder) AppendValues(idx int, values []float64) error {
 	columns := cb.block.columns
 	if len(columns) <= idx {
 		return fmt.Errorf("idx out of range for append: %d", idx)
@@ -191,8 +191,8 @@ func (cb ColumnBlockBuilder) AppendValues(idx int, values []float64) error {
 	return nil
 }
 
-// AddCols adds new columns
-func (cb ColumnBlockBuilder) AddCols(num int) error {
+// AddCols adds new columns.
+func (cb columnBlockBuilder) AddCols(num int) error {
 	newCols := make([]column, num)
 	cb.block.columns = append(cb.block.columns, newCols...)
 	return nil
@@ -200,7 +200,7 @@ func (cb ColumnBlockBuilder) AddCols(num int) error {
 
 // Build extracts the block
 // TODO: Return an immutable copy
-func (cb ColumnBlockBuilder) Build() Block {
+func (cb columnBlockBuilder) Build() Block {
 	return cb.block
 }
 

--- a/src/query/executor/transform/controller.go
+++ b/src/query/executor/transform/controller.go
@@ -48,7 +48,24 @@ func (t *Controller) Process(block block.Block) error {
 	return nil
 }
 
-// BlockBuilder returns a BlockBuilder instance with associated metadata
-func (t *Controller) BlockBuilder(blockMeta block.Metadata, seriesMeta []block.SeriesMeta) (block.Builder, error) {
+// BlockBuilder returns a BlockBuilder instance with associated metadata.
+func (t *Controller) BlockBuilder(
+	blockMeta block.Metadata,
+	seriesMeta []block.SeriesMeta,
+) (block.Builder, error) {
 	return block.NewColumnBlockBuilder(blockMeta, seriesMeta), nil
+}
+
+// AsyncBlockBuilder returns an asynchronous BlockBuilder instance with
+// associated metadata.
+func (t *Controller) AsyncBlockBuilder(
+	blockMeta block.Metadata,
+	seriesMeta []block.SeriesMeta,
+) (block.AsyncBuilder, error) {
+	builder, err := t.BlockBuilder(blockMeta, seriesMeta)
+	if err != nil {
+		return nil, err
+	}
+
+	return block.NewAsyncColumnBlockBuilder(builder), nil
 }

--- a/src/query/executor/transform/types.go
+++ b/src/query/executor/transform/types.go
@@ -39,6 +39,12 @@ type OpNode interface {
 	Process(ID parser.NodeID, block block.Block) error
 }
 
+// OpNodeAsync represents an asynchronous execution node.
+type OpNodeAsync interface {
+	ProcessSteps(ID parser.NodeID, block block.AsyncBlock) error
+	ProcessValueChannel(ID parser.NodeID, block block.AsyncBlock) error
+}
+
 // TimeSpec defines the time bounds for the query execution. End is exclusive
 type TimeSpec struct {
 	Start time.Time

--- a/src/query/functions/aggregation/base_async.go
+++ b/src/query/functions/aggregation/base_async.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregation
+
+import (
+	"sync"
+
+	"github.com/m3db/m3/src/query/block"
+	"github.com/m3db/m3/src/query/executor/transform"
+	"github.com/m3db/m3/src/query/functions/utils"
+	"github.com/m3db/m3/src/query/parser"
+	xsync "github.com/m3db/m3x/sync"
+)
+
+type baseNodeAsync struct {
+	op         baseOp
+	controller *transform.Controller
+
+	workerPool xsync.PooledWorkerPool
+}
+
+// Node creates an execution node
+func (o baseOp) AsyncNode(
+	controller *transform.Controller,
+	workerPool xsync.PooledWorkerPool,
+) transform.OpNodeAsync {
+	return &baseNodeAsync{
+		op:         o,
+		controller: controller,
+		workerPool: workerPool,
+	}
+}
+
+// ProcessSteps processes the block asynchronously using step channels.
+func (n *baseNodeAsync) ProcessSteps(ID parser.NodeID, b block.AsyncBlock) error {
+	stepIter, err := b.AsyncStepIter()
+	if err != nil {
+		return err
+	}
+
+	params := n.op.params
+	meta := stepIter.Meta()
+	seriesMetas := utils.FlattenMetadata(meta, stepIter.SeriesMeta())
+	buckets, metas := utils.GroupSeries(
+		params.MatchingTags,
+		params.Without,
+		n.op.opType,
+		seriesMetas,
+	)
+	meta.Tags, metas = utils.DedupeMetadata(metas)
+
+	builder, err := n.controller.AsyncBlockBuilder(meta, metas)
+	if err != nil {
+		return err
+	}
+
+	stepCount := stepIter.StepCount()
+	builder.AddCols(stepCount)
+	if err := builder.Error(); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(stepCount)
+	for index := 0; stepIter.Next(); index++ {
+		// capture loop variables
+		index := index
+		ch := stepIter.Current()
+		n.workerPool.Go(func() {
+			step := <-ch
+			aggregatedValues := make([]float64, len(buckets))
+			values := step.Values()
+			for i, bucket := range buckets {
+				aggregatedValues[i] = n.op.aggFn(values, bucket)
+			}
+
+			builder.AppendValues(index, aggregatedValues)
+			wg.Done()
+		})
+	}
+
+	wg.Wait()
+	if err := builder.Error(); err != nil {
+		return err
+	}
+
+	if err := stepIter.Err(); err != nil {
+		return err
+	}
+
+	nextBlock := builder.Build()
+	defer nextBlock.Close()
+	return n.controller.Process(nextBlock)
+}
+
+// ProcessValueChannel processes the block asynchronously using the value channel.
+func (n *baseNodeAsync) ProcessValueChannel(ID parser.NodeID, b block.AsyncBlock) error {
+	stepIter, err := b.AsyncStepIter()
+	if err != nil {
+		return err
+	}
+
+	params := n.op.params
+	meta := stepIter.Meta()
+	seriesMetas := utils.FlattenMetadata(meta, stepIter.SeriesMeta())
+	buckets, metas := utils.GroupSeries(
+		params.MatchingTags,
+		params.Without,
+		n.op.opType,
+		seriesMetas,
+	)
+	meta.Tags, metas = utils.DedupeMetadata(metas)
+
+	builder, err := n.controller.AsyncBlockBuilder(meta, metas)
+	if err != nil {
+		return err
+	}
+
+	stepCount := stepIter.StepCount()
+	builder.AddCols(stepCount)
+	if err := builder.Error(); err != nil {
+		return err
+	}
+
+	aggregatedValues := make([]float64, len(buckets))
+	for indexedStep := range stepIter.ValuesChannel() {
+		values := indexedStep.Values()
+		for i, bucket := range buckets {
+			aggregatedValues[i] = n.op.aggFn(values, bucket)
+		}
+
+		builder.AppendValues(indexedStep.Idx, aggregatedValues)
+	}
+
+	if err := builder.Error(); err != nil {
+		return err
+	}
+
+	if err := stepIter.Err(); err != nil {
+		return err
+	}
+
+	nextBlock := builder.Build()
+	defer nextBlock.Close()
+	return n.controller.Process(nextBlock)
+}

--- a/src/query/functions/aggregation/base_async_benchmark_test.go
+++ b/src/query/functions/aggregation/base_async_benchmark_test.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregation
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/query/block"
+	"github.com/m3db/m3/src/query/executor/transform"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/parser"
+	"github.com/m3db/m3/src/query/test/executor"
+	"github.com/m3db/m3/src/query/ts"
+	xsync "github.com/m3db/m3x/sync"
+
+	"github.com/stretchr/testify/require"
+)
+
+/*
+NB: Benchmark results (average across 10 runs)
+
+1 Series,   100 Steps
+Steps: 20000 runs, 83403.8 ns/op,  29250.8 allocs/op
+Chan:  50000 runs, 25404.4 ns/op,  13686 allocs/op
+
+100 Series, 100 Steps
+Steps: 8000  runs, 203090 ns/op,   147566 allocs/op
+Chan:  10000 runs, 142081 ns/op,   131903 allocs/op
+
+10k Series, 100 Steps
+Steps: 100 runs, 11473111.4 ns/op, 11334547.2 allocs/op
+Chan:  100 runs, 12721183.8 ns/op, 11317352.9 allocs/op
+
+100 Series, 10k Steps
+Steps: 100 runs, 15840414.9 ns/op, 11696304.5 allocs/op
+Chan:  100 runs, 10403478.3 ns/op, 10052040.3 allocs/op
+
+10k Series, 10k Steps
+Steps: 2.5 runs, 507341991 ns/op,  827119034.7 allocs/op
+Chan:  2.8 runs, 499723487 ns/op,  823376332.7 allocs/op
+*/
+
+func benchNode(
+	b *testing.B,
+	workerPool xsync.PooledWorkerPool,
+) (transform.OpNodeAsync, *executor.SinkNode) {
+	op, err := NewAggregationOp(SumType, NodeParams{})
+	require.NoError(b, err)
+	c, sink := executor.NewControllerWithSink(parser.NodeID(1))
+	require.NoError(b, err)
+
+	asyncOp, valid := op.(baseOp)
+	require.True(b, valid)
+	return asyncOp.AsyncNode(c, workerPool), sink
+}
+
+func benchWorkerPools(b *testing.B) xsync.PooledWorkerPool {
+	poolSize := 16
+	poolOpts := xsync.NewPooledWorkerPoolOptions().
+		SetGrowOnDemand(true).
+		SetNumShards(int64(poolSize))
+	workerPool, err := xsync.NewPooledWorkerPool(poolSize, poolOpts)
+	require.NoError(b, err)
+	workerPool.Init()
+	return workerPool
+}
+
+type mockBlock struct {
+	seriesCount int
+	stepCount   int
+}
+
+func (b *mockBlock) Close() error { return nil }
+func (b *mockBlock) AsyncStepIter() (block.AsyncStepIter, error) {
+	metas := make([]block.SeriesMeta, b.seriesCount)
+	for i := 0; i < b.seriesCount; i++ {
+		b := []byte(fmt.Sprint(i))
+		metas[i] = block.SeriesMeta{
+			Name: "a",
+			Tags: models.NewTags(1, models.NewTagOptions()).AddTag(
+				models.Tag{
+					Name:  b,
+					Value: b,
+				},
+			),
+		}
+	}
+
+	return &mockIter{
+		stepCount:   b.stepCount,
+		seriesCount: b.seriesCount,
+		metas:       metas,
+	}, nil
+}
+
+type mockIter struct {
+	seriesCount int
+	stepCount   int
+	step        int
+	metas       []block.SeriesMeta
+}
+
+func (it *mockIter) SeriesMeta() []block.SeriesMeta {
+	return it.metas
+}
+
+func (it *mockIter) Meta() block.Metadata {
+	return block.Metadata{}
+}
+
+func (it *mockIter) StepCount() int {
+	return it.stepCount
+}
+
+func (it *mockIter) Next() bool {
+	it.step = it.step + 1
+	return it.step < it.stepCount+1
+}
+
+func (it *mockIter) Current() <-chan block.Step {
+	ch := make(chan block.Step)
+	go func() {
+		ch <- &mockStep{
+			seriesCount: it.seriesCount,
+		}
+	}()
+	return ch
+}
+
+func (it *mockIter) ValuesChannel() <-chan block.IndexedStep {
+	ch := make(chan block.IndexedStep, it.stepCount)
+	for i := 0; i < it.stepCount; i++ {
+		ch <- block.IndexedStep{
+			Idx: i,
+			Step: &mockStep{
+				seriesCount: it.seriesCount,
+			},
+		}
+	}
+	close(ch)
+	return ch
+}
+
+func (it *mockIter) Err() error { return nil }
+func (it *mockIter) Close()     {}
+
+type mockStep struct {
+	seriesCount int
+}
+
+func (s *mockStep) Time() time.Time {
+	return time.Time{}
+}
+
+func (s *mockStep) Values() []float64 {
+	values := make([]float64, s.seriesCount)
+	ts.Memset(values, float64(12))
+	return values
+}
+
+func BenchmarkSteps1Series100Step(b *testing.B) {
+	benchmarkSteps(b, 1, 100)
+}
+
+func BenchmarkValueChannel1Series100Step(b *testing.B) {
+	benchmarkValueChannel(b, 1, 100)
+}
+
+func BenchmarkSteps100Series100Step(b *testing.B) {
+	benchmarkSteps(b, 100, 100)
+}
+
+func BenchmarkValueChannel100Series100Step(b *testing.B) {
+	benchmarkValueChannel(b, 100, 100)
+}
+
+func BenchmarkSteps10kSeries100Step(b *testing.B) {
+	benchmarkSteps(b, 10000, 100)
+}
+
+func BenchmarkValueChannel10kSeries100Step(b *testing.B) {
+	benchmarkValueChannel(b, 10000, 100)
+}
+
+func BenchmarkSteps100Series10kStep(b *testing.B) {
+	benchmarkSteps(b, 100, 10000)
+}
+func BenchmarkValueChannel100Series10kStep(b *testing.B) {
+	benchmarkValueChannel(b, 100, 10000)
+}
+
+func BenchmarkSteps10kSeries10kStep(b *testing.B) {
+	benchmarkSteps(b, 10000, 10000)
+}
+
+func BenchmarkValueChannel10kSeries10kStep(b *testing.B) {
+	benchmarkValueChannel(b, 10000, 10000)
+}
+
+func benchmarkValueChannel(b *testing.B, seriesCount, stepCount int) {
+	node, _ := benchNode(b, benchWorkerPools(b))
+	bl := &mockBlock{
+		seriesCount: seriesCount,
+		stepCount:   stepCount,
+	}
+
+	for i := 0; i < b.N; i++ {
+		node.ProcessValueChannel(parser.NodeID(1), bl)
+	}
+}
+
+func benchmarkSteps(b *testing.B, seriesCount, stepCount int) {
+	node, _ := benchNode(b, benchWorkerPools(b))
+	bl := &mockBlock{
+		seriesCount: seriesCount,
+		stepCount:   stepCount,
+	}
+
+	for i := 0; i < b.N; i++ {
+		node.ProcessSteps(parser.NodeID(1), bl)
+	}
+}

--- a/src/query/functions/aggregation/base_async_test.go
+++ b/src/query/functions/aggregation/base_async_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/query/block"
+	"github.com/m3db/m3/src/query/executor/transform"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/parser"
+	"github.com/m3db/m3/src/query/test"
+	"github.com/m3db/m3/src/query/test/executor"
+	"github.com/m3db/m3/src/query/ts/m3db"
+	xsync "github.com/m3db/m3x/sync"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildNode(
+	t *testing.T,
+	workerPool xsync.PooledWorkerPool,
+) (transform.OpNodeAsync, *executor.SinkNode) {
+	op, err := NewAggregationOp(SumType, NodeParams{})
+	require.NoError(t, err)
+	c, sink := executor.NewControllerWithSink(parser.NodeID(1))
+	require.NoError(t, err)
+
+	asyncOp, valid := op.(baseOp)
+	require.True(t, valid)
+	return asyncOp.AsyncNode(c, workerPool), sink
+}
+
+func applyToNode(t *testing.T) (
+	transform.OpNodeAsync,
+	block.AsyncBlock,
+	*executor.SinkNode,
+) {
+	poolSize := 16
+	poolOpts := xsync.NewPooledWorkerPoolOptions().
+		SetGrowOnDemand(true).
+		SetNumShards(int64(poolSize))
+	workerPool, err := xsync.NewPooledWorkerPool(poolSize, poolOpts)
+	workerPool.Init()
+
+	require.NoError(t, err)
+
+	node, sink := buildNode(t, workerPool)
+	it, err := test.BuildTestSeriesIterator()
+	require.NoError(t, err)
+
+	bounds := models.Bounds{
+		Start:    it.Start(),
+		Duration: it.End().Sub(it.Start()),
+		StepSize: time.Minute,
+	}
+
+	bl, err := m3db.NewEncodedAsyncBlock(
+		[]encoding.SeriesIterator{it},
+		bounds,
+		models.NewTagOptions(),
+		workerPool,
+		true,
+	)
+	require.NoError(t, err)
+	return node, bl, sink
+}
+
+func buildExpected() [][]float64 {
+	expected := make([]float64, 0, 57)
+	for i := 3; i <= 30; i++ {
+		expected = append(expected, float64(i))
+	}
+
+	for i := 101; i <= 130; i++ {
+		expected = append(expected, float64(i))
+	}
+
+	return [][]float64{expected}
+}
+
+func TestAsync(t *testing.T) {
+	node, bl, sink := applyToNode(t)
+	node.ProcessValueChannel(parser.NodeID(1), bl)
+	assert.Equal(t, buildExpected(), sink.Values)
+}
+
+func TestAsyncSteps(t *testing.T) {
+	node, bl, sink := applyToNode(t)
+	node.ProcessSteps(parser.NodeID(1), bl)
+	assert.Equal(t, buildExpected(), sink.Values)
+}

--- a/src/query/functions/aggregation/base_real_benchmark_test.go
+++ b/src/query/functions/aggregation/base_real_benchmark_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package aggregation
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/query/block"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/parser"
+	"github.com/m3db/m3/src/query/test"
+	"github.com/m3db/m3/src/query/ts/m3db"
+	xsync "github.com/m3db/m3x/sync"
+
+	"github.com/stretchr/testify/require"
+)
+
+func buildSeriesIterators(
+	b *testing.B,
+	seriesCount int,
+) []encoding.SeriesIterator {
+	iters := make([]encoding.SeriesIterator, seriesCount)
+	for i := range iters {
+		it, err := test.BuildTestSeriesIterator()
+		require.NoError(b, err)
+		iters[i] = it
+	}
+
+	return iters
+}
+
+func buildRealBlock(b *testing.B, seriesCount int) block.Block {
+	iterators := buildSeriesIterators(b, seriesCount)
+	require.True(b, len(iterators) > 0)
+	it := iterators[0]
+	bounds := models.Bounds{
+		Start:    it.Start(),
+		Duration: it.End().Sub(it.Start()),
+		StepSize: time.Minute,
+	}
+
+	bl, err := m3db.NewEncodedBlock(
+		iterators,
+		bounds,
+		models.NewTagOptions(),
+		true,
+	)
+	require.NoError(b, err)
+	return bl
+}
+
+func buildRealAsyncBlock(
+	b *testing.B,
+	workerPools xsync.PooledWorkerPool,
+	seriesCount int,
+) block.AsyncBlock {
+	iterators := buildSeriesIterators(b, seriesCount)
+	require.True(b, len(iterators) > 0)
+	it := iterators[0]
+	bounds := models.Bounds{
+		Start:    it.Start(),
+		Duration: it.End().Sub(it.Start()),
+		StepSize: time.Minute,
+	}
+
+	bl, err := m3db.NewEncodedAsyncBlock(
+		iterators,
+		bounds,
+		models.NewTagOptions(),
+		workerPools,
+		true,
+	)
+	require.NoError(b, err)
+	return bl
+}
+
+func buildExpectedMultiple(seriesCount int) [][]float64 {
+	expected := make([]float64, 0, 57)
+	for i := 3; i <= 30; i++ {
+		expected = append(expected, float64(i*seriesCount))
+	}
+
+	for i := 101; i <= 130; i++ {
+		expected = append(expected, float64(i*seriesCount))
+	}
+
+	return [][]float64{expected}
+}
+
+var realTests = []struct {
+	name        string
+	seriesCount int
+}{
+	{"1   series", 1},
+	{"100 series", 100},
+	{"1k  series", 1000},
+	{"10k series", 10000},
+}
+
+func BenchmarkRealSync(b *testing.B) {
+	for _, t := range realTests {
+		b.Run(fmt.Sprint("Sync steps ", t.name), func(b *testing.B) {
+			benchmarkRealSync(b, t.seriesCount)
+		})
+	}
+}
+
+func BenchmarkRealSteps(b *testing.B) {
+	for _, t := range realTests {
+		b.Run(fmt.Sprint("Async steps", t.name), func(b *testing.B) {
+			benchmarkRealSteps(b, t.seriesCount)
+		})
+	}
+}
+
+func BenchmarkRealValueChannel(b *testing.B) {
+	for _, t := range realTests {
+		b.Run(fmt.Sprint("Async chans", t.name), func(b *testing.B) {
+			benchmarkRealValueChannel(b, t.seriesCount)
+		})
+	}
+}
+
+func benchmarkRealSync(b *testing.B, seriesCount int) {
+	node, _ := benchNode(b, benchWorkerPools(b))
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bl := buildRealBlock(b, seriesCount)
+		b.StartTimer()
+		node.Process(parser.NodeID(1), bl)
+	}
+}
+
+func benchmarkRealValueChannel(b *testing.B, seriesCount int) {
+	node, _ := benchAsyncNode(b, benchWorkerPools(b))
+	pools := benchWorkerPools(b)
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bl := buildRealAsyncBlock(b, pools, seriesCount)
+		b.StartTimer()
+		node.ProcessValueChannel(parser.NodeID(1), bl)
+	}
+}
+
+func benchmarkRealSteps(b *testing.B, seriesCount int) {
+	node, _ := benchAsyncNode(b, benchWorkerPools(b))
+	pools := benchWorkerPools(b)
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bl := buildRealAsyncBlock(b, pools, seriesCount)
+		b.StartTimer()
+		node.ProcessSteps(parser.NodeID(1), bl)
+	}
+}

--- a/src/query/storage/completed_tags_test.go
+++ b/src/query/storage/completed_tags_test.go
@@ -196,12 +196,6 @@ func TestMergeCompletedTagResult(t *testing.T) {
 				}
 
 				expected := mapToCompletedTag(nameOnly, exResult)
-				for _, tags := range expected.CompletedTags {
-					for _, val := range tags.Values {
-						fmt.Println(string(tags.Name), string(val))
-					}
-				}
-
 				assert.Equal(t, expected, actual)
 			})
 		}

--- a/src/query/ts/m3db/async_encoded_step_iterator.go
+++ b/src/query/ts/m3db/async_encoded_step_iterator.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package m3db
+
+import (
+	"sync"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/dbnode/ts"
+	"github.com/m3db/m3/src/query/block"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/ts/m3db/consolidators"
+	xsync "github.com/m3db/m3x/sync"
+)
+
+type encodedStepIterAsync struct {
+	mu            sync.RWMutex
+	lastBlock     bool
+	started       bool
+	err           error
+	currentTime   time.Time
+	currentValues []float64
+	bounds        models.Bounds
+	meta          block.Metadata
+	seriesMeta    []block.SeriesMeta
+	seriesIters   []encoding.SeriesIterator
+	seriesPeek    []peekValue
+	consolidator  *consolidators.StepLookbackConsolidator
+	workerPools   xsync.PooledWorkerPool
+}
+
+func (b *encodedBlock) asyncStepIter() block.AsyncStepIter {
+	cs := b.consolidation
+	consolidator := consolidators.NewStepLookbackConsolidator(
+		time.Minute,
+		cs.bounds.StepSize,
+		cs.currentTime,
+		len(b.seriesBlockIterators),
+		cs.consolidationFn,
+	)
+	return &encodedStepIterAsync{
+		lastBlock:    b.lastBlock,
+		currentTime:  cs.currentTime,
+		bounds:       cs.bounds,
+		meta:         b.meta,
+		seriesMeta:   b.seriesMetas,
+		seriesIters:  b.seriesBlockIterators,
+		consolidator: consolidator,
+		workerPools:  b.workerPools,
+	}
+}
+
+func (it *encodedStepIterAsync) Err() error {
+	return it.err
+}
+
+func (it *encodedStepIterAsync) Current() <-chan (block.Step) {
+	it.mu.RLock()
+	defer it.mu.RUnlock()
+	currentTime := it.currentTime
+	if !it.started || currentTime.After(it.bounds.End()) {
+		panic("out of bounds")
+	}
+
+	// if it.err != nil {
+	// 	return nil
+	// }
+
+	step := &encodedStep{
+		time:   currentTime,
+		values: it.currentValues,
+	}
+
+	ch := make(chan (block.Step))
+	it.workerPools.Go(func() {
+		// go func() {
+		ch <- step
+		// }()
+	})
+	return ch
+}
+
+func (it *encodedStepIterAsync) ValuesChannel() <-chan (block.IndexedStep) {
+	if it.err != nil {
+		return nil
+	}
+	stepCount := it.StepCount()
+	ch := make(chan (block.IndexedStep), stepCount)
+	workerPools := it.workerPools
+	var wg sync.WaitGroup
+	wg.Add(it.StepCount())
+	for i := 0; it.Next(); i++ {
+		idx := i
+		currentTime := it.currentTime
+		currentValues := it.currentValues
+		workerPools.Go(func() {
+			ch <- block.IndexedStep{
+				Idx: idx,
+				Step: &encodedStep{
+					time:   currentTime,
+					values: currentValues,
+				},
+			}
+
+			wg.Done()
+		})
+	}
+
+	workerPools.Go(func() {
+		wg.Wait()
+		close(ch)
+	})
+
+	return ch
+}
+
+// Moves to the next consolidated step for the i-th series in the block,
+// populating the consolidator for that step. Will keep reading values
+// until either hitting the next step boundary and returning, or until
+// encountering a value beyond the boundary, at which point it adds it
+// to a stored peeked value that is consumed on the next pass.
+func (it *encodedStepIterAsync) nextConsolidatedForStep(i int) {
+	peek := it.seriesPeek[i]
+	if peek.finished {
+		// No next value in this iterator
+		return
+	}
+
+	if peek.started {
+		point := peek.point
+		if point.Timestamp.After(it.currentTime) {
+			// This point exists further than the current step
+			// There are next values, but this point should be NaN
+			return
+		}
+
+		// Currently at a potentially viable data point.
+		// Record previously peeked value, and all potentially valid
+		// values, then apply consolidation function to them to get the
+		// consolidated point.
+		it.consolidator.AddPointForIterator(point, i)
+		// clear peeked point.
+		it.seriesPeek[i].started = false
+		// If at boundary, add the point as the current value.
+		if point.Timestamp.Equal(it.currentTime) {
+			return
+		}
+	}
+
+	iter := it.seriesIters[i]
+	// Read through iterator until finding a data point outside of the
+	// range of this consolidated step; then consolidate those points into
+	// a value, set the next peek value, and return true.
+	for iter.Next() {
+		dp, _, _ := iter.Current()
+
+		// If this datapoint is before the current timestamp, add it as a
+		// consolidation candidate.
+		if !dp.Timestamp.After(it.currentTime) {
+			it.seriesPeek[i].started = false
+			it.consolidator.AddPointForIterator(dp, i)
+		} else {
+			// This point exists further than the current step.
+			// Set peeked value to this point, then consolidate the retrieved
+			// series.
+			it.seriesPeek[i].point = dp
+			it.seriesPeek[i].started = true
+			return
+		}
+	}
+
+	if err := iter.Err(); err != nil {
+		it.err = err
+	}
+}
+
+func (it *encodedStepIterAsync) nextConsolidated() {
+	end := it.bounds.End()
+	// Check that current time is not before end since end is exclusive
+	if it.currentTime.After(end) {
+		return
+	}
+
+	for i := range it.seriesIters {
+		it.nextConsolidatedForStep(i)
+	}
+}
+
+// Need to run an initial step; if there are any values
+// that appear at exactly the start, they must be added.
+func (it *encodedStepIterAsync) initialStep() {
+	it.seriesPeek = make([]peekValue, len(it.seriesIters))
+	for i, iter := range it.seriesIters {
+		if iter.Next() {
+			dp, _, _ := iter.Current()
+			if dp.Timestamp.Equal(it.bounds.Start) {
+				it.consolidator.AddPointForIterator(dp, i)
+			} else {
+				it.seriesPeek[i] = peekValue{
+					point: ts.Datapoint{
+						Timestamp: dp.Timestamp,
+						Value:     dp.Value,
+					},
+					started: true,
+				}
+			}
+		}
+
+		if err := iter.Err(); err != nil {
+			it.err = err
+			return
+		}
+	}
+}
+
+func (it *encodedStepIterAsync) Next() bool {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+
+	if !it.started {
+		it.initialStep()
+		it.started = true
+	} else {
+		it.currentTime = it.currentTime.Add(it.bounds.StepSize)
+		it.nextConsolidated()
+	}
+
+	it.currentValues = it.consolidator.ConsolidateAndMoveToNext()
+
+	nextTime := it.currentTime.Add(it.bounds.StepSize)
+
+	if err := it.Err(); err != nil {
+		return false
+	}
+
+	// Has next values if the next step is before end boundary.
+	return !it.bounds.End().Before(nextTime)
+}
+
+func (it *encodedStepIterAsync) StepCount() int {
+	return it.bounds.Steps()
+}
+
+func (it *encodedStepIterAsync) SeriesMeta() []block.SeriesMeta {
+	return it.seriesMeta
+}
+
+func (it *encodedStepIterAsync) Meta() block.Metadata {
+	return it.meta
+}
+
+func (it *encodedStepIterAsync) Close() {
+	// noop, as the resources at the step may still be in use;
+	// instead call Close() on the encodedBlock that generated this
+}

--- a/src/query/ts/m3db/async_encoded_step_iterator.go
+++ b/src/query/ts/m3db/async_encoded_step_iterator.go
@@ -81,9 +81,9 @@ func (it *encodedStepIterAsync) Current() <-chan (block.Step) {
 		panic("out of bounds")
 	}
 
-	// if it.err != nil {
-	// 	return nil
-	// }
+	if it.err != nil {
+		return nil
+	}
 
 	step := &encodedStep{
 		time:   currentTime,
@@ -92,9 +92,7 @@ func (it *encodedStepIterAsync) Current() <-chan (block.Step) {
 
 	ch := make(chan (block.Step))
 	it.workerPools.Go(func() {
-		// go func() {
 		ch <- step
-		// }()
 	})
 	return ch
 }


### PR DESCRIPTION
Adds asynchronous query execution for blocks. Has two different approaches:
1) Single channel per `Current()` call, with caller determining execution
2) Value channel that will handle iteration through `Current()` values in the iterator as available, and adds them to the channel with an appropriate index

Currently a race condition exists within the step channel approach
Next step is feedback/benchmarking to determine which approach is best, and refactoring more functions to allow async execution, then introducing actual async.