### PR TITLE
Enforce mockgen is installed at retool installed version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-vendor/
 bin/
 _tools/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ install-tools: install-retool
 	@# We cannot solely use the retool binary as mock-gen requires its full source
 	@# code to be present in the GOPATH at runtime.
 	@echo "Installing mockgen"
-	$(eval curr_mockgen_md5=`which mockgen | xargs -I{} cat {} | md5`)
+	$(eval curr_mockgen_md5=`cat $(gopath_bin_path)/mockgen | md5`)
 	$(eval retool_mockgen_md5=`cat $(retool_bin_path)/mockgen | md5`)
 	@test "$(curr_mockgen_md5)" = "$(retool_mockgen_md5)" && echo "Mockgen already up to date" || ( \
 		echo "Installing mockgen from Retool directory"                                            && \

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ install-tools: install-retool
 	@# NB(r): to ensure correct version of mock-gen is present we match the version
 	@# of the retool installed mockgen, and if not a match in binary contents, then
 	@# we explicitly install at the version we desire.
-	@# We cannot solely use the retool binary as mock-gen requires it's full source
+	@# We cannot solely use the retool binary as mock-gen requires its full source
 	@# code to be present in the GOPATH at runtime.
 	@echo "Installing mockgen"
 	$(eval curr_mockgen_md5=`which mockgen | xargs -I{} cat {} | md5`)

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,12 @@ SHELL=/bin/bash -o pipefail
 auto_gen             := scripts/auto-gen.sh
 process_coverfile    := scripts/process-cover.sh
 gopath_prefix        := $(GOPATH)/src
+gopath_bin_path      := $(GOPATH)/bin
 m3db_package         := github.com/m3db/m3
 m3db_package_path    := $(gopath_prefix)/$(m3db_package)
 mockgen_package      := github.com/golang/mock/mockgen
 retool_bin_path      := $(m3db_package_path)/_tools/bin
+retool_src_prefix    := $(m3db_package_path)/_tools/src
 retool_package       := github.com/twitchtv/retool
 metalint_check       := .ci/metalint.sh
 metalint_config      := .metalinter.json
@@ -123,18 +125,6 @@ tools-linux-amd64:
 all: metalint test-ci-unit test-ci-integration services tools
 	@echo Made all successfully
 
-# NB(prateek): cannot use retool for mock-gen, as mock-gen reflection mode requires
-# it's full source code be present in the GOPATH at runtime.
-.PHONY: install-mockgen
-install-mockgen:
-	@echo Installing mockgen
-	@which mockgen >/dev/null || (                                                     \
-		rm -rf $(gopath_prefix)/$(mockgen_package)                                    && \
-		mkdir -p $(shell dirname $(gopath_prefix)/$(mockgen_package))                 && \
- 		cp -r $(vendor_prefix)/$(mockgen_package) $(gopath_prefix)/$(mockgen_package) && \
-		go install $(mockgen_package)                                                    \
-	)
-
 .PHONY: install-retool
 install-retool:
 	@which retool >/dev/null || go get $(retool_package)
@@ -142,8 +132,26 @@ install-retool:
 .PHONY: install-tools
 install-tools: install-retool
 	@echo "Installing retool dependencies"
-	@retool sync >/dev/null 2>/dev/null
-	@retool build >/dev/null 2>/dev/null
+	retool sync
+	retool build
+
+	@# NB(r): to ensure correct version of mock-gen is present we match the version
+	@# of the retool installed mockgen, and if not a match in binary contents, then
+	@# we explicitly install at the version we desire.
+	@# We cannot solely use the retool binary as mock-gen requires it's full source
+	@# code to be present in the GOPATH at runtime.
+	@echo "Installing mockgen"
+	$(eval curr_mockgen_md5=`which mockgen | xargs -I{} cat {} | md5`)
+	$(eval retool_mockgen_md5=`cat $(retool_bin_path)/mockgen | md5`)
+	@test "$(curr_mockgen_md5)" = "$(retool_mockgen_md5)" && echo "Mockgen already up to date" || ( \
+		echo "Installing mockgen from Retool directory"                                            && \
+		rm -rf $(gopath_prefix)/$(mockgen_package)                                                 && \
+		mkdir -p $(shell dirname $(gopath_prefix)/$(mockgen_package))                              && \
+ 		cp -r $(retool_src_prefix)/$(mockgen_package) $(gopath_prefix)/$(mockgen_package)          && \
+		(rm $(gopath_bin_path)/mockgen || echo "No installed mockgen" > /dev/null)                 && \
+		cp $(retool_bin_path)/mockgen $(gopath_bin_path)/mockgen                                   && \
+		echo "Installed mockgen from Retool directory"                                                \
+	)
 
 .PHONY: install-gometalinter
 install-gometalinter:
@@ -222,7 +230,7 @@ test-ci-integration:
 define SUBDIR_RULES
 
 .PHONY: mock-gen-$(SUBDIR)
-mock-gen-$(SUBDIR): install-tools install-mockgen
+mock-gen-$(SUBDIR): install-tools
 	@echo "--- Generating mocks $(SUBDIR)"
 	@[ ! -d src/$(SUBDIR)/$(mocks_rules_dir) ] || \
 		PATH=$(retool_bin_path):$(PATH) PACKAGE=$(m3db_package) $(auto_gen) src/$(SUBDIR)/$(mocks_output_dir) src/$(SUBDIR)/$(mocks_rules_dir)

--- a/docker/grafana/Dockerfile
+++ b/docker/grafana/Dockerfile
@@ -4,7 +4,8 @@ COPY ./docker/grafana/datasource.yaml /etc/grafana/provisioning/datasources/data
 COPY ./docker/grafana/dashboards.yaml /etc/grafana/provisioning/dashboards/all.yaml
 
 # Need to replace datasource template variable with name of actual data source so auto-import
-# JustWorksTM. Need to chown the file because the /var/lib/grafana/dashboards directory is
-# only writable by root by default.
-COPY --chown=grafana:grafana ./integrations/grafana/m3db_dashboard.json /var/lib/grafana/dashboards/m3db_dashboard.json
-RUN sed -i 's/${DS_PROMETHEUS}/Prometheus/g' /var/lib/grafana/dashboards/m3db_dashboard.json
+# JustWorksTM. Use a temporary directory to host the dashboards since the default
+# directory is owned by root.
+COPY ./integrations/grafana/m3db_dashboard.json /tmp/m3db_dashboard.json
+RUN mkdir -p /tmp/grafana_dashboards
+RUN awk '{gsub(/\${DS_PROMETHEUS}/,"Prometheus");print}' /tmp/m3db_dashboard.json > /tmp/grafana_dashboards/m3db_dashboard.json

--- a/docker/grafana/Dockerfile
+++ b/docker/grafana/Dockerfile
@@ -2,11 +2,9 @@ FROM grafana/grafana:latest
 
 COPY ./docker/grafana/datasource.yaml /etc/grafana/provisioning/datasources/datasource.yaml
 COPY ./docker/grafana/dashboards.yaml /etc/grafana/provisioning/dashboards/all.yaml
-COPY ./integrations/grafana/m3db_dashboard.json /var/lib/grafana/dashboards/m3db_dashboard.json
+
 # Need to replace datasource template variable with name of actual data source so auto-import
-# JustWorksTM. Need to switch users because the /var/lib/grafana/dashboards directory is
-# only writable by root.
-USER root
+# JustWorksTM. Need to chown the file because the /var/lib/grafana/dashboards directory is
+# only writable by root by default.
+COPY --chown=grafana:grafana ./integrations/grafana/m3db_dashboard.json /var/lib/grafana/dashboards/m3db_dashboard.json
 RUN sed -i 's/${DS_PROMETHEUS}/Prometheus/g' /var/lib/grafana/dashboards/m3db_dashboard.json
-# Switch back to grafana user.
-USER grafana

--- a/docker/grafana/dashboards.yaml
+++ b/docker/grafana/dashboards.yaml
@@ -3,4 +3,4 @@
   folder: ''
   type: 'file'
   options:
-    folder: '/var/lib/grafana/dashboards'
+    folder: '/tmp/grafana_dashboards'

--- a/docker/grafana/datasource.yaml
+++ b/docker/grafana/datasource.yaml
@@ -3,3 +3,7 @@ datasources:
     type: prometheus
     access: proxy
     url: http://prometheus01:9090
+  - name: M3Query
+    type: prometheus
+    access: proxy
+    url: http://m3coordinator01:7201

--- a/tools.json
+++ b/tools.json
@@ -27,6 +27,10 @@
     {
       "Repository": "github.com/pointlander/peg",
       "Commit": "eb55cbbebc6d419fa4fcf4baa100aa0a9ee95ec0"
+    },
+    {
+      "Repository": "github.com/golang/mock/mockgen",
+      "Commit": "51421b967af1f557f93a59e0057aaf15ca02e29c"
     }
   ],
   "RetoolVersion": "1.3.7"


### PR DESCRIPTION
This pins mockgen that's used for generating mocks to a specific version installed by retool.  This will ensure mock generation does not break due to updates of mockgen without an explicit update.