### PR TITLE
Add CompleteTags method for M3 storage and by default enable it

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -70,6 +70,9 @@ type Configuration struct {
 	// ListenAddress is the server listen address.
 	ListenAddress *listenaddress.Configuration `yaml:"listenAddress" validate:"nonzero"`
 
+	// Filter is the read/write/complete tags filter configuration.
+	Filter FilterConfiguration `yaml:"filter"`
+
 	// RPC is the RPC configuration.
 	RPC *RPCConfiguration `yaml:"rpc"`
 
@@ -93,6 +96,27 @@ type Configuration struct {
 
 	// Limits specifies limits on per-query resource usage.
 	Limits LimitsConfiguration `yaml:"limits"`
+}
+
+// Filter is a query filter type.
+type Filter string
+
+const (
+	// FilterLocalOnly is a filter that specifies local only storage should be used.
+	FilterLocalOnly Filter = "local_only"
+	// FilterRemoteOnly is a filter that specifies remote only storage should be used.
+	FilterRemoteOnly Filter = "remote_only"
+	// FilterAllowAll is a filter that specifies all storages should be used.
+	FilterAllowAll Filter = "allow_all"
+	// FilterAllowNone is a filter that specifies no storages should be used.
+	FilterAllowNone Filter = "allow_none"
+)
+
+// FilterConfiguration is the filters for write/read/complete tags storage filters.
+type FilterConfiguration struct {
+	Read         Filter `yaml:"read"`
+	Write        Filter `yaml:"write"`
+	CompleteTags Filter `yaml:"completeTags"`
 }
 
 // LimitsConfiguration represents limitations on per-query resource usage. Zero or negative values imply no limit.

--- a/src/query/api/v1/handler/prometheus/common.go
+++ b/src/query/api/v1/handler/prometheus/common.go
@@ -53,7 +53,7 @@ const (
 )
 
 var (
-	matchValues = []byte("*")
+	matchValues = []byte(".*")
 )
 
 // ParsePromCompressedRequest parses a snappy compressed request from Prometheus
@@ -296,6 +296,51 @@ func RenderTagCompletionResultsJSON(
 	}
 
 	return renderDefaultTagCompletionResultsJSON(w, results)
+}
+
+// RenderTagValuesResultsJSON renders tag values results to json format
+func RenderTagValuesResultsJSON(
+	w io.Writer,
+	result *storage.CompleteTagsResult,
+) error {
+	if result.CompleteNameOnly {
+		return errors.ErrNamesOnly
+	}
+
+	tagCount := len(result.CompletedTags)
+
+	if tagCount > 1 {
+		return errors.ErrMultipleResults
+	}
+
+	jw := json.NewWriter(w)
+	jw.BeginObject()
+
+	jw.BeginObjectField("status")
+	jw.WriteString("success")
+
+	jw.BeginObjectField("data")
+	jw.BeginArray()
+
+	// if no tags found, return empty array
+	if tagCount == 0 {
+		jw.EndArray()
+
+		jw.EndObject()
+
+		return jw.Close()
+	}
+
+	values := result.CompletedTags[0].Values
+	for _, value := range values {
+		jw.WriteString(string(value))
+	}
+
+	jw.EndArray()
+
+	jw.EndObject()
+
+	return jw.Close()
 }
 
 type tag struct {

--- a/src/query/api/v1/handler/prometheus/common.go
+++ b/src/query/api/v1/handler/prometheus/common.go
@@ -53,7 +53,7 @@ const (
 )
 
 var (
-	matchValues = []byte("*")
+	matchValues = []byte(".*")
 )
 
 // ParsePromCompressedRequest parses a snappy compressed request from Prometheus

--- a/src/query/api/v1/handler/prometheus/common.go
+++ b/src/query/api/v1/handler/prometheus/common.go
@@ -53,7 +53,7 @@ const (
 )
 
 var (
-	matchValues = []byte(".*")
+	matchValues = []byte("*")
 )
 
 // ParsePromCompressedRequest parses a snappy compressed request from Prometheus

--- a/src/query/api/v1/handler/prometheus/remote/tag_values.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values.go
@@ -82,5 +82,9 @@ func (h *TagValuesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO: Support multiple result types
-	prometheus.RenderTagCompletionResultsJSON(w, result)
+	err = prometheus.RenderTagValuesResultsJSON(w, result)
+	if err != nil {
+		logger.Error("unable to render tag values", zap.Error(err))
+		xhttp.Error(w, err, http.StatusBadRequest)
+	}
 }

--- a/src/query/api/v1/handler/search_test.go
+++ b/src/query/api/v1/handler/search_test.go
@@ -97,7 +97,7 @@ func searchServer(t *testing.T) *SearchHandler {
 
 	storage, session := m3.NewStorageAndSession(t, ctrl)
 	session.EXPECT().FetchTaggedIDs(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(mockTaggedIDsIter, false, nil)
+		Return(mockTaggedIDsIter, false, nil).AnyTimes()
 
 	search := &SearchHandler{store: storage}
 	return search

--- a/src/query/errors/handler.go
+++ b/src/query/errors/handler.go
@@ -38,4 +38,8 @@ var (
 	ErrNoName = errors.New("invalid path with no name present")
 	// ErrInvalidMatchers is returned when invalid matchers are provided
 	ErrInvalidMatchers = errors.New("invalid matchers")
+	// ErrNamesOnly is returned when label values results are name only
+	ErrNamesOnly = errors.New("can not render label values; result has label names only")
+	// ErrMultipleResults is returned when there are multiple label values results
+	ErrMultipleResults = errors.New("can not render label values; multiple results detected")
 )

--- a/src/query/policy/filter/storage.go
+++ b/src/query/policy/filter/storage.go
@@ -26,8 +26,13 @@ import "github.com/m3db/m3/src/query/storage"
 type Storage func(query storage.Query, store storage.Storage) bool
 
 // LocalOnly filters out all remote storages
-func LocalOnly(query storage.Query, store storage.Storage) bool {
+func LocalOnly(_ storage.Query, store storage.Storage) bool {
 	return store.Type() == storage.TypeLocalDC
+}
+
+// RemoteOnly filters out any non-remote storages
+func RemoteOnly(_ storage.Query, store storage.Storage) bool {
+	return store.Type() == storage.TypeRemoteDC
 }
 
 // AllowAll does not filter any storages
@@ -43,7 +48,22 @@ func AllowNone(_ storage.Query, _ storage.Storage) bool {
 // StorageCompleteTags determines whether storage can fulfil the complete tag query
 type StorageCompleteTags func(query storage.CompleteTagsQuery, store storage.Storage) bool
 
-// RemoteOnly filters out any non-remote storages
-func RemoteOnly(_ storage.CompleteTagsQuery, store storage.Storage) bool {
+// CompleteTagsLocalOnly filters out all remote storages
+func CompleteTagsLocalOnly(_ storage.CompleteTagsQuery, store storage.Storage) bool {
+	return store.Type() == storage.TypeLocalDC
+}
+
+// CompleteTagsRemoteOnly filters out any non-remote storages
+func CompleteTagsRemoteOnly(_ storage.CompleteTagsQuery, store storage.Storage) bool {
 	return store.Type() == storage.TypeRemoteDC
+}
+
+// CompleteTagsAllowAll does not filter any storages
+func CompleteTagsAllowAll(_ storage.CompleteTagsQuery, _ storage.Storage) bool {
+	return true
+}
+
+// CompleteTagsAllowNone filters all storages
+func CompleteTagsAllowNone(_ storage.CompleteTagsQuery, _ storage.Storage) bool {
+	return false
 }

--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -586,11 +586,49 @@ func newStorages(
 	}
 
 	readFilter := filter.LocalOnly
+	writeFilter := filter.LocalOnly
+	completeTagsFilter := filter.CompleteTagsLocalOnly
 	if remoteEnabled {
+		// If remote enabled, allow all for read and complete tags
+		// but continue to only send writes locally
 		readFilter = filter.AllowAll
+		completeTagsFilter = filter.CompleteTagsAllowAll
 	}
 
-	fanoutStorage := fanout.NewStorage(stores, readFilter, filter.LocalOnly, filter.RemoteOnly)
+	switch cfg.Filter.Read {
+	case config.FilterLocalOnly:
+		readFilter = filter.LocalOnly
+	case config.FilterRemoteOnly:
+		readFilter = filter.RemoteOnly
+	case config.FilterAllowAll:
+		readFilter = filter.AllowAll
+	case config.FilterAllowNone:
+		readFilter = filter.AllowNone
+	}
+
+	switch cfg.Filter.Write {
+	case config.FilterLocalOnly:
+		writeFilter = filter.LocalOnly
+	case config.FilterRemoteOnly:
+		writeFilter = filter.RemoteOnly
+	case config.FilterAllowAll:
+		writeFilter = filter.AllowAll
+	case config.FilterAllowNone:
+		writeFilter = filter.AllowNone
+	}
+
+	switch cfg.Filter.CompleteTags {
+	case config.FilterLocalOnly:
+		completeTagsFilter = filter.CompleteTagsLocalOnly
+	case config.FilterRemoteOnly:
+		completeTagsFilter = filter.CompleteTagsRemoteOnly
+	case config.FilterAllowAll:
+		completeTagsFilter = filter.CompleteTagsAllowAll
+	case config.FilterAllowNone:
+		completeTagsFilter = filter.CompleteTagsAllowNone
+	}
+
+	fanoutStorage := fanout.NewStorage(stores, readFilter, writeFilter, completeTagsFilter)
 	return fanoutStorage, cleanup, nil
 }
 

--- a/src/query/storage/fanout/storage_test.go
+++ b/src/query/storage/fanout/storage_test.go
@@ -113,6 +113,8 @@ func setupFanoutWrite(t *testing.T, output bool, errs ...error) storage.Storage 
 		Return(errs[0])
 	session1.EXPECT().IteratorPools().
 		Return(nil, nil).AnyTimes()
+	session1.EXPECT().FetchTaggedIDs(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, true, errs[0]).AnyTimes()
 
 	session2.EXPECT().
 		WriteTagged(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -193,7 +195,7 @@ func TestFanoutWriteSuccess(t *testing.T) {
 }
 
 func TestCompleteTagsFailure(t *testing.T) {
-	store := setupFanoutWrite(t, true, nil)
+	store := setupFanoutWrite(t, true, fmt.Errorf("err"))
 	datapoints := make(ts.Datapoints, 1)
 	datapoints[0] = ts.Datapoint{Timestamp: time.Now(), Value: 1}
 	_, err := store.CompleteTags(

--- a/src/query/storage/index.go
+++ b/src/query/storage/index.go
@@ -94,6 +94,16 @@ func FetchOptionsToM3Options(fetchOptions *FetchOptions, fetchQuery *FetchQuery)
 // FetchQueryToM3Query converts an m3coordinator fetch query to an M3 query
 func FetchQueryToM3Query(fetchQuery *FetchQuery) (index.Query, error) {
 	matchers := fetchQuery.TagMatchers
+	// Optimization for single matcher case.
+	if len(matchers) == 1 {
+		q, err := matcherToQuery(matchers[0])
+		if err != nil {
+			return index.Query{}, err
+		}
+
+		return index.Query{Query: q}, nil
+	}
+
 	idxQueries := make([]idx.Query, len(matchers))
 	var err error
 	for i, matcher := range matchers {

--- a/src/query/storage/index.go
+++ b/src/query/storage/index.go
@@ -94,16 +94,6 @@ func FetchOptionsToM3Options(fetchOptions *FetchOptions, fetchQuery *FetchQuery)
 // FetchQueryToM3Query converts an m3coordinator fetch query to an M3 query
 func FetchQueryToM3Query(fetchQuery *FetchQuery) (index.Query, error) {
 	matchers := fetchQuery.TagMatchers
-	// Optimization for single matcher case.
-	if len(matchers) == 1 {
-		q, err := matcherToQuery(matchers[0])
-		if err != nil {
-			return index.Query{}, err
-		}
-
-		return index.Query{Query: q}, nil
-	}
-
 	idxQueries := make([]idx.Query, len(matchers))
 	var err error
 	for i, matcher := range matchers {

--- a/src/query/storage/index_test.go
+++ b/src/query/storage/index_test.go
@@ -88,7 +88,7 @@ func TestFetchQueryToM3Query(t *testing.T) {
 	}{
 		{
 			name:     "exact match",
-			expected: "conjunction(term(t1, v1))",
+			expected: "term(t1, v1)",
 			matchers: models.Matchers{
 				{
 					Type:  models.MatchEqual,
@@ -99,7 +99,7 @@ func TestFetchQueryToM3Query(t *testing.T) {
 		},
 		{
 			name:     "exact match negated",
-			expected: "conjunction(negation(term(t1, v1)))",
+			expected: "negation(term(t1, v1))",
 			matchers: models.Matchers{
 				{
 					Type:  models.MatchNotEqual,
@@ -110,7 +110,7 @@ func TestFetchQueryToM3Query(t *testing.T) {
 		},
 		{
 			name:     "regexp match",
-			expected: "conjunction(regexp(t1, v1))",
+			expected: "regexp(t1, v1)",
 			matchers: models.Matchers{
 				{
 					Type:  models.MatchRegexp,
@@ -121,7 +121,7 @@ func TestFetchQueryToM3Query(t *testing.T) {
 		},
 		{
 			name:     "regexp match negated",
-			expected: "conjunction(negation(regexp(t1, v1)))",
+			expected: "negation(regexp(t1, v1))",
 			matchers: models.Matchers{
 				{
 					Type:  models.MatchNotRegexp,

--- a/src/query/storage/m3/multi_fetch_tags_result.go
+++ b/src/query/storage/m3/multi_fetch_tags_result.go
@@ -102,7 +102,7 @@ func (r *multiSearchResult) Add(
 		if !exists {
 			r.dedupeMap[id] = MultiTagResult{
 				ID:   ident,
-				Iter: tagIter,
+				Iter: tagIter.Duplicate(),
 			}
 		}
 	}

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -247,41 +247,65 @@ func (s *m3storage) CompleteTags(
 	}
 
 	// TODO: instead of aggregating locally, have the DB aggregate it before
-	// sending results back.
+	// sending results back
 	fetchQuery := &storage.FetchQuery{
 		TagMatchers: query.TagMatchers,
 	}
-
 	results, cleanup, err := s.SearchCompressed(ctx, fetchQuery, options)
-	defer cleanup()
-
 	if err != nil {
 		return nil, err
 	}
 
-	accumulatedTags := storage.NewCompleteTagsResultBuilder(query.CompleteNameOnly)
-	for _, elem := range results {
-		tags := make([]storage.CompletedTag, 0, elem.Iter.Len())
-		for i := 0; elem.Iter.Next(); i++ {
-			tag := elem.Iter.Current()
-			tags[i] = storage.CompletedTag{
-				Name:   tag.Name.Bytes(),
-				Values: [][]byte{tag.Value.Bytes()},
-			}
-		}
+	defer func() { _ = cleanup() }()
 
+	tagsToTagValues := make(map[string]map[string]struct{})
+	for _, elem := range results {
+		for elem.Iter.Next() {
+			tag := elem.Iter.Current()
+			tagName := tag.Name.String()
+
+			values, ok := tagsToTagValues[tagName]
+			if !ok {
+				values = make(map[string]struct{})
+				tagsToTagValues[tagName] = values
+			}
+
+			values[tag.Value.String()] = struct{}{}
+		}
 		if err := elem.Iter.Err(); err != nil {
 			return nil, err
 		}
+	}
 
-		accumulatedTags.Add(&storage.CompleteTagsResult{
-			CompleteNameOnly: query.CompleteNameOnly,
-			CompletedTags:    tags,
+	if query.CompleteNameOnly {
+		// If just returning name only, return directly just that tag
+		completed := storage.CompletedTag{
+			Name: s.tagOptions.MetricName(),
+		}
+		if values, ok := tagsToTagValues[string(completed.Name)]; ok {
+			for value := range values {
+				completed.Values = append(completed.Values, []byte(value))
+			}
+		}
+		return &storage.CompleteTagsResult{
+			CompleteNameOnly: true,
+			CompletedTags:    []storage.CompletedTag{completed},
+		}, nil
+	}
+
+	result := &storage.CompleteTagsResult{}
+	for name, values := range tagsToTagValues {
+		elems := make([][]byte, 0, len(values))
+		for value := range values {
+			elems = append(elems, []byte(value))
+		}
+		result.CompletedTags = append(result.CompletedTags, storage.CompletedTag{
+			Name:   []byte(name),
+			Values: elems,
 		})
 	}
 
-	built := accumulatedTags.Build()
-	return &built, nil
+	return result, nil
 }
 
 func (s *m3storage) SearchCompressed(
@@ -315,6 +339,7 @@ func (s *m3storage) SearchCompressed(
 	wg.Add(len(namespaces))
 	for _, namespace := range namespaces {
 		namespace := namespace // Capture var
+
 		go func() {
 			session := namespace.Session()
 			namespaceID := namespace.NamespaceID()

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -263,22 +263,26 @@ func (s *m3storage) CompleteTags(
 	}
 
 	accumulatedTags := storage.NewCompleteTagsResultBuilder(query.CompleteNameOnly)
+	// only filter if there are tags to filter on.
+	filtering := len(query.FilterNameTags) > 0
 	for _, elem := range results {
 		it := elem.Iter
 		tags := make([]storage.CompletedTag, 0, it.Len())
 		for i := 0; it.Next(); i++ {
 			tag := it.Current()
 			name := tag.Name.Bytes()
-			found := false
-			for _, filterName := range query.FilterNameTags {
-				if bytes.Equal(filterName, name) {
-					found = true
-					break
+			if filtering {
+				found := false
+				for _, filterName := range query.FilterNameTags {
+					if bytes.Equal(filterName, name) {
+						found = true
+						break
+					}
 				}
-			}
 
-			if !found {
-				continue
+				if !found {
+					continue
+				}
 			}
 
 			tags = append(tags, storage.CompletedTag{

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -235,11 +235,70 @@ func (s *m3storage) FetchTags(
 }
 
 func (s *m3storage) CompleteTags(
-	_ context.Context,
-	_ *storage.CompleteTagsQuery,
-	_ *storage.FetchOptions,
+	ctx context.Context,
+	query *storage.CompleteTagsQuery,
+	options *storage.FetchOptions,
 ) (*storage.CompleteTagsResult, error) {
-	return nil, errors.ErrNotImplemented
+	// TODO: instead of aggregating locally, have the DB aggregate it before
+	// sending results back
+	fetchQuery := &storage.FetchQuery{
+		TagMatchers: query.TagMatchers,
+	}
+	results, cleanup, err := s.SearchCompressed(ctx, fetchQuery, options)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = cleanup() }()
+
+	tagsToTagValues := make(map[string]map[string]struct{})
+	for _, elem := range results {
+		for elem.Iter.Next() {
+			tag := elem.Iter.Current()
+			tagName := tag.Name.String()
+
+			values, ok := tagsToTagValues[tagName]
+			if !ok {
+				values = make(map[string]struct{})
+				tagsToTagValues[tagName] = values
+			}
+
+			values[tag.Value.String()] = struct{}{}
+		}
+		if err := elem.Iter.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	if query.CompleteNameOnly {
+		// If just returning name only, return directly just that tag
+		completed := storage.CompletedTag{
+			Name: s.tagOptions.MetricName(),
+		}
+		if values, ok := tagsToTagValues[string(completed.Name)]; ok {
+			for value := range values {
+				completed.Values = append(completed.Values, []byte(value))
+			}
+		}
+		return &storage.CompleteTagsResult{
+			CompleteNameOnly: true,
+			CompletedTags:    []storage.CompletedTag{completed},
+		}, nil
+	}
+
+	result := &storage.CompleteTagsResult{}
+	for name, values := range tagsToTagValues {
+		elems := make([][]byte, 0, len(values))
+		for value := range values {
+			elems = append(elems, []byte(value))
+		}
+		result.CompletedTags = append(result.CompletedTags, storage.CompletedTag{
+			Name:   []byte(name),
+			Values: elems,
+		})
+	}
+
+	return result, nil
 }
 
 func (s *m3storage) SearchCompressed(

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -239,6 +239,13 @@ func (s *m3storage) CompleteTags(
 	query *storage.CompleteTagsQuery,
 	options *storage.FetchOptions,
 ) (*storage.CompleteTagsResult, error) {
+	// Check if the query was interrupted.
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// TODO: instead of aggregating locally, have the DB aggregate it before
 	// sending results back
 	fetchQuery := &storage.FetchQuery{

--- a/src/query/test/seriesiter/mock_iter.go
+++ b/src/query/test/seriesiter/mock_iter.go
@@ -34,6 +34,7 @@ import (
 // GenerateSingleSampleTagIterator generates a new tag iterator
 func GenerateSingleSampleTagIterator(ctrl *gomock.Controller, tag ident.Tag) ident.TagIterator {
 	mockTagIterator := ident.NewMockTagIterator(ctrl)
+	mockTagIterator.EXPECT().Duplicate().Return(mockTagIterator).MaxTimes(1)
 	mockTagIterator.EXPECT().Remaining().Return(1).MaxTimes(1)
 	mockTagIterator.EXPECT().Next().Return(true).MaxTimes(1)
 	mockTagIterator.EXPECT().Current().Return(tag).MaxTimes(1)


### PR DESCRIPTION
Remote storage was hard coded to be the only storage allowed to return complete tags results, this sets it to local only by default and allows overriding any of the read/write/complete tags filter in config.

It also adds CompleteTags for M3 storage so it can be used for local storage CompleteTags queries.  This is for now just aggregating results of a search query, but in the future the DB could natively aggregate and return specifically just the unique tag values over the wire to the query server.