### PR TITLE
[query] Refactor to PR to use existing accumulators

### DIFF
--- a/src/query/api/v1/handler/prometheus/common.go
+++ b/src/query/api/v1/handler/prometheus/common.go
@@ -53,7 +53,7 @@ const (
 )
 
 var (
-	matchValues = []byte("*")
+	matchValues = []byte(".*")
 )
 
 // ParsePromCompressedRequest parses a snappy compressed request from Prometheus

--- a/src/query/storage/index.go
+++ b/src/query/storage/index.go
@@ -94,6 +94,16 @@ func FetchOptionsToM3Options(fetchOptions *FetchOptions, fetchQuery *FetchQuery)
 // FetchQueryToM3Query converts an m3coordinator fetch query to an M3 query
 func FetchQueryToM3Query(fetchQuery *FetchQuery) (index.Query, error) {
 	matchers := fetchQuery.TagMatchers
+	// Optimization for single matcher case.
+	if len(matchers) == 1 {
+		q, err := matcherToQuery(matchers[0])
+		if err != nil {
+			return index.Query{}, err
+		}
+
+		return index.Query{Query: q}, nil
+	}
+
 	idxQueries := make([]idx.Query, len(matchers))
 	var err error
 	for i, matcher := range matchers {

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -240,65 +240,41 @@ func (s *m3storage) CompleteTags(
 	}
 
 	// TODO: instead of aggregating locally, have the DB aggregate it before
-	// sending results back
+	// sending results back.
 	fetchQuery := &storage.FetchQuery{
 		TagMatchers: query.TagMatchers,
 	}
+
 	results, cleanup, err := s.SearchCompressed(ctx, fetchQuery, options)
+	defer cleanup()
+
 	if err != nil {
 		return nil, err
 	}
 
-	defer func() { _ = cleanup() }()
-
-	tagsToTagValues := make(map[string]map[string]struct{})
+	accumulatedTags := storage.NewCompleteTagsResultBuilder(query.CompleteNameOnly)
 	for _, elem := range results {
-		for elem.Iter.Next() {
+		tags := make([]storage.CompletedTag, 0, elem.Iter.Len())
+		for i := 0; elem.Iter.Next(); i++ {
 			tag := elem.Iter.Current()
-			tagName := tag.Name.String()
-
-			values, ok := tagsToTagValues[tagName]
-			if !ok {
-				values = make(map[string]struct{})
-				tagsToTagValues[tagName] = values
+			tags[i] = storage.CompletedTag{
+				Name:   tag.Name.Bytes(),
+				Values: [][]byte{tag.Value.Bytes()},
 			}
-
-			values[tag.Value.String()] = struct{}{}
 		}
+
 		if err := elem.Iter.Err(); err != nil {
 			return nil, err
 		}
-	}
 
-	if query.CompleteNameOnly {
-		// If just returning name only, return directly just that tag
-		completed := storage.CompletedTag{
-			Name: s.tagOptions.MetricName(),
-		}
-		if values, ok := tagsToTagValues[string(completed.Name)]; ok {
-			for value := range values {
-				completed.Values = append(completed.Values, []byte(value))
-			}
-		}
-		return &storage.CompleteTagsResult{
-			CompleteNameOnly: true,
-			CompletedTags:    []storage.CompletedTag{completed},
-		}, nil
-	}
-
-	result := &storage.CompleteTagsResult{}
-	for name, values := range tagsToTagValues {
-		elems := make([][]byte, 0, len(values))
-		for value := range values {
-			elems = append(elems, []byte(value))
-		}
-		result.CompletedTags = append(result.CompletedTags, storage.CompletedTag{
-			Name:   []byte(name),
-			Values: elems,
+		accumulatedTags.Add(&storage.CompleteTagsResult{
+			CompleteNameOnly: query.CompleteNameOnly,
+			CompletedTags:    tags,
 		})
 	}
 
-	return result, nil
+	built := accumulatedTags.Build()
+	return &built, nil
 }
 
 func (s *m3storage) SearchCompressed(
@@ -332,7 +308,6 @@ func (s *m3storage) SearchCompressed(
 	wg.Add(len(namespaces))
 	for _, namespace := range namespaces {
 		namespace := namespace // Capture var
-
 		go func() {
 			session := namespace.Session()
 			namespaceID := namespace.NamespaceID()


### PR DESCRIPTION
Just some updates to Rob's proposed changes that use existing accumulator logic rather than handling it in the fetch tags function itself. Considering the time zone difference, figured might be easier to put up updated PR rather than leaving comments.

Currently the query looks good, but there is some issue with how we're using M3 `FetchTaggedIDs` endpoint