### PR TITLE
[m3x] Change conjunction query String() method to add any negated queries

### DIFF
--- a/src/m3ninx/search/query/conjunction.go
+++ b/src/m3ninx/search/query/conjunction.go
@@ -151,5 +151,10 @@ func (q *ConjuctionQuery) ToProto() *querypb.Query {
 }
 
 func (q *ConjuctionQuery) String() string {
+	if len(q.negations) > 0 {
+		return fmt.Sprintf("conjunction(%s,%s)",
+			join(q.queries), joinNegation(q.negations))
+	}
+
 	return fmt.Sprintf("conjunction(%s)", join(q.queries))
 }

--- a/src/m3ninx/search/query/util.go
+++ b/src/m3ninx/search/query/util.go
@@ -22,8 +22,16 @@ package query
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/m3db/m3/src/m3ninx/search"
+)
+
+const (
+	separator         = ", "
+	negationPrefix    = "negation("
+	negationSeparator = "), negation("
+	negationPostfix   = ")"
 )
 
 // singular returns a bool indicating whether a given query is composed of a single
@@ -56,9 +64,30 @@ func join(qs []search.Query) string {
 	var b bytes.Buffer
 	b.WriteString(qs[0].String())
 	for _, q := range qs[1:] {
-		b.WriteString(", ")
+		b.WriteString(separator)
 		b.WriteString(q.String())
 	}
 
+	return b.String()
+}
+
+// joinNegation concatenates a slice of negated queries.
+func joinNegation(qs []search.Query) string {
+	switch len(qs) {
+	case 0:
+		return ""
+	case 1:
+		return fmt.Sprintf("%s%s%s", negationPrefix, qs[0].String(), negationPostfix)
+	}
+
+	var b bytes.Buffer
+	b.WriteString(negationPrefix)
+	b.WriteString(qs[0].String())
+	for _, q := range qs[1:] {
+		b.WriteString(negationSeparator)
+		b.WriteString(q.String())
+	}
+
+	b.WriteString(negationPostfix)
 	return b.String()
 }

--- a/src/m3ninx/search/query/util_test.go
+++ b/src/m3ninx/search/query/util_test.go
@@ -37,30 +37,35 @@ func TestJoin(t *testing.T) {
 	query.EXPECT().String().AnyTimes().Return("query")
 
 	tests := []struct {
-		name     string
-		input    []search.Query
-		expected string
+		name             string
+		input            []search.Query
+		expected         string
+		expectedNegation string
 	}{
 		{
-			name:     "0 queries",
-			input:    nil,
-			expected: "",
+			name:             "0 queries",
+			input:            nil,
+			expected:         "",
+			expectedNegation: "",
 		},
 		{
-			name:     "1 query",
-			input:    []search.Query{query},
-			expected: "query",
+			name:             "1 query",
+			input:            []search.Query{query},
+			expected:         "query",
+			expectedNegation: "negation(query)",
 		},
 		{
-			name:     "multiple queries",
-			input:    []search.Query{query, query, query},
-			expected: "query, query, query",
+			name:             "multiple queries",
+			input:            []search.Query{query, query, query},
+			expected:         "query, query, query",
+			expectedNegation: "negation(query), negation(query), negation(query)",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.expected, join(test.input))
+			require.Equal(t, test.expectedNegation, joinNegation(test.input))
 		})
 	}
 }


### PR DESCRIPTION
Previously, ConjunctionQuery.String() would only print out actual queries, but not show any negated.