### PR TITLE
Reduce process limit validator spam when running on non-Linux OS

### DIFF
--- a/src/dbnode/server/limits.go
+++ b/src/dbnode/server/limits.go
@@ -34,6 +34,10 @@ const (
 	maxSwappiness = 1
 )
 
+func canValidateProcessLimits() (bool, string) {
+	return xos.CanGetProcessLimits()
+}
+
 func validateProcessLimits() error {
 	limits, err := xos.GetProcessLimits()
 	if err != nil {

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -637,6 +637,13 @@ func interrupt() <-chan os.Signal {
 }
 
 func bgValidateProcessLimits(logger xlog.Logger) {
+	// If unable to validate process limits on the current configuration,
+	// do not run background validator task.
+	if canValidate, message := canValidateProcessLimits(); !canValidate {
+		logger.Warnf(`cannot validate process limits: invalid configuration found [%v]`, message)
+		return
+	}
+
 	start := time.Now()
 	t := time.NewTicker(bgProcessLimitInterval)
 	defer t.Stop()

--- a/src/x/os/limits_linux.go
+++ b/src/x/os/limits_linux.go
@@ -34,6 +34,12 @@ const (
 	vmSwappinessKey  = "vm.swappiness"
 )
 
+// CanGetProcessLimits returns a boolean to signify if it can return limits,
+// and a warning message if it cannot.
+func CanGetProcessLimits() (bool, string) {
+	return true, ""
+}
+
 // GetProcessLimits returns the known process limits.
 func GetProcessLimits() (ProcessLimits, error) {
 	var noFile syscall.Rlimit

--- a/src/x/os/limits_other.go
+++ b/src/x/os/limits_other.go
@@ -24,9 +24,19 @@ package xos
 
 import "errors"
 
-var (
-	errUnableToDetermineProcessLimits = errors.New("unable to determine process limits on non-linux os")
+const (
+	nonLinuxWarning = "unable to determine process limits on non-linux os"
 )
+
+var (
+	errUnableToDetermineProcessLimits = errors.New(nonLinuxWarning)
+)
+
+// CanGetProcessLimits returns a boolean to signify if it can return limits,
+// and a warning message if it cannot.
+func CanGetProcessLimits() (bool, string) {
+	return false, nonLinuxWarning
+}
 
 // GetProcessLimits returns the known process limits.
 func GetProcessLimits() (ProcessLimits, error) {


### PR DESCRIPTION
When developing/running locally, validate process limits check would spin constantly and spit out `invalid configuration found [unable to determine process limits: unable to determine process limits on non-linux os], refer to linked documentation for more information [{url https://m3db.github.io/m3/operational_guide/kernel_configuration}]` without ever resolving, since that path will always fail on other systems.

This adds a check to see if the limit check is possible on the current OS, and if it's not will warn once and stop checking.