### PR TITLE
Arnikola/fix compressed iterator bugs

### DIFF
--- a/src/query/api/v1/handler/prometheus/native/common.go
+++ b/src/query/api/v1/handler/prometheus/native/common.go
@@ -48,8 +48,12 @@ const (
 	queryParam        = "query"
 	stepParam         = "step"
 	debugParam        = "debug"
-	useIterParam      = "iters"
 	endExclusiveParam = "end-exclusive"
+
+	// NB: this will force series decompression on fetch. Will be left for a few
+	// releases to help debug any issues that may arise with compressed series
+	// block fetch
+	useLegacyParam = "legacy"
 
 	formatErrStr = "error parsing param: %s, error: %v"
 )
@@ -118,7 +122,7 @@ func parseParams(r *http.Request) (models.RequestParams, *xhttp.ParseError) {
 	}
 
 	params.Query = query
-	params.Debug, params.UseIterators = parseDebugAndIterFlags(r)
+	params.Debug, params.UseLegacy = parseDebugAndLegacyFlags(r)
 	// Default to including end if unable to parse the flag
 	endExclusiveVal := r.FormValue(endExclusiveParam)
 	params.IncludeEnd = true
@@ -138,11 +142,12 @@ func parseParams(r *http.Request) (models.RequestParams, *xhttp.ParseError) {
 	return params, nil
 }
 
-func parseDebugAndIterFlags(r *http.Request) (bool, bool) {
+func parseDebugAndLegacyFlags(r *http.Request) (bool, bool) {
 	var (
-		debug, useIter bool
-		err            error
+		debug, useLegacy bool
+		err              error
 	)
+
 	// Skip debug if unable to parse debug param
 	debugVal := r.FormValue(debugParam)
 	if debugVal != "" {
@@ -152,16 +157,16 @@ func parseDebugAndIterFlags(r *http.Request) (bool, bool) {
 		}
 	}
 
-	// Skip useIterators if unable to parse useIterators param
-	useIterVal := r.FormValue(useIterParam)
-	if useIterVal != "" {
-		useIter, err = strconv.ParseBool(r.FormValue(useIterParam))
+	// Skip useLegacy if unable to parse useLegacy param
+	useLegacyVal := r.FormValue(useLegacyParam)
+	if useLegacyVal != "" {
+		useLegacy, err = strconv.ParseBool(r.FormValue(useLegacyParam))
 		if err != nil {
-			logging.WithContext(r.Context()).Warn("unable to parse useIter flag", zap.Error(err))
+			logging.WithContext(r.Context()).Warn("unable to parse useLegacy flag", zap.Error(err))
 		}
 	}
 
-	return debug, useIter
+	return debug, useLegacy
 }
 
 // parseInstantaneousParams parses all params from the GET request
@@ -194,7 +199,7 @@ func parseInstantaneousParams(r *http.Request) (models.RequestParams, *xhttp.Par
 		return params, xhttp.NewParseError(fmt.Errorf(formatErrStr, queryParam, err), http.StatusBadRequest)
 	}
 	params.Query = query
-	params.Debug, params.UseIterators = parseDebugAndIterFlags(r)
+	params.Debug, params.UseLegacy = parseDebugAndLegacyFlags(r)
 	return params, nil
 }
 

--- a/src/query/api/v1/handler/prometheus/native/read_common.go
+++ b/src/query/api/v1/handler/prometheus/native/read_common.go
@@ -191,7 +191,7 @@ func sortedBlocksToSeriesList(blockList []blockWithMeta) ([]*ts.Series, error) {
 			}
 		}
 
-		tags := seriesMeta[i].Tags.AddTags(commonTags).WithoutName()
+		tags := seriesMeta[i].Tags.AddTags(commonTags)
 		seriesList[i] = ts.NewSeries(seriesMeta[i].Name, values, tags)
 	}
 

--- a/src/query/executor/state.go
+++ b/src/query/executor/state.go
@@ -118,9 +118,9 @@ func GenerateExecutionState(
 	}
 
 	options := transform.Options{
-		TimeSpec:     pplan.TimeSpec,
-		Debug:        pplan.Debug,
-		UseIterators: pplan.UseIterators,
+		TimeSpec:  pplan.TimeSpec,
+		Debug:     pplan.Debug,
+		UseLegacy: pplan.UseLegacy,
 	}
 
 	controller, err := state.createNode(step, options)

--- a/src/query/executor/transform/controller.go
+++ b/src/query/executor/transform/controller.go
@@ -31,12 +31,12 @@ type Controller struct {
 	transforms []OpNode
 }
 
-// AddTransform adds a dependent transformation to the controller
+// AddTransform adds a dependent transformation to the controller.
 func (t *Controller) AddTransform(node OpNode) {
 	t.transforms = append(t.transforms, node)
 }
 
-// Process performs processing on the underlying transforms
+// Process performs processing on the underlying transforms.
 func (t *Controller) Process(block block.Block) error {
 	for _, ts := range t.transforms {
 		err := ts.Process(t.ID, block)
@@ -48,7 +48,15 @@ func (t *Controller) Process(block block.Block) error {
 	return nil
 }
 
-// BlockBuilder returns a BlockBuilder instance with associated metadata
-func (t *Controller) BlockBuilder(blockMeta block.Metadata, seriesMeta []block.SeriesMeta) (block.Builder, error) {
+// BlockBuilder returns a BlockBuilder instance with associated metadata.
+func (t *Controller) BlockBuilder(
+	blockMeta block.Metadata,
+	seriesMeta []block.SeriesMeta,
+) (block.Builder, error) {
 	return block.NewColumnBlockBuilder(blockMeta, seriesMeta), nil
+}
+
+// HasMultipleOperations returns true if there are multiple operations.
+func (t *Controller) HasMultipleOperations() bool {
+	return len(t.transforms) > 1
 }

--- a/src/query/executor/transform/types.go
+++ b/src/query/executor/transform/types.go
@@ -30,9 +30,9 @@ import (
 
 // Options to create transform nodes
 type Options struct {
-	TimeSpec     TimeSpec
-	Debug        bool
-	UseIterators bool
+	TimeSpec  TimeSpec
+	Debug     bool
+	UseLegacy bool
 }
 
 // OpNode represents the execution node

--- a/src/query/functions/fetch.go
+++ b/src/query/functions/fetch.go
@@ -49,12 +49,12 @@ type FetchOp struct {
 // FetchNode is the execution node
 // TODO: Make FetchNode private
 type FetchNode struct {
-	op           FetchOp
-	controller   *transform.Controller
-	storage      storage.Storage
-	timespec     transform.TimeSpec
-	debug        bool
-	useIterators bool
+	op         FetchOp
+	controller *transform.Controller
+	storage    storage.Storage
+	timespec   transform.TimeSpec
+	debug      bool
+	useLegacy  bool
 }
 
 // OpType for the operator
@@ -78,12 +78,12 @@ func (o FetchOp) String() string {
 // Node creates an execution node
 func (o FetchOp) Node(controller *transform.Controller, storage storage.Storage, options transform.Options) parser.Source {
 	return &FetchNode{
-		op:           o,
-		controller:   controller,
-		storage:      storage,
-		timespec:     options.TimeSpec,
-		debug:        options.Debug,
-		useIterators: options.UseIterators,
+		op:         o,
+		controller: controller,
+		storage:    storage,
+		timespec:   options.TimeSpec,
+		debug:      options.Debug,
+		useLegacy:  options.UseLegacy,
 	}
 }
 
@@ -99,7 +99,7 @@ func (n *FetchNode) Execute(ctx context.Context) error {
 		TagMatchers: n.op.Matchers,
 		Interval:    timeSpec.Step,
 	}, &storage.FetchOptions{
-		UseIterators: n.useIterators,
+		UseLegacy: n.useLegacy,
 	})
 	if err != nil {
 		return err

--- a/src/query/functions/fetch.go
+++ b/src/query/functions/fetch.go
@@ -120,7 +120,17 @@ func (n *FetchNode) Execute(ctx context.Context) error {
 			return err
 		}
 
-		block.Close()
+		// TODO: Revisit how and when we close blocks. At the each function step
+		// defers Close(), which means that we have half blocks hanging around for
+		// a long time. Ideally we should be able to transform blocks in place.
+		//
+		// NB: Until block closing is implemented correctly, this handles closing
+		// encoded iterators when there are additional processing steps, as these
+		// steps will not properly close the block. If there are no additional steps
+		// beyond the fetch, the read handler will close blocks.
+		if n.controller.HasMultipleOperations() {
+			block.Close()
+		}
 	}
 
 	return nil

--- a/src/query/functions/temporal/base.go
+++ b/src/query/functions/temporal/base.go
@@ -257,7 +257,6 @@ func (c *baseNode) processSingleRequest(request processRequest) error {
 	resultSeriesMeta := make([]block.SeriesMeta, len(seriesMeta))
 	for i, m := range seriesMeta {
 		tags := m.Tags.WithoutName()
-		resultSeriesMeta[i].Tags = tags
 		resultSeriesMeta[i].Name = tags.ID()
 	}
 

--- a/src/query/models/params.go
+++ b/src/query/models/params.go
@@ -44,14 +44,14 @@ type RequestParams struct {
 	Start time.Time
 	End   time.Time
 	// Now captures the current time and fixes it throughout the request, we may let people override it in the future
-	Now          time.Time
-	Timeout      time.Duration
-	Step         time.Duration
-	Query        string
-	Debug        bool
-	UseIterators bool
-	IncludeEnd   bool
-	FormatType   FormatType
+	Now        time.Time
+	Timeout    time.Duration
+	Step       time.Duration
+	Query      string
+	Debug      bool
+	IncludeEnd bool
+	UseLegacy  bool
+	FormatType FormatType
 }
 
 // ExclusiveEnd returns the end exclusive

--- a/src/query/plan/physical.go
+++ b/src/query/plan/physical.go
@@ -32,12 +32,12 @@ import (
 
 // PhysicalPlan represents the physical plan
 type PhysicalPlan struct {
-	steps        map[parser.NodeID]LogicalStep
-	pipeline     []parser.NodeID // Ordered list of steps to be performed
-	ResultStep   ResultOp
-	TimeSpec     transform.TimeSpec
-	Debug        bool
-	UseIterators bool
+	steps      map[parser.NodeID]LogicalStep
+	pipeline   []parser.NodeID // Ordered list of steps to be performed
+	ResultStep ResultOp
+	TimeSpec   transform.TimeSpec
+	Debug      bool
+	UseLegacy  bool
 }
 
 // ResultOp is resonsible for delivering results to the clients
@@ -60,8 +60,8 @@ func NewPhysicalPlan(lp LogicalPlan, storage storage.Storage, params models.Requ
 			Now:   params.Now,
 			Step:  params.Step,
 		},
-		Debug:        params.Debug,
-		UseIterators: params.UseIterators,
+		Debug:     params.Debug,
+		UseLegacy: params.UseLegacy,
 	}
 
 	pl, err := p.createResultNode()

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -93,7 +93,7 @@ func (s *m3storage) FetchBlocks(
 	query *storage.FetchQuery,
 	options *storage.FetchOptions,
 ) (block.Result, error) {
-	if !options.UseIterators {
+	if options.UseLegacy {
 		fetchResult, err := s.Fetch(ctx, query, options)
 		if err != nil {
 			return block.Result{}, err

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -81,8 +81,8 @@ func (q *FetchQuery) String() string {
 // FetchOptions represents the options for fetch query.
 type FetchOptions struct {
 	// Limit is the maximum number of series to return.
-	Limit        int
-	UseIterators bool
+	Limit     int
+	UseLegacy bool
 }
 
 // NewFetchOptions creates a new fetch options.

--- a/src/query/ts/m3db/encoded_series_iterator.go
+++ b/src/query/ts/m3db/encoded_series_iterator.go
@@ -96,7 +96,7 @@ func (it *encodedSeriesIter) Current() (block.Series, error) {
 
 	// Consolidate any remaining points iff has not been finished
 	// Fill up any missing values with NaNs
-	for ; !it.consolidator.Empty(); i++ {
+	for ; i < len(values) && !it.consolidator.Empty(); i++ {
 		values[i] = it.consolidator.ConsolidateAndMoveToNext()
 	}
 

--- a/src/query/ts/m3db/encoded_unconsolidated_iterator_test.go
+++ b/src/query/ts/m3db/encoded_unconsolidated_iterator_test.go
@@ -79,11 +79,29 @@ func TestUnconsolidatedStepIterator(t *testing.T) {
 	}
 }
 
+func datapointsToFloatSlices(t *testing.T, dps []ts.Datapoints) [][]float64 {
+	vals := make([][]float64, len(dps))
+	for i, dp := range dps {
+		vals[i] = dp.Values()
+	}
+
+	return vals
+}
+
 func TestUnconsolidatedSeriesIterator(t *testing.T) {
-	expected := [][]float64{
-		{1, 2, 3, 4, 5, 6, 7, 8, 9},
-		{10, 20, 30, 40},
-		{100, 200, 300, 400, 500},
+	expected := [][][]float64{
+		{
+			{}, {}, {}, {}, {}, {}, {1}, {1}, {2, 3}, {4}, {5}, {6}, {7}, {7},
+			{}, {}, {}, {8}, {8}, {}, {}, {}, {9}, {9}, {}, {}, {}, {}, {}, {},
+		},
+		{
+			{}, {}, {10}, {20}, {20}, {}, {}, {}, {}, {}, {}, {}, {}, {30},
+			{30}, {}, {}, {}, {}, {40}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {},
+		},
+		{
+			{}, {}, {}, {100}, {100}, {}, {}, {}, {}, {200}, {200}, {}, {}, {}, {},
+			{300}, {300}, {}, {}, {}, {}, {400}, {400}, {}, {500}, {500}, {}, {}, {}, {},
+		},
 	}
 
 	j := 0
@@ -100,7 +118,7 @@ func TestUnconsolidatedSeriesIterator(t *testing.T) {
 			series, err := iters.Current()
 			require.NoError(t, err)
 			vals := series.Datapoints()
-			actual := datapointsToFloats(t, vals)
+			actual := datapointsToFloatSlices(t, vals)
 			test.EqualsWithNans(t, expected[j], actual)
 			j++
 		}

--- a/src/query/ts/m3db/encoded_unconsolidated_series_iterator.go
+++ b/src/query/ts/m3db/encoded_unconsolidated_series_iterator.go
@@ -42,15 +42,14 @@ func (it *encodedSeriesIterUnconsolidated) Current() (
 ) {
 	it.mu.RLock()
 	iter := it.seriesIters[it.idx]
-
-	values := make([]xts.Datapoints, 0, initBlockReplicaLength)
+	values := make(xts.Datapoints, 0, initBlockReplicaLength)
 	for iter.Next() {
 		dp, _, _ := iter.Current()
 		values = append(values,
-			[]xts.Datapoint{{
+			xts.Datapoint{
 				Timestamp: dp.Timestamp,
 				Value:     dp.Value,
-			}})
+			})
 	}
 
 	if err := iter.Err(); err != nil {
@@ -58,7 +57,8 @@ func (it *encodedSeriesIterUnconsolidated) Current() (
 		return block.UnconsolidatedSeries{}, err
 	}
 
-	series := block.NewUnconsolidatedSeries(values, it.seriesMeta[it.idx])
+	alignedValues := values.AlignToBounds(it.meta.Bounds)
+	series := block.NewUnconsolidatedSeries(alignedValues, it.seriesMeta[it.idx])
 	it.mu.RUnlock()
 	return series, nil
 }


### PR DESCRIPTION
Fixes bugs in compressed block iterator processing

Bugs fixed:
1. Unconsolidated series iterator was returning series of an incorrect
length, since it would not align correctly to bounds. This could cause
panics in query execution depending on downstream functions.

2. Consolidated series iterator would attempt to fill in values if its
internal consolidator still had valid values, without ensuring that those
values were still needed

3. Fetch function was closing blocks too early which caused values to be
lost in compressed block iterators. This was not an issue before since
the previous implementation was not backed by pooled arrays so closing
was less impactful

4. Tags common to all series in a block now correctly added to output (this was an issue in the decompressed case, too)

Also resolves https://github.com/m3db/m3/issues/1259 by flipping the flag and defaulting to compressed iterators