### PR TITLE
[M3agg] Add flush handler to flush aggregated metrics in protobuf

### DIFF
--- a/scripts/development/m3_stack/m3aggregator.yml
+++ b/scripts/development/m3_stack/m3aggregator.yml
@@ -240,6 +240,7 @@ aggregator:
           name: m3msg
           hashType: murmur32
           totalShards: 64
+          protobufEnabled: false
           producer:
             buffer:
               maxBufferSize: 1000000000 # max buffer before m3msg start dropping data.

--- a/scripts/development/m3_stack/m3coordinator.yml
+++ b/scripts/development/m3_stack/m3coordinator.yml
@@ -65,3 +65,5 @@ ingest:
       retry:
         maxBackoff: 10s
         jitter: true
+    handler:
+      protobufEnabled: false

--- a/src/aggregator/aggregator/handler/protobuf.go
+++ b/src/aggregator/aggregator/handler/protobuf.go
@@ -44,7 +44,7 @@ func (h protobufHandler) NewWriter(scope tally.Scope) (writer.Writer, error) {
 	iOpts := h.opts.InstrumentOptions()
 	return writer.NewProtobufWriter(
 		h.p, h.opts.SetInstrumentOptions(iOpts.SetMetricsScope(scope)),
-	)
+	), nil
 }
 
 func (h protobufHandler) Close() {

--- a/src/aggregator/aggregator/handler/protobuf.go
+++ b/src/aggregator/aggregator/handler/protobuf.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package handler
+
+import (
+	"github.com/m3db/m3/src/aggregator/aggregator/handler/writer"
+	"github.com/m3db/m3/src/msg/producer"
+
+	"github.com/uber-go/tally"
+)
+
+type protobufHandler struct {
+	p    producer.Producer
+	opts writer.Options
+}
+
+// NewProtobufHandler creates a new protobuf handler.
+func NewProtobufHandler(p producer.Producer, opts writer.Options) Handler {
+	return protobufHandler{
+		p:    p,
+		opts: opts,
+	}
+}
+
+func (h protobufHandler) NewWriter(scope tally.Scope) (writer.Writer, error) {
+	iOpts := h.opts.InstrumentOptions()
+	return writer.NewProtobufWriter(
+		h.p, h.opts.SetInstrumentOptions(iOpts.SetMetricsScope(scope)),
+	)
+}
+
+func (h protobufHandler) Close() {
+	h.p.Close(producer.WaitForConsumption)
+}

--- a/src/aggregator/aggregator/handler/protobuf_test.go
+++ b/src/aggregator/aggregator/handler/protobuf_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/m3db/m3/src/aggregator/aggregator/handler/writer"
+	"github.com/m3db/m3/src/msg/producer"
+
+	"github.com/golang/mock/gomock"
+)
+
+func TestProtobufHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	p := producer.NewMockProducer(ctrl)
+	h := NewProtobufHandler(p, writer.NewOptions())
+	p.EXPECT().Close(producer.WaitForConsumption)
+	h.Close()
+}

--- a/src/aggregator/aggregator/handler/writer/options.go
+++ b/src/aggregator/aggregator/handler/writer/options.go
@@ -24,6 +24,7 @@ import (
 	"github.com/m3db/m3/src/metrics/encoding/msgpack"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/pool"
 )
 
 const (
@@ -57,6 +58,12 @@ type Options interface {
 	// BufferedEncoderPool returns the buffered encoder pool.
 	BufferedEncoderPool() msgpack.BufferedEncoderPool
 
+	// SetBytesPool sets the bytes pool.
+	SetBytesPool(value pool.BytesPool) Options
+
+	// BytesPool returns the bytes pool.
+	BytesPool() pool.BytesPool
+
 	// SetEncodingTimeSampleRate sets the sampling rate at which the encoding time is
 	// included in the encoded data. A value of 0 means the encoding time is never included,
 	// and a value of 1 means the encoding time is always included.
@@ -73,6 +80,7 @@ type options struct {
 	instrumentOpts           instrument.Options
 	maxBufferSize            int
 	bufferedEncoderPool      msgpack.BufferedEncoderPool
+	bytesPool                pool.BytesPool
 	encodingTimeSamplingRate float64
 }
 
@@ -129,6 +137,16 @@ func (o *options) SetBufferedEncoderPool(value msgpack.BufferedEncoderPool) Opti
 
 func (o *options) BufferedEncoderPool() msgpack.BufferedEncoderPool {
 	return o.bufferedEncoderPool
+}
+
+func (o *options) SetBytesPool(value pool.BytesPool) Options {
+	opts := *o
+	opts.bytesPool = value
+	return &opts
+}
+
+func (o *options) BytesPool() pool.BytesPool {
+	return o.bytesPool
 }
 
 func (o *options) SetEncodingTimeSamplingRate(value float64) Options {

--- a/src/aggregator/aggregator/handler/writer/protobuf.go
+++ b/src/aggregator/aggregator/handler/writer/protobuf.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package writer
+
+import (
+	"errors"
+	"math/rand"
+
+	"github.com/m3db/m3/src/metrics/encoding/protobuf"
+	"github.com/m3db/m3/src/metrics/metric/aggregated"
+	"github.com/m3db/m3/src/msg/producer"
+	"github.com/m3db/m3x/clock"
+	murmur3 "github.com/m3db/stackmurmur3"
+
+	"github.com/uber-go/tally"
+)
+
+var (
+	errWriterClosed = errors.New("writer is closed")
+)
+
+type protobufWriterMetrics struct {
+	writerClosed  tally.Counter
+	encodeSuccess tally.Counter
+	encodeErrors  tally.Counter
+	routeSuccess  tally.Counter
+	routeErrors   tally.Counter
+}
+
+func newProtobufWriterMetrics(scope tally.Scope) protobufWriterMetrics {
+	encodeScope := scope.SubScope("encode")
+	routeScope := scope.SubScope("route")
+	return protobufWriterMetrics{
+		writerClosed:  scope.Counter("writer-closed"),
+		encodeSuccess: encodeScope.Counter("success"),
+		encodeErrors:  encodeScope.Counter("errors"),
+		routeSuccess:  routeScope.Counter("success"),
+		routeErrors:   routeScope.Counter("errors"),
+	}
+}
+
+type idShardFn func([]byte) uint32
+
+// protobufWriter encodes data and routes them to the backend.
+// protobufWriter is not thread safe.
+type protobufWriter struct {
+	encodingTimeSamplingRate float64
+	encoder                  protobuf.AggregatedEncoder
+	p                        producer.Producer
+	numShards                uint32
+
+	closed  bool
+	m       aggregated.MetricWithStoragePolicy
+	rand    *rand.Rand
+	metrics protobufWriterMetrics
+
+	nowFn   clock.NowFn
+	randFn  randFn
+	shardFn idShardFn
+}
+
+// NewProtobufWriter creates a writer that encodes metric in protobuf.
+func NewProtobufWriter(
+	producer producer.Producer,
+	opts Options,
+) (Writer, error) {
+	nowFn := opts.ClockOptions().NowFn()
+	instrumentOpts := opts.InstrumentOptions()
+	w := &protobufWriter{
+		encodingTimeSamplingRate: opts.EncodingTimeSamplingRate(),
+		encoder:                  protobuf.NewAggregatedEncoder(opts.BytesPool()),
+		p:                        producer,
+		numShards:                producer.NumShards(),
+		closed:                   false,
+		rand:                     rand.New(rand.NewSource(nowFn().UnixNano())),
+		metrics:                  newProtobufWriterMetrics(instrumentOpts.MetricsScope()),
+		nowFn:                    nowFn,
+	}
+	w.randFn = w.rand.Float64
+	w.shardFn = w.shard
+	return w, nil
+}
+
+func (w *protobufWriter) Write(mp aggregated.ChunkedMetricWithStoragePolicy) error {
+	if w.closed {
+		w.metrics.writerClosed.Inc(1)
+		return errWriterClosed
+	}
+	var encodeNanos int64
+	if w.encodingTimeSamplingRate > 0 && w.randFn() < w.encodingTimeSamplingRate {
+		encodeNanos = w.nowFn().UnixNano()
+	}
+	m, shard := w.prepare(mp)
+	if err := w.encoder.Encode(m, encodeNanos); err != nil {
+		w.metrics.encodeErrors.Inc(1)
+		return err
+	}
+
+	w.metrics.encodeSuccess.Inc(1)
+	if err := w.p.Produce(newMessage(shard, w.encoder.Buffer())); err != nil {
+		w.metrics.routeErrors.Inc(1)
+		return err
+	}
+	w.metrics.routeSuccess.Inc(1)
+	return nil
+}
+
+func (w *protobufWriter) shard(b []byte) uint32 {
+	return murmur3.Sum32(b) % w.numShards
+}
+
+func (w *protobufWriter) prepare(mp aggregated.ChunkedMetricWithStoragePolicy) (aggregated.MetricWithStoragePolicy, uint32) {
+	// TODO(cw) Chunked metric has no 'type' field, consider adding one.
+	w.m.ID = w.m.ID[:0]
+	w.m.ID = append(w.m.ID, mp.Prefix...)
+	w.m.ID = append(w.m.ID, mp.Data...)
+	w.m.ID = append(w.m.ID, mp.Suffix...)
+	w.m.Metric.TimeNanos = mp.TimeNanos
+	w.m.Metric.Value = mp.Value
+	w.m.StoragePolicy = mp.StoragePolicy
+	shard := w.shardFn(w.m.ID)
+	return w.m, shard
+}
+
+func (w *protobufWriter) Flush() error {
+	return nil
+}
+
+func (w *protobufWriter) Close() error {
+	if w.closed {
+		w.metrics.writerClosed.Inc(1)
+		return errWriterClosed
+	}
+	// Don't close the producer here, it maybe shared by other writers.
+	w.closed = true
+	return nil
+}
+
+type message struct {
+	shard uint32
+	data  protobuf.Buffer
+}
+
+func newMessage(shard uint32, data protobuf.Buffer) producer.Message {
+	return message{shard: shard, data: data}
+}
+
+func (d message) Shard() uint32 {
+	return d.shard
+}
+
+func (d message) Bytes() []byte {
+	return d.data.Bytes()
+}
+
+func (d message) Size() int {
+	// Use the cap of the underlying byte slice in the buffer instead of
+	// the length of the byte encoded to avoid "memory leak", for example
+	// when the underlying buffer is 2KB, and it only encoded 300B, if we
+	// use 300 as the size, then a producer with a buffer of 3GB could be
+	// actually buffering 20GB in total for the underlying buffers.
+	return cap(d.data.Bytes())
+}
+
+func (d message) Finalize(producer.FinalizeReason) {
+	d.data.Close()
+}

--- a/src/aggregator/aggregator/handler/writer/protobuf.go
+++ b/src/aggregator/aggregator/handler/writer/protobuf.go
@@ -81,7 +81,7 @@ type protobufWriter struct {
 func NewProtobufWriter(
 	producer producer.Producer,
 	opts Options,
-) (Writer, error) {
+) Writer {
 	nowFn := opts.ClockOptions().NowFn()
 	instrumentOpts := opts.InstrumentOptions()
 	w := &protobufWriter{
@@ -96,7 +96,7 @@ func NewProtobufWriter(
 	}
 	w.randFn = w.rand.Float64
 	w.shardFn = w.shard
-	return w, nil
+	return w
 }
 
 func (w *protobufWriter) Write(mp aggregated.ChunkedMetricWithStoragePolicy) error {

--- a/src/aggregator/aggregator/handler/writer/protobuf_test.go
+++ b/src/aggregator/aggregator/handler/writer/protobuf_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package writer
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/metrics/encoding/protobuf"
+	"github.com/m3db/m3/src/metrics/metric/aggregated"
+	"github.com/m3db/m3/src/msg/producer"
+	"github.com/m3db/m3x/clock"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtobufWriterWriteClosed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	writer := testProtobufWriter(t, ctrl, NewOptions())
+	writer.closed = true
+	require.Equal(t, errWriterClosed, writer.Write(testChunkedMetricWithStoragePolicy))
+}
+
+func TestProtobufWriterWrite(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
+	opts := NewOptions().
+		SetClockOptions(clock.NewOptions().SetNowFn(nowFn)).
+		SetMaxBufferSize(math.MaxInt64).
+		SetEncodingTimeSamplingRate(0.5)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	writer := testProtobufWriter(t, ctrl, opts)
+
+	actualData := make(map[uint32][]decodeData)
+	writer.p.(*producer.MockProducer).EXPECT().Produce(gomock.Any()).Do(func(m producer.Message) error {
+		d := protobuf.NewAggregatedDecoder(nil)
+		d.Decode(m.Bytes())
+		s := m.Shard()
+		sp, err := d.StoragePolicy()
+		require.NoError(t, err)
+		actualData[s] = append(actualData[s], decodeData{
+			MetricWithStoragePolicy: aggregated.MetricWithStoragePolicy{
+				Metric: aggregated.Metric{
+					ID:        d.ID(),
+					TimeNanos: d.TimeNanos(),
+					Value:     d.Value(),
+				},
+				StoragePolicy: sp,
+			},
+			encodedAtNanos: d.EncodeNanos(),
+		})
+		return nil
+	}).AnyTimes()
+	writer.shardFn = func(id []byte) uint32 {
+		if bytes.Equal(id, testRawID) {
+			return 1
+		}
+		if bytes.Equal(id, testRawID2) {
+			return 2
+		}
+		require.Fail(t, "unexpected chunked id %v", id)
+		return 0
+	}
+	var iter int
+	writer.randFn = func() float64 {
+		iter++
+		if iter%2 == 0 {
+			return 0.1
+		}
+		return 0.9
+	}
+
+	inputs := []aggregated.ChunkedMetricWithStoragePolicy{
+		testChunkedMetricWithStoragePolicy,
+		testChunkedMetricWithStoragePolicy2,
+		testChunkedMetricWithStoragePolicy2,
+		testChunkedMetricWithStoragePolicy,
+	}
+	for _, input := range inputs {
+		require.NoError(t, writer.Write(input))
+	}
+
+	encodedAtNanos := now.UnixNano()
+	expectedData := map[uint32][]decodeData{
+		1: []decodeData{
+			{
+				MetricWithStoragePolicy: testMetricWithStoragePolicy,
+				encodedAtNanos:          0,
+			},
+			{
+				MetricWithStoragePolicy: testMetricWithStoragePolicy,
+				encodedAtNanos:          encodedAtNanos,
+			},
+		},
+		2: []decodeData{
+			{
+				MetricWithStoragePolicy: testMetricWithStoragePolicy2,
+				encodedAtNanos:          encodedAtNanos,
+			},
+			{
+				MetricWithStoragePolicy: testMetricWithStoragePolicy2,
+				encodedAtNanos:          0,
+			},
+		},
+	}
+	for s, expected := range expectedData {
+		actual := actualData[s]
+		require.Equal(t, expected, actual)
+	}
+	require.NoError(t, writer.Close())
+
+}
+
+func testProtobufWriter(t *testing.T, ctrl *gomock.Controller, opts Options) *protobufWriter {
+	p := producer.NewMockProducer(ctrl)
+	p.EXPECT().NumShards().Return(uint32(1024))
+	writer, err := NewProtobufWriter(p, opts)
+	require.NoError(t, err)
+	return writer.(*protobufWriter)
+}

--- a/src/aggregator/aggregator/handler/writer/protobuf_test.go
+++ b/src/aggregator/aggregator/handler/writer/protobuf_test.go
@@ -139,7 +139,5 @@ func TestProtobufWriterWrite(t *testing.T) {
 func testProtobufWriter(t *testing.T, ctrl *gomock.Controller, opts Options) *protobufWriter {
 	p := producer.NewMockProducer(ctrl)
 	p.EXPECT().NumShards().Return(uint32(1024))
-	writer, err := NewProtobufWriter(p, opts)
-	require.NoError(t, err)
-	return writer.(*protobufWriter)
+	return NewProtobufWriter(p, opts).(*protobufWriter)
 }

--- a/src/aggregator/aggregator/handler/writer/sharded.go
+++ b/src/aggregator/aggregator/handler/writer/sharded.go
@@ -21,7 +21,6 @@
 package writer
 
 import (
-	"errors"
 	"math/rand"
 
 	"github.com/m3db/m3/src/aggregator/aggregator/handler/common"
@@ -34,10 +33,6 @@ import (
 	xerrors "github.com/m3db/m3x/errors"
 
 	"github.com/uber-go/tally"
-)
-
-var (
-	errWriterClosed = errors.New("writer is closed")
 )
 
 type shardedWriterMetrics struct {

--- a/src/aggregator/aggregator/handler/writer/sharded_test.go
+++ b/src/aggregator/aggregator/handler/writer/sharded_test.go
@@ -48,11 +48,13 @@ var (
 		Data:   []byte("testData"),
 		Suffix: []byte(".testSuffix"),
 	}
+	testRawID      = []byte("testPrefix.testData.testSuffix")
 	testChunkedID2 = id.ChunkedID{
 		Prefix: []byte("testPrefix2."),
 		Data:   []byte("testData2"),
 		Suffix: []byte(".testSuffix2"),
 	}
+	testRawID2                         = []byte("testPrefix2.testData2.testSuffix2")
 	testChunkedMetricWithStoragePolicy = aggregated.ChunkedMetricWithStoragePolicy{
 		ChunkedMetric: aggregated.ChunkedMetric{
 			ChunkedID: testChunkedID,
@@ -61,9 +63,25 @@ var (
 		},
 		StoragePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour),
 	}
+	testMetricWithStoragePolicy = aggregated.MetricWithStoragePolicy{
+		Metric: aggregated.Metric{
+			ID:        testRawID,
+			TimeNanos: 123456,
+			Value:     3.14,
+		},
+		StoragePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour),
+	}
 	testChunkedMetricWithStoragePolicy2 = aggregated.ChunkedMetricWithStoragePolicy{
 		ChunkedMetric: aggregated.ChunkedMetric{
 			ChunkedID: testChunkedID2,
+			TimeNanos: 1000,
+			Value:     987,
+		},
+		StoragePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour),
+	}
+	testMetricWithStoragePolicy2 = aggregated.MetricWithStoragePolicy{
+		Metric: aggregated.Metric{
+			ID:        testRawID2,
 			TimeNanos: 1000,
 			Value:     987,
 		},

--- a/src/cmd/services/m3coordinator/server/m3msg/protobuf_handler.go
+++ b/src/cmd/services/m3coordinator/server/m3msg/protobuf_handler.go
@@ -54,7 +54,7 @@ func newProtobufProcessor(opts Options) consumer.MessageProcessor {
 func (h *pbHandler) Process(msg consumer.Message) {
 	dec := h.pool.Get()
 	if err := dec.Decode(msg.Bytes()); err != nil {
-		h.logger.WithFields(log.NewErrField(err)).Error("invalid raw metric")
+		h.logger.WithFields(log.NewErrField(err)).Error("could not decode metric from message")
 		h.m.droppedMetricDecodeError.Inc(1)
 		return
 	}

--- a/src/metrics/encoding/protobuf/aggregated_encoder.go
+++ b/src/metrics/encoding/protobuf/aggregated_encoder.go
@@ -62,7 +62,8 @@ func (enc *aggregatedEncoder) Encode(
 	enc.pb.EncodeNanos = encodedAtNanos
 	// Always allocate a new byte slice to avoid modifying the existing one which may still being used.
 	enc.buf = allocate(enc.pool, enc.pb.Size())
-	_, err := enc.pb.MarshalTo(enc.buf)
+	n, err := enc.pb.MarshalTo(enc.buf)
+	enc.buf = enc.buf[:n]
 	return err
 }
 


### PR DESCRIPTION
New flush handler to flush aggregated metrics in protobuf

Placeholder for config changes, could turn on sending/receiving metrics in protobuf by toggling the config in the future, need to coordinate external users.
