### PR TITLE
[query] Refactor encoded block conversion to use options

### DIFF
--- a/src/query/ts/m3db/convert_test.go
+++ b/src/query/ts/m3db/convert_test.go
@@ -161,13 +161,13 @@ func generateBlocks(
 	stepSize time.Duration,
 ) ([]block.Block, models.Bounds) {
 	iterators, bounds := generateIterators(t, stepSize)
+	blockOptions := NewOptions().SetLookbackDuration(time.Minute)
 	blocks, err := ConvertM3DBSeriesIterators(
 		iterators,
-		models.NewTagOptions(),
 		bounds,
+		blockOptions,
 	)
 
 	require.NoError(t, err)
-
 	return blocks, bounds
 }

--- a/src/query/ts/m3db/encoded_block_iterator_builder.go
+++ b/src/query/ts/m3db/encoded_block_iterator_builder.go
@@ -21,6 +21,8 @@
 package m3db
 
 import (
+	"time"
+
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/models"
@@ -59,10 +61,13 @@ func (b *encodedBlockBuilder) add(
 	str := start.String()
 	if _, found := b.blocksAtTime[str]; !found {
 		// Add a new encoded block
+		// NB: the lookback will always be 0, as splitting series into blocks is not
+		// supported with positive lookback durations.
 		b.blocksAtTime[str] = newEncodedBlock(
 			[]encoding.SeriesIterator{},
 			b.tagOptions,
 			consolidation,
+			time.Duration(0),
 			lastBlock,
 		)
 	}

--- a/src/query/ts/m3db/encoded_series_iterator.go
+++ b/src/query/ts/m3db/encoded_series_iterator.go
@@ -23,7 +23,6 @@ package m3db
 import (
 	"math"
 	"sync"
-	"time"
 
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/query/block"
@@ -46,7 +45,7 @@ func (b *encodedBlock) seriesIter() block.SeriesIter {
 	cs := b.consolidation
 	bounds := cs.bounds
 	consolidator := consolidators.NewSeriesLookbackConsolidator(
-		time.Minute,
+		b.lookback,
 		bounds.StepSize,
 		cs.currentTime,
 		cs.consolidationFn,

--- a/src/query/ts/m3db/encoded_step_iterator.go
+++ b/src/query/ts/m3db/encoded_step_iterator.go
@@ -55,7 +55,7 @@ type encodedStepIter struct {
 func (b *encodedBlock) stepIter() block.StepIter {
 	cs := b.consolidation
 	consolidator := consolidators.NewStepLookbackConsolidator(
-		time.Minute,
+		b.lookback,
 		cs.bounds.StepSize,
 		cs.currentTime,
 		len(b.seriesBlockIterators),

--- a/src/query/ts/m3db/options.go
+++ b/src/query/ts/m3db/options.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package m3db
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/pools"
+	"github.com/m3db/m3/src/query/ts/m3db/consolidators"
+)
+
+var (
+	defaultLookbackDuration = time.Duration(0)
+	defaultConsolidationFn  = consolidators.TakeLast
+	defaultIterAlloc        = func(r io.Reader) encoding.ReaderIterator {
+		return m3tsz.NewReaderIterator(r, m3tsz.DefaultIntOptimizationEnabled, encoding.NewOptions())
+	}
+)
+
+type encodedBlockOptions struct {
+	splitSeries      bool
+	lookbackDuration time.Duration
+	consolidationFn  consolidators.ConsolidationFunc
+	tagOptions       models.TagOptions
+	iterAlloc        encoding.ReaderIteratorAllocate
+	pools            encoding.IteratorPools
+}
+
+// NewOptions creates a default encoded block options which dictates how
+// encoded blocks are generated.
+func NewOptions() Options {
+	return &encodedBlockOptions{
+		lookbackDuration: defaultLookbackDuration,
+		consolidationFn:  defaultConsolidationFn,
+		tagOptions:       models.NewTagOptions(),
+		iterAlloc:        defaultIterAlloc,
+		pools:            pools.BuildIteratorPools(),
+	}
+}
+
+func (o *encodedBlockOptions) SetSplitSeriesByBlock(split bool) Options {
+	opts := *o
+	opts.splitSeries = split
+	return &opts
+}
+
+func (o *encodedBlockOptions) SplittingSeriesByBlock() bool {
+	// If any lookback duration has been set, cannot split series by block.
+	if o.lookbackDuration > 0 {
+		return false
+	}
+
+	return o.splitSeries
+}
+
+func (o *encodedBlockOptions) SetLookbackDuration(lookback time.Duration) Options {
+	opts := *o
+	opts.lookbackDuration = lookback
+	return &opts
+}
+
+func (o *encodedBlockOptions) LookbackDuration() time.Duration {
+	return o.lookbackDuration
+}
+
+func (o *encodedBlockOptions) SetConsolidationFunc(fn consolidators.ConsolidationFunc) Options {
+	opts := *o
+	opts.consolidationFn = fn
+	return &opts
+}
+
+func (o *encodedBlockOptions) ConsolidationFunc() consolidators.ConsolidationFunc {
+	return o.consolidationFn
+}
+
+func (o *encodedBlockOptions) SetTagOptions(tagOptions models.TagOptions) Options {
+	opts := *o
+	opts.tagOptions = tagOptions
+	return &opts
+}
+
+func (o *encodedBlockOptions) TagOptions() models.TagOptions {
+	return o.tagOptions
+}
+
+func (o *encodedBlockOptions) SetIterAlloc(ia encoding.ReaderIteratorAllocate) Options {
+	opts := *o
+	opts.iterAlloc = ia
+	return &opts
+}
+
+func (o *encodedBlockOptions) IterAlloc() encoding.ReaderIteratorAllocate {
+	return o.iterAlloc
+}
+
+func (o *encodedBlockOptions) SetIteratorPools(p encoding.IteratorPools) Options {
+	opts := *o
+	opts.pools = p
+	return &opts
+}
+
+func (o *encodedBlockOptions) IteratorPools() encoding.IteratorPools {
+	return o.pools
+}
+
+func (o *encodedBlockOptions) Validate() error {
+	if o.lookbackDuration < 0 {
+		return errors.New("unable to validate block options; negative lookback")
+	}
+
+	if err := o.tagOptions.Validate(); err != nil {
+		return fmt.Errorf("unable to validate tag options, err: %v", err)
+	}
+
+	return nil
+}

--- a/src/query/ts/m3db/types.go
+++ b/src/query/ts/m3db/types.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package m3db
+
+import (
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/ts/m3db/consolidators"
+)
+
+// Options describes the options for encoded block converters.
+// These options are generally config-backed and don't usually change accross
+// queries, unless certain query string parameters are present.
+type Options interface {
+	// SetSplitSeriesByBlock determines if the converter will split the series
+	// by blocks, or if it will instead treat the entire series as a single block.
+	//
+	// NB: if a lookback duration greater than 0 has been set, the series will
+	// always be treated as a single block.
+	SetSplitSeriesByBlock(bool) Options
+	// SplittingSeriesByBlock returns true iff lookback duration is 0, and the
+	// options has not been forced to return a single block.
+	SplittingSeriesByBlock() bool
+	// SetLookbackDuration sets the lookback duration.
+	SetLookbackDuration(time.Duration) Options
+	// LookbackDuration returns the lookback duration.
+	LookbackDuration() time.Duration
+	// SetLookbackDuration sets the consolidation function for the converter.
+	SetConsolidationFunc(consolidators.ConsolidationFunc) Options
+	// LookbackDuration returns the consolidation function.
+	ConsolidationFunc() consolidators.ConsolidationFunc
+	// SetLookbackDuration sets the tag options for the converter.
+	SetTagOptions(models.TagOptions) Options
+	// TagOptions returns the tag options.
+	TagOptions() models.TagOptions
+	// SetIterAlloc sets the iterator allocator.
+	SetIterAlloc(encoding.ReaderIteratorAllocate) Options
+	// IterAlloc returns the reader iterator allocator.
+	IterAlloc() encoding.ReaderIteratorAllocate
+	// SetIteratorPools sets the iterator pools for the converter.
+	SetIteratorPools(encoding.IteratorPools) Options
+	// IteratorPools returns the iterator pools for the converter.
+	IteratorPools() encoding.IteratorPools
+
+	// Validate ensures that the given block options are valid.
+	Validate() error
+}

--- a/src/query/ts/m3db/types.go
+++ b/src/query/ts/m3db/types.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Options describes the options for encoded block converters.
-// These options are generally config-backed and don't usually change accross
+// These options are generally config-backed and don't usually change across
 // queries, unless certain query string parameters are present.
 type Options interface {
 	// SetSplitSeriesByBlock determines if the converter will split the series


### PR DESCRIPTION
Refactors the list of args taken in by encoded block conversion to avoid long argument lists and consolidate all option permutations into one object.