### PR TITLE
[query] splits series into blocks, filling in missing blocks

### DIFF
--- a/src/query/api/v1/handler/prometheus/native/common.go
+++ b/src/query/api/v1/handler/prometheus/native/common.go
@@ -157,16 +157,7 @@ func parseDebugFlag(r *http.Request) bool {
 	return debug
 }
 
-var (
-	validBlockTypes = []models.FetchedBlockType{
-		models.TypeSingleBlock,
-		models.TypeMultiBlock,
-		models.TypeDecodedBlock,
-	}
-)
-
 func parseBlockType(r *http.Request) models.FetchedBlockType {
-	var parseBlockType models.FetchedBlockType
 	// Use default block type if unable to parse blockTypeParam.
 	useLegacyVal := r.FormValue(blockTypeParam)
 	if useLegacyVal != "" {
@@ -175,15 +166,16 @@ func parseBlockType(r *http.Request) models.FetchedBlockType {
 			logging.WithContext(r.Context()).Warn("unable to parse useLegacy flag", zap.Error(err))
 		}
 
-		// If invalid value, return default.
-		if intVal < 0 || int(intVal) >= len(validBlockTypes) {
+		blockType := models.FetchedBlockType(intVal)
+		// Ignore error from receiving an invalid block type, and return default.
+		if blockType.Validate() != nil {
 			return models.TypeSingleBlock
 		}
 
-		return validBlockTypes[intVal]
+		return blockType
 	}
 
-	return parseBlockType
+	return models.TypeSingleBlock
 }
 
 // parseInstantaneousParams parses all params from the GET request

--- a/src/query/api/v1/handler/prometheus/native/common_test.go
+++ b/src/query/api/v1/handler/prometheus/native/common_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/test"
 	"github.com/m3db/m3/src/query/ts"
+	"github.com/m3db/m3/src/query/util/logging"
 	xtest "github.com/m3db/m3/src/x/test"
 
 	"github.com/stretchr/testify/assert"
@@ -116,6 +117,34 @@ func TestParseDurationError(t *testing.T) {
 	require.NoError(t, err)
 	_, err = parseDuration(r, stepParam)
 	assert.Error(t, err)
+}
+
+func TestParseBlockType(t *testing.T) {
+	logging.InitWithCores(nil)
+
+	r, err := http.NewRequest(http.MethodGet, "/foo", nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.TypeSingleBlock, parseBlockType(r))
+
+	r, err = http.NewRequest(http.MethodGet, "/foo?block-type=0", nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.TypeSingleBlock, parseBlockType(r))
+
+	r, err = http.NewRequest(http.MethodGet, "/foo?block-type=1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.TypeMultiBlock, parseBlockType(r))
+
+	r, err = http.NewRequest(http.MethodGet, "/foo?block-type=2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.TypeDecodedBlock, parseBlockType(r))
+
+	r, err = http.NewRequest(http.MethodGet, "/foo?block-type=3", nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.TypeSingleBlock, parseBlockType(r))
+
+	r, err = http.NewRequest(http.MethodGet, "/foo?block-type=bar", nil)
+	require.NoError(t, err)
+	assert.Equal(t, models.TypeSingleBlock, parseBlockType(r))
 }
 
 func TestRenderResultsJSON(t *testing.T) {

--- a/src/query/executor/state.go
+++ b/src/query/executor/state.go
@@ -120,7 +120,7 @@ func GenerateExecutionState(
 	options := transform.Options{
 		TimeSpec:  pplan.TimeSpec,
 		Debug:     pplan.Debug,
-		UseLegacy: pplan.UseLegacy,
+		BlockType: pplan.BlockType,
 	}
 
 	controller, err := state.createNode(step, options)

--- a/src/query/executor/transform/types.go
+++ b/src/query/executor/transform/types.go
@@ -32,7 +32,7 @@ import (
 type Options struct {
 	TimeSpec  TimeSpec
 	Debug     bool
-	UseLegacy bool
+	BlockType models.FetchedBlockType
 }
 
 // OpNode represents the execution node

--- a/src/query/functions/fetch.go
+++ b/src/query/functions/fetch.go
@@ -49,12 +49,12 @@ type FetchOp struct {
 // FetchNode is the execution node
 // TODO: Make FetchNode private
 type FetchNode struct {
+	debug      bool
+	blockType  models.FetchedBlockType
 	op         FetchOp
 	controller *transform.Controller
 	storage    storage.Storage
 	timespec   transform.TimeSpec
-	debug      bool
-	useLegacy  bool
 }
 
 // OpType for the operator
@@ -83,7 +83,7 @@ func (o FetchOp) Node(controller *transform.Controller, storage storage.Storage,
 		storage:    storage,
 		timespec:   options.TimeSpec,
 		debug:      options.Debug,
-		useLegacy:  options.UseLegacy,
+		blockType:  options.BlockType,
 	}
 }
 
@@ -99,7 +99,7 @@ func (n *FetchNode) Execute(ctx context.Context) error {
 		TagMatchers: n.op.Matchers,
 		Interval:    timeSpec.Step,
 	}, &storage.FetchOptions{
-		UseLegacy: n.useLegacy,
+		BlockType: n.blockType,
 	})
 	if err != nil {
 		return err

--- a/src/query/models/block_type.go
+++ b/src/query/models/block_type.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package models
+
+import (
+	"fmt"
+)
+
+var (
+	validBlockTypes = []FetchedBlockType{
+		TypeSingleBlock,
+		TypeMultiBlock,
+		TypeDecodedBlock,
+	}
+)
+
+// Validate validates the fetched block type.
+func (t FetchedBlockType) Validate() error {
+	if t >= TypeSingleBlock && t <= TypeDecodedBlock {
+		return nil
+	}
+
+	return fmt.Errorf("invalid fetched block type '%v': should be one of %v",
+		t, validBlockTypes)
+}

--- a/src/query/models/block_type_test.go
+++ b/src/query/models/block_type_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchedBlockType(t *testing.T) {
+	assert.NoError(t, TypeDecodedBlock.Validate())
+	assert.NoError(t, TypeMultiBlock.Validate())
+	assert.NoError(t, TypeSingleBlock.Validate())
+	assert.EqualError(t, FetchedBlockType(3).Validate(), "invalid fetched block "+
+		"type '3': should be one of [0 1 2]")
+}

--- a/src/query/models/params.go
+++ b/src/query/models/params.go
@@ -39,6 +39,25 @@ const (
 // TODO: Make this configurable
 var LookbackDelta = time.Minute
 
+// FetchedBlockType determines the type for fetched blocks, and how they are
+// transformed from storage type.
+type FetchedBlockType uint8
+
+const (
+	// TypeSingleBlock represents a single block which contains each encoded fetched
+	// series. Default block type for Prometheus queries.
+	TypeSingleBlock FetchedBlockType = iota
+	// TypeMultiBlock represents multiple blocks, each containing a time-based slice
+	// of encoded fetched series. Default block type for Prometheus queries.
+	TypeMultiBlock
+	// TypeDecodedBlock represents a single block which contains all fetched series
+	// which get decoded.
+	//
+	// NB: this is a legacy block type, will be deprecated once there is
+	// sufficient confidence that other block types are performing correctly.
+	TypeDecodedBlock
+)
+
 // RequestParams represents the params from the request
 type RequestParams struct {
 	Start time.Time
@@ -50,7 +69,7 @@ type RequestParams struct {
 	Query      string
 	Debug      bool
 	IncludeEnd bool
-	UseLegacy  bool
+	BlockType  FetchedBlockType
 	FormatType FormatType
 }
 

--- a/src/query/models/params.go
+++ b/src/query/models/params.go
@@ -48,7 +48,7 @@ const (
 	// series. Default block type for Prometheus queries.
 	TypeSingleBlock FetchedBlockType = iota
 	// TypeMultiBlock represents multiple blocks, each containing a time-based slice
-	// of encoded fetched series. Default block type for Prometheus queries.
+	// of encoded fetched series. Default block type for non-Prometheus queries.
 	TypeMultiBlock
 	// TypeDecodedBlock represents a single block which contains all fetched series
 	// which get decoded.

--- a/src/query/plan/physical.go
+++ b/src/query/plan/physical.go
@@ -37,7 +37,7 @@ type PhysicalPlan struct {
 	ResultStep ResultOp
 	TimeSpec   transform.TimeSpec
 	Debug      bool
-	UseLegacy  bool
+	BlockType  models.FetchedBlockType
 }
 
 // ResultOp is resonsible for delivering results to the clients
@@ -61,7 +61,7 @@ func NewPhysicalPlan(lp LogicalPlan, storage storage.Storage, params models.Requ
 			Step:  params.Step,
 		},
 		Debug:     params.Debug,
-		UseLegacy: params.UseLegacy,
+		BlockType: params.BlockType,
 	}
 
 	pl, err := p.createResultNode()

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -106,16 +106,18 @@ func (s *m3storage) FetchBlocks(
 	options *storage.FetchOptions,
 ) (block.Result, error) {
 	opts := s.opts
-	switch options.BlockType {
-	case models.TypeDecodedBlock:
+	// If using decoded block, return the legacy path.
+	if options.BlockType == models.TypeDecodedBlock {
 		fetchResult, err := s.Fetch(ctx, query, options)
 		if err != nil {
 			return block.Result{}, err
 		}
 
 		return storage.FetchResultToBlockResult(fetchResult, query)
-	case models.TypeMultiBlock:
-		// If using multiblock, update options to reflect this.
+	}
+
+	// If using multiblock, update options to reflect this.
+	if options.BlockType == models.TypeMultiBlock {
 		opts = opts.
 			SetLookbackDuration(0).
 			SetSplitSeriesByBlock(true)

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -82,7 +82,7 @@ func (q *FetchQuery) String() string {
 type FetchOptions struct {
 	// Limit is the maximum number of series to return.
 	Limit     int
-	UseLegacy bool
+	BlockType models.FetchedBlockType
 }
 
 // NewFetchOptions creates a new fetch options.

--- a/src/query/ts/m3db/convert.go
+++ b/src/query/ts/m3db/convert.go
@@ -95,7 +95,6 @@ func convertM3DBSegmentedBlockIterators(
 	opts Options,
 ) ([]block.Block, error) {
 	defer iterators.Close()
-	// TODO bounds here should be bounds for this block only not for everything!
 	blockBuilder := newEncodedBlockBuilder(opts.TagOptions(), opts.ConsolidationFunc())
 	var (
 		iterAlloc = opts.IterAlloc()
@@ -114,7 +113,7 @@ func convertM3DBSegmentedBlockIterators(
 		}
 	}
 
-	return blockBuilder.build(), nil
+	return blockBuilder.build()
 }
 
 func blockReplicasFromSeriesIterator(

--- a/src/query/ts/m3db/convert_test.go
+++ b/src/query/ts/m3db/convert_test.go
@@ -147,7 +147,6 @@ func verifyBoundsAndGetBlockIndex(t *testing.T, bounds, sub models.Bounds) int {
 func verifyMetas(
 	t *testing.T,
 	i int,
-	bounds models.Bounds,
 	meta block.Metadata,
 	metas []block.SeriesMeta,
 ) {

--- a/src/query/ts/m3db/convert_test.go
+++ b/src/query/ts/m3db/convert_test.go
@@ -134,6 +134,16 @@ func buildCustomIterator(
 	return iter, bounds
 }
 
+// verifies that given sub-bounds are valid, and returns the index of the
+// generated block being checked.
+func verifyBoundsAndGetBlockIndex(t *testing.T, bounds, sub models.Bounds) int {
+	require.Equal(t, bounds.StepSize, sub.StepSize)
+	require.Equal(t, blockSize, sub.Duration)
+	diff := sub.Start.Sub(bounds.Start)
+	require.Equal(t, 0, int(diff%blockSize))
+	return int(diff / blockSize)
+}
+
 func verifyMetas(
 	t *testing.T,
 	i int,
@@ -141,7 +151,6 @@ func verifyMetas(
 	meta block.Metadata,
 	metas []block.SeriesMeta,
 ) {
-	assert.True(t, meta.Bounds.Equals(bounds))
 	require.Equal(t, 1, meta.Tags.Len())
 	val, found := meta.Tags.Get([]byte("a"))
 	assert.True(t, found)
@@ -156,18 +165,21 @@ func verifyMetas(
 	}
 }
 
+// NB: blocks are not necessarily generated in order; last block may be the first
+// one in the returned array. This is fine since they are processed independently
+// and are put back together at the read step, or at any temporal functions in
+// the execution pipeline.
 func generateBlocks(
 	t *testing.T,
 	stepSize time.Duration,
+	opts Options,
 ) ([]block.Block, models.Bounds) {
 	iterators, bounds := generateIterators(t, stepSize)
-	blockOptions := NewOptions().SetLookbackDuration(time.Minute)
 	blocks, err := ConvertM3DBSeriesIterators(
 		iterators,
 		bounds,
-		blockOptions,
+		opts,
 	)
-
 	require.NoError(t, err)
 	return blocks, bounds
 }

--- a/src/query/ts/m3db/encoded_block_iterator_builder.go
+++ b/src/query/ts/m3db/encoded_block_iterator_builder.go
@@ -75,7 +75,6 @@ func (b *encodedBlockBuilder) add(
 			block := bl.block
 			block.seriesBlockIterators = append(block.seriesBlockIterators, iter)
 			b.blocksAtTime[idx].block = block
-
 			return
 		}
 	}
@@ -98,6 +97,11 @@ func (b *encodedBlockBuilder) add(
 func (b *encodedBlockBuilder) build() ([]block.Block, error) {
 	if err := b.backfillMissing(); err != nil {
 		return nil, err
+	}
+
+	// Sort blocks by ID.
+	for _, bl := range b.blocksAtTime {
+		sort.Sort(seriesIteratorByID(bl.block.seriesBlockIterators))
 	}
 
 	blocks := make([]block.Block, 0, len(b.blocksAtTime))
@@ -186,10 +190,6 @@ func (b *encodedBlockBuilder) backfillMissing() error {
 			block.seriesBlockIterators = append(block.seriesBlockIterators, iter)
 			b.blocksAtTime[blockIdx].block = block
 		}
-	}
-
-	for _, bl := range b.blocksAtTime {
-		sort.Sort(seriesIteratorByID(bl.block.seriesBlockIterators))
 	}
 
 	return nil

--- a/src/query/ts/m3db/encoded_series_iterator_test.go
+++ b/src/query/ts/m3db/encoded_series_iterator_test.go
@@ -96,19 +96,146 @@ var consolidatedSeriesIteratorTests = []struct {
 	},
 }
 
-func TestConsolidatedSeriesIterator(t *testing.T) {
+func TestConsolidatedSeriesIteratorWithLookback(t *testing.T) {
 	for _, tt := range consolidatedSeriesIteratorTests {
-		blocks, bounds := generateBlocks(t, tt.stepSize)
+		opts := NewOptions().
+			SetLookbackDuration(1 * time.Minute).
+			SetSplitSeriesByBlock(false)
+		blocks, bounds := generateBlocks(t, tt.stepSize, opts)
 		j := 0
 		for i, block := range blocks {
 			iters, err := block.SeriesIter()
 			require.NoError(t, err)
 
+			require.True(t, bounds.Equals(iters.Meta().Bounds))
 			verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
 			for iters.Next() {
 				series, err := iters.Current()
 				require.NoError(t, err)
 				test.EqualsWithNans(t, tt.expected[j], series.Values())
+				j++
+			}
+		}
+	}
+}
+
+var consolidatedSeriesIteratorTestsSplitByBlock = []struct {
+	name     string
+	stepSize time.Duration
+	expected [][][]float64
+}{
+	{
+		name:     "1 minute",
+		stepSize: time.Minute,
+		expected: [][][]float64{
+			{
+				{nan, nan, nan, nan, nan, nan},
+				{nan, nan, 10, 20, nan, nan},
+				{nan, nan, nan, 100, nan, nan},
+			},
+			{
+				{1, nan, 3, 4, 5, 6},
+				{nan, nan, nan, nan, nan, nan},
+				{nan, nan, nan, 200, nan, nan},
+			},
+			{
+				{7, nan, nan, nan, nan, 8},
+				{nan, 30, nan, nan, nan, nan},
+				{nan, nan, nan, 300, nan, nan},
+			},
+			{
+				{nan, nan, nan, nan, 9, nan},
+				{nan, nan, nan, nan, nan, nan},
+				{nan, nan, nan, 400, nan, nan},
+			},
+			{
+				{nan, nan, nan, nan, nan, nan},
+				{nan, nan, nan, nan, nan, nan},
+				{500, nan, nan, nan, nan, nan},
+			},
+		},
+	},
+	{
+		name:     "2 minute",
+		stepSize: time.Minute * 2,
+		expected: [][][]float64{
+			{
+				{nan, nan, nan},
+				{nan, 10, nan},
+				{nan, nan, nan},
+			},
+			{
+				{1, 3, 5},
+				{nan, nan, nan},
+				{nan, nan, nan},
+			},
+			{
+				{7, nan, nan},
+				{nan, nan, nan},
+				{nan, nan, nan},
+			},
+			{
+				{nan, nan, 9},
+				{nan, nan, nan},
+				{nan, nan, nan},
+			},
+			{
+				{nan, nan, nan},
+				{nan, nan, nan},
+				{500, nan, nan},
+			},
+		},
+	},
+	{
+		name:     "3 minute",
+		stepSize: time.Minute * 3,
+		expected: [][][]float64{
+			{
+				{nan, nan},
+				{nan, 20},
+				{nan, 100},
+			},
+			{
+				{1, 4},
+				{nan, nan},
+				{nan, 200},
+			},
+			{
+				{7, nan},
+				{nan, nan},
+				{nan, 300},
+			},
+			{
+				{nan, nan},
+				{nan, nan},
+				{nan, 400},
+			},
+			{
+				{nan, nan},
+				{nan, nan},
+				{500, nan},
+			},
+		},
+	},
+}
+
+func TestConsolidatedSeriesIteratorSplitByBlock(t *testing.T) {
+	for _, tt := range consolidatedSeriesIteratorTestsSplitByBlock {
+		opts := NewOptions().
+			SetLookbackDuration(0).
+			SetSplitSeriesByBlock(true)
+		blocks, bounds := generateBlocks(t, tt.stepSize, opts)
+		for i, block := range blocks {
+			iters, err := block.SeriesIter()
+			require.NoError(t, err)
+
+			j := 0
+			idx := verifyBoundsAndGetBlockIndex(t, bounds, iters.Meta().Bounds)
+			verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
+			for iters.Next() {
+				series, err := iters.Current()
+				require.NoError(t, err)
+				test.EqualsWithNans(t, tt.expected[idx][j], series.Values())
 				j++
 			}
 		}

--- a/src/query/ts/m3db/encoded_series_iterator_test.go
+++ b/src/query/ts/m3db/encoded_series_iterator_test.go
@@ -108,7 +108,7 @@ func TestConsolidatedSeriesIteratorWithLookback(t *testing.T) {
 			require.NoError(t, err)
 
 			require.True(t, bounds.Equals(iters.Meta().Bounds))
-			verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
+			verifyMetas(t, i, iters.Meta(), iters.SeriesMeta())
 			for iters.Next() {
 				series, err := iters.Current()
 				require.NoError(t, err)
@@ -231,7 +231,7 @@ func TestConsolidatedSeriesIteratorSplitByBlock(t *testing.T) {
 
 			j := 0
 			idx := verifyBoundsAndGetBlockIndex(t, bounds, iters.Meta().Bounds)
-			verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
+			verifyMetas(t, i, iters.Meta(), iters.SeriesMeta())
 			for iters.Next() {
 				series, err := iters.Current()
 				require.NoError(t, err)

--- a/src/query/ts/m3db/encoded_step_iterator_test.go
+++ b/src/query/ts/m3db/encoded_step_iterator_test.go
@@ -121,7 +121,7 @@ func TestConsolidatedStepIteratorMinuteLookback(t *testing.T) {
 			require.NoError(t, err)
 
 			require.True(t, bounds.Equals(iters.Meta().Bounds))
-			verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
+			verifyMetas(t, i, iters.Meta(), iters.SeriesMeta())
 			for iters.Next() {
 				step, err := iters.Current()
 				require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestConsolidatedStepIteratorSplitByBlock(t *testing.T) {
 
 			j := 0
 			idx := verifyBoundsAndGetBlockIndex(t, bounds, iters.Meta().Bounds)
-			verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
+			verifyMetas(t, i, iters.Meta(), iters.SeriesMeta())
 			for iters.Next() {
 				step, err := iters.Current()
 				require.NoError(t, err)

--- a/src/query/ts/m3db/encoded_step_iterator_test.go
+++ b/src/query/ts/m3db/encoded_step_iterator_test.go
@@ -109,20 +109,158 @@ var consolidatedStepIteratorTests = []struct {
 	},
 }
 
-func TestConsolidatedStepIterator(t *testing.T) {
+func TestConsolidatedStepIteratorMinuteLookback(t *testing.T) {
 	for _, tt := range consolidatedStepIteratorTests {
-		blocks, bounds := generateBlocks(t, tt.stepSize)
+		opts := NewOptions().
+			SetLookbackDuration(1 * time.Minute).
+			SetSplitSeriesByBlock(false)
+		blocks, bounds := generateBlocks(t, tt.stepSize, opts)
 		j := 0
 		for i, block := range blocks {
 			iters, err := block.StepIter()
 			require.NoError(t, err)
 
+			require.True(t, bounds.Equals(iters.Meta().Bounds))
 			verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
 			for iters.Next() {
 				step, err := iters.Current()
 				require.NoError(t, err)
 				vals := step.Values()
 				test.EqualsWithNans(t, tt.expected[j], vals)
+				j++
+			}
+		}
+	}
+}
+
+var consolidatedStepIteratorTestsSplitByBlock = []struct {
+	name     string
+	stepSize time.Duration
+	expected [][][]float64
+}{
+	{
+		name:     "1 minute",
+		stepSize: time.Minute,
+		expected: [][][]float64{
+			{
+				{nan, nan, nan},
+				{nan, nan, nan},
+				{nan, 10, nan},
+				{nan, 20, 100},
+				{nan, nan, nan},
+				{nan, nan, nan},
+			},
+			{
+				{1, nan, nan},
+				{nan, nan, nan},
+				{3, nan, nan},
+				{4, nan, 200},
+				{5, nan, nan},
+				{6, nan, nan},
+			},
+			{
+				{7, nan, nan},
+				{nan, 30, nan},
+				{nan, nan, nan},
+				{nan, nan, 300},
+				{nan, nan, nan},
+				{8, nan, nan},
+			},
+			{
+				{nan, nan, nan},
+				{nan, nan, nan},
+				{nan, nan, nan},
+				{nan, nan, 400},
+				{9, nan, nan},
+				{nan, nan, nan},
+			},
+			{
+				{nan, nan, 500},
+				{nan, nan, nan},
+				{nan, nan, nan},
+				{nan, nan, nan},
+				{nan, nan, nan},
+				{nan, nan, nan},
+			},
+		},
+	},
+	{
+		name:     "2 minute",
+		stepSize: time.Minute * 2,
+		expected: [][][]float64{
+			{
+				{nan, nan, nan},
+				{nan, 10, nan},
+				{nan, nan, nan},
+			},
+			{
+				{1, nan, nan},
+				{3, nan, nan},
+				{5, nan, nan},
+			},
+			{
+				{7, nan, nan},
+				{nan, nan, nan},
+				{nan, nan, nan},
+			},
+			{
+				{nan, nan, nan},
+				{nan, nan, nan},
+				{9, nan, nan},
+			},
+			{
+				{nan, nan, 500},
+				{nan, nan, nan},
+				{nan, nan, nan},
+			},
+		},
+	},
+	{
+		name:     "3 minute",
+		stepSize: time.Minute * 3,
+		expected: [][][]float64{
+			{
+				{nan, nan, nan},
+				{nan, 20, 100},
+			},
+			{
+				{1, nan, nan},
+				{4, nan, 200},
+			},
+			{
+				{7, nan, nan},
+				{nan, nan, 300},
+			},
+			{
+				{nan, nan, nan},
+				{nan, nan, 400},
+			},
+			{
+				{nan, nan, 500},
+				{nan, nan, nan},
+			},
+		},
+	},
+}
+
+func TestConsolidatedStepIteratorSplitByBlock(t *testing.T) {
+	for _, tt := range consolidatedStepIteratorTestsSplitByBlock {
+		opts := NewOptions().
+			SetLookbackDuration(0).
+			SetSplitSeriesByBlock(true)
+		blocks, bounds := generateBlocks(t, tt.stepSize, opts)
+		for i, block := range blocks {
+			iters, err := block.StepIter()
+			require.NoError(t, err)
+
+			j := 0
+			idx := verifyBoundsAndGetBlockIndex(t, bounds, iters.Meta().Bounds)
+			verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
+			for iters.Next() {
+				step, err := iters.Current()
+				require.NoError(t, err)
+				vals := step.Values()
+				test.EqualsWithNans(t, tt.expected[idx][j], vals)
 				j++
 			}
 		}

--- a/src/query/ts/m3db/encoded_unconsolidated_iterator_test.go
+++ b/src/query/ts/m3db/encoded_unconsolidated_iterator_test.go
@@ -71,7 +71,7 @@ func TestUnconsolidatedStepIterator(t *testing.T) {
 		require.NoError(t, err)
 
 		require.True(t, bounds.Equals(iters.Meta().Bounds))
-		verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
+		verifyMetas(t, i, iters.Meta(), iters.SeriesMeta())
 		for iters.Next() {
 			step, err := iters.Current()
 			require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestUnconsolidatedSeriesIterator(t *testing.T) {
 		require.NoError(t, err)
 
 		require.True(t, bounds.Equals(iters.Meta().Bounds))
-		verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
+		verifyMetas(t, i, iters.Meta(), iters.SeriesMeta())
 		for iters.Next() {
 			series, err := iters.Current()
 			require.NoError(t, err)

--- a/src/query/ts/m3db/encoded_unconsolidated_iterator_test.go
+++ b/src/query/ts/m3db/encoded_unconsolidated_iterator_test.go
@@ -59,7 +59,10 @@ func TestUnconsolidatedStepIterator(t *testing.T) {
 	}
 
 	j := 0
-	blocks, bounds := generateBlocks(t, time.Minute)
+	opts := NewOptions().
+		SetLookbackDuration(1 * time.Minute).
+		SetSplitSeriesByBlock(true)
+	blocks, bounds := generateBlocks(t, time.Minute, opts)
 	for i, block := range blocks {
 		unconsolidated, err := block.Unconsolidated()
 		require.NoError(t, err)
@@ -67,6 +70,7 @@ func TestUnconsolidatedStepIterator(t *testing.T) {
 		iters, err := unconsolidated.StepIter()
 		require.NoError(t, err)
 
+		require.True(t, bounds.Equals(iters.Meta().Bounds))
 		verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
 		for iters.Next() {
 			step, err := iters.Current()
@@ -105,7 +109,10 @@ func TestUnconsolidatedSeriesIterator(t *testing.T) {
 	}
 
 	j := 0
-	blocks, bounds := generateBlocks(t, time.Minute)
+	opts := NewOptions().
+		SetLookbackDuration(1 * time.Minute).
+		SetSplitSeriesByBlock(false)
+	blocks, bounds := generateBlocks(t, time.Minute, opts)
 	for i, block := range blocks {
 		unconsolidated, err := block.Unconsolidated()
 		require.NoError(t, err)
@@ -113,6 +120,7 @@ func TestUnconsolidatedSeriesIterator(t *testing.T) {
 		iters, err := unconsolidated.SeriesIter()
 		require.NoError(t, err)
 
+		require.True(t, bounds.Equals(iters.Meta().Bounds))
 		verifyMetas(t, i, bounds, iters.Meta(), iters.SeriesMeta())
 		for iters.Next() {
 			series, err := iters.Current()


### PR DESCRIPTION
Adds tests and fills in blocks in sparse series with empty iterators, allowing downstream functions to work correctly.