### PR TITLE
[query] Ignore autogenerated grammar peg file from metalinting

### DIFF
--- a/.excludemetalint
+++ b/.excludemetalint
@@ -8,3 +8,4 @@ mocks/
 vendor/
 src/m3ninx/x/bytes/slice_arraypool_gen.go
 src/m3ninx/index/segment/mem/ids_map_gen.go
+src/query/parser/m3ql/grammar.peg.go


### PR DESCRIPTION
Removes autogenerated grammar.peg.go file from the metalinter, as it generates structures the linter is unhappy with.