### PR TITLE
Use IsBootstrappedAndDurable instead of IsBootstrapped in health checks

### DIFF
--- a/scripts/development/m3_stack/start_m3.sh
+++ b/scripts/development/m3_stack/start_m3.sh
@@ -170,7 +170,7 @@ echo "Validating topology"
 echo "Done validating topology"
 
 echo "Waiting until shards are marked as available"
-ATTEMPTS=10 TIMEOUT=1 retry_with_backoff  \
+ATTEMPTS=10 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | grep -c INITIALIZING)" -eq 0 ]'
 
 if [[ "$AGGREGATOR_PIPELINE" = true ]]; then

--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -100,7 +100,7 @@ ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | jq .placement.instances.m3db_local.id)" == \"m3db_local\" ]'
 
 echo "Sleep until bootstrapped"
-ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
+ATTEMPTS=10 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
 
 echo "Waiting until shards are marked as available"

--- a/scripts/docker-integration-tests/simple/test.sh
+++ b/scripts/docker-integration-tests/simple/test.sh
@@ -78,7 +78,7 @@ ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | jq .placement.instances.m3db_local.id)" == \"m3db_local\" ]'
 
 echo "Sleep until bootstrapped"
-ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
+ATTEMPTS=10 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
 
 echo "Waiting until shards are marked as available"

--- a/src/dbnode/integration/fetch_tagged_quorum_test.go
+++ b/src/dbnode/integration/fetch_tagged_quorum_test.go
@@ -294,7 +294,7 @@ func startAndWriteTagged(
 	ctx := context.NewContext()
 	defer ctx.BlockingClose()
 	for _, n := range nodes {
-		require.NoError(t, n.startServer())
+		require.NoError(t, n.startServerDontWaitBootstrap())
 		require.NoError(t, n.db.WriteTagged(ctx, testNamespaces[0], ident.StringID("quorumTest"),
 			ident.NewTagsIterator(ident.NewTags(ident.StringTag("foo", "bar"), ident.StringTag("boo", "baz"))),
 			n.getNowFn(), 42, xtime.Second, nil))

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -140,7 +140,7 @@ func newTestSetup(t *testing.T, opts testOptions, fsOpts fs.Options) (*testSetup
 		SetNamespaceInitializer(nsInit).
 		SetMinimumSnapshotInterval(opts.MinimumSnapshotInterval())
 
-		// Use specified series cache policy from environment if set
+	// Use specified series cache policy from environment if set.
 	seriesCachePolicy := strings.ToLower(os.Getenv("TEST_SERIES_CACHE_POLICY"))
 	if seriesCachePolicy != "" {
 		value, err := series.ParseCachePolicy(seriesCachePolicy)

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -450,7 +450,15 @@ func (ts *testSetup) waitUntilServerIsDown() error {
 	return errServerStopTimedOut
 }
 
+func (ts *testSetup) startServerDontWaitBootstrap() error {
+	return ts.startServerBase(false)
+}
+
 func (ts *testSetup) startServer() error {
+	return ts.startServerBase(true)
+}
+
+func (ts *testSetup) startServerBase(waitForBootstrap bool) error {
 	ts.logger.Infof("starting server")
 
 	var (
@@ -491,9 +499,13 @@ func (ts *testSetup) startServer() error {
 		ts.closedCh <- struct{}{}
 	}()
 
+	waitFn := ts.waitUntilServerIsUp
+	if waitForBootstrap {
+		waitFn = ts.waitUntilServerIsBootstrapped
+	}
 	go func() {
 		select {
-		case resultCh <- ts.waitUntilServerIsBootstrapped():
+		case resultCh <- waitFn():
 		default:
 		}
 	}()

--- a/src/dbnode/integration/write_quorum_test.go
+++ b/src/dbnode/integration/write_quorum_test.go
@@ -55,7 +55,7 @@ func TestNormalQuorumOnlyOneUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[0].startServer())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 
 	// Writes succeed to one node
@@ -81,9 +81,9 @@ func TestNormalQuorumOnlyTwoUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[0].startServer())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
-	require.NoError(t, nodes[1].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[1].startServer())
 	defer func() { require.NoError(t, nodes[1].stopServer()) }()
 
 	// Writes succeed to two nodes
@@ -109,11 +109,11 @@ func TestNormalQuorumAllUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[0].startServer())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
-	require.NoError(t, nodes[1].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[1].startServer())
 	defer func() { require.NoError(t, nodes[1].stopServer()) }()
-	require.NoError(t, nodes[2].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[2].startServer())
 	defer func() { require.NoError(t, nodes[2].stopServer()) }()
 
 	// Writes succeed to all nodes
@@ -140,7 +140,7 @@ func TestAddNodeQuorumOnlyLeavingInitializingUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[0].startServer())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 
 	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
@@ -170,9 +170,9 @@ func TestAddNodeQuorumOnlyOneNormalAndLeavingInitializingUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[0].startServer())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
-	require.NoError(t, nodes[1].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[1].startServer())
 	defer func() { require.NoError(t, nodes[1].stopServer()) }()
 	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[3].stopServer()) }()
@@ -201,11 +201,11 @@ func TestAddNodeQuorumAllUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[0].startServer())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
-	require.NoError(t, nodes[1].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[1].startServer())
 	defer func() { require.NoError(t, nodes[1].stopServer()) }()
-	require.NoError(t, nodes[2].startServerDontWaitBootstrap())
+	require.NoError(t, nodes[2].startServer())
 	defer func() { require.NoError(t, nodes[2].stopServer()) }()
 	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[3].stopServer()) }()

--- a/src/dbnode/integration/write_quorum_test.go
+++ b/src/dbnode/integration/write_quorum_test.go
@@ -55,7 +55,7 @@ func TestNormalQuorumOnlyOneUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServer())
+	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 
 	// Writes succeed to one node
@@ -81,9 +81,9 @@ func TestNormalQuorumOnlyTwoUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServer())
+	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
-	require.NoError(t, nodes[1].startServer())
+	require.NoError(t, nodes[1].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[1].stopServer()) }()
 
 	// Writes succeed to two nodes
@@ -109,11 +109,11 @@ func TestNormalQuorumAllUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServer())
+	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
-	require.NoError(t, nodes[1].startServer())
+	require.NoError(t, nodes[1].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[1].stopServer()) }()
-	require.NoError(t, nodes[2].startServer())
+	require.NoError(t, nodes[2].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[2].stopServer()) }()
 
 	// Writes succeed to all nodes
@@ -140,10 +140,10 @@ func TestAddNodeQuorumOnlyLeavingInitializingUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServer())
+	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 
-	require.NoError(t, nodes[3].startServer())
+	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[3].stopServer()) }()
 
 	// No writes succeed to available nodes
@@ -170,11 +170,11 @@ func TestAddNodeQuorumOnlyOneNormalAndLeavingInitializingUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServer())
+	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
-	require.NoError(t, nodes[1].startServer())
+	require.NoError(t, nodes[1].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[1].stopServer()) }()
-	require.NoError(t, nodes[3].startServer())
+	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[3].stopServer()) }()
 
 	// Writes succeed to one available node
@@ -201,13 +201,13 @@ func TestAddNodeQuorumAllUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	require.NoError(t, nodes[0].startServer())
+	require.NoError(t, nodes[0].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[0].stopServer()) }()
-	require.NoError(t, nodes[1].startServer())
+	require.NoError(t, nodes[1].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[1].stopServer()) }()
-	require.NoError(t, nodes[2].startServer())
+	require.NoError(t, nodes[2].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[2].stopServer()) }()
-	require.NoError(t, nodes[3].startServer())
+	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
 	defer func() { require.NoError(t, nodes[3].stopServer()) }()
 
 	// Writes succeed to two available nodes

--- a/src/dbnode/integration/write_quorum_test.go
+++ b/src/dbnode/integration/write_quorum_test.go
@@ -233,9 +233,8 @@ func makeTestWrite(
 	nodes, topoInit, closeFn := newNodes(t, numShards, instances, nspaces, false)
 	now := nodes[0].getNowFn()
 	go func() {
-		// Tick the time up in the background so that background operations like
-		// snapshotting will run (they have a configurable minimum interval between
-		// runs.)
+		// Tick the time up in the background so that operations like snapshotting
+		// will run (they have a configurable minimum interval between runs.)
 		for {
 			now = now.Add(time.Second)
 			for _, node := range nodes {

--- a/src/dbnode/integration/write_quorum_test.go
+++ b/src/dbnode/integration/write_quorum_test.go
@@ -232,6 +232,18 @@ func makeTestWrite(
 	nspaces := []namespace.Metadata{md}
 	nodes, topoInit, closeFn := newNodes(t, numShards, instances, nspaces, false)
 	now := nodes[0].getNowFn()
+	go func() {
+		// Tick the time up in the background so that background operations like
+		// snapshotting will run (they have a configurable minimum interval between
+		// runs.)
+		for {
+			now = now.Add(time.Second)
+			for _, node := range nodes {
+				node.setNowFn(now)
+			}
+			time.Sleep(time.Second)
+		}
+	}()
 
 	for _, node := range nodes {
 		node.opts = node.opts.SetNumShards(numShards)

--- a/src/dbnode/integration/write_quorum_test.go
+++ b/src/dbnode/integration/write_quorum_test.go
@@ -232,17 +232,6 @@ func makeTestWrite(
 	nspaces := []namespace.Metadata{md}
 	nodes, topoInit, closeFn := newNodes(t, numShards, instances, nspaces, false)
 	now := nodes[0].getNowFn()
-	go func() {
-		// Tick the time up in the background so that operations like snapshotting
-		// will run (they have a configurable minimum interval between runs.)
-		for {
-			now = now.Add(time.Second)
-			for _, node := range nodes {
-				node.setNowFn(now)
-			}
-			time.Sleep(time.Second)
-		}
-	}()
 
 	for _, node := range nodes {
 		node.opts = node.opts.SetNumShards(numShards)

--- a/src/dbnode/integration/write_tagged_quorum_test.go
+++ b/src/dbnode/integration/write_tagged_quorum_test.go
@@ -144,7 +144,7 @@ func TestWriteTaggedAddNodeQuorumOnlyLeavingInitializingUp(t *testing.T) {
 
 	// No writes succeed to available nodes
 	require.NoError(t, nodes[0].startServer())
-	require.NoError(t, nodes[3].startServer())
+	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
 
 	assert.Error(t, testWrite(topology.ConsistencyLevelOne))
 	numWrites := numNodesWithTaggedWrite(t, []*testSetup{nodes[1], nodes[2]})
@@ -180,7 +180,7 @@ func TestWriteTaggedAddNodeQuorumOnlyOneNormalAndLeavingInitializingUp(t *testin
 	// Writes succeed to one available node
 	require.NoError(t, nodes[0].startServer())
 	require.NoError(t, nodes[1].startServer())
-	require.NoError(t, nodes[3].startServer())
+	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
 
 	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
 	numWrites := numNodesWithTaggedWrite(t, []*testSetup{nodes[1], nodes[2]})
@@ -217,7 +217,7 @@ func TestWriteTaggedAddNodeQuorumAllUp(t *testing.T) {
 	require.NoError(t, nodes[0].startServer())
 	require.NoError(t, nodes[1].startServer())
 	require.NoError(t, nodes[2].startServer())
-	require.NoError(t, nodes[3].startServer())
+	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
 
 	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
 	numWrites := numNodesWithTaggedWrite(t, []*testSetup{nodes[1], nodes[2]})

--- a/src/dbnode/integration/write_tagged_quorum_test.go
+++ b/src/dbnode/integration/write_tagged_quorum_test.go
@@ -60,6 +60,8 @@ func TestWriteTaggedNormalQuorumOnlyOneUp(t *testing.T) {
 
 	// Writes succeed to one node
 	require.NoError(t, nodes[0].startServer())
+	defer func() { require.NoError(t, nodes[0].stopServer()) }()
+
 	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
 	assert.Equal(t, 1, numNodesWithTaggedWrite(t, nodes))
 	assert.Error(t, testWrite(topology.ConsistencyLevelMajority))
@@ -85,9 +87,12 @@ func TestWriteTaggedNormalQuorumOnlyTwoUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	// Writes succeed to two nodes
 	require.NoError(t, nodes[0].startServer())
+	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 	require.NoError(t, nodes[1].startServer())
+	defer func() { require.NoError(t, nodes[1].stopServer()) }()
+
+	// Writes succeed to two nodes
 	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
 	assert.True(t, numNodesWithTaggedWrite(t, nodes) >= 1)
 	assert.NoError(t, testWrite(topology.ConsistencyLevelMajority))
@@ -112,10 +117,14 @@ func TestWriteTaggedNormalQuorumAllUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	// Writes succeed to all nodes
 	require.NoError(t, nodes[0].startServer())
+	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 	require.NoError(t, nodes[1].startServer())
+	defer func() { require.NoError(t, nodes[1].stopServer()) }()
 	require.NoError(t, nodes[2].startServer())
+	defer func() { require.NoError(t, nodes[2].stopServer()) }()
+
+	// Writes succeed to all nodes
 	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
 	assert.True(t, numNodesWithTaggedWrite(t, nodes) >= 1)
 	assert.NoError(t, testWrite(topology.ConsistencyLevelMajority))
@@ -142,10 +151,12 @@ func TestWriteTaggedAddNodeQuorumOnlyLeavingInitializingUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	// No writes succeed to available nodes
 	require.NoError(t, nodes[0].startServer())
+	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
+	defer func() { require.NoError(t, nodes[3].stopServer()) }()
 
+	// No writes succeed to available nodes
 	assert.Error(t, testWrite(topology.ConsistencyLevelOne))
 	numWrites := numNodesWithTaggedWrite(t, []*testSetup{nodes[1], nodes[2]})
 	assert.True(t, numWrites == 0)
@@ -177,11 +188,14 @@ func TestWriteTaggedAddNodeQuorumOnlyOneNormalAndLeavingInitializingUp(t *testin
 	})
 	defer closeFn()
 
-	// Writes succeed to one available node
 	require.NoError(t, nodes[0].startServer())
+	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 	require.NoError(t, nodes[1].startServer())
+	defer func() { require.NoError(t, nodes[1].stopServer()) }()
 	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
+	defer func() { require.NoError(t, nodes[3].stopServer()) }()
 
+	// Writes succeed to one available node
 	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
 	numWrites := numNodesWithTaggedWrite(t, []*testSetup{nodes[1], nodes[2]})
 	assert.True(t, numWrites == 1)
@@ -213,12 +227,16 @@ func TestWriteTaggedAddNodeQuorumAllUp(t *testing.T) {
 	})
 	defer closeFn()
 
-	// Writes succeed to two available nodes
 	require.NoError(t, nodes[0].startServer())
+	defer func() { require.NoError(t, nodes[0].stopServer()) }()
 	require.NoError(t, nodes[1].startServer())
+	defer func() { require.NoError(t, nodes[1].stopServer()) }()
 	require.NoError(t, nodes[2].startServer())
+	defer func() { require.NoError(t, nodes[2].stopServer()) }()
 	require.NoError(t, nodes[3].startServerDontWaitBootstrap())
+	defer func() { require.NoError(t, nodes[3].stopServer()) }()
 
+	// Writes succeed to two available nodes
 	assert.NoError(t, testWrite(topology.ConsistencyLevelOne))
 	numWrites := numNodesWithTaggedWrite(t, []*testSetup{nodes[1], nodes[2]})
 	assert.True(t, numWrites >= 1, numWrites)

--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -73,7 +73,7 @@ func TestServiceHealth(t *testing.T) {
 	service := NewService(mockDB, nil).(*service)
 
 	// Assert bootstrapped false
-	mockDB.EXPECT().IsBootstrapped().Return(false)
+	mockDB.EXPECT().IsBootstrappedAndDurable().Return(false)
 
 	tctx, _ := thrift.NewContext(time.Minute)
 	result, err := service.Health(tctx)
@@ -84,7 +84,7 @@ func TestServiceHealth(t *testing.T) {
 	assert.Equal(t, false, result.Bootstrapped)
 
 	// Assert bootstrapped true
-	mockDB.EXPECT().IsBootstrapped().Return(true)
+	mockDB.EXPECT().IsBootstrappedAndDurable().Return(true)
 
 	tctx, _ = thrift.NewContext(time.Minute)
 	result, err = service.Health(tctx)
@@ -105,13 +105,13 @@ func TestServiceBootstrapped(t *testing.T) {
 	service := NewService(mockDB, nil).(*service)
 
 	// Should return an error when not bootstrapped
-	mockDB.EXPECT().IsBootstrapped().Return(false)
+	mockDB.EXPECT().IsBootstrappedAndDurable().Return(false)
 	tctx, _ := thrift.NewContext(time.Minute)
 	_, err := service.Bootstrapped(tctx)
 	require.Error(t, err)
 
 	// Should not return an error when bootstrapped
-	mockDB.EXPECT().IsBootstrapped().Return(true)
+	mockDB.EXPECT().IsBootstrappedAndDurable().Return(true)
 
 	tctx, _ = thrift.NewContext(time.Minute)
 	_, err = service.Health(tctx)

--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -156,6 +156,15 @@ func (d *clusterDB) IsBootstrappedAndDurable() bool {
 		return false
 	}
 
+	_, ok := d.topo.(topology.DynamicTopology)
+	if !ok {
+		// If the topology is not dynamic, then the only thing we care
+		// about is whether the node is bootstrapped or not because the
+		// concept of durability as it relates to shard state doesn't
+		// make sense if we're using a static topology.
+		return true
+	}
+
 	entry, ok := d.watch.Get().LookupHostShardSet(d.hostID)
 	if !ok {
 		// If we're bootstrapped, but not in the placement, then we

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -815,7 +815,7 @@ func (d *db) IsBootstrappedAndDurable() bool {
 	lastBootstrapCompletionTime, ok := d.mediator.LastBootstrapCompletionTime()
 	if !ok {
 		d.log.WithFields(
-			xlog.NewField("lastBootstrapCompletionTime", lastBootstrapCompletionTime),
+			xlog.NewField("lastBootstrapCompletionTime", lastBootstrapCompletionTime.String()),
 		).Debugf(
 			"not bootstrapped and durable because: no last bootstrap completion time")
 		return false
@@ -824,8 +824,8 @@ func (d *db) IsBootstrappedAndDurable() bool {
 	lastSnapshotStartTime, ok := d.mediator.LastSuccessfulSnapshotStartTime()
 	if !ok {
 		d.log.WithFields(
-			xlog.NewField("lastBootstrapCompletionTime", lastBootstrapCompletionTime),
-			xlog.NewField("lastSnapshotStartTime", lastSnapshotStartTime),
+			xlog.NewField("lastBootstrapCompletionTime", lastBootstrapCompletionTime.String()),
+			xlog.NewField("lastSnapshotStartTime", lastSnapshotStartTime.String()),
 		).Debugf(
 			"not bootstrapped and durable because: no last snapshot start time")
 		return false
@@ -841,9 +841,9 @@ func (d *db) IsBootstrappedAndDurable() bool {
 
 	if !isBootstrappedAndDurable {
 		d.log.WithFields(
-			xlog.NewField("lastBootstrapCompletionTime", lastBootstrapCompletionTime),
-			xlog.NewField("lastSnapshotStartTime", lastSnapshotStartTime),
-			xlog.NewField("lastReceivedNewShards", d.lastReceivedNewShards),
+			xlog.NewField("lastBootstrapCompletionTime", lastBootstrapCompletionTime.String()),
+			xlog.NewField("lastSnapshotStartTime", lastSnapshotStartTime.String()),
+			xlog.NewField("lastReceivedNewShards", d.lastReceivedNewShards.String()),
 		).Debugf(
 			"not bootstrapped and durable because: has not snapshotted post bootstrap and/or has not bootstrapped since receiving new shards")
 		return false

--- a/src/dbnode/storage/flush.go
+++ b/src/dbnode/storage/flush.go
@@ -139,6 +139,7 @@ func (m *flushManager) Flush(
 	// has completed, then all data that had been received by the dbnode up until the
 	// snapshot "start time" has been persisted durably.
 	shouldSnapshot := tickStart.Sub(m.lastSuccessfulSnapshotStartTime) >= m.opts.MinimumSnapshotInterval()
+
 	if shouldSnapshot {
 		m.setState(flushManagerSnapshotInProgress)
 		maxBlocksSnapshottedByNamespace := 0

--- a/src/dbnode/storage/flush.go
+++ b/src/dbnode/storage/flush.go
@@ -139,7 +139,6 @@ func (m *flushManager) Flush(
 	// has completed, then all data that had been received by the dbnode up until the
 	// snapshot "start time" has been persisted durably.
 	shouldSnapshot := tickStart.Sub(m.lastSuccessfulSnapshotStartTime) >= m.opts.MinimumSnapshotInterval()
-
 	if shouldSnapshot {
 		m.setState(flushManagerSnapshotInProgress)
 		maxBlocksSnapshottedByNamespace := 0


### PR DESCRIPTION
The existing health checks use IsBootstrapped() to determine if a node is healthy and bootstrapped which is fine in the normal case, but in the situation where a topology change has occurred this is problematic.

The reason its problematic in that scenario is that after a topology change, as a result of #1183 the node will not mark its shards as available until a snapshot has occurred. This is an issue for our automated tooling which will assume that once a node is "healthy" it can proceed with adding more nodes because we don't want the tooling to proceed until the previous node has marked all its shards as available otherwise we can end up in weird shards state (I.E R.F = 3 but we have 2 shard states AVAILABLE, 1 LEAVING, and 2 Initializing and 2/5 will not achieve quorum so writes / reads will begin to fail)