### PR TITLE
Fix Typo in m3dbnode.service.

### DIFF
--- a/integrations/systemd/m3dbnode.service
+++ b/integrations/systemd/m3dbnode.service
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 ExecStart=/usr/bin/m3dbnode -f /etc/m3db/m3dbnode.yaml
 Restart=on-failure
-RestartSecs=10s
+RestartSec=10s
 SuccessExitStatus=0
 LimitNOFILE=500000
 


### PR DESCRIPTION
The correct option name is RestartSec and not RestartSecs.