### PR TITLE
Change namespace URLs to be scoped by service

### DIFF
--- a/src/query/api/v1/handler/namespace/add.go
+++ b/src/query/api/v1/handler/namespace/add.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"path"
 
 	clusterclient "github.com/m3db/m3/src/cluster/client"
 	nsproto "github.com/m3db/m3/src/dbnode/generated/proto/namespace"
@@ -37,9 +38,13 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// AddURL is the url for the namespace add handler.
-	AddURL = handler.RoutePrefixV1 + "/namespace"
+var (
+	// DeprecatedM3DBAddURL is the old url for the namespace add handler, maintained
+	// for backwards compatibility.
+	DeprecatedM3DBAddURL = path.Join(handler.RoutePrefixV1, NamespacePathName)
+
+	// M3DBAddURL is the url for the M3DB namespace add handler.
+	M3DBAddURL = path.Join(handler.RoutePrefixV1, M3DBServiceNamespacePathName)
 
 	// AddHTTPMethod is the HTTP method used with this resource.
 	AddHTTPMethod = http.MethodPost

--- a/src/query/api/v1/handler/namespace/common.go
+++ b/src/query/api/v1/handler/namespace/common.go
@@ -22,6 +22,7 @@ package namespace
 
 import (
 	"fmt"
+	"path"
 
 	clusterclient "github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/kv"
@@ -33,8 +34,22 @@ import (
 )
 
 const (
-	// M3DBNodeNamespacesKey is the KV key that holds namespaces
+	// M3DBServiceName is the service name for M3DB.
+	M3DBServiceName = "m3db"
+
+	// ServicesPathName is the services part of the API path.
+	ServicesPathName = "services"
+
+	// M3DBNodeNamespacesKey is the KV key that holds namespaces.
 	M3DBNodeNamespacesKey = "m3db.node.namespaces"
+
+	// NamespacePathName is the namespace part of the API path.
+	NamespacePathName = "namespace"
+)
+
+var (
+	// M3DBServiceNamespacePathName is the M3DB service namespace API path.
+	M3DBServiceNamespacePathName = path.Join(ServicesPathName, M3DBServiceName, NamespacePathName)
 )
 
 // Handler represents a generic handler for namespace endpoints.
@@ -75,7 +90,12 @@ func Metadata(store kv.Store) ([]namespace.Metadata, int, error) {
 func RegisterRoutes(r *mux.Router, client clusterclient.Client) {
 	logged := logging.WithResponseTimeLogging
 
-	r.HandleFunc(GetURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
-	r.HandleFunc(AddURL, logged(NewAddHandler(client)).ServeHTTP).Methods(AddHTTPMethod)
-	r.HandleFunc(DeleteURL, logged(NewDeleteHandler(client)).ServeHTTP).Methods(DeleteHTTPMethod)
+	// Deprecated routes, maintained for backwards compatibility.
+	r.HandleFunc(DeprecatedM3DBGetURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
+	r.HandleFunc(DeprecatedM3DBAddURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
+	r.HandleFunc(DeprecatedM3DBDeleteURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
+
+	r.HandleFunc(M3DBGetURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
+	r.HandleFunc(M3DBAddURL, logged(NewAddHandler(client)).ServeHTTP).Methods(AddHTTPMethod)
+	r.HandleFunc(M3DBDeleteURL, logged(NewDeleteHandler(client)).ServeHTTP).Methods(DeleteHTTPMethod)
 }

--- a/src/query/api/v1/handler/namespace/common.go
+++ b/src/query/api/v1/handler/namespace/common.go
@@ -92,8 +92,8 @@ func RegisterRoutes(r *mux.Router, client clusterclient.Client) {
 
 	// Deprecated routes, maintained for backwards compatibility.
 	r.HandleFunc(DeprecatedM3DBGetURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
-	r.HandleFunc(DeprecatedM3DBAddURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
-	r.HandleFunc(DeprecatedM3DBDeleteURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
+	r.HandleFunc(DeprecatedM3DBAddURL, logged(NewGetHandler(client)).ServeHTTP).Methods(AddHTTPMethod)
+	r.HandleFunc(DeprecatedM3DBDeleteURL, logged(NewGetHandler(client)).ServeHTTP).Methods(DeleteHTTPMethod)
 
 	r.HandleFunc(M3DBGetURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
 	r.HandleFunc(M3DBAddURL, logged(NewAddHandler(client)).ServeHTTP).Methods(AddHTTPMethod)

--- a/src/query/api/v1/handler/namespace/common.go
+++ b/src/query/api/v1/handler/namespace/common.go
@@ -90,12 +90,18 @@ func Metadata(store kv.Store) ([]namespace.Metadata, int, error) {
 func RegisterRoutes(r *mux.Router, client clusterclient.Client) {
 	logged := logging.WithResponseTimeLogging
 
-	// Deprecated routes, maintained for backwards compatibility.
-	r.HandleFunc(DeprecatedM3DBGetURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
-	r.HandleFunc(DeprecatedM3DBAddURL, logged(NewGetHandler(client)).ServeHTTP).Methods(AddHTTPMethod)
-	r.HandleFunc(DeprecatedM3DBDeleteURL, logged(NewGetHandler(client)).ServeHTTP).Methods(DeleteHTTPMethod)
+	// Get M3DB namespaces.
+	getHandler := logged(NewGetHandler(client)).ServeHTTP
+	r.HandleFunc(DeprecatedM3DBGetURL, getHandler).Methods(GetHTTPMethod)
+	r.HandleFunc(M3DBGetURL, getHandler).Methods(GetHTTPMethod)
 
-	r.HandleFunc(M3DBGetURL, logged(NewGetHandler(client)).ServeHTTP).Methods(GetHTTPMethod)
-	r.HandleFunc(M3DBAddURL, logged(NewAddHandler(client)).ServeHTTP).Methods(AddHTTPMethod)
-	r.HandleFunc(M3DBDeleteURL, logged(NewDeleteHandler(client)).ServeHTTP).Methods(DeleteHTTPMethod)
+	// Add M3DB mamespaces
+	addHandler := logged(NewAddHandler(client)).ServeHTTP
+	r.HandleFunc(DeprecatedM3DBAddURL, addHandler).Methods(AddHTTPMethod)
+	r.HandleFunc(M3DBAddURL, addHandler).Methods(AddHTTPMethod)
+
+	// Delete M3DB namespaces.
+	deleteHandler := logged(NewDeleteHandler(client)).ServeHTTP
+	r.HandleFunc(DeprecatedM3DBDeleteURL, deleteHandler).Methods(DeleteHTTPMethod)
+	r.HandleFunc(M3DBDeleteURL, deleteHandler).Methods(DeleteHTTPMethod)
 }

--- a/src/query/api/v1/handler/namespace/delete.go
+++ b/src/query/api/v1/handler/namespace/delete.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 
 	clusterclient "github.com/m3db/m3/src/cluster/client"
@@ -45,8 +46,16 @@ const (
 )
 
 var (
-	// DeleteURL is the url for the namespace delete handler.
-	DeleteURL = fmt.Sprintf("%s/namespace/{%s}", handler.RoutePrefixV1, namespaceIDVar)
+	// DeprecatedM3DBDeleteURL is the deprecated url for the M3DB namespace delete handler.
+	// Maintained for backwards compatibility.
+	DeprecatedM3DBDeleteURL = fmt.Sprintf("%s/namespace/{%s}", handler.RoutePrefixV1, namespaceIDVar)
+
+	// M3DBDeleteURL is the url for the M3DB namespace delete handler.
+	M3DBDeleteURL = path.Join(
+		handler.RoutePrefixV1,
+		M3DBServiceNamespacePathName,
+		fmt.Sprintf("{%s}", namespaceIDVar),
+	)
 )
 
 var (

--- a/src/query/api/v1/handler/namespace/get.go
+++ b/src/query/api/v1/handler/namespace/get.go
@@ -23,6 +23,7 @@ package namespace
 import (
 	"fmt"
 	"net/http"
+	"path"
 
 	clusterclient "github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/kv"
@@ -35,9 +36,13 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	// GetURL is the url for the namespace get handler (with the GET method).
-	GetURL = handler.RoutePrefixV1 + "/namespace"
+var (
+	// DeprecatedM3DBGetURL is the deprecated url for the namespace get handler (with the GET method).
+	// Maintained for backwards compatibility.
+	DeprecatedM3DBGetURL = path.Join(handler.RoutePrefixV1, NamespacePathName)
+
+	// M3DBGetURL is the url for the namespace get handler (with the GET method).
+	M3DBGetURL = path.Join(handler.RoutePrefixV1, M3DBServiceNamespacePathName)
 
 	// GetHTTPMethod is the HTTP method used with this resource.
 	GetHTTPMethod = http.MethodGet


### PR DESCRIPTION
Our documentation (and all of our other APIs) are scoped by service, but namespace APIs weren't scoped by service properly. This P.R scopes them by service, but continues to register the old APIs for backwards compatibility. 

Addresses #1274