### PR TITLE
Increase recommended max_map_count to 3 million

### DIFF
--- a/docs/operational_guide/kernel_configuration.md
+++ b/docs/operational_guide/kernel_configuration.md
@@ -4,11 +4,11 @@ Kernel Configuration
 This document lists the Kernel tweaks M3DB needs to run well.
 
 ## vm.max_map_count
-M3DB uses a lot of mmap-ed files for performance, as a result, you might need to bump `vm.max_map_count`. We suggest setting this value to `262144`, so you don’t have to come back and debug issues later.
+M3DB uses a lot of mmap-ed files for performance, as a result, you might need to bump `vm.max_map_count`. We suggest setting this value to `3000000`, so you don’t have to come back and debug issues later.
 
 On Linux, you can increase the limits by running the following command as root:
 ```
-sysctl -w vm.max_map_count=262144
+sysctl -w vm.max_map_count=3000000
 ```
 
 To set this value permanently, update the `vm.max_map_count` setting in `/etc/sysctl.conf`.

--- a/src/dbnode/server/limits.go
+++ b/src/dbnode/server/limits.go
@@ -30,7 +30,7 @@ import (
 const (
 	// TODO: determine these values based on topology/namespace configuration.
 	minNoFile     = 500000
-	minVMMapCount = 262144
+	minVMMapCount = 3000000
 	maxSwappiness = 1
 )
 


### PR DESCRIPTION
A lot of users run into this issue, there is no cost to using a higher value, and 3 million is what we run in production.