### PR TITLE
Correctly return error for failed json unmarshal

### DIFF
--- a/src/query/api/v1/handler/json/write.go
+++ b/src/query/api/v1/handler/json/write.go
@@ -124,7 +124,9 @@ func (h *WriteJSONHandler) parseRequest(r *http.Request) (*WriteQuery, *xhttp.Pa
 	}
 
 	var writeQuery *WriteQuery
-	json.Unmarshal(js, &writeQuery)
+	if err = json.Unmarshal(js, &writeQuery); err != nil {
+		return nil, xhttp.NewParseError(err, http.StatusBadRequest)
+	}
 
 	return writeQuery, nil
 }

--- a/src/query/api/v1/handler/json/write_test.go
+++ b/src/query/api/v1/handler/json/write_test.go
@@ -33,6 +33,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFailingJSONWriteParsing(t *testing.T) {
+	badJSON := `{
+		   "tags": { "t
+			 "timestamp": "1534952005",
+			 "value": 10.0
+					}`
+
+	req, _ := http.NewRequest("POST", WriteJSONURL, strings.NewReader(badJSON))
+	jsonWrite := &WriteJSONHandler{store: nil}
+	_, err := jsonWrite.parseRequest(req)
+	require.Error(t, err)
+}
+
 func generateJSONWriteRequest() string {
 	return `{
 		   "tags": { "tag_one": "val_one", "tag_two": "val_two" },


### PR DESCRIPTION
Unmarshaling error was not being returned correctly, which could cause null pointer references later on.