### PR TITLE
Enable and fix carbon and graphite docker integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,8 +200,7 @@ docker-integration-test:
 	@./scripts/docker-integration-tests/setup.sh
 	@./scripts/docker-integration-tests/simple/test.sh
 	@./scripts/docker-integration-tests/prometheus/test.sh
-	# TODO(rartoul): Re-enable once the query P.R lands and we can fix this test.
-	# @./scripts/docker-integration-tests/carbon/test.sh
+	@./scripts/docker-integration-tests/carbon/test.sh
 
 .PHONY: site-build
 site-build:

--- a/scripts/development/m3_stack/m3coordinator.yml
+++ b/scripts/development/m3_stack/m3coordinator.yml
@@ -61,10 +61,13 @@ ingest:
     logSampleRate: 0.01
   m3msg:
     server:
-      listenAddress: 0.0.0.0:7507
+      listenAddress: "0.0.0.0:7507"
       retry:
         maxBackoff: 10s
         jitter: true
     handler:
       protobufEnabled: true
 
+carbon:
+  ingester:
+    listenAddress: "0.0.0.0:7204"

--- a/scripts/docker-integration-tests/carbon/m3coordinator.yml
+++ b/scripts/docker-integration-tests/carbon/m3coordinator.yml
@@ -51,4 +51,5 @@ clusters:
       backgroundHealthCheckFailThrottleFactor: 0.5
 
 carbon:
-  enabled: true
+  ingester:
+    listenAddress: "0.0.0.0:7204"

--- a/scripts/docker-integration-tests/common.sh
+++ b/scripts/docker-integration-tests/common.sh
@@ -42,8 +42,9 @@ function setup_single_m3db_node {
 }
 
 function wait_for_db_init {
-  echo "Sleeping for a bit to ensure db up"
-  sleep 15 # TODO Replace sleeps with logic to determine when to proceed
+  echo "Wait for API to be available"
+  ATTEMPTS=10 TIMEOUT=2 retry_with_backoff  \
+    '[ "$(curl -sSf 0.0.0.0:7201/api/v1/namespace | jq ".namespaces | length")" == "0" ]'
 
   echo "Adding namespace"
   curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/namespace -d '{
@@ -70,7 +71,7 @@ function wait_for_db_init {
     }
   }'
 
-  echo "Sleep until namespace is init'd"
+  echo "Wait until namespace is init'd"
   ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
     '[ "$(curl -sSf 0.0.0.0:7201/api/v1/namespace | jq .registry.namespaces.agg.indexOptions.enabled)" == true ]'
 

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -47,8 +47,7 @@ const (
 )
 
 var (
-	defaultCarbonIngesterTimeout = 5 * time.Second
-	defaultCarbonIngesterEnabled = true
+	defaultCarbonIngesterWriteTimeout = 15 * time.Second
 
 	// defaultLimitsConfiguration is applied if `limits` isn't specified.
 	defaultLimitsConfiguration = &LimitsConfiguration{
@@ -102,7 +101,7 @@ type Configuration struct {
 	Ingest *IngestConfiguration `yaml:"ingest"`
 
 	// Carbon is the carbon configuration.
-	Carbon CarbonConfiguration `yaml:"carbon"`
+	Carbon *CarbonConfiguration `yaml:"carbon"`
 
 	// Limits specifies limits on per-query resource usage.
 	Limits LimitsConfiguration `yaml:"limits"`
@@ -145,45 +144,24 @@ type IngestConfiguration struct {
 
 // CarbonConfiguration is the configuration for the carbon server.
 type CarbonConfiguration struct {
-	Ingestion CarbonIngestionConfiguration
+	Ingester *CarbonIngesterConfiguration `yaml:"ingester"`
 }
 
-// CarbonIngestionConfiguration is the configuration struct for carbon ingestion.
-type CarbonIngestionConfiguration struct {
-	Enabled        *bool          `yaml:"enabled"`
-	MaxConcurrency int            `yaml:"maxConcurrency"`
+// CarbonIngesterConfiguration is the configuration struct for carbon ingestion.
+type CarbonIngesterConfiguration struct {
 	ListenAddress  string         `yaml:"listenAddress"`
-	Timeout        *time.Duration `yaml:"timeout"`
+	MaxConcurrency int            `yaml:"maxConcurrency"`
+	WriteTimeout   *time.Duration `yaml:"writeTimeout"`
 }
 
-// EnabledOrDefault returns the configured value for Enabled, if set, or the default
-// value otherwise.
-func (c *CarbonIngestionConfiguration) EnabledOrDefault() bool {
-	if c.Enabled != nil {
-		return *c.Enabled
+// WriteTimeoutOrDefault returns the configured value for the write timeout,
+// if set, or the default value otherwise.
+func (c *CarbonIngesterConfiguration) WriteTimeoutOrDefault() time.Duration {
+	if c.WriteTimeout != nil {
+		return *c.WriteTimeout
 	}
 
-	return defaultCarbonIngesterEnabled
-}
-
-// TimeoutOrDefault returns the configured value for Timeout, if set, or the default
-// value otherwise.
-func (c *CarbonIngestionConfiguration) TimeoutOrDefault() time.Duration {
-	if c.Timeout != nil {
-		return *c.Timeout
-	}
-
-	return defaultCarbonIngesterTimeout
-}
-
-// ListenAddressOrDefault returns the configured value for ListenAddress, if set, or the default
-// value otherwise.
-func (c *CarbonIngestionConfiguration) ListenAddressOrDefault() string {
-	if c.ListenAddress != "" {
-		return c.ListenAddress
-	}
-
-	return defaultCarbonIngesterListenAddress
+	return defaultCarbonIngesterWriteTimeout
 }
 
 // LocalConfiguration is the local embedded configuration if running

--- a/src/query/server/server_test.go
+++ b/src/query/server/server_test.go
@@ -235,7 +235,7 @@ listenAddress:
   value: "127.0.0.1:17201"
 
 carbon:
-  ingestion:
+  ingester:
     listenAddress: "127.0.0.1:17204"
 
 metrics:


### PR DESCRIPTION
This also updates the carbon ingester configuration to match the default M3 ingester config where if the config is not nil, then it is used, otherwise it's not. This removes the enabled field which was rather different to how the M3 ingester config's presence or absence defines whether to use it or not.