### PR TITLE
Copy cors from etcd, since they eliminated the package

### DIFF
--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -1,0 +1,19 @@
+M3DB includes derived work from etcd (https://github.com/etcd-io/etcd) under the Apache License 2.0:
+
+    Copyright 2015 The etcd Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+The derived work can be found in the files:
+- src/x/net/http/cors/cors.go
+- src/x/net/http/cors/cors_test.go

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -98,9 +98,9 @@ func NewHandler(
 	r := mux.NewRouter()
 
 	// apply middleware. Just CORS for now, but we could add more here as needed.
-	withMiddleware := &cors.CORSHandler{
+	withMiddleware := &cors.Handler{
 		Handler: r,
-		Info: &cors.CORSInfo{
+		Info: &cors.Info{
 			"*": true,
 		},
 	}

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -47,8 +47,8 @@ import (
 	"github.com/m3db/m3/src/query/storage/m3"
 	"github.com/m3db/m3/src/query/util/logging"
 	xhttp "github.com/m3db/m3/src/x/net/http"
+	"github.com/m3db/m3/src/x/net/http/cors"
 
-	"github.com/coreos/etcd/pkg/cors"
 	"github.com/gorilla/mux"
 	"github.com/uber-go/tally"
 )

--- a/src/x/net/http/cors/cors.go
+++ b/src/x/net/http/cors/cors.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// COPIED FROM https://github.com/etcd-io/etcd/tree/v3.2.10/pkg/cors under
+// http://www.apache.org/licenses/LICENSE-2.0#redistribution .
+// Original copyright follows:
+
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cors handles cross-origin HTTP requests (CORS).
+package cors
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+type CORSInfo map[string]bool
+
+// Set implements the flag.Value interface to allow users to define a list of CORS origins
+func (ci *CORSInfo) Set(s string) error {
+	m := make(map[string]bool)
+	for _, v := range strings.Split(s, ",") {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if v != "*" {
+			if _, err := url.Parse(v); err != nil {
+				return fmt.Errorf("Invalid CORS origin: %s", err)
+			}
+		}
+		m[v] = true
+
+	}
+	*ci = CORSInfo(m)
+	return nil
+}
+
+func (ci *CORSInfo) String() string {
+	o := make([]string, 0)
+	for k := range *ci {
+		o = append(o, k)
+	}
+	sort.StringSlice(o).Sort()
+	return strings.Join(o, ",")
+}
+
+// OriginAllowed determines whether the server will allow a given CORS origin.
+func (c CORSInfo) OriginAllowed(origin string) bool {
+	return c["*"] || c[origin]
+}
+
+type CORSHandler struct {
+	Handler http.Handler
+	Info    *CORSInfo
+}
+
+// addHeader adds the correct cors headers given an origin
+func (h *CORSHandler) addHeader(w http.ResponseWriter, origin string) {
+	w.Header().Add("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	w.Header().Add("Access-Control-Allow-Origin", origin)
+	w.Header().Add("Access-Control-Allow-Headers", "accept, content-type, authorization")
+}
+
+// ServeHTTP adds the correct CORS headers based on the origin and returns immediately
+// with a 200 OK if the method is OPTIONS.
+func (h *CORSHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Write CORS header.
+	if h.Info.OriginAllowed("*") {
+		h.addHeader(w, "*")
+	} else if origin := req.Header.Get("Origin"); h.Info.OriginAllowed(origin) {
+		h.addHeader(w, origin)
+	}
+
+	if req.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	h.Handler.ServeHTTP(w, req)
+}

--- a/src/x/net/http/cors/cors_test.go
+++ b/src/x/net/http/cors/cors_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// COPIED FROM https://github.com/etcd-io/etcd/tree/v3.2.10/pkg/cors under
+// http://www.apache.org/licenses/LICENSE-2.0#redistribution .
+// Original copyright follows:
+
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestCORSInfo(t *testing.T) {
+	tests := []struct {
+		s     string
+		winfo CORSInfo
+		ws    string
+	}{
+		{"", CORSInfo{}, ""},
+		{"http://127.0.0.1", CORSInfo{"http://127.0.0.1": true}, "http://127.0.0.1"},
+		{"*", CORSInfo{"*": true}, "*"},
+		// with space around
+		{" http://127.0.0.1 ", CORSInfo{"http://127.0.0.1": true}, "http://127.0.0.1"},
+		// multiple addrs
+		{
+			"http://127.0.0.1,http://127.0.0.2",
+			CORSInfo{"http://127.0.0.1": true, "http://127.0.0.2": true},
+			"http://127.0.0.1,http://127.0.0.2",
+		},
+	}
+	for i, tt := range tests {
+		info := CORSInfo{}
+		if err := info.Set(tt.s); err != nil {
+			t.Errorf("#%d: set error = %v, want nil", i, err)
+		}
+		if !reflect.DeepEqual(info, tt.winfo) {
+			t.Errorf("#%d: info = %v, want %v", i, info, tt.winfo)
+		}
+		if g := info.String(); g != tt.ws {
+			t.Errorf("#%d: info string = %s, want %s", i, g, tt.ws)
+		}
+	}
+}
+
+func TestCORSInfoOriginAllowed(t *testing.T) {
+	tests := []struct {
+		set      string
+		origin   string
+		wallowed bool
+	}{
+		{"http://127.0.0.1,http://127.0.0.2", "http://127.0.0.1", true},
+		{"http://127.0.0.1,http://127.0.0.2", "http://127.0.0.2", true},
+		{"http://127.0.0.1,http://127.0.0.2", "*", false},
+		{"http://127.0.0.1,http://127.0.0.2", "http://127.0.0.3", false},
+		{"*", "*", true},
+		{"*", "http://127.0.0.1", true},
+	}
+	for i, tt := range tests {
+		info := CORSInfo{}
+		if err := info.Set(tt.set); err != nil {
+			t.Errorf("#%d: set error = %v, want nil", i, err)
+		}
+		if g := info.OriginAllowed(tt.origin); g != tt.wallowed {
+			t.Errorf("#%d: allowed = %v, want %v", i, g, tt.wallowed)
+		}
+	}
+}
+
+func TestCORSHandler(t *testing.T) {
+	info := &CORSInfo{}
+	if err := info.Set("http://127.0.0.1,http://127.0.0.2"); err != nil {
+		t.Fatalf("unexpected set error: %v", err)
+	}
+	h := &CORSHandler{
+		Handler: http.NotFoundHandler(),
+		Info:    info,
+	}
+
+	header := func(origin string) http.Header {
+		return http.Header{
+			"Access-Control-Allow-Methods": []string{"POST, GET, OPTIONS, PUT, DELETE"},
+			"Access-Control-Allow-Origin":  []string{origin},
+			"Access-Control-Allow-Headers": []string{"accept, content-type, authorization"},
+		}
+	}
+	tests := []struct {
+		method  string
+		origin  string
+		wcode   int
+		wheader http.Header
+	}{
+		{"GET", "http://127.0.0.1", http.StatusNotFound, header("http://127.0.0.1")},
+		{"GET", "http://127.0.0.2", http.StatusNotFound, header("http://127.0.0.2")},
+		{"GET", "http://127.0.0.3", http.StatusNotFound, http.Header{}},
+		{"OPTIONS", "http://127.0.0.1", http.StatusOK, header("http://127.0.0.1")},
+	}
+	for i, tt := range tests {
+		rr := httptest.NewRecorder()
+		req := &http.Request{
+			Method: tt.method,
+			Header: http.Header{"Origin": []string{tt.origin}},
+		}
+		h.ServeHTTP(rr, req)
+		if rr.Code != tt.wcode {
+			t.Errorf("#%d: code = %v, want %v", i, rr.Code, tt.wcode)
+		}
+		// it is set by http package, and there is no need to test it
+		rr.HeaderMap.Del("Content-Type")
+		rr.HeaderMap.Del("X-Content-Type-Options")
+		if !reflect.DeepEqual(rr.HeaderMap, tt.wheader) {
+			t.Errorf("#%d: header = %+v, want %+v", i, rr.HeaderMap, tt.wheader)
+		}
+	}
+}

--- a/src/x/net/http/cors/cors_test.go
+++ b/src/x/net/http/cors/cors_test.go
@@ -17,24 +17,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
-// COPIED FROM https://github.com/etcd-io/etcd/tree/v3.2.10/pkg/cors under
+//
+// Derived from https://github.com/etcd-io/etcd/tree/v3.2.10/pkg/cors under
 // http://www.apache.org/licenses/LICENSE-2.0#redistribution .
-// Original copyright follows:
-
-// Copyright 2015 The etcd Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// See https://github.com/m3db/m3/blob/master/NOTICES.txt for the original copyright.
 
 package cors
 
@@ -48,23 +34,23 @@ import (
 func TestCORSInfo(t *testing.T) {
 	tests := []struct {
 		s     string
-		winfo CORSInfo
+		winfo Info
 		ws    string
 	}{
-		{"", CORSInfo{}, ""},
-		{"http://127.0.0.1", CORSInfo{"http://127.0.0.1": true}, "http://127.0.0.1"},
-		{"*", CORSInfo{"*": true}, "*"},
+		{"", Info{}, ""},
+		{"http://127.0.0.1", Info{"http://127.0.0.1": true}, "http://127.0.0.1"},
+		{"*", Info{"*": true}, "*"},
 		// with space around
-		{" http://127.0.0.1 ", CORSInfo{"http://127.0.0.1": true}, "http://127.0.0.1"},
+		{" http://127.0.0.1 ", Info{"http://127.0.0.1": true}, "http://127.0.0.1"},
 		// multiple addrs
 		{
 			"http://127.0.0.1,http://127.0.0.2",
-			CORSInfo{"http://127.0.0.1": true, "http://127.0.0.2": true},
+			Info{"http://127.0.0.1": true, "http://127.0.0.2": true},
 			"http://127.0.0.1,http://127.0.0.2",
 		},
 	}
 	for i, tt := range tests {
-		info := CORSInfo{}
+		info := Info{}
 		if err := info.Set(tt.s); err != nil {
 			t.Errorf("#%d: set error = %v, want nil", i, err)
 		}
@@ -91,7 +77,7 @@ func TestCORSInfoOriginAllowed(t *testing.T) {
 		{"*", "http://127.0.0.1", true},
 	}
 	for i, tt := range tests {
-		info := CORSInfo{}
+		info := Info{}
 		if err := info.Set(tt.set); err != nil {
 			t.Errorf("#%d: set error = %v, want nil", i, err)
 		}
@@ -102,11 +88,11 @@ func TestCORSInfoOriginAllowed(t *testing.T) {
 }
 
 func TestCORSHandler(t *testing.T) {
-	info := &CORSInfo{}
+	info := &Info{}
 	if err := info.Set("http://127.0.0.1,http://127.0.0.2"); err != nil {
 		t.Fatalf("unexpected set error: %v", err)
 	}
-	h := &CORSHandler{
+	h := &Handler{
 		Handler: http.NotFoundHandler(),
 		Info:    info,
 	}


### PR DESCRIPTION
A small hack I did caught up to me--etcd had a reasonable cors middleware implementation, which I added to m3query. They later removed the package (not surprisingly--it was a random thing to expose). This causes `glide up` to fail. To fix this, I copied in the package to `x/net/http`. We could instead add a different dependency (e.g. https://github.com/rs/cors); let me know your preference on that. I mostly went with the copy route because the package is quite small and it didn't seem worth the added dep.