### PR TITLE
[dbnode] allow replacing of seed node + docs

### DIFF
--- a/docs/operational_guide/placement_configuration.md
+++ b/docs/operational_guide/placement_configuration.md
@@ -56,6 +56,9 @@ This value should be in the form of <M3DB_NODE_LISTEN_PORT> and identifies the p
 
 ### Placement Operations
 
+**NOTE**: If you find yourself performing operations on seed nodes, please refer to the seed node-specific sections
+below before making changes.
+
 The instructions below all contain sample curl commands, but you can always review the API documentation by navigating to
 
 `http://<M3_COORDINATOR_HOST_NAME>:<CONFIGURED_PORT(default 7201)>/api/v1/openapi` or our [online API documentation](https://m3db.io/openapi/).

--- a/docs/operational_guide/placement_configuration.md
+++ b/docs/operational_guide/placement_configuration.md
@@ -134,6 +134,16 @@ curl -X DELETE <M3_COORDINATOR_HOST_NAME>:<M3_COORDINATOR_PORT(default 7201)>/ap
 
 After sending the delete command you will need to wait for the M3DB cluster to reach the new desired state. You'll know that this has been achieved when the placement shows that all shards for all hosts are in the `Available` state.
 
+#### Adding / Removing Seed Nodes
+
+If you find yourself adding or removing etcd seed nodes then we highly recommend setting up an external etcd cluster, as
+the overhead of operating two stateful systems at once is non-trivial. As this is not a recommended production setup,
+this section is intentionally brief.
+
+To add or remove nodes to the etcd cluster, use `etcdctl member add` and `etcdctl member remove` as found in `Replacing
+a Seed Node` below. A general rule to keep in mind is that any time the M3DB process starts on a seed node, the list of
+cluster members in `etcdctl member list` must match *exactly* the list in config.
+
 #### Replacing a Node
 
 **NOTE**: If using embedded etcd and replacing a seed node, please read the section below.
@@ -218,8 +228,7 @@ initialCluster:
 4. Start M3DB on `host4`.
 
 5. On all other seed nodes, update their `initialCluster` list to be exactly equal to the list on `host4` from step 3.
+   Rolling restart the hosts one at a time, waiting until they indicate they are bootstrapped (indicated in the
+   `/health`) endpoint before continuing to the next.
 
 6. Follow the steps from `Replacing a Seed Node` to replace `host3` with `host4` in the M3DB placement.
-
-Once the M3DB replace finishes, you may want to rolling restart the other seed nodes to ensure they have an up-to-date
-config loaded.

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -34,264 +34,265 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func TestConfiguration(t *testing.T) {
-	in := `
+const testBaseConfig = `
 db:
-    logging:
-        level: info
-        file: /var/log/m3dbnode.log
+  logging:
+      level: info
+      file: /var/log/m3dbnode.log
 
-    metrics:
-        prometheus:
-            handlerPath: /metrics
-        sanitization: prometheus
-        samplingRate: 1.0
-        extended: detailed
+  metrics:
+      prometheus:
+          handlerPath: /metrics
+      sanitization: prometheus
+      samplingRate: 1.0
+      extended: detailed
 
-    listenAddress: 0.0.0.0:9000
-    clusterListenAddress: 0.0.0.0:9001
-    httpNodeListenAddress: 0.0.0.0:9002
-    httpClusterListenAddress: 0.0.0.0:9003
-    debugListenAddress: 0.0.0.0:9004
+  listenAddress: 0.0.0.0:9000
+  clusterListenAddress: 0.0.0.0:9001
+  httpNodeListenAddress: 0.0.0.0:9002
+  httpClusterListenAddress: 0.0.0.0:9003
+  debugListenAddress: 0.0.0.0:9004
 
-    hostID:
-        resolver: config
-        value: host1
+  hostID:
+      resolver: config
+      value: host1
 
-    client:
-        writeConsistencyLevel: majority
-        readConsistencyLevel: unstrict_majority
-        connectConsistencyLevel: any
-        writeTimeout: 10s
-        fetchTimeout: 15s
-        connectTimeout: 20s
-        writeRetry:
-            initialBackoff: 500ms
-            backoffFactor: 3
-            maxRetries: 2
-            jitter: true
-        fetchRetry:
-            initialBackoff: 500ms
-            backoffFactor: 2
-            maxRetries: 3
-            jitter: true
-        backgroundHealthCheckFailLimit: 4
-        backgroundHealthCheckFailThrottleFactor: 0.5
-        hashing:
-          seed: 42
+  client:
+      writeConsistencyLevel: majority
+      readConsistencyLevel: unstrict_majority
+      connectConsistencyLevel: any
+      writeTimeout: 10s
+      fetchTimeout: 15s
+      connectTimeout: 20s
+      writeRetry:
+          initialBackoff: 500ms
+          backoffFactor: 3
+          maxRetries: 2
+          jitter: true
+      fetchRetry:
+          initialBackoff: 500ms
+          backoffFactor: 2
+          maxRetries: 3
+          jitter: true
+      backgroundHealthCheckFailLimit: 4
+      backgroundHealthCheckFailThrottleFactor: 0.5
+      hashing:
+        seed: 42
 
 
-    gcPercentage: 100
+  gcPercentage: 100
 
-    writeNewSeriesLimitPerSecond: 1048576
-    writeNewSeriesBackoffDuration: 2ms
+  writeNewSeriesLimitPerSecond: 1048576
+  writeNewSeriesBackoffDuration: 2ms
 
-    bootstrap:
-        bootstrappers:
-            - filesystem
-            - peers
-            - noop-all
-        fs:
-            numProcessorsPerCPU: 0.125
+  bootstrap:
+      bootstrappers:
+          - filesystem
+          - peers
+          - noop-all
+      fs:
+          numProcessorsPerCPU: 0.125
 
-    commitlog:
-        flushMaxBytes: 524288
-        flushEvery: 1s
-        queue:
-            calculationType: fixed
-            size: 2097152
-        blockSize: 10m
+  commitlog:
+      flushMaxBytes: 524288
+      flushEvery: 1s
+      queue:
+          calculationType: fixed
+          size: 2097152
+      blockSize: 10m
 
-    fs:
-        filePathPrefix: /var/lib/m3db
-        writeBufferSize: 65536
-        dataReadBufferSize: 65536
-        infoReadBufferSize: 128
-        seekReadBufferSize: 4096
-        throughputLimitMbps: 100.0
-        throughputCheckEvery: 128
-        force_index_summaries_mmap_memory: true
-        force_bloom_filter_mmap_memory: true
+  fs:
+      filePathPrefix: /var/lib/m3db
+      writeBufferSize: 65536
+      dataReadBufferSize: 65536
+      infoReadBufferSize: 128
+      seekReadBufferSize: 4096
+      throughputLimitMbps: 100.0
+      throughputCheckEvery: 128
+      force_index_summaries_mmap_memory: true
+      force_bloom_filter_mmap_memory: true
 
-    repair:
-        enabled: false
-        interval: 2h
-        offset: 30m
-        jitter: 1h
-        throttle: 2m
-        checkInterval: 1m
+  repair:
+      enabled: false
+      interval: 2h
+      offset: 30m
+      jitter: 1h
+      throttle: 2m
+      checkInterval: 1m
 
-    pooling:
-        blockAllocSize: 16
-        type: simple
-        seriesPool:
-            size: 5242880
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        blockPool:
-            size: 4194304
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        encoderPool:
-            size: 25165824
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        closersPool:
-            size: 104857
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        contextPool:
-            size: 524288
-            lowWatermark: 0.01
-            highWatermark: 0.02
-            maxFinalizerCapacity: 8
-        segmentReaderPool:
-            size: 16384
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        iteratorPool:
-            size: 2048
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        fetchBlockMetadataResultsPool:
-            size: 65536
-            capacity: 32
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        fetchBlocksMetadataResultsPool:
-            size: 32
-            capacity: 4096
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        hostBlockMetadataSlicePool:
-            size: 131072
-            capacity: 3
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        blockMetadataPool:
-            size: 65536
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        blockMetadataSlicePool:
-            size: 65536
-            capacity: 32
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        blocksMetadataPool:
-            size: 65536
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        blocksMetadataSlicePool:
-            size: 32
-            capacity: 4096
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        tagsPool:
-            size: 65536
-            capacity: 8
-            maxCapacity: 32
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        tagIteratorPool:
+  pooling:
+      blockAllocSize: 16
+      type: simple
+      seriesPool:
+          size: 5242880
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      blockPool:
+          size: 4194304
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      encoderPool:
+          size: 25165824
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      closersPool:
+          size: 104857
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      contextPool:
+          size: 524288
+          lowWatermark: 0.01
+          highWatermark: 0.02
+          maxFinalizerCapacity: 8
+      segmentReaderPool:
+          size: 16384
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      iteratorPool:
+          size: 2048
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      fetchBlockMetadataResultsPool:
+          size: 65536
+          capacity: 32
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      fetchBlocksMetadataResultsPool:
+          size: 32
+          capacity: 4096
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      hostBlockMetadataSlicePool:
+          size: 131072
+          capacity: 3
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      blockMetadataPool:
+          size: 65536
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      blockMetadataSlicePool:
+          size: 65536
+          capacity: 32
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      blocksMetadataPool:
+          size: 65536
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      blocksMetadataSlicePool:
+          size: 32
+          capacity: 4096
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      tagsPool:
+          size: 65536
+          capacity: 8
+          maxCapacity: 32
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      tagIteratorPool:
+          size: 8192
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      indexResultsPool:
+          size: 8192
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      tagEncoderPool:
+          size: 8192
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      tagDecoderPool:
+          size: 8192
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      writeBatchPool:
+          initialBatchSize: 128
+          maxBatchSize: 100000
+          pool:
             size: 8192
             lowWatermark: 0.01
             highWatermark: 0.02
-        indexResultsPool:
-            size: 8192
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        tagEncoderPool:
-            size: 8192
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        tagDecoderPool:
-            size: 8192
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        writeBatchPool:
-            initialBatchSize: 128
-            maxBatchSize: 100000
-            pool:
-              size: 8192
-              lowWatermark: 0.01
-              highWatermark: 0.02
-        postingsListPool:
-            size: 8
-            lowWatermark: 0
-            highWatermark: 0
-        identifierPool:
-            size: 9437184
-            lowWatermark: 0.01
-            highWatermark: 0.02
-        bytesPool:
-            buckets:
-                - capacity: 16
-                  size: 6291456
-                  lowWatermark: 0.10
-                  highWatermark: 0.12
-                - capacity: 32
-                  size: 3145728
-                  lowWatermark: 0.10
-                  highWatermark: 0.12
-                - capacity: 64
-                  size: 3145728
-                  lowWatermark: 0.10
-                  highWatermark: 0.12
-                - capacity: 128
-                  size: 3145728
-                  lowWatermark: 0.10
-                  highWatermark: 0.12
-                - capacity: 256
-                  size: 3145728
-                  lowWatermark: 0.10
-                  highWatermark: 0.12
-                - capacity: 1440
-                  size: 524288
-                  lowWatermark: 0.10
-                  highWatermark: 0.12
-                - capacity: 4096
-                  size: 524288
-                  lowWatermark: 0.01
-                  highWatermark: 0.02
-                - capacity: 8192
-                  size: 32768
-                  lowWatermark: 0.01
-                  highWatermark: 0.02
+      postingsListPool:
+          size: 8
+          lowWatermark: 0
+          highWatermark: 0
+      identifierPool:
+          size: 9437184
+          lowWatermark: 0.01
+          highWatermark: 0.02
+      bytesPool:
+          buckets:
+              - capacity: 16
+                size: 6291456
+                lowWatermark: 0.10
+                highWatermark: 0.12
+              - capacity: 32
+                size: 3145728
+                lowWatermark: 0.10
+                highWatermark: 0.12
+              - capacity: 64
+                size: 3145728
+                lowWatermark: 0.10
+                highWatermark: 0.12
+              - capacity: 128
+                size: 3145728
+                lowWatermark: 0.10
+                highWatermark: 0.12
+              - capacity: 256
+                size: 3145728
+                lowWatermark: 0.10
+                highWatermark: 0.12
+              - capacity: 1440
+                size: 524288
+                lowWatermark: 0.10
+                highWatermark: 0.12
+              - capacity: 4096
+                size: 524288
+                lowWatermark: 0.01
+                highWatermark: 0.02
+              - capacity: 8192
+                size: 32768
+                lowWatermark: 0.01
+                highWatermark: 0.02
 
-    config:
-        service:
-            env: production
-            zone: embedded
-            service: m3db
-            cacheDir: /var/lib/m3kv
-            etcdClusters:
-                - zone: embedded
-                  endpoints:
-                      - 1.1.1.1:2379
-                      - 1.1.1.2:2379
-                      - 1.1.1.3:2379
-        seedNodes:
-            listenPeerUrls:
-                - http://0.0.0.0:2380
-            listenClientUrls:
-                - http://0.0.0.0:2379
-            rootDir: /var/lib/etcd
-            initialAdvertisePeerUrls:
-                - http://1.1.1.1:2380
-            advertiseClientUrls:
-                - http://1.1.1.1:2379
-            initialCluster:
-                - hostID: host1
-                  endpoint: http://1.1.1.1:2380
-                - hostID: host2
-                  endpoint: http://1.1.1.2:2380
-                - hostID: host3
-                  endpoint: http://1.1.1.3:2380
-    hashing:
-      seed: 42
-    writeNewSeriesAsync: true
+  config:
+      service:
+          env: production
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+              - zone: embedded
+                endpoints:
+                    - 1.1.1.1:2379
+                    - 1.1.1.2:2379
+                    - 1.1.1.3:2379
+      seedNodes:
+          listenPeerUrls:
+              - http://0.0.0.0:2380
+          listenClientUrls:
+              - http://0.0.0.0:2379
+          rootDir: /var/lib/etcd
+          initialAdvertisePeerUrls:
+              - http://1.1.1.1:2380
+          advertiseClientUrls:
+              - http://1.1.1.1:2379
+          initialCluster:
+              - hostID: host1
+                endpoint: http://1.1.1.1:2380
+                clusterState: existing
+              - hostID: host2
+                endpoint: http://1.1.1.2:2380
+              - hostID: host3
+                endpoint: http://1.1.1.3:2380
+  hashing:
+    seed: 42
+  writeNewSeriesAsync: true
 `
 
+func TestConfiguration(t *testing.T) {
 	fd, err := ioutil.TempFile("", "config.yaml")
 	require.NoError(t, err)
 	defer func() {
@@ -299,7 +300,7 @@ db:
 		assert.NoError(t, os.Remove(fd.Name()))
 	}()
 
-	_, err = fd.Write([]byte(in))
+	_, err = fd.Write([]byte(testBaseConfig))
 	require.NoError(t, err)
 
 	// Verify is valid
@@ -581,10 +582,13 @@ db:
       initialCluster:
       - hostID: host1
         endpoint: http://1.1.1.1:2380
+        clusterState: existing
       - hostID: host2
         endpoint: http://1.1.1.2:2380
+        clusterState: ""
       - hostID: host3
         endpoint: http://1.1.1.3:2380
+        clusterState: ""
       clientTransportSecurity:
         caFile: ""
         certFile: ""
@@ -701,4 +705,76 @@ func TestIsSeedNode(t *testing.T) {
 	}
 	res = IsSeedNode(seedNodes, "host4")
 	assert.Equal(t, false, res)
+}
+
+func TestGetHostAndEndpointFromID(t *testing.T) {
+	test2Seeds := []environment.SeedNode{
+		environment.SeedNode{
+			HostID:       "host1",
+			Endpoint:     "http://1.1.1.1:2380",
+			ClusterState: "existing",
+		},
+		environment.SeedNode{
+			HostID:   "host2",
+			Endpoint: "http://1.1.1.2:2380",
+		},
+	}
+
+	tests := []struct {
+		initialCluster []environment.SeedNode
+		hostID         string
+		expSeedNode    environment.SeedNode
+		expEndpoint    string
+		expErr         bool
+	}{
+		{
+			initialCluster: test2Seeds,
+			hostID:         "host1",
+			expSeedNode:    test2Seeds[0],
+			expEndpoint:    "http://1.1.1.1",
+		},
+		{
+			initialCluster: test2Seeds,
+			hostID:         "host3",
+			expErr:         true,
+		},
+		{
+			initialCluster: test2Seeds[:0],
+			hostID:         "host1",
+			expErr:         true,
+		},
+	}
+
+	for _, test := range tests {
+		node, ep, err := getHostAndEndpointFromID(test.initialCluster, test.hostID)
+		if test.expErr {
+			assert.Error(t, err)
+			continue
+		}
+
+		assert.Equal(t, test.expSeedNode, node)
+		assert.Equal(t, test.expEndpoint, ep)
+	}
+}
+
+func TestNewEtcdEmbedConfig(t *testing.T) {
+	fd, err := ioutil.TempFile("", "config2.yaml")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, fd.Close())
+		assert.NoError(t, os.Remove(fd.Name()))
+	}()
+
+	_, err = fd.Write([]byte(testBaseConfig))
+	require.NoError(t, err)
+
+	// Verify is valid
+	var cfg Configuration
+	err = xconfig.LoadFile(&cfg, fd.Name(), xconfig.Options{})
+	require.NoError(t, err)
+
+	embedCfg, err := NewEtcdEmbedConfig(*cfg.DB)
+	require.NoError(t, err)
+
+	assert.Equal(t, "existing", embedCfg.ClusterState)
 }

--- a/src/dbnode/environment/config.go
+++ b/src/dbnode/environment/config.go
@@ -67,8 +67,9 @@ type SeedNodesConfig struct {
 
 // SeedNode represents a seed node for the cluster
 type SeedNode struct {
-	HostID   string `yaml:"hostID"`
-	Endpoint string `yaml:"endpoint"`
+	HostID       string `yaml:"hostID"`
+	Endpoint     string `yaml:"endpoint"`
+	ClusterState string `yaml:"clusterState"`
 }
 
 // SeedNodeSecurityConfig contains the data used for security in seed nodes


### PR DESCRIPTION
Replacing a seed node requires some extra steps and was previously not
feasible using config alone. This adds a config flag to the seed node
list to allow a new seed node to join the etcd cluster, and adds docs
for replacing a seed node.