### PR TITLE
[ci] docker builds via buildkite

### DIFF
--- a/.buildkite/docker-pipeline.yml
+++ b/.buildkite/docker-pipeline.yml
@@ -1,0 +1,16 @@
+steps:
+  - wait
+  - name: ":docker: build"
+    command: "scripts/docker_build.sh"
+    agents:
+      queue: builder
+    timeout_in_minutes: 40
+    retry:
+      automatic:
+        limit: 1
+      manual: true
+    plugins:
+      - docker-login#v2.0.1:
+          server: quay.io
+          username: m3db+buildkite
+          password-env: QUAY_M3DB_TOKEN

--- a/.buildkite/docker-pipeline.yml
+++ b/.buildkite/docker-pipeline.yml
@@ -2,8 +2,6 @@ steps:
   - wait
   - name: ":docker: build"
     command: "docker/build.sh"
-    env:
-      DRYRUN: "true"
     agents:
       queue: builder
     timeout_in_minutes: 60

--- a/.buildkite/docker-pipeline.yml
+++ b/.buildkite/docker-pipeline.yml
@@ -1,10 +1,12 @@
 steps:
   - wait
   - name: ":docker: build"
-    command: "scripts/docker_build.sh"
+    command: "docker/build.sh"
+    env:
+      DRYRUN: "true"
     agents:
       queue: builder
-    timeout_in_minutes: 40
+    timeout_in_minutes: 60
     retry:
       automatic:
         limit: 1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,15 @@ common: &common
     manual: true
 
 steps:
+  - name: "Check for :docker: build"
+    command: ".buildkite/scripts/check_do_docker.sh"
+    agents:
+      queue: init
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+      manual: true
   - name: "Codegen"
     command: make clean install-vendor test-all-gen
     env:

--- a/.buildkite/scripts/check_do_docker.sh
+++ b/.buildkite/scripts/check_do_docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+# This script checks if we should do a docker build, and if so adds a step in
+# the build pipeline to do so.
+
+CURRENT_SHA=$(git rev-parse HEAD)
+MASTER_SHA=$(git rev-parse origin/master)
+
+# If this commit matches an exact tag, or HEAD is origin/master, kick off the
+# docker step.
+if git describe --tags --exact-match || [[ "$CURRENT_SHA" == "$MASTER_SHA" ]]; then
+  buildkite-agent pipeline upload .buildkite/docker-pipeline.yml
+fi

--- a/.buildkite/scripts/check_do_docker.sh
+++ b/.buildkite/scripts/check_do_docker.sh
@@ -2,6 +2,9 @@
 
 set -exuo pipefail
 
+# TODO remove
+git tag -f mschalle-test
+
 # This script checks if we should do a docker build, and if so adds a step in
 # the build pipeline to do so.
 

--- a/.buildkite/scripts/check_do_docker.sh
+++ b/.buildkite/scripts/check_do_docker.sh
@@ -2,9 +2,6 @@
 
 set -exuo pipefail
 
-# TODO remove
-git tag -f mschalle-test
-
 # This script checks if we should do a docker build, and if so adds a step in
 # the build pipeline to do so.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,30 @@
+# M3 Docker Builds
+
+M3 docker images are built according to the following policy:
+
+1. For all images, `${IMAGE}:master` will point to the latest build on `origin/master` for that image.
+
+2. For all images, `${IMAGE}:latest` will point to the latest tagged release.
+
+3. For all images, and for all releases, there will be an image tagged `${IMAGE}:${RELEASE}`.
+
+## Builds
+
+This directory contains the Dockerfiles, configs, and build scripts for building images according to the above policy. `images.json` contains the base repo that will be used to tag images, as well as the config for each image. For example, with the following config:
+
+```json
+{
+  "image_base": "quay.io/m3db",
+  "images": {
+    "m3dbnode": {
+      "dockerfile": "docker/m3dbnode/Dockerfile",
+      "aliases": [
+        "m3db"
+      ]
+    }
+  }
+}
+```
+
+`quay.io/m3db/m3dbnode` will be dual-published under `quay.io/m3db/m3dbnode:latest` and `quay.io/m3db/m3db:latest` for
+the latest release.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,9 +9,6 @@
 
 set -exuo pipefail
 
-# TODO remove
-git tag -f mschalle-test
-
 function cleanup() {
   docker system prune -f
   find /tmp -name '*m3-docker' -print0 | xargs -0 rm -fv

--- a/docker/images.json
+++ b/docker/images.json
@@ -1,0 +1,20 @@
+{
+  "image_base": "quay.io/m3db",
+  "images": {
+    "m3dbnode": {
+      "dockerfile": "docker/m3dbnode/Dockerfile",
+      "aliases": [
+        "m3db"
+      ]
+    },
+    "m3coordinator": {
+      "dockerfile": "docker/m3coordinator/Dockerfile"
+    },
+    "m3query": {
+      "dockerfile": "docker/m3query/Dockerfile"
+    },
+    "m3nsch": {
+      "dockerfile": "docker/m3nsch/Dockerfile"
+    }
+  }
+}

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# This script creates builds according to our custom build policy, which is:
+# - "master" will always point to the most recent build on master
+# - "latest" will refer to the latest tagged release
+# - Each release "foo" will have a tag "foo"
+#
+# This script is a noop if HEAD is not origin/master OR tagged.
+
+set -exuo pipefail
+
+IMAGES="m3dbnode m3coordinator m3query m3nsch"
+TAG_BASE="quay.io/m3db"
+TAGS_TO_PUSH=""
+
+# If this commit matches an exact tag, push a tagged build and "latest".
+if git describe --tags --exact-match; then
+  TAG=$(git describe --tags --exact-match)
+  TAGS_TO_PUSH="${TAGS_TO_PUSH} ${TAG} latest"
+fi
+
+CURRENT_SHA=$(git rev-parse HEAD)
+MASTER_SHA=$(git rev-parse origin/master)
+
+# If the current commit is exactly origin/master, push a tag for "master".
+if [[ "$CURRENT_SHA" == "$MASTER_SHA" ]]; then
+  TAGS_TO_PUSH="${TAGS_TO_PUSH} master"
+fi
+
+if [[ -z "$TAGS_TO_PUSH" ]]; then
+  exit 0
+fi
+
+for IMAGE in $IMAGES; do
+  # Do one build, then push all the necessary tags.
+  SHA_TMP=$(mktemp --suffix m3-docker)
+  docker build --iidfile "$SHA_TMP" -f "docker/${IMAGE}/Dockerfile" .
+  IMAGE_SHA=$(cat "$SHA_TMP")
+  for TAG in $TAGS_TO_PUSH; do
+    FULL_TAG="${TAG_BASE}/${IMAGE}:${TAG}"
+    docker tag "$IMAGE_SHA" "$FULL_TAG"
+    docker push "$FULL_TAG"
+
+    # We also dual-publish m3dbnode under m3db
+    if [[ "$IMAGE" == "m3dbnode" ]]; then
+      DUAL_TAG="${TAG_BASE}/m3db:${TAG}"
+      docker tag "$IMAGE_SHA" "$DUAL_TAG"
+      docker push "$DUAL_TAG"
+    fi
+  done
+done
+
+# Clean up
+CLEANUP_IMAGES=$(docker images | grep "$TAG_BASE" | awk '{print $3}' | sort | uniq)
+for IMG in $CLEANUP_IMAGES; do
+  docker rmi -f "$IMG"
+done
+
+docker system prune -f
+find /tmp -name '*m3-docker' -print0 | xargs -0 sudo rm -fv


### PR DESCRIPTION
Up until now we've been using Quay automated builds, which doesn't give
us all the granularity we want in tags. That is, every build Quay
creates it tags `latest` and `master` depending on the ref it builds
from.

What we really want is `master` to always point to `origin/master` and
`latest` to point to the latest tagged release, along with having a tag
for that release.

This PR modifies our buildkite pipeline to check if `HEAD` is
`origin/master` OR tagged, and if so dynamically add another step to the
pipeline to actually do the docker build. This minimizes blocking in the
queue for other jobs.