### PR TITLE
Add m3coordinator capability to downsample using remote m3aggregator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ docker-integration-test:
 	@./scripts/docker-integration-tests/simple/test.sh
 	@./scripts/docker-integration-tests/prometheus/test.sh
 	@./scripts/docker-integration-tests/carbon/test.sh
+	@./scripts/docker-integration-tests/aggregator/test.sh
 
 .PHONY: site-build
 site-build:

--- a/scripts/docker-integration-tests/aggregator/docker-compose.yml
+++ b/scripts/docker-integration-tests/aggregator/docker-compose.yml
@@ -18,13 +18,13 @@ services:
       - "7203"
       - "7204"
     ports:
-      - "0.0.0.0:7202:7201"
+      - "0.0.0.0:7202:7202"
       - "0.0.0.0:7204:7204"
     networks:
       - backend
     image: "m3coordinator_integration:${REVISION}"
     volumes:
-      - "./:/etc/m3coordinator/"
+      - "./m3coordinator.yml:/etc/m3coordinator/m3coordinator.yml"
   m3aggregator01:
     expose:
       - "6001"
@@ -36,7 +36,7 @@ services:
       - M3AGGREGATOR_HOST_ID=m3aggregator01
     image: "m3aggregator_integration:${REVISION}"
     volumes:
-      - "./:/etc/m3aggregator/"
+      - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"
   m3aggregator02:
     networks:
       - backend
@@ -44,6 +44,6 @@ services:
       - M3AGGREGATOR_HOST_ID=m3aggregator01
     image: "m3aggregator_integration:${REVISION}"
     volumes:
-      - "./:/etc/m3aggregator/"
+      - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"
 networks:
   backend:

--- a/scripts/docker-integration-tests/aggregator/docker-compose.yml
+++ b/scripts/docker-integration-tests/aggregator/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.5"
+services:
+  dbnode01:
+    expose:
+      - "9000-9004"
+      - "2379-2380"
+      - "7201"
+    ports:
+      - "0.0.0.0:9000-9004:9000-9004"
+      - "0.0.0.0:2379-2380:2379-2380"
+      - "0.0.0.0:7201:7201"
+    networks:
+      - backend
+    image: "m3dbnode_integration:${REVISION}"
+  m3coordinator01:
+    expose:
+      - "7202"
+      - "7203"
+      - "7204"
+    ports:
+      - "0.0.0.0:7202:7201"
+      - "0.0.0.0:7204:7204"
+    networks:
+      - backend
+    image: "m3coordinator_integration:${REVISION}"
+    volumes:
+      - "./:/etc/m3coordinator/"
+  m3aggregator01:
+    expose:
+      - "6001"
+    ports:
+      - "127.0.0.1:6001:6001"
+    networks:
+      - backend
+    environment:
+      - M3AGGREGATOR_HOST_ID=m3aggregator01
+    image: "m3aggregator_integration:${REVISION}"
+    volumes:
+      - "./:/etc/m3aggregator/"
+  m3aggregator02:
+    networks:
+      - backend
+    environment:
+      - M3AGGREGATOR_HOST_ID=m3aggregator01
+    image: "m3aggregator_integration:${REVISION}"
+    volumes:
+      - "./:/etc/m3aggregator/"
+networks:
+  backend:

--- a/scripts/docker-integration-tests/aggregator/m3aggregator.yml
+++ b/scripts/docker-integration-tests/aggregator/m3aggregator.yml
@@ -78,7 +78,7 @@ kvClient:
     etcdClusters:
       - zone: embedded
         endpoints:
-          - m3db_seed:2379
+          - dbnode01:2379
 
 runtimeOptions:
   kvConfig:

--- a/scripts/docker-integration-tests/aggregator/m3coordinator.yml
+++ b/scripts/docker-integration-tests/aggregator/m3coordinator.yml
@@ -1,0 +1,88 @@
+listenAddress:
+  type: "config"
+  value: "0.0.0.0:7201"
+
+metrics:
+  scope:
+    prefix: "coordinator"
+  prometheus:
+    handlerPath: /metrics
+    listenAddress: 0.0.0.0:7203 # until https://github.com/m3db/m3/issues/682 is resolved
+  sanitization: prometheus
+  samplingRate: 1.0
+  extended: none
+
+tagOptions:
+  idScheme: quoted
+
+carbon:
+  ingester:
+    listenAddress: "0.0.0.0:7204"
+
+clusters:
+  - namespaces:
+      - namespace: agg
+        type: aggregated
+        retention: 6h
+        resolution: 10s
+      - namespace: unagg
+        type: unaggregated
+        retention: 1s
+    client:
+      config:
+        service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+            - zone: embedded
+              endpoints:
+                - dbnode01:2379
+      writeConsistencyLevel: majority
+      readConsistencyLevel: unstrict_majority
+
+downsample:
+  remoteAggregator:
+    client:
+      placementKV:
+        namespace: /placement
+      placementWatcher:
+        key: m3aggregator
+        initWatchTimeout: 10s
+      hashType: murmur32
+      shardCutoffLingerDuration: 1m
+      flushSize: 1440
+      maxTimerBatchSize: 1120
+      queueSize: 10000
+      queueDropType: oldest
+      encoder:
+        initBufferSize: 2048
+        maxMessageSize: 10485760
+        bytesPool:
+          buckets:
+            - capacity: 2048
+              count: 4096
+            - capacity: 4096
+              count: 4096
+          watermark:
+            low: 0.7
+            high: 1.0
+      connection:
+        writeTimeout: 250ms
+
+ingest:
+  ingester:
+    workerPoolSize: 100
+    opPool:
+      size: 100
+    retry:
+      maxRetries: 3
+      jitter: true
+    logSampleRate: 0.01
+  m3msg:
+    server:
+      listenAddress: "0.0.0.0:7507"
+      retry:
+        maxBackoff: 10s
+        jitter: true

--- a/scripts/docker-integration-tests/aggregator/m3coordinator.yml
+++ b/scripts/docker-integration-tests/aggregator/m3coordinator.yml
@@ -1,6 +1,6 @@
 listenAddress:
   type: "config"
-  value: "0.0.0.0:7201"
+  value: "0.0.0.0:7202"
 
 metrics:
   scope:
@@ -18,13 +18,20 @@ tagOptions:
 carbon:
   ingester:
     listenAddress: "0.0.0.0:7204"
+    rules:
+      - pattern: .*
+        aggregation:
+          type: mean
+        policies:
+          - resolution: 10s
+            retention: 6h
 
 clusters:
   - namespaces:
       - namespace: agg
         type: aggregated
-        retention: 6h
         resolution: 10s
+        retention: 6h
       - namespace: unagg
         type: unaggregated
         retention: 1s

--- a/scripts/docker-integration-tests/aggregator/test.sh
+++ b/scripts/docker-integration-tests/aggregator/test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -xe
+
+source $GOPATH/src/github.com/m3db/m3/scripts/docker-integration-tests/common.sh
+REVISION=$(git rev-parse HEAD)
+COMPOSE_FILE=$GOPATH/src/github.com/m3db/m3/scripts/docker-integration-tests/aggregator/docker-compose.yml
+export REVISION
+
+echo "Run m3dbnode"
+docker-compose -f ${COMPOSE_FILE} up -d dbnode01
+
+# Stop containers on exit
+METRIC_EMIT_PID="-1"
+function defer {
+  docker-compose -f ${COMPOSE_FILE} down || echo "unable to shutdown containers" # CI fails to stop all containers sometimes
+  if [ "$METRIC_EMIT_PID" != "-1" ]; then
+    echo "Kill metric emit process"
+    kill $METRIC_EMIT_PID
+  fi
+}
+trap defer EXIT
+
+echo "Setup DB node"
+setup_single_m3db_node
+
+echo "Initializing aggregator topology"
+curl -vvvsSf -X POST localhost:7201/api/v1/services/m3aggregator/placement/init -d '{
+    "num_shards": 64,
+    "replication_factor": 2,
+    "instances": [
+        {
+            "id": "m3aggregator01:6000",
+            "isolation_group": "availability-zone-a",
+            "zone": "embedded",
+            "weight": 100,
+            "endpoint": "m3aggregator01:6000",
+            "hostname": "m3aggregator01",
+            "port": 6000
+        },
+        {
+            "id": "m3aggregator02:6000",
+            "isolation_group": "availability-zone-b",
+            "zone": "embedded",
+            "weight": 100,
+            "endpoint": "m3aggregator02:6000",
+            "hostname": "m3aggregator02",
+            "port": 6000
+        }
+    ]
+}'
+
+echo "Initializing m3msg topic for m3coordinator ingestion from m3aggregators"
+curl -vvvsSf -X POST localhost:7201/api/v1/topic/init -d '{
+    "numberOfShards": 64
+}'
+
+echo "Initializing m3coordinator topology"
+curl -vvvsSf -X POST localhost:7201/api/v1/services/m3coordinator/placement/init -d '{
+    "instances": [
+        {
+            "id": "m3coordinator01",
+            "zone": "embedded",
+            "endpoint": "m3coordinator01:7507",
+            "hostname": "m3coordinator01",
+            "port": 7507
+        }
+    ]
+}'
+echo "Done initializing m3coordinator topology"
+
+echo "Validating m3coordinator topology"
+[ "$(curl -sSf localhost:7201/api/v1/services/m3coordinator/placement | jq .placement.instances.m3coordinator01.id)" == '"m3coordinator01"' ]
+echo "Done validating topology"
+
+# Do this after placement for m3coordinator is created.
+echo "Adding m3coordinator as a consumer to the aggregator topic"
+curl -vvvsSf -X POST localhost:7201/api/v1/topic -d '{
+  "consumerService": {
+    "serviceId": {
+      "name": "m3coordinator",
+      "environment": "default_env",
+      "zone": "embedded"
+    },
+    "consumptionType": "SHARED",
+    "messageTtlNanos": "600000000000"
+  }
+}' # msgs will be discarded after 600000000000ns = 10mins
+
+echo "Running m3coordinator container"
+echo "> port 7202 is coordinator API"
+echo "> port 7203 is coordinator metrics"
+echo "> port 7204 is coordinator graphite ingest"
+echo "> port 7507 is coordinator m3msg ingest from aggregator ingest"
+docker-compose -f ${COMPOSE_FILE} up -d m3coordinator01
+COORDINATOR_API="localhost:7202"
+
+echo "Running m3aggregator containers"
+docker-compose -f ${COMPOSE_FILE} up -d m3aggregator01
+docker-compose -f ${COMPOSE_FILE} up -d m3aggregator02
+
+echo "Verifying aggregation with remote aggregators"
+
+function read_carbon {
+  target=$1
+  expected_val=$2
+  end=$(date +%s)
+  start=$(($end-1000))
+  RESPONSE=$(curl -sSfg "http://${COORDINATOR_API}/api/v1/graphite/render?target=$target&from=$start&until=$end")
+  test "$(echo "$RESPONSE" | jq ".[0].datapoints | .[][0] | select(. != null)" | tail -n 1)" = "$expected_val"
+  return $?
+}
+
+echo "Sending unaggregated carbon metrics to m3coordinator"
+bash -c 'for i in $(seq 1 100); do echo "foo.bar.baz 42 $(date +%s)" | nc 0.0.0.0 7204; sleep 1; done' &
+
+# Track PID to kill on exit
+METRIC_EMIT_PID="$!"
+
+echo "Read back aggregated metric"
+ATTEMPTS=10 TIMEOUT=1 retry_with_backoff read_carbon foo.bar.* 42

--- a/scripts/docker-integration-tests/aggregator/test.sh
+++ b/scripts/docker-integration-tests/aggregator/test.sh
@@ -111,11 +111,15 @@ function read_carbon {
   return $?
 }
 
+# Send metric values 40 and 44 every second
 echo "Sending unaggregated carbon metrics to m3coordinator"
-bash -c 'for i in $(seq 1 100); do echo "foo.bar.baz 42 $(date +%s)" | nc 0.0.0.0 7204; sleep 1; done' &
+bash -c 'for i in $(seq 1 100); do t=$(date +%s); echo "foo.bar.baz 40 $t" | nc 0.0.0.0 7204; echo "foo.bar.baz 44 $t" | nc 0.0.0.0 7204; sleep 1; done' &
 
 # Track PID to kill on exit
 METRIC_EMIT_PID="$!"
 
-echo "Read back aggregated metric"
+# Read back the averaged averaged metric, we configured graphite
+# aggregation policy to average each tile and we are emitting
+# values 40 and 44 to get an average of 42 each tile
+echo "Read back aggregated averaged metric"
 ATTEMPTS=10 TIMEOUT=1 retry_with_backoff read_carbon foo.bar.* 42

--- a/scripts/docker-integration-tests/common.sh
+++ b/scripts/docker-integration-tests/common.sh
@@ -50,7 +50,7 @@ function wait_for_db_init {
   curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/database/create -d '{
     "type": "cluster",
     "namespaceName": "agg",
-    "retentionTime": "24h",
+    "retentionTime": "6h",
     "replicationFactor": 1,
     "hosts": [
       {
@@ -75,7 +75,7 @@ function wait_for_db_init {
   echo "Adding unagg namespace"
   curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/database/namespace/create -d '{
     "namespaceName": "unagg",
-    "retentionTime": "24h"
+    "retentionTime": "6h"
   }'
 
   echo "Wait until unagg namespace is init'd"

--- a/scripts/docker-integration-tests/m3aggregator.Dockerfile
+++ b/scripts/docker-integration-tests/m3aggregator.Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest AS builder
+LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
+
+RUN mkdir -p /bin
+RUN mkdir -p /etc/m3aggregator
+ADD ./m3aggregator /bin/
+ADD ./m3aggregator.yml /etc/m3aggregator/m3aggregator.yml
+
+EXPOSE 6000-6001/tcp
+
+ENTRYPOINT [ "/bin/m3aggregator" ]
+CMD [ "-f", "/etc/m3aggregator/m3aggregator.yml" ]

--- a/scripts/docker-integration-tests/setup.sh
+++ b/scripts/docker-integration-tests/setup.sh
@@ -5,7 +5,7 @@ set -xe
 # expected to be run from root of repository
 cd $GOPATH/src/github.com/m3db/m3
 
-SERVICES=(m3dbnode m3coordinator)
+SERVICES=(m3dbnode m3coordinator m3aggregator)
 REVISION=$(git rev-parse HEAD)
 make clean
 mkdir -p ./bin

--- a/scripts/docker-integration-tests/setup.sh
+++ b/scripts/docker-integration-tests/setup.sh
@@ -14,6 +14,7 @@ mkdir -p ./bin
 # for docker much smaller
 cp ./src/query/config/m3coordinator-local-etcd.yml ./bin
 cp ./src/dbnode/config/m3dbnode-local-etcd.yml ./bin
+cp ./src/aggregator/config/m3aggregator.yml ./bin
 
 # build images
 echo "building docker images"

--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -69,6 +69,7 @@ type downsampler struct {
 func (d *downsampler) NewMetricsAppender() (MetricsAppender, error) {
 	return newMetricsAppender(metricsAppenderOptions{
 		agg:                    d.agg.aggregator,
+		clientRemote:           d.agg.clientRemote,
 		defaultStagedMetadatas: d.agg.defaultStagedMetadatas,
 		clockOpts:              d.agg.clockOpts,
 		tagEncoder:             d.agg.pools.tagEncoderPool.Get(),

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	clusterclient "github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/kv/mem"
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/metrics/generated/proto/rulepb"
@@ -43,6 +44,7 @@ import (
 	xlog "github.com/m3db/m3x/log"
 	"github.com/m3db/m3x/pool"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -354,6 +356,7 @@ func newTestDownsampler(t *testing.T, opts testDownsamplerOptions) testDownsampl
 	var cfg Configuration
 	instance, err := cfg.NewDownsampler(DownsamplerOptions{
 		Storage:               storage,
+		ClusterClient:         clusterclient.NewMockClient(gomock.NewController(t)),
 		RulesKVStore:          rulesKVStore,
 		AutoMappingRules:      opts.autoMappingRules,
 		ClockOptions:          clockOpts,

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -22,15 +22,19 @@ package downsample
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/m3db/m3/src/aggregator/client"
 	clusterclient "github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/kv/mem"
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/metrics/generated/proto/rulepb"
 	"github.com/m3db/m3/src/metrics/matcher"
+	"github.com/m3db/m3/src/metrics/metadata"
 	"github.com/m3db/m3/src/metrics/metric/id"
+	"github.com/m3db/m3/src/metrics/metric/unaggregated"
 	"github.com/m3db/m3/src/metrics/policy"
 	"github.com/m3db/m3/src/metrics/rules"
 	ruleskv "github.com/m3db/m3/src/metrics/rules/store/kv"
@@ -54,6 +58,10 @@ var (
 	testAggregationStoragePolicies = []policy.StoragePolicy{
 		policy.MustParseStoragePolicy("2s:1d"),
 	}
+)
+
+const (
+	nameTag = "__name__"
 )
 
 func TestDownsamplerAggregationWithAutoMappingRules(t *testing.T) {
@@ -165,9 +173,214 @@ func TestDownsamplerAggregationWithOverrideRules(t *testing.T) {
 	testDownsamplerAggregation(t, testDownsampler)
 }
 
+func TestDownsamplerAggregationWithRemoteAggregatorClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create mock client
+	remoteClientMock := client.NewMockClient(ctrl)
+	remoteClientMock.EXPECT().Init().Return(nil)
+
+	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
+		autoMappingRules: []MappingRule{
+			{
+				Aggregations: []aggregation.Type{testAggregationType},
+				Policies:     testAggregationStoragePolicies,
+			},
+		},
+		remoteClientMock: remoteClientMock,
+	})
+
+	// Test expected output
+	testDownsamplerRemoteAggregation(t, testDownsampler)
+}
+
+type testCounterMetric struct {
+	tags     map[string]string
+	samples  []int64
+	expected int64
+}
+
+type testGaugeMetric struct {
+	tags     map[string]string
+	samples  []float64
+	expected float64
+}
+
+func testCounterMetrics() []testCounterMetric {
+	return []testCounterMetric{
+		{
+			tags:     map[string]string{nameTag: "counter0", "app": "testapp", "foo": "bar"},
+			samples:  []int64{1, 2, 3},
+			expected: 6,
+		},
+	}
+}
+
+func testGaugeMetrics() []testGaugeMetric {
+	return []testGaugeMetric{
+		{
+			tags:     map[string]string{nameTag: "gauge0", "app": "testapp", "qux": "qaz"},
+			samples:  []float64{4, 5, 6},
+			expected: 15,
+		},
+	}
+}
+
 func testDownsamplerAggregation(
 	t *testing.T,
 	testDownsampler testDownsampler,
+) {
+	testOpts := testDownsampler.testOpts
+
+	logger := testDownsampler.instrumentOpts.Logger().
+		WithFields(xlog.NewField("test", t.Name()))
+
+	testCounterMetrics := testCounterMetrics()
+	testGaugeMetrics := testGaugeMetrics()
+
+	// Ingest points
+	testDownsamplerAggregationIngest(t, testDownsampler,
+		testCounterMetrics, testGaugeMetrics)
+
+	// Wait for writes
+	logger.Infof("wait for test metrics to appear")
+	for {
+		writes := testDownsampler.storage.Writes()
+		if len(writes) == len(testCounterMetrics)+len(testGaugeMetrics) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Verify writes
+	logger.Infof("verify test metrics")
+	writes := testDownsampler.storage.Writes()
+	for _, metric := range testCounterMetrics {
+		name := metric.tags["__name__"]
+		expected := metric.expected
+		if v, ok := testOpts.expectedAdjusted[name]; ok {
+			expected = int64(v)
+		}
+
+		write := mustFindWrite(t, writes, name)
+		assert.Equal(t, metric.tags, tagsToStringMap(write.Tags))
+		require.Equal(t, 1, len(write.Datapoints))
+		assert.Equal(t, float64(expected), write.Datapoints[0].Value)
+	}
+	for _, metric := range testGaugeMetrics {
+		name := metric.tags["__name__"]
+		expected := metric.expected
+		if v, ok := testOpts.expectedAdjusted[name]; ok {
+			expected = v
+		}
+
+		write := mustFindWrite(t, writes, name)
+		assert.Equal(t, metric.tags, tagsToStringMap(write.Tags))
+		require.Equal(t, 1, len(write.Datapoints))
+		assert.Equal(t, float64(expected), write.Datapoints[0].Value)
+	}
+}
+
+func testDownsamplerRemoteAggregation(
+	t *testing.T,
+	testDownsampler testDownsampler,
+) {
+	testOpts := testDownsampler.testOpts
+
+	testCounterMetrics, expectTestCounterMetrics := testCounterMetrics(), testCounterMetrics()
+	testGaugeMetrics, expectTestGaugeMetrics := testGaugeMetrics(), testGaugeMetrics()
+
+	remoteClientMock := testOpts.remoteClientMock
+	require.NotNil(t, remoteClientMock)
+
+	// Expect ingestion
+	checkedCounterSamples := 0
+	remoteClientMock.EXPECT().
+		WriteUntimedCounter(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Do(func(counter unaggregated.Counter,
+			metadatas metadata.StagedMetadatas,
+		) error {
+			for _, c := range expectTestCounterMetrics {
+				if !strings.Contains(counter.ID.String(), c.tags[nameTag]) {
+					continue
+				}
+
+				var remainingSamples []int64
+				found := false
+				for _, s := range c.samples {
+					if !found && s == counter.Value {
+						found = true
+					} else {
+						remainingSamples = append(remainingSamples, s)
+					}
+				}
+				c.samples = remainingSamples
+				if found {
+					checkedCounterSamples++
+				}
+
+				break
+			}
+
+			return nil
+		})
+
+	checkedGaugeSamples := 0
+	remoteClientMock.EXPECT().
+		WriteUntimedGauge(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Do(func(gauge unaggregated.Gauge,
+			metadatas metadata.StagedMetadatas,
+		) error {
+			for _, g := range expectTestGaugeMetrics {
+				if !strings.Contains(gauge.ID.String(), g.tags[nameTag]) {
+					continue
+				}
+
+				var remainingSamples []float64
+				found := false
+				for _, s := range g.samples {
+					if !found && s == gauge.Value {
+						found = true
+					} else {
+						remainingSamples = append(remainingSamples, s)
+					}
+				}
+				g.samples = remainingSamples
+				if found {
+					checkedGaugeSamples++
+				}
+
+				break
+			}
+
+			return nil
+		})
+
+	// Ingest points
+	testDownsamplerAggregationIngest(t, testDownsampler,
+		testCounterMetrics, testGaugeMetrics)
+
+	// Ensure we checked counters and gauges
+	samplesCounters := 0
+	for _, c := range testCounterMetrics {
+		samplesCounters += len(c.samples)
+	}
+	samplesGauges := 0
+	for _, c := range testGaugeMetrics {
+		samplesGauges += len(c.samples)
+	}
+	require.Equal(t, samplesCounters, checkedCounterSamples)
+	require.Equal(t, samplesGauges, checkedGaugeSamples)
+}
+
+func testDownsamplerAggregationIngest(
+	t *testing.T,
+	testDownsampler testDownsampler,
+	testCounterMetrics []testCounterMetric,
+	testGaugeMetrics []testGaugeMetric,
 ) {
 	downsampler := testDownsampler.downsampler
 
@@ -175,30 +388,6 @@ func testDownsamplerAggregation(
 
 	logger := testDownsampler.instrumentOpts.Logger().
 		WithFields(xlog.NewField("test", t.Name()))
-
-	testCounterMetrics := []struct {
-		tags     map[string]string
-		samples  []int64
-		expected int64
-	}{
-		{
-			tags:     map[string]string{"__name__": "counter0", "app": "testapp", "foo": "bar"},
-			samples:  []int64{1, 2, 3},
-			expected: 6,
-		},
-	}
-
-	testGaugeMetrics := []struct {
-		tags     map[string]string
-		samples  []float64
-		expected float64
-	}{
-		{
-			tags:     map[string]string{"__name__": "gauge0", "app": "testapp", "qux": "qaz"},
-			samples:  []float64{4, 5, 6},
-			expected: 15,
-		},
-	}
 
 	logger.Infof("write test metrics")
 	appender, err := downsampler.NewMetricsAppender()
@@ -245,44 +434,6 @@ func testDownsamplerAggregation(
 			require.NoError(t, err)
 		}
 	}
-
-	// Wait for writes
-	logger.Infof("wait for test metrics to appear")
-	for {
-		writes := testDownsampler.storage.Writes()
-		if len(writes) == len(testCounterMetrics)+len(testGaugeMetrics) {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	// Verify writes
-	logger.Infof("verify test metrics")
-	writes := testDownsampler.storage.Writes()
-	for _, metric := range testCounterMetrics {
-		name := metric.tags["__name__"]
-		expected := metric.expected
-		if v, ok := testOpts.expectedAdjusted[name]; ok {
-			expected = int64(v)
-		}
-
-		write := mustFindWrite(t, writes, name)
-		assert.Equal(t, metric.tags, tagsToStringMap(write.Tags))
-		require.Equal(t, 1, len(write.Datapoints))
-		assert.Equal(t, float64(expected), write.Datapoints[0].Value)
-	}
-	for _, metric := range testGaugeMetrics {
-		name := metric.tags["__name__"]
-		expected := metric.expected
-		if v, ok := testOpts.expectedAdjusted[name]; ok {
-			expected = v
-		}
-
-		write := mustFindWrite(t, writes, name)
-		assert.Equal(t, metric.tags, tagsToStringMap(write.Tags))
-		require.Equal(t, 1, len(write.Datapoints))
-		assert.Equal(t, float64(expected), write.Datapoints[0].Value)
-	}
 }
 
 func tagsToStringMap(tags models.Tags) map[string]string {
@@ -312,6 +463,7 @@ type testDownsamplerOptions struct {
 	autoMappingRules   []MappingRule
 	timedSamples       bool
 	sampleAppenderOpts *SampleAppenderOptions
+	remoteClientMock   *client.MockClient
 
 	// Expected values overrides
 	expectedAdjusted map[string]float64
@@ -354,6 +506,14 @@ func newTestDownsampler(t *testing.T, opts testDownsamplerOptions) testDownsampl
 				SubScope("tag-decoder-pool")))
 
 	var cfg Configuration
+	if opts.remoteClientMock != nil {
+		// Optionally set an override to use remote aggregation
+		// with a mock client
+		cfg.RemoteAggregator = &RemoteAggregatorConfiguration{
+			clientOverride: opts.remoteClientMock,
+		}
+	}
+
 	instance, err := cfg.NewDownsampler(DownsamplerOptions{
 		Storage:               storage,
 		ClusterClient:         clusterclient.NewMockClient(gomock.NewController(t)),

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/aggregator/aggregator"
+	"github.com/m3db/m3/src/aggregator/client"
 	"github.com/m3db/m3/src/metrics/matcher"
 	"github.com/m3db/m3/src/metrics/metadata"
 	"github.com/m3db/m3/src/x/serialize"
@@ -39,8 +40,11 @@ type metricsAppender struct {
 	multiSamplesAppender *multiSamplesAppender
 }
 
+// metricsAppenderOptions will have one of agg or clientRemote set.
 type metricsAppenderOptions struct {
-	agg                    aggregator.Aggregator
+	agg          aggregator.Aggregator
+	clientRemote client.Client
+
 	defaultStagedMetadatas []metadata.StagedMetadatas
 	clockOpts              clock.Options
 	tagEncoder             serialize.TagEncoder
@@ -88,6 +92,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			}
 			a.multiSamplesAppender.addSamplesAppender(samplesAppender{
 				agg:             a.agg,
+				clientRemote:    a.clientRemote,
 				unownedID:       unownedID,
 				stagedMetadatas: stagedMetadatas,
 			})
@@ -97,6 +102,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 		for _, stagedMetadatas := range a.defaultStagedMetadatas {
 			a.multiSamplesAppender.addSamplesAppender(samplesAppender{
 				agg:             a.agg,
+				clientRemote:    a.clientRemote,
 				unownedID:       unownedID,
 				stagedMetadatas: stagedMetadatas,
 			})
@@ -107,6 +113,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			// Only sample if going to actually aggregate
 			a.multiSamplesAppender.addSamplesAppender(samplesAppender{
 				agg:             a.agg,
+				clientRemote:    a.clientRemote,
 				unownedID:       unownedID,
 				stagedMetadatas: stagedMetadatas,
 			})
@@ -117,6 +124,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			rollup := matchResult.ForNewRollupIDsAt(i, nowNanos)
 			a.multiSamplesAppender.addSamplesAppender(samplesAppender{
 				agg:             a.agg,
+				clientRemote:    a.clientRemote,
 				unownedID:       rollup.ID,
 				stagedMetadatas: rollup.Metadatas,
 			})

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -185,8 +185,9 @@ type agg struct {
 
 // Configuration configurates a downsampler.
 type Configuration struct {
-	// RemoteAggregator specifies that downsampling should be not
-	// done locally but sent to a remote aggregator.
+	// RemoteAggregator specifies that downsampling should be done remotely
+	// by sending values to a remote m3aggregator cluster which then
+	// can forward the aggregated values to stateless m3coordinator backends.
 	RemoteAggregator *RemoteAggregatorConfiguration `yaml:"remoteAggregator"`
 
 	// AggregationTypes configs the aggregation types.

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -272,6 +272,9 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 			err = fmt.Errorf("could not create remote aggregator client: %v", err)
 			return agg{}, err
 		}
+		if err := client.Init(); err != nil {
+			return agg{}, fmt.Errorf("could not initialize remote aggregator client: %v", err)
+		}
 
 		return agg{
 			clientRemote:           client,

--- a/src/cmd/services/m3coordinator/downsample/samples_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/samples_appender.go
@@ -43,7 +43,7 @@ type samplesAppender struct {
 
 func (a samplesAppender) AppendCounterSample(value int64) error {
 	if a.clientRemote != nil {
-		// Remote client write instead
+		// Remote client write instead of local aggregation.
 		sample := unaggregated.Counter{
 			ID:    a.unownedID,
 			Value: value,
@@ -61,7 +61,7 @@ func (a samplesAppender) AppendCounterSample(value int64) error {
 
 func (a samplesAppender) AppendGaugeSample(value float64) error {
 	if a.clientRemote != nil {
-		// Remote client write instead
+		// Remote client write instead of local aggregation.
 		sample := unaggregated.Gauge{
 			ID:    a.unownedID,
 			Value: value,
@@ -106,12 +106,12 @@ func (a *samplesAppender) appendTimedSample(sample aggregated.Metric) error {
 				}
 
 				if a.clientRemote != nil {
-					// Remote client write instead
+					// Remote client write instead of local aggregation.
 					multiErr = multiErr.Add(a.clientRemote.WriteTimed(sample, metadata))
 					continue
 				}
 
-				// Add timed to local aggregator
+				// Add timed to local aggregator.
 				multiErr = multiErr.Add(a.agg.AddTimed(sample, metadata))
 			}
 		}
@@ -119,7 +119,7 @@ func (a *samplesAppender) appendTimedSample(sample aggregated.Metric) error {
 	return multiErr.FinalError()
 }
 
-// Ensure multiSamplesAppender implements SamplesAppender
+// Ensure multiSamplesAppender implements SamplesAppender.
 var _ SamplesAppender = (*multiSamplesAppender)(nil)
 
 type multiSamplesAppender struct {

--- a/src/query/config/m3coordinator-local-etcd.yml
+++ b/src/query/config/m3coordinator-local-etcd.yml
@@ -28,10 +28,6 @@ clusters:
             - zone: embedded
               endpoints:
                 - 127.0.0.1:2379
-        seedNodes:
-          initialCluster:
-            - hostID: m3db_local
-              endpoint: http://127.0.0.1:2380
       writeConsistencyLevel: majority
       readConsistencyLevel: unstrict_majority
 

--- a/src/query/config/m3query-dev-etcd.yml
+++ b/src/query/config/m3query-dev-etcd.yml
@@ -31,10 +31,6 @@ clusters:
             - zone: embedded
               endpoints:
                 - 127.0.0.1:2379
-        seedNodes:
-          initialCluster:
-            - hostID: m3db_local
-              endpoint: http://127.0.0.1:2380
       writeConsistencyLevel: majority
       readConsistencyLevel: unstrict_majority
       writeTimeout: 10s

--- a/src/query/config/m3query-local-etcd.yml
+++ b/src/query/config/m3query-local-etcd.yml
@@ -31,10 +31,6 @@ clusters:
             - zone: embedded
               endpoints:
                 - 127.0.0.1:2379
-        seedNodes:
-          initialCluster:
-            - hostID: m3db_local
-              endpoint: http://127.0.0.1:2380
       writeConsistencyLevel: majority
       readConsistencyLevel: unstrict_majority
       writeTimeout: 10s

--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -284,7 +284,7 @@ func Run(runOpts RunOptions) {
 	}()
 
 	go func() {
-		logger.Info("starting server", zap.String("address", listenAddress))
+		logger.Info("starting API server", zap.String("address", listenAddress))
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			logger.Fatal("server error while listening",
 				zap.String("address", listenAddress), zap.Error(err))
@@ -292,7 +292,8 @@ func Run(runOpts RunOptions) {
 	}()
 
 	if cfg.Ingest != nil {
-		logger.Info("starting m3msg server")
+		logger.Info("starting m3msg server",
+			zap.String("address", cfg.Ingest.M3Msg.Server.ListenAddress))
 		ingester, err := cfg.Ingest.Ingester.NewIngester(backendStorage, instrumentOptions)
 		if err != nil {
 			logger.Fatal("unable to create ingester", zap.Error(err))

--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -492,6 +492,7 @@ func newDownsampler(
 
 	downsampler, err := cfg.NewDownsampler(downsample.DownsamplerOptions{
 		Storage:          storage,
+		ClusterClient:    clusterManagementClient,
 		RulesKVStore:     kvStore,
 		AutoMappingRules: autoMappingRules,
 		ClockOptions:     clock.NewOptions(),


### PR DESCRIPTION
To do:
- [x] Add docker integration test

Followups tracked in "Remote metrics aggregation integration followups" issue https://github.com/m3db/m3/issues/1507.