### PR TITLE
Update documentation for isNonNull

### DIFF
--- a/src/query/graphite/common/transform.go
+++ b/src/query/graphite/common/transform.go
@@ -95,7 +95,7 @@ func TransformNull(value float64) TransformFunc {
 	}
 }
 
-// IsNonNull takes a series or series list and counts up how many non-null values are specified.
+// IsNonNull replaces datapoints that are non-null with 1, and null values with 0.
 // This is useful for understanding which series have data at a given point in time (i.e. to count
 // which servers are alive).
 func IsNonNull() TransformFunc {

--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -332,7 +332,7 @@ func transformNull(ctx *common.Context, input singlePathSpec, defaultValue float
 	)
 }
 
-// isNonNull takes a metric or wild card seriesList and counts up how many non-null values are specified.
+// isNonNull replaces datapoints that are non-null with 1, and null values with 0.
 // This is useful for understanding which metrics have data at a given point in time
 // (ie, to count which servers are alive).
 func isNonNull(ctx *common.Context, input singlePathSpec) (ts.SeriesList, error) {


### PR DESCRIPTION
isNonNull doesn't count up values itself, but replaces datapoints
with 1 or 0 depending on whether the datapoint is null.