### PR TITLE
Better error responses for unknown namespaces

### DIFF
--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -295,7 +295,7 @@ func TestServiceQueryOverloaded(t *testing.T) {
 	require.Equal(t, tterrors.NewInternalError(errServerIsOverloaded), err)
 }
 
-func TestServiceQueryUnknownNs(t *testing.T) {
+func TestServiceQueryUnknownErr(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -351,7 +351,6 @@ func TestServiceQueryUnknownNs(t *testing.T) {
 }
 
 func TestServiceFetch(t *testing.T) {
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -450,7 +449,7 @@ func TestServiceFetchIsOverloaded(t *testing.T) {
 	require.Equal(t, tterrors.NewInternalError(errServerIsOverloaded), err)
 }
 
-func TestServiceFetchUnknownNs(t *testing.T) {
+func TestServiceFetchUnknownErr(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := storage.NewMockDatabase(ctrl)

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage/block"
+	dberrors "github.com/m3db/m3/src/dbnode/storage/errors"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	"github.com/m3db/m3/src/dbnode/ts"
@@ -894,7 +895,7 @@ func (d *db) namespaceFor(namespace ident.ID) (databaseNamespace, error) {
 	d.RUnlock()
 
 	if !exists {
-		return nil, fmt.Errorf("no such namespace %s", namespace)
+		return nil, dberrors.NewUnknownNamespaceError(namespace.String())
 	}
 	return n, nil
 }

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage/block"
+	dberrors "github.com/m3db/m3/src/dbnode/storage/errors"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
 	"github.com/m3db/m3/src/dbnode/storage/repair"
@@ -284,7 +285,7 @@ func TestDatabaseReadEncodedNamespaceNotOwned(t *testing.T) {
 		close(mapCh)
 	}()
 	_, err := d.ReadEncoded(ctx, ident.StringID("nonexistent"), ident.StringID("foo"), time.Now(), time.Now())
-	require.Equal(t, "no such namespace nonexistent", err.Error())
+	require.True(t, dberrors.IsUnknownNamespaceError(err))
 }
 
 func TestDatabaseReadEncodedNamespaceOwned(t *testing.T) {

--- a/src/dbnode/storage/errors/types.go
+++ b/src/dbnode/storage/errors/types.go
@@ -35,7 +35,7 @@ var (
 	ErrTooPast = xerrors.NewInvalidParamsError(errors.New("datapoint is too far in the past"))
 )
 
-// NewUnknownNamespace returns a new error indicating an unknown namespace parameter.
+// NewUnknownNamespaceError returns a new error indicating an unknown namespace parameter.
 func NewUnknownNamespaceError(namespace string) error {
 	return xerrors.NewInvalidParamsError(unknownNamespace{namespace})
 }

--- a/src/dbnode/storage/errors/types.go
+++ b/src/dbnode/storage/errors/types.go
@@ -48,7 +48,7 @@ func (e unknownNamespace) Error() string {
 	return fmt.Sprintf("unknown namespace: %s", e.namespace)
 }
 
-// IsUnknownNamespace returns true if this is an unknown namespace.
+// IsUnknownNamespaceError returns true if this is an unknown namespace.
 func IsUnknownNamespaceError(err error) bool {
 	nsErr := xerrors.GetInnerInvalidParamsError(err)
 	if nsErr == nil {

--- a/src/dbnode/storage/errors/types_test.go
+++ b/src/dbnode/storage/errors/types_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,39 +21,13 @@
 package errors
 
 import (
-	"errors"
-	"fmt"
+	"testing"
 
-	xerrors "github.com/m3db/m3x/errors"
+	"github.com/stretchr/testify/require"
 )
 
-var (
-	// ErrTooFuture is returned for a write which is too far in the future.
-	ErrTooFuture = xerrors.NewInvalidParamsError(errors.New("datapoint is too far in the future"))
-
-	// ErrTooPast is returned for a write which is too far in the past.
-	ErrTooPast = xerrors.NewInvalidParamsError(errors.New("datapoint is too far in the past"))
-)
-
-// NewUnknownNamespace returns a new error indicating an unknown namespace parameter.
-func NewUnknownNamespaceError(namespace string) error {
-	return xerrors.NewInvalidParamsError(unknownNamespace{namespace})
-}
-
-type unknownNamespace struct {
-	namespace string
-}
-
-func (e unknownNamespace) Error() string {
-	return fmt.Sprintf("unknown namespace: %s", e.namespace)
-}
-
-// IsUnknownNamespace returns true if this is an unknown namespace.
-func IsUnknownNamespaceError(err error) bool {
-	nsErr := xerrors.GetInnerInvalidParamsError(err)
-	if nsErr == nil {
-		return false
-	}
-	_, ok := nsErr.(unknownNamespace)
-	return ok
+func TestUnknownNamespaceError(t *testing.T) {
+	err := NewUnknownNamespaceError("ns")
+	require.Equal(t, "unknown namespace: ns", err.Error())
+	require.True(t, IsUnknownNamespaceError(err))
 }


### PR DESCRIPTION
Return clearer RPC errors when requests use unknown namespaces
