### PR TITLE
Remove fail silent from curl

### DIFF
--- a/docs/how_to/cluster_hard_way.md
+++ b/docs/how_to/cluster_hard_way.md
@@ -190,7 +190,7 @@ Read more about namespaces and the various knobs in the docs.
 Now you can experiment with writing tagged metrics:
 
 ```json
-curl -sSf -X POST localhost:9003/writetagged -d '{
+curl -sS -X POST localhost:9003/writetagged -d '{
   "namespace": "metrics",
   "id": "foo",
   "tags": [
@@ -213,7 +213,7 @@ curl -sSf -X POST localhost:9003/writetagged -d '{
 And reading the metrics you've written:
 
 ```json
-curl -sSf -X POST http://localhost:9003/query -d '{
+curl -sS -X POST http://localhost:9003/query -d '{
   "namespace": "metrics",
   "query": {
     "regexp": {

--- a/docs/how_to/single_node.md
+++ b/docs/how_to/single_node.md
@@ -53,7 +53,7 @@ going to `localhost:7201/api/v1/openapi` in your browser.
 
 Now you can experiment with writing tagged metrics:
 ```json
-curl -sSf -X POST http://localhost:9003/writetagged -d '{
+curl -sS -X POST http://localhost:9003/writetagged -d '{
   "namespace": "default",
   "id": "foo",
   "tags": [
@@ -76,7 +76,7 @@ curl -sSf -X POST http://localhost:9003/writetagged -d '{
 
 And reading the metrics you've written:
 ```json
-curl -sSf -X POST http://localhost:9003/query -d '{
+curl -sS -X POST http://localhost:9003/query -d '{
   "namespace": "default",
   "query": {
     "regexp": {


### PR DESCRIPTION
We should keep `-sS` but remove `-f`
```
  -s/--silent
     Silent or quiet mode. Do not show progress meter or error messages.  
     Makes Curl mute.

  -S/--show-error
     When used with -s it makes curl show an error message if it fails.

  -f/--fail
     (HTTP)  Fail silently (no output at all) on server errors. This is mostly
     done to better enable scripts etc to better deal with failed attempts. In
     normal  cases  when a HTTP server fails to deliver a document, it returns
     an HTML document stating so (which often also describes  why  and  more).
     This flag will prevent curl from outputting that and return error 22.

     This method is not fail-safe and there are occasions where non-successful
     response codes will  slip  through,  especially  when  authentication  is
     involved (response codes 401 and 407).
```
This along with https://github.com/m3db/m3/pull/1412 bubbles up the `unknown namespace` error