### PR TITLE
[m3nsch] script to more easily run on k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ SUBDIRS :=    \
 	m3ninx      \
 	aggregator  \
 	ctl         \
+	kube        \
 
 TOOLS :=               \
 	read_ids             \
@@ -247,6 +248,17 @@ test-ci-integration:
 
 define SUBDIR_RULES
 
+# We override the rules for `*-gen-kube` to just generate the kube manifest
+# bundle.
+ifeq ($(SUBDIR), kube)
+
+# Builds the single kube bundle from individual manifest files.
+all-gen-kube:
+	@echo "--- Generating kube bundle"
+	@./kube/scripts/build_bundle.sh
+
+else
+
 .PHONY: mock-gen-$(SUBDIR)
 mock-gen-$(SUBDIR): install-tools
 	@echo "--- Generating mocks $(SUBDIR)"
@@ -341,6 +353,8 @@ metalint-$(SUBDIR): install-gometalinter install-linter-badtime install-linter-i
 	@echo "--- metalinting $(SUBDIR)"
 	@(PATH=$(retool_bin_path):$(PATH) $(metalint_check) \
 		$(metalint_config) $(metalint_exclude) src/$(SUBDIR))
+
+endif
 
 endef
 

--- a/docs/how_to/single_node.md
+++ b/docs/how_to/single_node.md
@@ -14,8 +14,8 @@ To begin, first start up a Docker container with port `7201` (used to manage the
 directory on your host for durability:
 
 ```
-docker pull quay.io/m3/m3dbnode:latest
-docker run -p 7201:7201 -p 7203:7203 -p 9003:9003 --name m3db -v $(pwd)/m3db_data:/var/lib/m3db -v <PATH_TO_M3DB_CONFIG.yml>:/etc/m3dbnode/m3dbnode.yml quay.io/m3/m3dbnode:latest
+docker pull quay.io/m3db/m3dbnode:latest
+docker run -p 7201:7201 -p 7203:7203 -p 9003:9003 --name m3db -v $(pwd)/m3db_data:/var/lib/m3db -v <PATH_TO_M3DB_CONFIG.yml>:/etc/m3dbnode/m3dbnode.yml quay.io/m3db/m3dbnode:latest
 ```
 
 **Note:** For the single node case, we recommend that you start with this [sample config file](https://github.com/m3db/m3/blob/master/src/dbnode/config/m3dbnode-local-etcd.yml). If you inspect the file, you'll see that all the configuration is namespaced by `coordinator` or `db`. That's because this setup runs `M3DB` and `M3Coordinator` as one application. While this is convenient for testing and development, you'll want to run clustered `M3DB` with a separate `M3Coordinator` in production. You can read more about that [here.](cluster_hard_way.md).

--- a/docs/integrations/prometheus.md
+++ b/docs/integrations/prometheus.md
@@ -76,8 +76,8 @@ m3coordinator -f <config-name.yml>
 Or, use the docker container:
 
 ```
-docker pull quay.io/m3/m3coordinator:latest
-docker run -p 7201:7201 --name m3coordinator -v <config-name.yml>:/etc/m3coordinator/m3coordinator.yml quay.io/m3/m3coordinator:latest
+docker pull quay.io/m3db/m3coordinator:latest
+docker run -p 7201:7201 --name m3coordinator -v <config-name.yml>:/etc/m3coordinator/m3coordinator.yml quay.io/m3db/m3coordinator:latest
 ```
 
 ## Prometheus configuration

--- a/kube/README.md
+++ b/kube/README.md
@@ -24,19 +24,17 @@ service/m3nsch-agent-debug created
 deployment.apps/m3nsch-server created
 deployment.apps/m3nsch-client created
 
-$ kubectl get po -l app=m3nsch,component=client
-NAME                             READY   STATUS    RESTARTS   AGE
-m3nsch-client-78987775f5-l5pvs   1/1     Running   0          5s
-
-$ kubectlc exec -it m3nsch-client-78987775f5-l5pvs
-/ # ./bin/m3nsch_client -e m3nsch-agent-0.m3nsch-agent:2580,m3nsch-agent-1.m3nsch-agent:2580,m3nsch-agent-2.m3nsch-agent:2580 init -t foo -z default_zone -v default_env -n m3db-cluster
+$ ./kube/scripts/m3nsch_client.sh init -t foo -z default_zone -v default_env -n m3db-cluster
+...
 2018/09/30 15:24:16 Go Runtime version: go1.10.2
 2018/09/30 15:24:16 Build Version:      v0.4.5
 2018/09/30 15:24:16 Build Revision:     aa253ca01
 2018/09/30 15:24:16 Build Branch:       schallert/m3nsch_update
 2018/09/30 15:24:16 Build Date:         2018-09-29-21:31:30
 2018/09/30 15:24:16 Build TimeUnix:     1538256690
-/ # ./bin/m3nsch_client -e m3nsch-agent:2580 start
+
+$ ./kube/scripts/m3nsch_client.sh start
+...
 2018/09/30 15:24:23 Go Runtime version: go1.10.2
 2018/09/30 15:24:23 Build Version:      v0.4.5
 2018/09/30 15:24:23 Build Revision:     aa253ca01
@@ -46,10 +44,12 @@ $ kubectlc exec -it m3nsch-client-78987775f5-l5pvs
 15:24:23.205737[I] workload started!
 ```
 
-You can view the stats of the ongoing benchmark via `m3nsch_server`'s prometheus endpoints:
+You can view the stats of the ongoing benchmark via `m3nsch_server`'s prometheus endpoints, or using our [grafana dashboard][dash]:
 ```
 $ kubectl port-forward svc/m3nch-agent 12580
 $ curl -sSf localhost:12580/metrics | rg write.+success
 # TYPE write_req_success counter
 write_req_success 146000
 ```
+
+[dash]: https://github.com/m3db/m3/blob/75661bc2e7fc806ee3424c068db6812455ba0878/integrations/grafana/m3nsch_dashboard.json

--- a/kube/README.md
+++ b/kube/README.md
@@ -52,4 +52,4 @@ $ curl -sSf localhost:12580/metrics | rg write.+success
 write_req_success 146000
 ```
 
-[dash]: https://github.com/m3db/m3/blob/75661bc2e7fc806ee3424c068db6812455ba0878/integrations/grafana/m3nsch_dashboard.json
+[dash]: https://raw.githubusercontent.com/m3db/m3/master/integrations/grafana/m3nsch_dashboard.json

--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -119,9 +119,9 @@ data:
         value: "0.0.0.0:7201"
       local:
         namespaces:
-          - namespace: default
-            type: unaggregated
-            retention: 48h
+            - namespace: default
+              type: unaggregated
+              retention: 48h
       metrics:
         scope:
           prefix: "coordinator"
@@ -157,21 +157,6 @@ data:
       client:
         writeConsistencyLevel: majority
         readConsistencyLevel: unstrict_majority
-        writeTimeout: 10s
-        fetchTimeout: 15s
-        connectTimeout: 20s
-        writeRetry:
-            initialBackoff: 500ms
-            backoffFactor: 3
-            maxRetries: 2
-            jitter: true
-        fetchRetry:
-            initialBackoff: 500ms
-            backoffFactor: 2
-            maxRetries: 3
-            jitter: true
-        backgroundHealthCheckFailLimit: 4
-        backgroundHealthCheckFailThrottleFactor: 0.5
 
       gcPercentage: 100
 
@@ -197,119 +182,7 @@ data:
 
       fs:
         filePathPrefix: /var/lib/m3db
-        writeBufferSize: 65536
-        dataReadBufferSize: 65536
-        infoReadBufferSize: 128
-        seekReadBufferSize: 4096
-        throughputLimitMbps: 100.0
-        throughputCheckEvery: 128
 
-      repair:
-        enabled: false
-        interval: 2h
-        offset: 30m
-        jitter: 1h
-        throttle: 2m
-        checkInterval: 1m
-
-      pooling:
-        blockAllocSize: 16
-        type: simple
-        seriesPool:
-            size: 262144
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        blockPool:
-            size: 262144
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        encoderPool:
-            size: 262144
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        closersPool:
-            size: 104857
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        contextPool:
-            size: 262144
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        segmentReaderPool:
-            size: 16384
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        iteratorPool:
-            size: 2048
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        fetchBlockMetadataResultsPool:
-            size: 65536
-            capacity: 32
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        fetchBlocksMetadataResultsPool:
-            size: 32
-            capacity: 4096
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        hostBlockMetadataSlicePool:
-            size: 131072
-            capacity: 3
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        blockMetadataPool:
-            size: 65536
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        blockMetadataSlicePool:
-            size: 65536
-            capacity: 32
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        blocksMetadataPool:
-            size: 65536
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        blocksMetadataSlicePool:
-            size: 32
-            capacity: 4096
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        identifierPool:
-            size: 262144
-            lowWatermark: 0.7
-            highWatermark: 1.0
-        bytesPool:
-            buckets:
-                - capacity: 16
-                  size: 524288
-                  lowWatermark: 0.7
-                  highWatermark: 1.0
-                - capacity: 32
-                  size: 262144
-                  lowWatermark: 0.7
-                  highWatermark: 1.0
-                - capacity: 64
-                  size: 131072
-                  lowWatermark: 0.7
-                  highWatermark: 1.0
-                - capacity: 128
-                  size: 65536
-                  lowWatermark: 0.7
-                  highWatermark: 1.0
-                - capacity: 256
-                  size: 65536
-                  lowWatermark: 0.7
-                  highWatermark: 1.0
-                - capacity: 1440
-                  size: 16384
-                  lowWatermark: 0.7
-                  highWatermark: 1.0
-                - capacity: 4096
-                  size: 8192
-                  lowWatermark: 0.7
-                  highWatermark: 1.0
       config:
         service:
             env: default_env

--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -280,7 +280,7 @@ spec:
             weight: 10
       containers:
       - name: m3db
-        image: quay.io/m3/m3dbnode:latest
+        image: quay.io/m3db/m3dbnode:latest
         imagePullPolicy: Always
         # resources:
         #   limits:

--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -282,7 +282,7 @@ spec:
             weight: 10
       containers:
       - name: m3db
-        image: quay.io/m3db/m3dbnode:latest
+        image: quay.io/m3/m3dbnode:latest
         imagePullPolicy: Always
         # resources:
         #   limits:

--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -95,6 +95,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ETCDCTL_API
+          value: "3"
   volumeClaimTemplates:
     - metadata:
         name: etcd-data

--- a/kube/etcd.yaml
+++ b/kube/etcd.yaml
@@ -88,6 +88,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ETCDCTL_API
+          value: "3"
   volumeClaimTemplates:
     - metadata:
         name: etcd-data

--- a/kube/m3dbnode-statefulset.yaml
+++ b/kube/m3dbnode-statefulset.yaml
@@ -82,7 +82,7 @@ spec:
             weight: 10
       containers:
       - name: m3db
-        image: quay.io/m3db/m3dbnode:latest
+        image: quay.io/m3/m3dbnode:latest
         imagePullPolicy: Always
         # resources:
         #   limits:

--- a/kube/m3dbnode-statefulset.yaml
+++ b/kube/m3dbnode-statefulset.yaml
@@ -82,7 +82,7 @@ spec:
             weight: 10
       containers:
       - name: m3db
-        image: quay.io/m3/m3dbnode:latest
+        image: quay.io/m3db/m3dbnode:latest
         imagePullPolicy: Always
         # resources:
         #   limits:

--- a/kube/m3nsch.yaml
+++ b/kube/m3nsch.yaml
@@ -79,6 +79,11 @@ metadata:
     component: agent
 spec:
   replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 100%
   selector:
     matchLabels:
       app: m3nsch

--- a/kube/m3nsch.yaml
+++ b/kube/m3nsch.yaml
@@ -55,6 +55,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: m3nsch-agent
+  labels:
+    app: m3nsch
+    component: agent
 spec:
   type: ClusterIP
   clusterIP: None
@@ -68,11 +71,10 @@ spec:
     component: agent
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: m3nsch-agent
 spec:
-  serviceName: m3nsch-agent
   replicas: 3
   selector:
     matchLabels:

--- a/kube/m3nsch.yaml
+++ b/kube/m3nsch.yaml
@@ -74,6 +74,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: m3nsch-agent
+  labels:
+    app: m3nsch
+    component: agent
 spec:
   replicas: 3
   selector:
@@ -112,6 +115,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: m3nsch-client
+  labels:
+    app: m3nsch
+    component: client
 spec:
   replicas: 1
   selector:

--- a/kube/m3nsch.yaml
+++ b/kube/m3nsch.yaml
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
       - name: m3nsch-agent
-        image: quay.io/m3db/m3nsch:latest
+        image: quay.io/m3/m3nsch:latest
         args:
         - "-f"
         - "/etc/m3nsch/m3nsch_server.yaml"
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
       - name: m3nsch-client
-        image: quay.io/m3db/m3nsch:latest
+        image: quay.io/m3/m3nsch:latest
         command:
         - "/bin/ash"
         args: ["-c", "while true; do sleep 300; done"]

--- a/kube/scripts/build_bundle.sh
+++ b/kube/scripts/build_bundle.sh
@@ -4,20 +4,23 @@
 # `kubectl apply`. This is somewhat hacky and will be replaced with either a
 # ksonnet-based build process, operator, or helm chart later on.
 
-TARGET="bundle.yaml"
 
 function sep() {
     echo "---" >> "$TARGET"
 }
 
-set -exuo pipefail
+set -euo pipefail
+
+DIR=$(dirname "$(dirname "${BASH_SOURCE[0]}")")
+TARGET="$DIR/bundle.yaml"
 
 rm -f "$TARGET"
 echo "# AUTOMATICALLY GENERATED (build_bundle.sh) - DO NOT EDIT" >> "$TARGET"
 sep
 # Ordering is important here (namespace must come first)
-for F in m3dbnode-namespace.yaml etcd.yaml m3dbnode-configmap.yaml m3dbnode-statefulset.yaml; do
+for N in m3dbnode-namespace.yaml etcd.yaml m3dbnode-configmap.yaml m3dbnode-statefulset.yaml; do
+    F="$DIR/$N"
     [[ -f "$F" ]] || exit 1
-    cat $F >> "$TARGET"
+    cat "$F" >> "$TARGET"
     sep
 done

--- a/kube/scripts/m3nsch_client.sh
+++ b/kube/scripts/m3nsch_client.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
 
 # The script makes it easier to run m3nsch by gathering the endpoints of all
-# agents and constructing the base m3nsch_client command.
+# agents and constructing the base m3nsch_client command. You may provide extra
+# labels to target agent pods if you are running multiple m3nsch agent
+# deployments in the same namespace (i.e. for concurrent load tests against
+# multiple m3db clusters).
 #
 # Example usage:
 # ./m3nsch_client.sh init -t foo -z default_zone -v default_env -n metrics-10s:2d -c 50000 -i 5000 -u 0.5
+# LABELS="deployment=foo" ./m3nsch_client.sh init -t foo -z default_zone -v default_env -n metrics-10s:2d -c 50000 -i 5000 -u 0.5
 # ./m3nsch_client.sh start
 # ./m3nsch_client.sh stop
 
+set -eo pipefail
+
 # Get endpoints of the agents
 function get_endpoints() {
+  local selector="app=m3nsch,component=agent"
+  if [[ -n "$LABELS" ]]; then
+    selector="$selector,$LABELS"
+  fi
   local jsonpath='{range .items[*]}{.status.podIP}:{.spec.containers[0].ports[0].containerPort},{end}'
   # cut trailing comma
-  kubectl get po -l app=m3nsch,component=agent -o jsonpath="$jsonpath" | sed 's/,$//'
+  kubectl get po -l "$selector" -o jsonpath="$jsonpath" | sed 's/,$//'
 }
 
 CLIENT_POD=$(kubectl get po | grep client | awk '{print $1}')

--- a/kube/scripts/m3nsch_client.sh
+++ b/kube/scripts/m3nsch_client.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# The script makes it easier to run m3nsch by gathering the endpoints of all
+# agents and constructing the base m3nsch_client command.
+#
+# Example usage:
+# ./m3nsch_client.sh init -t foo -z default_zone -v default_env -n metrics-10s:2d -c 50000 -i 5000 -u 0.5
+# ./m3nsch_client.sh start
+# ./m3nsch_client.sh stop
+
+# Get endpoints of the agents
+function get_endpoints() {
+  local jsonpath='{range .items[*]}{.status.podIP}:{.spec.containers[0].ports[0].containerPort},{end}'
+  # cut trailing comma
+  kubectl get po -l app=m3nsch,component=agent -o jsonpath="$jsonpath" | sed 's/,$//'
+}
+
+CLIENT_POD=$(kubectl get po | grep client | awk '{print $1}')
+
+if [[ -z "$CLIENT_POD" ]]; then
+  echo "could not find client pod"
+  exit 1
+fi
+
+AGENT_ENDPOINTS=$(get_endpoints)
+
+set -x
+kubectl exec "$CLIENT_POD" -- ./bin/m3nsch_client -e "$AGENT_ENDPOINTS" "$@"
+set +x

--- a/src/cmd/services/m3nsch_server/main/main.go
+++ b/src/cmd/services/m3nsch_server/main/main.go
@@ -21,7 +21,6 @@
 package main
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -94,10 +93,8 @@ func main() {
 func newSessionFn(conf config.Configuration, iopts instrument.Options) m3nsch.NewSessionFn {
 	return m3nsch.NewSessionFn(func(zone, env string) (client.Session, error) {
 		svc := conf.DBClient.EnvironmentConfig.Service
-		if zone != svc.Zone {
-			return nil, fmt.Errorf("request zone %s did not match config zone %s", zone, svc.Zone)
-		}
 		svc.Env = env
+		svc.Zone = zone
 		cl, err := conf.DBClient.NewClient(client.ConfigurationParameters{
 			InstrumentOptions: iopts,
 		})

--- a/src/cmd/services/m3nsch_server/main/main.go
+++ b/src/cmd/services/m3nsch_server/main/main.go
@@ -97,9 +97,7 @@ func newSessionFn(conf config.Configuration, iopts instrument.Options) m3nsch.Ne
 		if zone != svc.Zone {
 			return nil, fmt.Errorf("request zone %s did not match config zone %s", zone, svc.Zone)
 		}
-		if env != svc.Env {
-			return nil, fmt.Errorf("request env %s did not match config zone %s", env, svc.Env)
-		}
+		svc.Env = env
 		cl, err := conf.DBClient.NewClient(client.ConfigurationParameters{
 			InstrumentOptions: iopts,
 		})


### PR DESCRIPTION
Previously users had to `exec` into a pod and manually provide m3nsch
endpoints. This is unnecessary as we can gather the IPs of the agent
pods and pass that via the command line.

Also included a make target to generate the simple manifest bundle in CI
to avoid it becoming stale.