### PR TITLE
[api] more granular status codes in ns-add/pl-init

### DIFF
--- a/src/query/api/v1/handler/namespace/add_test.go
+++ b/src/query/api/v1/handler/namespace/add_test.go
@@ -28,11 +28,38 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/cluster/kv"
+	nsproto "github.com/m3db/m3/src/dbnode/generated/proto/namespace"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testAddJSON = `
+{
+		"name": "testNamespace",
+		"options": {
+			"bootstrapEnabled": true,
+			"flushEnabled": true,
+			"writesToCommitLog": true,
+			"cleanupEnabled": true,
+			"repairEnabled": true,
+			"retentionOptions": {
+				"retentionPeriodNanos": 172800000000000,
+				"blockSizeNanos": 7200000000000,
+				"bufferFutureNanos": 600000000000,
+				"bufferPastNanos": 600000000000,
+				"blockDataExpiry": true,
+				"blockDataExpiryAfterNotAccessPeriodNanos": 300000000000
+			},
+			"snapshotEnabled": true,
+			"indexOptions": {
+				"enabled": true,
+				"blockSizeNanos": 7200000000000
+			}
+		}
+}
+`
 
 func TestNamespaceAddHandler(t *testing.T) {
 	mockClient, mockKV, _ := SetupNamespaceTest(t)
@@ -65,33 +92,7 @@ func TestNamespaceAddHandler(t *testing.T) {
 	// being false and it not being set by a user.
 	w = httptest.NewRecorder()
 
-	jsonInput = `
-        {
-            "name": "testNamespace",
-            "options": {
-              "bootstrapEnabled": true,
-              "flushEnabled": true,
-              "writesToCommitLog": true,
-              "cleanupEnabled": true,
-              "repairEnabled": true,
-              "retentionOptions": {
-                "retentionPeriodNanos": 172800000000000,
-                "blockSizeNanos": 7200000000000,
-                "bufferFutureNanos": 600000000000,
-                "bufferPastNanos": 600000000000,
-                "blockDataExpiry": true,
-                "blockDataExpiryAfterNotAccessPeriodNanos": 300000000000
-              },
-              "snapshotEnabled": true,
-              "indexOptions": {
-                "enabled": true,
-                "blockSizeNanos": 7200000000000
-              }
-            }
-        }
-    `
-
-	req = httptest.NewRequest("POST", "/namespace", strings.NewReader(jsonInput))
+	req = httptest.NewRequest("POST", "/namespace", strings.NewReader(testAddJSON))
 	require.NotNil(t, req)
 
 	mockKV.EXPECT().Get(M3DBNodeNamespacesKey).Return(nil, kv.ErrNotFound)
@@ -102,4 +103,44 @@ func TestNamespaceAddHandler(t *testing.T) {
 	body, _ = ioutil.ReadAll(resp.Body)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "{\"registry\":{\"namespaces\":{\"testNamespace\":{\"bootstrapEnabled\":true,\"flushEnabled\":true,\"writesToCommitLog\":true,\"cleanupEnabled\":true,\"repairEnabled\":true,\"retentionOptions\":{\"retentionPeriodNanos\":\"172800000000000\",\"blockSizeNanos\":\"7200000000000\",\"bufferFutureNanos\":\"600000000000\",\"bufferPastNanos\":\"600000000000\",\"blockDataExpiry\":true,\"blockDataExpiryAfterNotAccessPeriodNanos\":\"300000000000\"},\"snapshotEnabled\":true,\"indexOptions\":{\"enabled\":true,\"blockSizeNanos\":\"7200000000000\"}}}}}", string(body))
+}
+
+func TestNamespaceAddHandler_Conflict(t *testing.T) {
+	mockClient, mockKV, ctrl := SetupNamespaceTest(t)
+	addHandler := NewAddHandler(mockClient)
+
+	// Ensure adding an existing namespace returns 409
+	req := httptest.NewRequest("POST", "/namespace", strings.NewReader(testAddJSON))
+	require.NotNil(t, req)
+
+	registry := nsproto.Registry{
+		Namespaces: map[string]*nsproto.NamespaceOptions{
+			"testNamespace": &nsproto.NamespaceOptions{
+				BootstrapEnabled:  true,
+				FlushEnabled:      true,
+				SnapshotEnabled:   true,
+				WritesToCommitLog: true,
+				CleanupEnabled:    false,
+				RepairEnabled:     false,
+				RetentionOptions: &nsproto.RetentionOptions{
+					RetentionPeriodNanos:                     172800000000000,
+					BlockSizeNanos:                           7200000000000,
+					BufferFutureNanos:                        600000000000,
+					BufferPastNanos:                          600000000000,
+					BlockDataExpiry:                          true,
+					BlockDataExpiryAfterNotAccessPeriodNanos: 3600000000000,
+				},
+			},
+		},
+	}
+
+	mockValue := kv.NewMockValue(ctrl)
+	mockValue.EXPECT().Unmarshal(gomock.Any()).Return(nil).SetArg(0, registry)
+	mockValue.EXPECT().Version().Return(0)
+	mockKV.EXPECT().Get(M3DBNodeNamespacesKey).Return(mockValue, nil)
+
+	w := httptest.NewRecorder()
+	addHandler.ServeHTTP(w, req)
+	resp := w.Result()
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
 }

--- a/src/query/api/v1/handler/placement/init.go
+++ b/src/query/api/v1/handler/placement/init.go
@@ -25,11 +25,12 @@ import (
 	"path"
 	"time"
 
+	"github.com/m3db/m3/src/cluster/kv"
 	"github.com/m3db/m3/src/cluster/placement"
 	"github.com/m3db/m3/src/query/api/v1/handler"
 	"github.com/m3db/m3/src/query/generated/proto/admin"
 	"github.com/m3db/m3/src/query/util/logging"
-	"github.com/m3db/m3/src/x/net/http"
+	xhttp "github.com/m3db/m3/src/x/net/http"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"go.uber.org/zap"
@@ -77,6 +78,11 @@ func (h *InitHandler) ServeHTTP(serviceName string, w http.ResponseWriter, r *ht
 
 	placement, err := h.Init(serviceName, r, req)
 	if err != nil {
+		if err == kv.ErrAlreadyExists {
+			logger.Error("placement already exists", zap.Error(err))
+			xhttp.Error(w, err, http.StatusConflict)
+			return
+		}
 		logger.Error("unable to initialize placement", zap.Any("error", err))
 		xhttp.Error(w, err, http.StatusInternalServerError)
 		return

--- a/src/query/api/v1/handler/placement/init_test.go
+++ b/src/query/api/v1/handler/placement/init_test.go
@@ -147,7 +147,7 @@ func TestPlacementInitHandler(t *testing.T) {
 
 		handler.ServeHTTP(serviceName, w, req)
 		resp = w.Result()
-		body, err = ioutil.ReadAll(resp.Body)
+		_, err = ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusConflict, resp.StatusCode)
 	})


### PR DESCRIPTION
Currently when a placement exists and we try to initialize one we send
a 500 error, and when we try to add an existing placement we get a
generic 400 error. This PR adds 409 conflict statuses in both of those
cases.