### PR TITLE
[docker] add image for setting recommended sysctls

### DIFF
--- a/docker/sysctl-setter/Dockerfile
+++ b/docker/sysctl-setter/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:latest
+LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
+
+RUN apk add --no-cache procps && echo $'#!/bin/ash\n\
+set -e\n\
+while true; do\n\
+  MVAL=$(sysctl -n vm.max_map_count)\n\
+  if [ "$MVAL" -ne 3000000 ]; then\n\
+    sysctl -w vm.max_map_count=3000000\n\
+  fi\n\
+  SVAL=$(sysctl -n vm.swappiness)\n\
+  if [ "$SVAL" -ne 1 ]; then\n\
+    sysctl -w vm.swappiness=1\n\
+  fi\n\
+  sleep 60\n\
+done' > /bin/m3dbnode_sysctl.sh &&\
+  chmod +x /bin/m3dbnode_sysctl.sh
+
+ENTRYPOINT [ "/bin/m3dbnode_sysctl.sh" ]

--- a/docs/how_to/kubernetes.md
+++ b/docs/how_to/kubernetes.md
@@ -35,6 +35,11 @@ kubectl apply -f https://raw.githubusercontent.com/m3db/m3/master/kube/storage-f
 If you wish to use your cloud provider's default remote disk, or another disk class entirely, you'll have to modify them
 manifests.
 
+### Kernel Configuration
+
+We provide a Kubernetes daemonset that can make setting host-level sysctls easier. Please see the [kernel][kernel] docs
+for more.
+
 ## Deploying
 
 Apply the following manifest to create your cluster:
@@ -289,3 +294,5 @@ certain nodes. Specifically:
 1. The pods tolerate the taint `"dedicated-m3db"` to run on nodes that are specifically dedicated to m3db if you so
    choose.
 2. Via `nodeAffinity` the pods prefer to run on nodes with the label `m3db.io/dedicated-m3db="true"`.
+
+[kernel]: ../operational_guide/kernel_configuration

--- a/docs/operational_guide/kernel_configuration.md
+++ b/docs/operational_guide/kernel_configuration.md
@@ -3,7 +3,7 @@ Kernel Configuration
 
 This document lists the Kernel tweaks M3DB needs to run well. If you are running on Kubernetes, you may use our
 `sysctl-setter` [DaemonSet](https://github.com/m3db/m3/blob/master/kube/sysctl-daemonset.yaml) that will set these
-values for you.
+values for you. Please read the comment in that manifest to understand the implications of applying it.
 
 ## vm.max_map_count
 M3DB uses a lot of mmap-ed files for performance, as a result, you might need to bump `vm.max_map_count`. We suggest setting this value to `3000000`, so you don’t have to come back and debug issues later.

--- a/docs/operational_guide/kernel_configuration.md
+++ b/docs/operational_guide/kernel_configuration.md
@@ -1,7 +1,9 @@
 Kernel Configuration
 ====================
 
-This document lists the Kernel tweaks M3DB needs to run well.
+This document lists the Kernel tweaks M3DB needs to run well. If you are running on Kubernetes, you may use our
+`sysctl-setter` [DaemonSet](https://github.com/m3db/m3/blob/master/kube/sysctl-daemonset.yaml) that will set these
+values for you.
 
 ## vm.max_map_count
 M3DB uses a lot of mmap-ed files for performance, as a result, you might need to bump `vm.max_map_count`. We suggest setting this value to `3000000`, so you don’t have to come back and debug issues later.

--- a/kube/sysctl-daemonset.yaml
+++ b/kube/sysctl-daemonset.yaml
@@ -1,0 +1,38 @@
+# This manifest provides a daemonset that will ensure the host's sysctls are set
+# to M3DB's recommended values.
+#
+# WARNING: This will run a PRIVILEGED ROOT container on your HOST that will
+# modify host sysctl values. This is designed for managed Kubernetes platforms
+# that may have restrictions like read-only root FS, inability to set startup
+# scripts, etc. In very rare circumstances should you use this, and should
+# intead opt to use your usual host provisioning tooling to set these values.
+#
+# This daemonset pins to a specific SHA digest in the event that the M3DB Quay
+# repo is ever compromised. The manifest of this image can be verified here:
+# https://quay.io/repository/m3db/sysctl-setter/manifest/sha256:a4dbce681a9162e83a780fd647e7efabda1a4e720f4f62fc75494d9f2510abf5
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: sysctl-setter-ds
+  namespace: default
+  labels:
+    app: sysctl-setter
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: sysctl-setter
+  template:
+    metadata:
+      labels:
+        app: sysctl-setter
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - image: quay.io/m3db/sysctl-setter@sha256:a4dbce681a9162e83a780fd647e7efabda1a4e720f4f62fc75494d9f2510abf5
+        imagePullPolicy: Always
+        name: sysctl-setter
+        securityContext:
+          privileged: true

--- a/src/dbnode/server/limits.go
+++ b/src/dbnode/server/limits.go
@@ -29,7 +29,10 @@ import (
 
 const (
 	// TODO: determine these values based on topology/namespace configuration.
-	minNoFile     = 500000
+	minNoFile = 500000
+	// NB(schallert): If updating these values, be sure to update the associated
+	// Dockerfile and kube daemonset (see https://github.com/m3db/m3/pull/1436 for
+	// example).
 	minVMMapCount = 3000000
 	maxSwappiness = 1
 )


### PR DESCRIPTION
This PR provides users with a docker image and Kubernetes DaemonSet that
will set the host's sysctls to our recommended settings. We try to be
careful about this and recommend pinning to a docker image SHA so that
the content is immutable (i.e. someone who controlled our Quay repo
couldn't run arbitrary root containers on hosts that have the image).