### PR TITLE
Add error checks to all block.Builder calls

### DIFF
--- a/src/query/api/v1/handler/graphite/render.go
+++ b/src/query/api/v1/handler/graphite/render.go
@@ -125,7 +125,7 @@ func (h *renderHandler) serveHTTP(
 
 			childCtx := ctx.NewChildContext(common.NewChildContextOptions())
 			defer func() {
-				childCtx.Close()
+				_ = childCtx.Close()
 				wg.Done()
 			}()
 

--- a/src/query/functions/aggregation/base.go
+++ b/src/query/functions/aggregation/base.go
@@ -153,7 +153,9 @@ func (n *baseNode) ProcessBlock(queryCtx *models.QueryContext, ID parser.NodeID,
 			aggregatedValues[i] = n.op.aggFn(values, bucket)
 		}
 
-		builder.AppendValues(index, aggregatedValues)
+		if err := builder.AppendValues(index, aggregatedValues); err != nil {
+			return nil, err
+		}
 	}
 
 	if err = stepIter.Err(); err != nil {

--- a/src/query/functions/aggregation/count_values.go
+++ b/src/query/functions/aggregation/count_values.go
@@ -233,7 +233,9 @@ func (n *countValuesNode) ProcessBlock(queryCtx *models.QueryContext, ID parser.
 				bucketBlock.columns[columnIndex],
 				len(bucketBlock.indexMapping),
 			)
-			builder.AppendValues(columnIndex, valsToAdd)
+			if err := builder.AppendValues(columnIndex, valsToAdd); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/src/query/functions/aggregation/take.go
+++ b/src/query/functions/aggregation/take.go
@@ -150,7 +150,9 @@ func (n *takeNode) ProcessBlock(queryCtx *models.QueryContext, ID parser.NodeID,
 		step := stepIter.Current()
 		values := step.Values()
 		aggregatedValues := n.op.takeFunc(values, buckets)
-		builder.AppendValues(index, aggregatedValues)
+		if err := builder.AppendValues(index, aggregatedValues); err != nil {
+			return nil, err
+		}
 	}
 
 	if err = stepIter.Err(); err != nil {

--- a/src/query/functions/binary/and.go
+++ b/src/query/functions/binary/and.go
@@ -58,11 +58,16 @@ func makeAndBlock(
 		for idx, value := range lValues {
 			rIdx := intersection[idx]
 			if rIdx < 0 || math.IsNaN(rValues[rIdx]) {
-				builder.AppendValue(index, math.NaN())
+				if err := builder.AppendValue(index, math.NaN()); err != nil {
+					return nil, err
+				}
+
 				continue
 			}
 
-			builder.AppendValue(index, value)
+			if err := builder.AppendValue(index, value); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/src/query/functions/binary/binary.go
+++ b/src/query/functions/binary/binary.go
@@ -147,7 +147,9 @@ func processSingleBlock(
 		step := it.Current()
 		values := step.Values()
 		for _, value := range values {
-			builder.AppendValue(index, fn(value))
+			if err := builder.AppendValue(index, fn(value)); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -199,7 +201,9 @@ func processBothSeries(
 			lVal := lValues[lIdx]
 			rVal := rValues[rIdx]
 
-			builder.AppendValue(index, fn(lVal, rVal))
+			if err := builder.AppendValue(index, fn(lVal, rVal)); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/src/query/functions/binary/or.go
+++ b/src/query/functions/binary/or.go
@@ -65,7 +65,9 @@ func makeOrBlock(
 	for ; lIter.Next(); index++ {
 		lStep := lIter.Current()
 		lValues := lStep.Values()
-		builder.AppendValues(index, lValues)
+		if err := builder.AppendValues(index, lValues); err != nil {
+			return nil, err
+		}
 	}
 
 	if err = lIter.Err(); err != nil {

--- a/src/query/functions/linear/base.go
+++ b/src/query/functions/linear/base.go
@@ -109,7 +109,9 @@ func (c *baseNode) ProcessBlock(queryCtx *models.QueryContext, ID parser.NodeID,
 		step := stepIter.Current()
 		values := c.processor.Process(step.Values())
 		for _, value := range values {
-			builder.AppendValue(index, value)
+			if err := builder.AppendValue(index, value); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/src/query/functions/linear/histogram_quantile.go
+++ b/src/query/functions/linear/histogram_quantile.go
@@ -334,7 +334,9 @@ func processValidQuantile(
 			idx++
 		}
 
-		builder.AppendValues(index, aggregatedValues)
+		if err := builder.AppendValues(index, aggregatedValues); err != nil {
+			return nil, err
+		}
 	}
 
 	if err = stepIter.Err(); err != nil {
@@ -368,7 +370,9 @@ func processInvalidQuantile(
 	outValues := make([]float64, len(bucketedSeries))
 	ts.Memset(outValues, setValue)
 	for index := 0; stepIter.Next(); index++ {
-		builder.AppendValues(index, outValues)
+		if err := builder.AppendValues(index, outValues); err != nil {
+			return nil, err
+		}
 	}
 
 	if err = stepIter.Err(); err != nil {

--- a/src/query/functions/temporal/base.go
+++ b/src/query/functions/temporal/base.go
@@ -359,7 +359,9 @@ func (c *baseNode) processSingleRequest(request processRequest) (block.Block, er
 				newVal = c.processor.Process(flattenedValues, alignedTime)
 			}
 
-			builder.AppendValue(i, newVal)
+			if err := builder.AppendValue(i, newVal); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/src/query/functions/unconsolidated/timestamp.go
+++ b/src/query/functions/unconsolidated/timestamp.go
@@ -125,7 +125,9 @@ func (n *timestampNode) ProcessBlock(queryCtx *models.QueryContext, ID parser.No
 		}
 
 		for _, value := range values {
-			builder.AppendValue(index, value)
+			if err := builder.AppendValue(index, value); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/src/query/test/block.go
+++ b/src/query/test/block.go
@@ -124,16 +124,23 @@ func NewBlockFromValuesWithSeriesMeta(
 }
 
 // NewBlockFromValuesWithMetaAndSeriesMeta creates a new block using the provided values
+// Note: panics on errors, since this is a testutil
 func NewBlockFromValuesWithMetaAndSeriesMeta(
 	meta block.Metadata,
 	seriesMeta []block.SeriesMeta,
 	seriesValues [][]float64,
 ) block.Block {
 	columnBuilder := block.NewColumnBlockBuilder(meta, seriesMeta)
-	columnBuilder.AddCols(len(seriesValues[0]))
+
+	if err := columnBuilder.AddCols(len(seriesValues[0])); err != nil {
+		panic(err)
+	}
+
 	for _, seriesVal := range seriesValues {
 		for idx, val := range seriesVal {
-			columnBuilder.AppendValue(idx, val)
+			if err := columnBuilder.AppendValue(idx, val); err != nil {
+				panic(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
I don't think this is causing a bug right now, but I think it might be in my PR. I figured it was worth just adding err checks for all these calls; there's no reason (that I'm aware of) to ignore them.

Depending on how awful it is to do, I may try to get `errcheck` passing on this repo, so we can catch these kinds of things.