### PR TITLE
Fix postings list cache causing incorrect results

### DIFF
--- a/src/dbnode/storage/index/block_prop_test.go
+++ b/src/dbnode/storage/index/block_prop_test.go
@@ -1,0 +1,156 @@
+// +build big
+//
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package index
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	"github.com/m3db/m3/src/m3ninx/idx"
+	"github.com/m3db/m3/src/m3ninx/index/segment"
+	"github.com/m3db/m3/src/m3ninx/index/segment/fst"
+	"github.com/m3db/m3/src/m3ninx/search"
+	"github.com/m3db/m3/src/m3ninx/search/proptest"
+	"github.com/m3db/m3/src/m3ninx/util"
+	"github.com/m3db/m3x/instrument"
+
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/prop"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testFstOptions    = fst.NewOptions()
+	testBlockSize     = time.Hour
+	lotsTestDocuments = util.MustReadDocs("../../../m3ninx/util/testdata/node_exporter.json", 2000)
+)
+
+// TestPostingsListCacheDoesNotAffectBlockQueryResults verifies that the postings list
+// cache does not affect the results of querying a block by creating two blocks, one with
+// the postings list cache enable and one without. It then generates a bunch of queries
+// and executes them against both blocks, ensuring that both blocks return the exact same
+// results. It was added as a regression test when we encountered a bug that caused the
+// postings list cache to cause the block to return incorrect results.
+func TestPostingsListCacheDoesNotAffectBlockQueryResults(t *testing.T) {
+	parameters := gopter.DefaultTestParameters()
+	seed := time.Now().UnixNano()
+	parameters.MinSuccessfulTests = 500
+	parameters.MaxSize = 20
+	parameters.Rng = rand.New(rand.NewSource(seed))
+	properties := gopter.NewProperties(parameters)
+
+	testMD := newTestNSMetadata(t)
+	blockSize := time.Hour
+
+	now := time.Now()
+	blockStart := now.Truncate(blockSize)
+
+	uncachedBlock, err := newPropTestBlock(
+		t, blockStart, testMD, testOpts.SetPostingsListCache(nil))
+	require.NoError(t, err)
+
+	plCache, stopReporting, err := NewPostingsListCache(1000, PostingsListCacheOptions{
+		InstrumentOptions: instrument.NewOptions(),
+	})
+	require.NoError(t, err)
+	defer stopReporting()
+
+	cachedOptions := testOpts.
+		SetPostingsListCache(plCache).
+		SetReadThroughSegmentOptions(ReadThroughSegmentOptions{
+			CacheRegexp: true,
+			CacheTerms:  true,
+		})
+	cachedBlock, err := newPropTestBlock(t, blockStart, testMD, cachedOptions)
+	require.NoError(t, err)
+
+	properties.Property("Any distribution of test documents in segments does not affect query results", prop.ForAll(
+		func(q search.Query) (bool, error) {
+			indexQuery := Query{
+				idx.NewQueryFromSearchQuery(q),
+			}
+
+			uncachedResults := NewResults(testOpts)
+			exhaustive, err := uncachedBlock.Query(indexQuery, QueryOptions{StartInclusive: blockStart, EndExclusive: blockStart.Add(blockSize)}, uncachedResults)
+			if err != nil {
+				return false, fmt.Errorf("error querying uncached block: %v", err)
+			}
+			if !exhaustive {
+				return false, errors.New("querying uncached block was not exhaustive")
+			}
+
+			cachedResults := NewResults(testOpts)
+			exhaustive, err = cachedBlock.Query(indexQuery, QueryOptions{StartInclusive: blockStart, EndExclusive: blockStart.Add(blockSize)}, cachedResults)
+			if err != nil {
+				return false, fmt.Errorf("error querying uncached block: %v", err)
+			}
+			if !exhaustive {
+				return false, errors.New("querying uncached block was not exhaustive")
+			}
+
+			uncachedMap := uncachedResults.Map()
+			cachedMap := cachedResults.Map()
+			if uncachedMap.Len() != cachedMap.Len() {
+				return false, fmt.Errorf(
+					"uncached map size was: %d, but cached map sized was: %d",
+					uncachedMap.Len(), cachedMap.Len())
+			}
+
+			for _, entry := range uncachedMap.Iter() {
+				key := entry.Key()
+				_, ok := cachedMap.Get(key)
+				if !ok {
+					return false, fmt.Errorf("cached map did not contain: %v", key)
+				}
+			}
+
+			return true, nil
+		},
+		proptest.GenQuery(lotsTestDocuments),
+	))
+
+	reporter := gopter.NewFormatedReporter(true, 160, os.Stdout)
+	if !properties.Run(reporter) {
+		t.Errorf("failed with initial seed: %d", seed)
+	}
+}
+
+func newPropTestBlock(t *testing.T, blockStart time.Time, nsMeta namespace.Metadata, opts Options) (Block, error) {
+	blk, err := NewBlock(blockStart, nsMeta, opts)
+	require.NoError(t, err)
+
+	memSeg := testSegment(t, lotsTestDocuments...).(segment.MutableSegment)
+	fstSeg := fst.ToTestSegment(t, memSeg, testFstOptions)
+	// Need at least one shard to look fulfilled.
+	fulfilled := result.NewShardTimeRanges(blockStart, blockStart.Add(testBlockSize), uint32(1))
+	indexBlock := result.NewIndexBlock(blockStart, []segment.Segment{fstSeg}, fulfilled)
+	err = blk.AddResults(indexBlock)
+	require.NoError(t, err)
+	return blk, nil
+}

--- a/src/dbnode/storage/index/postings_list_cache_lru.go
+++ b/src/dbnode/storage/index/postings_list_cache_lru.go
@@ -30,13 +30,12 @@ import (
 )
 
 // PostingsListLRU implements a non-thread safe fixed size LRU cache of postings lists
-// that were resolved by running a given query against a particular segment. Normally
-// an key in the LRU would look like:
+// that were resolved by running a given query against a particular segment for a given
+// field. Normally a key in the LRU would look like:
 //
 // type key struct {
 //    segmentUUID uuid.UUID
-//    pattern     string
-//    patternType PatternType
+//    query       PostingsListCacheQuery,
 // }
 //
 // However, some of the postings lists that we will store in the LRU have a fixed lifecycle
@@ -51,7 +50,7 @@ import (
 // Instead of adding additional tracking on-top of an existing generic LRU, we've created a
 // specialized LRU that instead of having a single top-level map pointing into the linked-list,
 // has a two-level map where the top level map is keyed by segment UUID and the second level map
-// is keyed by pattern and pattern type.
+// is keyed by the PostingsListCacheQuery and PatternType.
 //
 // As a result, when a segment is ready to be closed, they can call into the cache with their
 // UUID and we can efficiently remove all the entries corresponding to that segment from the
@@ -60,25 +59,19 @@ import (
 type postingsListLRU struct {
 	size      int
 	evictList *list.List
-	items     map[uuid.Array]map[patternAndPatternType]*list.Element
+	items     map[uuid.Array]map[key]*list.Element
 }
 
 // entry is used to hold a value in the evictList.
 type entry struct {
 	uuid         uuid.UUID
-	pattern      string
+	query        PostingsListCacheQuery
 	patternType  PatternType
 	postingsList postings.List
 }
 
 type key struct {
-	uuid        uuid.UUID
-	pattern     string
-	patternType PatternType
-}
-
-type patternAndPatternType struct {
-	pattern     string
+	query       PostingsListCacheQuery
 	patternType PatternType
 }
 
@@ -91,22 +84,22 @@ func newPostingsListLRU(size int) (*postingsListLRU, error) {
 	return &postingsListLRU{
 		size:      size,
 		evictList: list.New(),
-		items:     make(map[uuid.Array]map[patternAndPatternType]*list.Element),
+		items:     make(map[uuid.Array]map[key]*list.Element),
 	}, nil
 }
 
 // Add adds a value to the cache. Returns true if an eviction occurred.
 func (c *postingsListLRU) Add(
 	segmentUUID uuid.UUID,
-	pattern string,
+	query PostingsListCacheQuery,
 	patternType PatternType,
 	pl postings.List,
 ) (evicted bool) {
+	newKey := newKey(query, patternType)
 	// Check for existing item.
 	uuidArray := segmentUUID.Array()
 	if uuidEntries, ok := c.items[uuidArray]; ok {
-		key := newPatternAndPatternType(pattern, patternType)
-		if ent, ok := uuidEntries[key]; ok {
+		if ent, ok := uuidEntries[newKey]; ok {
 			// If it already exists, just move it to the front. This avoids storing
 			// the same item in the LRU twice which is important because the maps
 			// can only point to one entry at a time and we use them for purges. Also,
@@ -121,18 +114,17 @@ func (c *postingsListLRU) Add(
 	var (
 		ent = &entry{
 			uuid:         segmentUUID,
-			pattern:      pattern,
+			query:        query,
 			patternType:  patternType,
 			postingsList: pl,
 		}
 		entry = c.evictList.PushFront(ent)
-		key   = newPatternAndPatternType(pattern, patternType)
 	)
-	if patterns, ok := c.items[uuidArray]; ok {
-		patterns[key] = entry
+	if queries, ok := c.items[uuidArray]; ok {
+		queries[newKey] = entry
 	} else {
-		c.items[uuidArray] = map[patternAndPatternType]*list.Element{
-			key: entry,
+		c.items[uuidArray] = map[key]*list.Element{
+			newKey: entry,
 		}
 	}
 
@@ -147,13 +139,13 @@ func (c *postingsListLRU) Add(
 // Get looks up a key's value from the cache.
 func (c *postingsListLRU) Get(
 	segmentUUID uuid.UUID,
-	pattern string,
+	query PostingsListCacheQuery,
 	patternType PatternType,
 ) (postings.List, bool) {
+	newKey := newKey(query, patternType)
 	uuidArray := segmentUUID.Array()
 	if uuidEntries, ok := c.items[uuidArray]; ok {
-		key := newPatternAndPatternType(pattern, patternType)
-		if ent, ok := uuidEntries[key]; ok {
+		if ent, ok := uuidEntries[newKey]; ok {
 			c.evictList.MoveToFront(ent)
 			return ent.Value.(*entry).postingsList, true
 		}
@@ -166,13 +158,13 @@ func (c *postingsListLRU) Get(
 // key was contained.
 func (c *postingsListLRU) Remove(
 	segmentUUID uuid.UUID,
-	pattern string,
+	query PostingsListCacheQuery,
 	patternType PatternType,
 ) bool {
+	newKey := newKey(query, patternType)
 	uuidArray := segmentUUID.Array()
 	if uuidEntries, ok := c.items[uuidArray]; ok {
-		key := newPatternAndPatternType(pattern, patternType)
-		if ent, ok := uuidEntries[key]; ok {
+		if ent, ok := uuidEntries[newKey]; ok {
 			c.removeElement(ent)
 			return true
 		}
@@ -208,14 +200,13 @@ func (c *postingsListLRU) removeElement(e *list.Element) {
 	entry := e.Value.(*entry)
 
 	if patterns, ok := c.items[entry.uuid.Array()]; ok {
-		key := newPatternAndPatternType(entry.pattern, entry.patternType)
-		delete(patterns, key)
+		delete(patterns, newKey(entry.query, entry.patternType))
 		if len(patterns) == 0 {
 			delete(c.items, entry.uuid.Array())
 		}
 	}
 }
 
-func newPatternAndPatternType(pattern string, patternType PatternType) patternAndPatternType {
-	return patternAndPatternType{pattern: pattern, patternType: patternType}
+func newKey(query PostingsListCacheQuery, patternType PatternType) key {
+	return key{query: query, patternType: patternType}
 }

--- a/src/dbnode/storage/index/postings_list_cache_lru.go
+++ b/src/dbnode/storage/index/postings_list_cache_lru.go
@@ -31,11 +31,13 @@ import (
 
 // PostingsListLRU implements a non-thread safe fixed size LRU cache of postings lists
 // that were resolved by running a given query against a particular segment for a given
-// field. Normally a key in the LRU would look like:
+// field and pattern type (term vs regexp). Normally a key in the LRU would look like:
 //
 // type key struct {
 //    segmentUUID uuid.UUID
-//    query       PostingsListCacheQuery,
+//    field       string
+//    pattern     string
+//    patternType PatternType
 // }
 //
 // However, some of the postings lists that we will store in the LRU have a fixed lifecycle
@@ -50,7 +52,7 @@ import (
 // Instead of adding additional tracking on-top of an existing generic LRU, we've created a
 // specialized LRU that instead of having a single top-level map pointing into the linked-list,
 // has a two-level map where the top level map is keyed by segment UUID and the second level map
-// is keyed by the PostingsListCacheQuery and PatternType.
+// is keyed by the field/pattern/patternType.
 //
 // As a result, when a segment is ready to be closed, they can call into the cache with their
 // UUID and we can efficiently remove all the entries corresponding to that segment from the

--- a/src/dbnode/storage/index/postings_list_cache_lru.go
+++ b/src/dbnode/storage/index/postings_list_cache_lru.go
@@ -65,8 +65,7 @@ type postingsListLRU struct {
 // entry is used to hold a value in the evictList.
 type entry struct {
 	uuid         uuid.UUID
-	query        PostingsListCacheQuery
-	patternType  PatternType
+	key          key
 	postingsList postings.List
 }
 
@@ -114,8 +113,7 @@ func (c *postingsListLRU) Add(
 	var (
 		ent = &entry{
 			uuid:         segmentUUID,
-			query:        query,
-			patternType:  patternType,
+			key:          newKey,
 			postingsList: pl,
 		}
 		entry = c.evictList.PushFront(ent)
@@ -200,7 +198,7 @@ func (c *postingsListLRU) removeElement(e *list.Element) {
 	entry := e.Value.(*entry)
 
 	if patterns, ok := c.items[entry.uuid.Array()]; ok {
-		delete(patterns, newKey(entry.query, entry.patternType))
+		delete(patterns, entry.key)
 		if len(patterns) == 0 {
 			delete(c.items, entry.uuid.Array())
 		}

--- a/src/dbnode/storage/index/postings_list_cache_lru.go
+++ b/src/dbnode/storage/index/postings_list_cache_lru.go
@@ -70,7 +70,8 @@ type entry struct {
 }
 
 type key struct {
-	query       PostingsListCacheQuery
+	field       string
+	pattern     string
 	patternType PatternType
 }
 
@@ -90,11 +91,12 @@ func newPostingsListLRU(size int) (*postingsListLRU, error) {
 // Add adds a value to the cache. Returns true if an eviction occurred.
 func (c *postingsListLRU) Add(
 	segmentUUID uuid.UUID,
-	query PostingsListCacheQuery,
+	field string,
+	pattern string,
 	patternType PatternType,
 	pl postings.List,
 ) (evicted bool) {
-	newKey := newKey(query, patternType)
+	newKey := newKey(field, pattern, patternType)
 	// Check for existing item.
 	uuidArray := segmentUUID.Array()
 	if uuidEntries, ok := c.items[uuidArray]; ok {
@@ -137,10 +139,11 @@ func (c *postingsListLRU) Add(
 // Get looks up a key's value from the cache.
 func (c *postingsListLRU) Get(
 	segmentUUID uuid.UUID,
-	query PostingsListCacheQuery,
+	field string,
+	pattern string,
 	patternType PatternType,
 ) (postings.List, bool) {
-	newKey := newKey(query, patternType)
+	newKey := newKey(field, pattern, patternType)
 	uuidArray := segmentUUID.Array()
 	if uuidEntries, ok := c.items[uuidArray]; ok {
 		if ent, ok := uuidEntries[newKey]; ok {
@@ -156,10 +159,11 @@ func (c *postingsListLRU) Get(
 // key was contained.
 func (c *postingsListLRU) Remove(
 	segmentUUID uuid.UUID,
-	query PostingsListCacheQuery,
+	field string,
+	pattern string,
 	patternType PatternType,
 ) bool {
-	newKey := newKey(query, patternType)
+	newKey := newKey(field, pattern, patternType)
 	uuidArray := segmentUUID.Array()
 	if uuidEntries, ok := c.items[uuidArray]; ok {
 		if ent, ok := uuidEntries[newKey]; ok {
@@ -205,6 +209,6 @@ func (c *postingsListLRU) removeElement(e *list.Element) {
 	}
 }
 
-func newKey(query PostingsListCacheQuery, patternType PatternType) key {
-	return key{query: query, patternType: patternType}
+func newKey(field, pattern string, patternType PatternType) key {
+	return key{field: field, pattern: pattern, patternType: patternType}
 }

--- a/src/dbnode/storage/index/postings_list_cache_lru_test.go
+++ b/src/dbnode/storage/index/postings_list_cache_lru_test.go
@@ -26,11 +26,7 @@ func (c *postingsListLRU) keys() []key {
 	keys := make([]key, 0, len(c.items))
 	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
 		entry := ent.Value.(*entry)
-		keys = append(keys, key{
-			uuid:        entry.uuid,
-			pattern:     entry.pattern,
-			patternType: entry.patternType,
-		})
+		keys = append(keys, newKey(entry.query, entry.patternType))
 	}
 	return keys
 }

--- a/src/dbnode/storage/index/postings_list_cache_lru_test.go
+++ b/src/dbnode/storage/index/postings_list_cache_lru_test.go
@@ -26,7 +26,7 @@ func (c *postingsListLRU) keys() []key {
 	keys := make([]key, 0, len(c.items))
 	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
 		entry := ent.Value.(*entry)
-		keys = append(keys, newKey(entry.query, entry.patternType))
+		keys = append(keys, entry.key)
 	}
 	return keys
 }

--- a/src/dbnode/storage/index/postings_list_cache_test.go
+++ b/src/dbnode/storage/index/postings_list_cache_test.go
@@ -102,17 +102,10 @@ func TestSimpleLRUBehavior(t *testing.T) {
 	putEntry(plCache, 0)
 	putEntry(plCache, 1)
 	putEntry(plCache, 2)
-
-	expectedOrder := []testEntry{e0, e1, e2}
-	for i, key := range plCache.lru.keys() {
-		require.Equal(t, expectedOrder[i].toKey(), key)
-	}
+	requireExpectedOrder(t, plCache, []testEntry{e0, e1, e2})
 
 	putEntry(plCache, 3)
-	expectedOrder = []testEntry{e1, e2, e3}
-	for i, key := range plCache.lru.keys() {
-		require.Equal(t, expectedOrder[i].toKey(), key)
-	}
+	requireExpectedOrder(t, plCache, []testEntry{e1, e2, e3})
 
 	putEntry(plCache, 4)
 	putEntry(plCache, 4)
@@ -120,34 +113,22 @@ func TestSimpleLRUBehavior(t *testing.T) {
 	putEntry(plCache, 5)
 	putEntry(plCache, 0)
 	putEntry(plCache, 0)
-
-	expectedOrder = []testEntry{e4, e5, e0}
-	for i, key := range plCache.lru.keys() {
-		require.Equal(t, expectedOrder[i].toKey(), key)
-	}
+	requireExpectedOrder(t, plCache, []testEntry{e4, e5, e0})
 
 	// Miss, no expected change.
 	getEntry(plCache, 100)
-	for i, key := range plCache.lru.keys() {
-		require.Equal(t, expectedOrder[i].toKey(), key)
-	}
+	requireExpectedOrder(t, plCache, []testEntry{e4, e5, e0})
 
 	// Hit.
 	getEntry(plCache, 4)
-	expectedOrder = []testEntry{e5, e0, e4}
-	for i, key := range plCache.lru.keys() {
-		require.Equal(t, expectedOrder[i].toKey(), key)
-	}
+	requireExpectedOrder(t, plCache, []testEntry{e5, e0, e4})
 
 	// Multiple hits.
 	getEntry(plCache, 4)
 	getEntry(plCache, 0)
 	getEntry(plCache, 5)
 	getEntry(plCache, 5)
-	expectedOrder = []testEntry{e4, e0, e5}
-	for i, key := range plCache.lru.keys() {
-		require.Equal(t, expectedOrder[i].toKey(), key)
-	}
+	requireExpectedOrder(t, plCache, []testEntry{e4, e0, e5})
 }
 
 func TestPurgeSegment(t *testing.T) {
@@ -330,6 +311,12 @@ func getEntry(cache *PostingsListCache, i int) (postings.List, bool) {
 		testPlEntries[i].segmentUUID,
 		testPlEntries[i].query,
 	)
+}
+
+func requireExpectedOrder(t *testing.T, plCache *PostingsListCache, expectedOrder []testEntry) {
+	for i, key := range plCache.lru.keys() {
+		require.Equal(t, expectedOrder[i].toKey(), key)
+	}
 }
 
 func printSortedKeys(t *testing.T, cache *PostingsListCache) {

--- a/src/dbnode/storage/index/read_through_segment.go
+++ b/src/dbnode/storage/index/read_through_segment.go
@@ -149,18 +149,16 @@ func (s *readThroughSegmentReader) MatchRegexp(
 	}
 
 	// TODO(rartoul): Would be nice to not allocate strings here.
-	plCacheQuery := PostingsListCacheQuery{
-		Field:   string(field),
-		Pattern: c.FSTSyntax.String(),
-	}
-	pl, ok := s.postingsListCache.GetRegexp(s.uuid, plCacheQuery)
+	fieldStr := string(field)
+	patternStr := c.FSTSyntax.String()
+	pl, ok := s.postingsListCache.GetRegexp(s.uuid, fieldStr, patternStr)
 	if ok {
 		return pl, nil
 	}
 
 	pl, err := s.Reader.MatchRegexp(field, c)
 	if err == nil {
-		s.postingsListCache.PutRegexp(s.uuid, plCacheQuery, pl)
+		s.postingsListCache.PutRegexp(s.uuid, fieldStr, patternStr, pl)
 	}
 	return pl, err
 }
@@ -175,18 +173,16 @@ func (s *readThroughSegmentReader) MatchTerm(
 	}
 
 	// TODO(rartoul): Would be nice to not allocate strings here.
-	plCacheQuery := PostingsListCacheQuery{
-		Field:   string(field),
-		Pattern: string(term),
-	}
-	pl, ok := s.postingsListCache.GetTerm(s.uuid, plCacheQuery)
+	fieldStr := string(field)
+	patternStr := string(term)
+	pl, ok := s.postingsListCache.GetTerm(s.uuid, fieldStr, patternStr)
 	if ok {
 		return pl, nil
 	}
 
 	pl, err := s.Reader.MatchTerm(field, term)
 	if err == nil {
-		s.postingsListCache.PutTerm(s.uuid, plCacheQuery, pl)
+		s.postingsListCache.PutTerm(s.uuid, fieldStr, patternStr, pl)
 	}
 	return pl, err
 }

--- a/src/dbnode/storage/index/read_through_segment.go
+++ b/src/dbnode/storage/index/read_through_segment.go
@@ -148,16 +148,18 @@ func (s *readThroughSegmentReader) MatchRegexp(
 		return s.Reader.MatchRegexp(field, c)
 	}
 
-	// TODO(rartoul): Would be nice not to allocate a string here.
-	pattern := c.FSTSyntax.String()
-	pl, ok := s.postingsListCache.GetRegexp(s.uuid, pattern)
+	plCacheQuery := PostingsListCacheQuery{
+		Field:   string(field),
+		Pattern: c.FSTSyntax.String(),
+	}
+	pl, ok := s.postingsListCache.GetRegexp(s.uuid, plCacheQuery)
 	if ok {
 		return pl, nil
 	}
 
 	pl, err := s.Reader.MatchRegexp(field, c)
 	if err == nil {
-		s.postingsListCache.PutRegexp(s.uuid, pattern, pl)
+		s.postingsListCache.PutRegexp(s.uuid, plCacheQuery, pl)
 	}
 	return pl, err
 }
@@ -171,16 +173,18 @@ func (s *readThroughSegmentReader) MatchTerm(
 		return s.Reader.MatchTerm(field, term)
 	}
 
-	// TODO(rartoul): Would be nice to not allocate a string here.
-	termString := string(term)
-	pl, ok := s.postingsListCache.GetTerm(s.uuid, termString)
+	plCacheQuery := PostingsListCacheQuery{
+		Field:   string(field),
+		Pattern: string(term),
+	}
+	pl, ok := s.postingsListCache.GetTerm(s.uuid, plCacheQuery)
 	if ok {
 		return pl, nil
 	}
 
 	pl, err := s.Reader.MatchTerm(field, term)
 	if err == nil {
-		s.postingsListCache.PutTerm(s.uuid, termString, pl)
+		s.postingsListCache.PutTerm(s.uuid, plCacheQuery, pl)
 	}
 	return pl, err
 }

--- a/src/dbnode/storage/index/read_through_segment.go
+++ b/src/dbnode/storage/index/read_through_segment.go
@@ -148,6 +148,7 @@ func (s *readThroughSegmentReader) MatchRegexp(
 		return s.Reader.MatchRegexp(field, c)
 	}
 
+	// TODO(rartoul): Would be nice to not allocate strings here.
 	plCacheQuery := PostingsListCacheQuery{
 		Field:   string(field),
 		Pattern: c.FSTSyntax.String(),
@@ -173,6 +174,7 @@ func (s *readThroughSegmentReader) MatchTerm(
 		return s.Reader.MatchTerm(field, term)
 	}
 
+	// TODO(rartoul): Would be nice to not allocate strings here.
 	plCacheQuery := PostingsListCacheQuery{
 		Field:   string(field),
 		Pattern: string(term),

--- a/src/dbnode/storage/index/read_through_segment_test.go
+++ b/src/dbnode/storage/index/read_through_segment_test.go
@@ -277,7 +277,11 @@ func TestClose(t *testing.T) {
 
 	// Store an entry for the segment in the cache so we can check if it
 	// gets purged after.
-	cache.PutRegexp(segmentUUID, "some-regexp", roaring.NewPostingsList())
+	query := PostingsListCacheQuery{
+		Field:   "some-field",
+		Pattern: "some-pattern",
+	}
+	cache.PutRegexp(segmentUUID, query, roaring.NewPostingsList())
 
 	segment.EXPECT().Close().Return(nil)
 	err = readThroughSeg.Close()

--- a/src/dbnode/storage/index/read_through_segment_test.go
+++ b/src/dbnode/storage/index/read_through_segment_test.go
@@ -277,11 +277,7 @@ func TestClose(t *testing.T) {
 
 	// Store an entry for the segment in the cache so we can check if it
 	// gets purged after.
-	query := PostingsListCacheQuery{
-		Field:   "some-field",
-		Pattern: "some-pattern",
-	}
-	cache.PutRegexp(segmentUUID, query, roaring.NewPostingsList())
+	cache.PutRegexp(segmentUUID, "some-field", "some-pattern", roaring.NewPostingsList())
 
 	segment.EXPECT().Close().Return(nil)
 	err = readThroughSeg.Close()

--- a/src/m3ninx/idx/query.go
+++ b/src/m3ninx/idx/query.go
@@ -34,6 +34,13 @@ func (q Query) String() string {
 	return q.query.String()
 }
 
+// NewQueryFromSearchQuery creates a new Query from a search.Query.
+func NewQueryFromSearchQuery(q search.Query) Query {
+	return Query{
+		query: q,
+	}
+}
+
 // NewTermQuery returns a new query for finding documents which match a term exactly.
 func NewTermQuery(field, term []byte) Query {
 	return Query{

--- a/src/m3ninx/search/proptest/concurrent_test.go
+++ b/src/m3ninx/search/proptest/concurrent_test.go
@@ -93,7 +93,7 @@ func TestConcurrentQueries(t *testing.T) {
 
 			return true, nil
 		},
-		genQuery(lotsTestDocuments),
+		GenQuery(lotsTestDocuments),
 	))
 
 	reporter := gopter.NewFormatedReporter(true, 160, os.Stdout)

--- a/src/m3ninx/search/proptest/prop_test.go
+++ b/src/m3ninx/search/proptest/prop_test.go
@@ -132,7 +132,7 @@ func TestFSTSimpleSegmentsQueryTheSame(t *testing.T) {
 
 			return true, nil
 		},
-		genQuery(lotsTestDocuments),
+		GenQuery(lotsTestDocuments),
 	))
 
 	reporter := gopter.NewFormatedReporter(true, 160, os.Stdout)

--- a/src/m3ninx/search/proptest/prop_test.go
+++ b/src/m3ninx/search/proptest/prop_test.go
@@ -84,7 +84,7 @@ func TestSegmentDistributionDoesNotAffectQuery(t *testing.T) {
 			return true, nil
 		},
 		genPropTestInput(len(lotsTestDocuments)),
-		genQuery(lotsTestDocuments),
+		GenQuery(lotsTestDocuments),
 	))
 
 	reporter := gopter.NewFormatedReporter(true, 160, os.Stdout)

--- a/src/m3ninx/search/proptest/query_gen.go
+++ b/src/m3ninx/search/proptest/query_gen.go
@@ -32,7 +32,8 @@ import (
 	"github.com/leanovate/gopter/gen"
 )
 
-func genTermQuery(docs []doc.Document) gopter.Gen {
+// GenTermQuery generates a term query.
+func GenTermQuery(docs []doc.Document) gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		docIDRes, ok := gen.IntRange(0, len(docs)-1)(genParams).Retrieve()
 		if !ok {
@@ -54,7 +55,8 @@ func genTermQuery(docs []doc.Document) gopter.Gen {
 	}
 }
 
-func genRegexpQuery(docs []doc.Document) gopter.Gen {
+// GenRegexpQuery generates a regexp query.
+func GenRegexpQuery(docs []doc.Document) gopter.Gen {
 	return func(genParams *gopter.GenParameters) *gopter.GenResult {
 		docIDRes, ok := gen.IntRange(0, len(docs)-1)(genParams).Retrieve()
 		if !ok {
@@ -102,45 +104,49 @@ func genRegexpQuery(docs []doc.Document) gopter.Gen {
 	}
 }
 
-func genNegationQuery(docs []doc.Document) gopter.Gen {
+// GenNegationQuery generates a negation query.
+func GenNegationQuery(docs []doc.Document) gopter.Gen {
 	return gen.OneGenOf(
-		genTermQuery(docs),
-		genRegexpQuery(docs),
+		GenTermQuery(docs),
+		GenRegexpQuery(docs),
 	).
 		Map(func(q search.Query) search.Query {
 			return query.NewNegationQuery(q)
 		})
 }
 
-func genConjuctionQuery(docs []doc.Document) gopter.Gen {
+// GenConjunctionQuery generates a conjunction query.
+func GenConjunctionQuery(docs []doc.Document) gopter.Gen {
 	return gen.SliceOf(
 		gen.OneGenOf(
-			genTermQuery(docs),
-			genRegexpQuery(docs),
-			genNegationQuery(docs)),
+			GenTermQuery(docs),
+			GenRegexpQuery(docs),
+			GenNegationQuery(docs)),
 		reflect.TypeOf((*search.Query)(nil)).Elem()).
 		Map(func(qs []search.Query) search.Query {
 			return query.NewConjunctionQuery(qs)
 		})
 }
 
-func genDisjunctionQuery(docs []doc.Document) gopter.Gen {
+// GenDisjunctionQuery generates a disjunction query.
+func GenDisjunctionQuery(docs []doc.Document) gopter.Gen {
 	return gen.SliceOf(
 		gen.OneGenOf(
-			genTermQuery(docs),
-			genRegexpQuery(docs),
-			genNegationQuery(docs)),
+			GenTermQuery(docs),
+			GenRegexpQuery(docs),
+			GenNegationQuery(docs)),
 		reflect.TypeOf((*search.Query)(nil)).Elem()).
 		Map(func(qs []search.Query) search.Query {
 			return query.NewDisjunctionQuery(qs)
 		})
 }
 
-func genQuery(docs []doc.Document) gopter.Gen {
+// GenQuery generates a query.
+func GenQuery(docs []doc.Document) gopter.Gen {
 	return gen.OneGenOf(
-		genTermQuery(docs),
-		genRegexpQuery(docs),
-		genNegationQuery(docs),
-		genConjuctionQuery(docs),
-		genDisjunctionQuery(docs))
+		GenTermQuery(docs),
+		GenRegexpQuery(docs),
+		GenNegationQuery(docs),
+		GenConjunctionQuery(docs),
+		GenDisjunctionQuery(docs))
 }


### PR DESCRIPTION
The postings list cache was broken in that the key did not include the field that the query was executed against. This meant that for a given segment UUID the results of a query for one term could be mixed up with the results of the same query but for a different term. This would lead to incorrect results being returned when the index block was queried.

This P.R introduces the field as part of the key in the postings list cache to resolve the issue. In addition, it introduces a property test that generates two index blocks, one with the postings list cache enabled and one without, and then executes hundreds of different queries against both blocks and makes sure that they return the exact same result in all cases.