### PR TITLE
[coordinator] only log stack traces on panic

### DIFF
--- a/src/query/util/logging/log.go
+++ b/src/query/util/logging/log.go
@@ -45,18 +45,20 @@ const (
 	undefinedID = "undefined"
 )
 
-var logger *zap.Logger
+var (
+	logger *zap.Logger
+
+	highPriority = zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return lvl >= zapcore.ErrorLevel
+	})
+	lowPriority = zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return lvl < zapcore.ErrorLevel
+	})
+)
 
 // InitWithCores is used to set up a new logger.
 func InitWithCores(cores []zapcore.Core) {
 	consoleEncoder := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
-
-	highPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-		return lvl >= zapcore.ErrorLevel
-	})
-	lowPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-		return lvl < zapcore.ErrorLevel
-	})
 
 	consoleErrors := zapcore.Lock(os.Stderr)
 	consoleDebugging := zapcore.Lock(os.Stdout)
@@ -162,7 +164,7 @@ func withPanicErrorResponderFunc(
 
 		defer func() {
 			if err := recover(); err != nil {
-				logger := WithContext(r.Context())
+				logger := WithContext(r.Context()).WithOptions(zap.AddStacktrace(highPriority))
 				logger.Error("panic captured", zap.Any("stack", err))
 
 				if !writeCheckWriter.Written() {

--- a/src/query/util/logging/log.go
+++ b/src/query/util/logging/log.go
@@ -30,7 +30,7 @@ import (
 
 	xhttp "github.com/m3db/m3/src/x/net/http"
 
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -70,7 +70,7 @@ func InitWithCores(cores []zapcore.Core) {
 
 	core := zapcore.NewTee(cores...)
 
-	logger = zap.New(core).WithOptions(zap.AddStacktrace(highPriority))
+	logger = zap.New(core)
 	defer logger.Sync()
 }
 


### PR DESCRIPTION
It's often clear where errors are coming from. When stack traces are
enabled, if a coordinator is being used as a prom backend and there's an
error with the M3DB cluster then every single prom write causes a stack
trace and the logs quickly fill up, making debugging difficult.