### PR TITLE
Tweak operational guide - cosmetics

### DIFF
--- a/docs/operational_guide/placement.md
+++ b/docs/operational_guide/placement.md
@@ -97,10 +97,10 @@ Replication factor: 3
 │                          │                             │                           │                         │                         │
 │                          │ ┌─────────────────────────┐ │ ┌───────────────────────┐ │┌───────────────────────┐│┌──────────────────────┐ │
 │                          │ │                         │ │ │                       │ ││                       │││                      │ │
-│                          │ │                         │ │ │                       │ ││  Shard 1: Available   │││                      │ │
-│                          │ │   Shard 1: Initializing │ │ │  Shard 1: Available   │ ││  Shard 2: Available   │││   Shard 1: Leaving   │ │
-│  2) Begin Node Remove    │ │   Shard 2: Available    │ │ │  Shard 2: Initializing│ ││  Shard 3: Initializing│││   Shard 2: Leaving   │ │
-│                          │ │   Shard 3: Available    │ │ │  Shard 3: Available   │ ││                       │││   Shard 3: Leaving   │ │
+│                          │ │                         │ │ │                       │ ││                       │││                      │ │
+│                          │ │   Shard 1: Initializing │ │ │  Shard 1: Available   │ ││  Shard 1: Available   │││   Shard 1: Leaving   │ │
+│  2) Begin Node Remove    │ │   Shard 2: Available    │ │ │  Shard 2: Initializing│ ││  Shard 2: Available   │││   Shard 2: Leaving   │ │
+│                          │ │   Shard 3: Available    │ │ │  Shard 3: Available   │ ││  Shard 3: Initializing│││   Shard 3: Leaving   │ │
 │                          │ │                         │ │ │                       │ ││                       │││                      │ │
 │                          │ │                         │ │ │                       │ ││                       │││                      │ │
 │                          │ └─────────────────────────┘ │ └───────────────────────┘ │└───────────────────────┘│└──────────────────────┘ │
@@ -111,7 +111,7 @@ Replication factor: 3
 │                          │ │                         │ │ │                       │ │ │                      ││                         │
 │                          │ │                         │ │ │                       │ │ │                      ││                         │
 │                          │ │    Shard 1: Avaiable    │ │ │  Shard 1: Available   │ │ │  Shard 1: Available  ││                         │
-│  3) Complete Node Add    │ │   Shard 2: Available    │ │ │  Shard 2: Available   │ │ │  Shard 2: Available  ││                         │
+│  3) Complete Node Remove │ │   Shard 2: Available    │ │ │  Shard 2: Available   │ │ │  Shard 2: Available  ││                         │
 │                          │ │   Shard 3: Available    │ │ │  Shard 3: Available   │ │ │  Shard 3: Available  ││                         │
 │                          │ │                         │ │ │                       │ │ │                      ││                         │
 │                          │ │                         │ │ │                       │ │ │                      ││                         │
@@ -145,7 +145,7 @@ Replication factor: 3
 │                          │ │                         │ │ │                       │ ││                       │││                      │ │
 │                          │ │                         │ │ │                       │ ││                       │││                      │ │
 │                          │ │   Shard 1: Available    │ │ │  Shard 1: Available   │ ││   Shard 1: Leaving    │││Shard 1: Initializing │ │
-│  2) Begin Node Remove    │ │   Shard 2: Available    │ │ │  Shard 2: Available   │ ││   Shard 2: Leaving    │││Shard 2: Initializing │ │
+│  2) Begin Node Replace   │ │   Shard 2: Available    │ │ │  Shard 2: Available   │ ││   Shard 2: Leaving    │││Shard 2: Initializing │ │
 │                          │ │   Shard 3: Available    │ │ │  Shard 3: Available   │ ││   Shard 3: Leaving    │││Shard 3: Initializing │ │
 │                          │ │                         │ │ │                       │ ││                       │││                      │ │
 │                          │ │                         │ │ │                       │ ││                       │││                      │ │
@@ -156,8 +156,8 @@ Replication factor: 3
 │                          │ ┌─────────────────────────┐ │ ┌───────────────────────┐ │                         │┌──────────────────────┐ │
 │                          │ │                         │ │ │                       │ │                         ││                      │ │
 │                          │ │                         │ │ │                       │ │                         ││                      │ │
-│                          │ │    Shard 1: Avaiable    │ │ │  Shard 1: Available   │ │                         ││  Shard 1: Available  │ │
-│  3) Complete Node Add    │ │   Shard 2: Available    │ │ │  Shard 2: Available   │ │                         ││  Shard 2: Available  │ │
+│                          │ │   Shard 1: Avaiable     │ │ │  Shard 1: Available   │ │                         ││  Shard 1: Available  │ │
+│  3) Complete Node Replace│ │   Shard 2: Available    │ │ │  Shard 2: Available   │ │                         ││  Shard 2: Available  │ │
 │                          │ │   Shard 3: Available    │ │ │  Shard 3: Available   │ │                         ││  Shard 3: Available  │ │
 │                          │ │                         │ │ │                       │ │                         ││                      │ │
 │                          │ │                         │ │ │                       │ │                         ││                      │ │

--- a/docs/operational_guide/placement_configuration.md
+++ b/docs/operational_guide/placement_configuration.md
@@ -44,15 +44,15 @@ This value should be an integer and controls how the cluster will weigh the numb
 
 #### Endpoint
 
-This value should be in the form of <M3DB_HOST_NAME>:<M3DB_NODE_LISTEN_PORT> and identifies how network requests should be routed to this particular node in the placement.
+This value should be in the form of `<M3DB_HOST_NAME>:<M3DB_NODE_LISTEN_PORT>` and identifies how network requests should be routed to this particular node in the placement.
 
 #### Hostname
 
-This value should be in the form of <M3DB_HOST_NAME> and identifies the address / host name of the M3DB node.
+This value should be in the form of `<M3DB_HOST_NAME>` and identifies the address / host name of the M3DB node.
 
 #### Port
 
-This value should be in the form of <M3DB_NODE_LISTEN_PORT> and identifies the port over which this M3DB node expects to receive traffic (defaults to 9000).
+This value should be in the form of `<M3DB_NODE_LISTEN_PORT>` and identifies the port over which this M3DB node expects to receive traffic (defaults to 9000).
 
 ### Placement Operations
 


### PR DESCRIPTION
This PR tweaks the operational guide for placement.

In placement.md a few cosmetics in the ascii diagrams addressed.

Regarding placement_configuration.md, now, when m3db.io is rendered,  this text

```
#### Endpoint

This value should be in the form of <M3DB_HOST_NAME>:<M3DB_NODE_LISTEN_PORT> and identifies how network requests should be routed to this particular node in the placement.
```

is rendered incorrectly:

<img width="857" alt="Screenshot 2019-03-21 at 15 01 45" src="https://user-images.githubusercontent.com/1532071/54753738-73476500-4bea-11e9-8a3e-7dbc5f7a2ee6.png">
