### PR TITLE
[docs] Update docs, fix typo and add a link to fanout docs

### DIFF
--- a/docs/m3db/architecture/peer_streaming.md
+++ b/docs/m3db/architecture/peer_streaming.md
@@ -2,17 +2,17 @@
 
 ## Client
 
-Peer streaming is managed by the M3DB client.  It fetches all blocks from peers for a specified time range for bootstrapping purposes.  It performs the following steps:
+Peer streaming is managed by the M3DB client. It fetches all blocks from peers for a specified time range for bootstrapping purposes. It performs the following steps:
 
 1. Fetch all metadata for blocks from all peers who own the specified shard
 2. Compares metadata from different peers and determines the best peer(s) from which to stream the actual data
 3. Streams the block data from peers
 
-Steps 1, 2 and 3 all happen concurrently.  As metadata streams in, we begin determining which peer is the best source to stream a given block's data for a given series from, and then we begin streaming data from that peer while we continue to receive metadata.  If the checksum for a given series block matches all three replicas then the least loaded (in terms of outstanding requests) and recently attempted will be selected to stream from.  If the checksum differs for the series block across any of the peers then a fanout fetch of the series block is performed.
+Steps 1, 2 and 3 all happen concurrently. As metadata streams in, we begin determining which peer is the best source to stream a given block's data for a given series from, and then we begin streaming data from that peer while we continue to receive metadata. If the checksum for a given series block matches all three replicas then the least loaded (in terms of outstanding requests) and recently attempted will be selected to stream from. If the checksum differs for the series block across any of the peers then a fanout fetch of the series block is performed.
 
-In terms of error handling, the client will respect the consistency level specified for bootstrap.  This means that when fetching metadata, indefinite retry is performed until the consistency level is achieved, for instance for quorum a majority of peers must successfully return metadata.  For fetching the block data, if checksum matches from all peers then one successful fetch must occur, unless bootstrap consistency level "none" is specified, and if checksum mismatches then the specified consistency level must be achieved when the series block fetch is fanned out to peers.  Fetching block data as well will indefinitely retry until the consistency level is achieved.
+In terms of error handling, the client will respect the consistency level specified for bootstrap. This means that when fetching metadata, indefinite retry is performed until the consistency level is achieved, for instance for quorum a majority of peers must successfully return metadata. For fetching the block data, if checksum matches from all peers then one successful fetch must occur, unless bootstrap consistency level "none" is specified, and if checksum mismatches then the specified consistency level must be achieved when the series block fetch is fanned out to peers. Fetching block data as well will indefinitely retry until the consistency level is achieved.
 
-The client supports dynamically changing the bootstrap consistency level, which is helfpul in disaster scenarios where the consistency level cannot be achieved.  To break the indefinite streaming attempt an operator can change the consistency level to "none" and a purely best-effort will be made to fetch the metadata and correspondingly to fetch the block data.
+The client supports dynamically changing the bootstrap consistency level, which is helpful in disaster scenarios where the consistency level cannot be achieved. To break the indefinite streaming attempt an operator can change the consistency level to "none" and a purely best-effort will be made to fetch the metadata and correspondingly to fetch the block data.
 
 The diagram below depicts the control flow and concurrency (goroutines and channels) in detail:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ pages:
     - "Architecture":
       - "Overview": "query_engine/architecture/index.md"
       - "Blocks": "query_engine/architecture/blocks.md"
+      - "Query Fanout": "query_engine/architecture/fanout.md"
       - "Function Processing": "query_engine/architecture/functions.md"
     - "Configuration":
       - "Annotated Config File": "query_engine/config/annotated_config.md"


### PR DESCRIPTION
Sorry about bunch of changes showing up for the peer_streaming doc, the
only real change there is fixing `helfpul` -> `helpful`, the rest is
autoformatted