### PR TITLE
[ci] push / build docs from BK

### DIFF
--- a/.buildkite/docs-build-pipeline.yml
+++ b/.buildkite/docs-build-pipeline.yml
@@ -1,0 +1,16 @@
+steps:
+  - wait
+  - name: "Docs build and push :books:"
+    command: ".buildkite/scripts/docs_push.sh"
+    agents:
+      queue: workers
+    timeout_in_minutes: 20
+    retry:
+      automatic:
+        limit: 1
+      manual: true
+    plugins:
+      docker-compose#v2.5.1:
+        run: docs
+        config: .buildkite/docs-docker-compose.yml
+        workdir: /go/src/github.com/m3db/m3

--- a/.buildkite/docs-docker-compose.yml
+++ b/.buildkite/docs-docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  docs:
+    build:
+        context: ./
+        dockerfile: ../scripts/docs.Dockerfile
+    volumes:
+      - ../:/go/src/github.com/m3db/m3
+      - $SSH_AUTH_SOCK:/ssh-agent
+    environment:
+      - CI
+      - BUILDKITE
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+      - BUILDKITE_BRANCH
+      - BUILDKITE_BUILD_URL
+      - BUILDKITE_PROJECT_SLUG
+      - BUILDKITE_COMMIT
+      - BUILDKITE_PULL_REQUEST
+      - BUILDKITE_TAG
+      - CODECOV_TOKEN
+      - SPLIT_IDX
+      - TOTAL_SPLITS
+      - SSH_AUTH_SOCK=/ssh-agent

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,15 @@ steps:
       automatic:
         limit: 1
       manual: true
+  - name: "Check for docs build :books:"
+    command: ".buildkite/scripts/check_do_docs.sh"
+    agents:
+      queue: init
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+      manual: true
   - name: "Codegen"
     command: make clean install-vendor test-all-gen
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,17 +10,10 @@ common: &common
     manual: true
 
 steps:
-  - name: "Check for :docker: build"
-    command: ".ci/docker/check_do_docker.sh"
-    agents:
-      queue: init
-    timeout_in_minutes: 10
-    retry:
-      automatic:
-        limit: 1
-      manual: true
-  - name: "Check for docs build :books:"
-    command: ".buildkite/scripts/check_do_docs.sh"
+  - name: "Check for docker and docs builds :docker: :books:"
+    commands:
+    - ".ci/docker/check_do_docker.sh"
+    - ".buildkite/scripts/check_do_docs.sh"
     agents:
       queue: init
     timeout_in_minutes: 10

--- a/.buildkite/scripts/check_do_docs.sh
+++ b/.buildkite/scripts/check_do_docs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ "$BUILDKITE_BRANCH" != "master" ]]; then
+  echo "nothing to do"
+  exit 0
+fi
+
+buildkite-agent pipeline upload .buildkite/docs-build-pipeline.yml

--- a/.buildkite/scripts/check_do_docs.sh
+++ b/.buildkite/scripts/check_do_docs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -exo pipefail
+
 if [[ "$BUILDKITE_BRANCH" != "master" ]]; then
   echo "nothing to do"
   exit 0

--- a/.buildkite/scripts/docs_push.sh
+++ b/.buildkite/scripts/docs_push.sh
@@ -1,0 +1,26 @@
+#!/bin/ash
+# shellcheck shell=dash
+
+set -exo pipefail
+
+if [ "$BUILDKITE_BRANCH" != "master" ]; then
+  echo "nothing to do"
+  exit 0
+fi
+
+mkdir -p "$HOME/.ssh"
+ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
+git config --local user.email "buildkite@m3db.io"
+git config --local user.name "M3 Buildkite Bot"
+
+rm -rf site
+mkdocs build -e docs/theme -t material
+
+git checkout -t origin/docs
+rm -rf m3db.io/*
+cp -r site/* m3db.io/
+
+git remote -v
+git add m3db.io
+git commit -m "Docs update $(date)"
+git push

--- a/.buildkite/scripts/docs_push.sh
+++ b/.buildkite/scripts/docs_push.sh
@@ -14,6 +14,9 @@ git config --local user.email "buildkite@m3db.io"
 git config --local user.name "M3 Buildkite Bot"
 
 rm -rf site
+
+# NB(schallert): if updating this build step be sure to update the docs-build
+# make target (see note there as to why we can't share code between the two).
 mkdocs build -e docs/theme -t material
 
 git checkout -t origin/docs

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,10 @@ docs-container:
 	docker run --rm hello-world >/dev/null
 	docker build -t m3db-docs -f scripts/docs.Dockerfile docs
 
+# NB(schallert): if updating this target, be sure to update the commands used in
+# the .buildkite/docs_push.sh. We can't share the make targets because our
+# Makefile assumes its running under bash and the container is alpine (ash
+# shell).
 .PHONY: docs-build
 docs-build: docs-container
 	docker run -v $(PWD):/m3db --rm m3db-docs "mkdocs build -e docs/theme -t material"


### PR DESCRIPTION
We currently have auto builds set up for our GH pages site, but not
https://docs.m3db.io which we also link to frequently.

This PR adds a Buildkite step that allows us to build and push docs from
builds on `master`.

Example of this working: https://github.com/m3db/m3/commit/a7f558c82c066d392be635192fd51899cd3fab16

Fixes #1406