### PR TITLE
Fix bug where data would sometimes not get loaded into cache after successful read

### DIFF
--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -328,7 +328,7 @@ func (r *blockRetriever) fetchBatch(
 				onRetrieveSeg = ts.NewSegment(dataCopy, nil, ts.FinalizeHead)
 				dataCopy.AppendAll(data.Bytes())
 			}
-			if tags := req.indexEntry.EncodedTags; tags != nil {
+			if tags := req.indexEntry.EncodedTags; tags != nil && tags.Len() > 0 {
 				decoder := tagDecoderPool.Get()
 				// DecRef because we're transferring ownership from the index entry to
 				// the tagDecoder which will IncRef().

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -415,7 +415,7 @@ func TestBlockRetrieverOnlyCreatesTagItersIfTagsExists(t *testing.T) {
 			startTime time.Time,
 			segment ts.Segment,
 		) {
-			require.Equal(t, tagsIter, ident.EmptyTagIterator)
+			require.Equal(t, ident.EmptyTagIterator, tagsIter)
 			for tagsIter.Next() {
 			}
 			require.NoError(t, tagsIter.Err())

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -299,6 +299,10 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 			require.True(t, ok, fmt.Sprintf("expected %s to be retrieved, but it was not", id))
 
 			expectedTags := ident.NewTags(testTagsFromTestID(id)...)
+			if !tags.Equal(expectedTags) {
+				fmt.Println("expected: ", len(expectedTags.Values()))
+				fmt.Println("actual: ", len(tags.Values()))
+			}
 			require.True(t, tags.Equal(expectedTags))
 		}
 	}

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -299,10 +299,6 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 			require.True(t, ok, fmt.Sprintf("expected %s to be retrieved, but it was not", id))
 
 			expectedTags := ident.NewTags(testTagsFromTestID(id)...)
-			if !tags.Equal(expectedTags) {
-				fmt.Println("expected: ", len(expectedTags.Values()))
-				fmt.Println("actual: ", len(tags.Values()))
-			}
 			require.True(t, tags.Equal(expectedTags))
 		}
 	}
@@ -420,6 +416,9 @@ func TestBlockRetrieverOnlyCreatesTagItersIfTagsExists(t *testing.T) {
 			segment ts.Segment,
 		) {
 			require.Equal(t, tagsIter, ident.EmptyTagIterator)
+			for tagsIter.Next() {
+			}
+			require.NoError(t, tagsIter.Err())
 		}))
 
 	_, err = retriever.Stream(ctx, shard,

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -299,7 +299,10 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 			require.True(t, ok, fmt.Sprintf("expected %s to be retrieved, but it was not", id))
 
 			expectedTags := ident.NewTags(testTagsFromTestID(id)...)
-			require.True(t, tags.Equal(expectedTags))
+			require.True(
+				t,
+				tags.Equal(expectedTags),
+				fmt.Sprintf("expectedNumTags=%d, actualNumTags=%d", len(expectedTags.Values()), len(tags.Values())))
 		}
 	}
 }

--- a/src/dbnode/persist/fs/seek.go
+++ b/src/dbnode/persist/fs/seek.go
@@ -427,7 +427,7 @@ func (s *seeker) SeekIndexEntry(
 			// because we're passing ownership of the bytes to the entry / caller.
 			var checkedEncodedTags checked.Bytes
 			if len(entry.EncodedTags) > 0 {
-				checkedEncodedTags := s.opts.bytesPool.Get(len(entry.EncodedTags))
+				checkedEncodedTags = s.opts.bytesPool.Get(len(entry.EncodedTags))
 				checkedEncodedTags.IncRef()
 				checkedEncodedTags.AppendAll(entry.EncodedTags)
 			}

--- a/src/dbnode/persist/fs/seek.go
+++ b/src/dbnode/persist/fs/seek.go
@@ -425,15 +425,18 @@ func (s *seeker) SeekIndexEntry(
 			// If it's a match, we need to copy the tags into a checked bytes
 			// so they can be passed along. We use the "real" bytes pool here
 			// because we're passing ownership of the bytes to the entry / caller.
-			checkedBytes := s.opts.bytesPool.Get(len(entry.EncodedTags))
-			checkedBytes.IncRef()
-			checkedBytes.AppendAll(entry.EncodedTags)
+			var checkedEncodedTags checked.Bytes
+			if len(entry.EncodedTags) > 0 {
+				checkedEncodedTags := s.opts.bytesPool.Get(len(entry.EncodedTags))
+				checkedEncodedTags.IncRef()
+				checkedEncodedTags.AppendAll(entry.EncodedTags)
+			}
 
 			indexEntry := IndexEntry{
 				Size:        uint32(entry.Size),
 				Checksum:    uint32(entry.Checksum),
 				Offset:      entry.Offset,
-				EncodedTags: checkedBytes,
+				EncodedTags: checkedEncodedTags,
 			}
 
 			// Safe to return resources to the pool because ID will not be


### PR DESCRIPTION
This bug had no impact on correctness, but could impact performance by preventing blocks for series that weren't already in memory from being added to the cache after being read from disk.

Bug was introduced by #1421

Basically even when there are no encoded tags, we wrapped the bytes into a checked.Bytes. The retriever would see that the encoded tags weren't nil and try to put them into a tag decoder. The tag decoder would attempt to read nil bytes and return an error which would prevent a new shard entry from being created for items that were recently read and needed to be put in the cache.

This P.R fixes the issue by performing a length test in the retriever so even if it receives checked.Bytes with zero length it will ignore it AND it changes the seek logic to only pass along a non-nil checked.Bytes if the encoded tags have length larger than zero.

It also adds a regression to test to the retriever to prevent this from happening in the future.