### PR TITLE
[ci] docs: also build operator docs

### DIFF
--- a/.buildkite/scripts/docs_push.sh
+++ b/.buildkite/scripts/docs_push.sh
@@ -30,12 +30,33 @@ git checkout -t origin/docs
 # between docs branch and our changes.
 if diff -qr site m3db.io; then
   echo "no docs changes"
+else
+  rm -rf m3db.io/*
+  cp -r site/* m3db.io/
+
+  git add m3db.io
+  git commit -m "Docs update $(date)"
+  git push
+fi
+
+# Also build & push the operator's docs.
+git clean -df
+git checkout -t origin/operator
+
+rm -rf m3db.io/*
+git clone git@github.com:m3db/m3db-operator.git
+
+(
+  cd m3db-operator
+  mkdocs build -e docs/theme -t material
+)
+
+if diff -qr m3db-operator/site m3db.io; then
+  echo "no operator docs changes"
   exit 0
 fi
 
-rm -rf m3db.io/*
-cp -r site/* m3db.io/
-
+cp -r m3db-operator/site/* m3db.io
 git add m3db.io
-git commit -m "Docs update $(date)"
+git commit -m "Operator docs update $(date)"
 git push


### PR DESCRIPTION
We serve the operator's docs from a branch subdomain of the monorepo.
Let's incorporate it into the build process.

This means that once we update docs in the operator repo (which will
eventually be merged w/ the monorepo anyway) we'll have to wait until
the next master build, but that slight drift is fine.