### PR TITLE
stuck at multi-reader-iterator init

### DIFF
--- a/src/dbnode/encoding/encoder_pool.go
+++ b/src/dbnode/encoding/encoder_pool.go
@@ -22,6 +22,7 @@ package encoding
 
 import (
 	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/ident"
 )
 
 type encoderPool struct {
@@ -39,7 +40,7 @@ func (p *encoderPool) Init(alloc EncoderAllocate) {
 	})
 }
 
-func (p *encoderPool) Get() Encoder {
+func (p *encoderPool) Get(id ident.ID) Encoder {
 	return p.pool.Get().(Encoder)
 }
 

--- a/src/dbnode/encoding/iterator_pool.go
+++ b/src/dbnode/encoding/iterator_pool.go
@@ -20,7 +20,10 @@
 
 package encoding
 
-import "github.com/m3db/m3/src/x/pool"
+import (
+	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/ident"
+)
 
 type readerIteratorPool struct {
 	pool pool.ObjectPool
@@ -37,8 +40,10 @@ func (p *readerIteratorPool) Init(alloc ReaderIteratorAllocate) {
 	})
 }
 
-func (p *readerIteratorPool) Get() ReaderIterator {
-	return p.pool.Get().(ReaderIterator)
+func (p *readerIteratorPool) Get(id ident.ID) ReaderIterator {
+	ri := p.pool.Get().(ReaderIterator)
+	ri.SetNamespace(id)
+	return ri
 }
 
 func (p *readerIteratorPool) Put(iter ReaderIterator) {
@@ -60,8 +65,10 @@ func (p *multiReaderIteratorPool) Init(alloc ReaderIteratorAllocate) {
 	})
 }
 
-func (p *multiReaderIteratorPool) Get() MultiReaderIterator {
-	return p.pool.Get().(MultiReaderIterator)
+func (p *multiReaderIteratorPool) Get(id ident.ID) MultiReaderIterator {
+	mi := p.pool.Get().(MultiReaderIterator)
+	mi.SetNamespace(id)
+	return mi
 }
 
 func (p *multiReaderIteratorPool) Put(iter MultiReaderIterator) {

--- a/src/dbnode/encoding/m3tsz/iterator.go
+++ b/src/dbnode/encoding/m3tsz/iterator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/ts"
 	xtime "github.com/m3db/m3/src/x/time"
+	"github.com/m3db/m3/src/dbnode/storage/namespace"
 )
 
 // readerIterator provides an interface for clients to incrementally
@@ -58,6 +59,8 @@ func NewReaderIterator(reader io.Reader, intOptimized bool, opts encoding.Option
 		intOptimized: intOptimized,
 	}
 }
+
+func (it *readerIterator) SetSchema(descr namespace.SchemaDescr) {}
 
 // Next moves to the next item
 func (it *readerIterator) Next() bool {

--- a/src/dbnode/encoding/null.go
+++ b/src/dbnode/encoding/null.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	xtime "github.com/m3db/m3/src/x/time"
+	"github.com/m3db/m3/src/x/ident"
 )
 
 type nullEncoder struct {
@@ -70,3 +71,4 @@ func (r *nullReaderIterator) Next() bool             { return false }
 func (r *nullReaderIterator) Err() error             { return fmt.Errorf("not implemented") }
 func (r *nullReaderIterator) Close()                 {}
 func (r *nullReaderIterator) Reset(reader io.Reader) {}
+func (r *nullReaderIterator) SetNamespace(id ident.ID) {}

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -35,6 +35,8 @@ import (
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/dbnode/storage/namespace"
 )
 
 const (
@@ -48,9 +50,11 @@ var (
 )
 
 type iterator struct {
+	nsID                   ident.ID
 	opts                   encoding.Options
 	err                    error
 	schema                 *desc.MessageDescriptor
+	schemaDesc             namespace.SchemaDescr
 	stream                 encoding.IStream
 	lastIterated           *dynamic.Message
 	lastIteratedProtoBytes []byte
@@ -217,8 +221,9 @@ func (it *iterator) Reset(reader io.Reader) {
 }
 
 // SetSchema sets the encoders schema.
-func (it *iterator) SetSchema(schema *desc.MessageDescriptor) {
-	it.schema = schema
+func (it *iterator) SetSchema(schemaDesc namespace.SchemaDescr) {
+	it.schemaDesc = schemaDesc
+	it.schema = schemaDesc.Get().MessageDescriptor
 	it.customFields = customFields(it.customFields, it.schema)
 }
 

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
 	xtime "github.com/m3db/m3/src/x/time"
+	"github.com/m3db/m3/src/dbnode/storage/namespace"
 )
 
 // Encoder is the generic interface for different types of encoders.
@@ -139,6 +140,8 @@ type Iterator interface {
 
 	// Close closes the iterator and if pooled will return to the pool.
 	Close()
+
+	SetSchema(descr namespace.SchemaDescr)
 }
 
 // ReaderIterator is the interface for a single-reader iterator.
@@ -285,7 +288,7 @@ type EncoderPool interface {
 	Init(alloc EncoderAllocate)
 
 	// Get provides an encoder from the pool
-	Get() Encoder
+	Get(id ident.ID) Encoder
 
 	// Put returns an encoder to the pool
 	Put(e Encoder)
@@ -297,7 +300,7 @@ type ReaderIteratorPool interface {
 	Init(alloc ReaderIteratorAllocate)
 
 	// Get provides a ReaderIterator from the pool
-	Get() ReaderIterator
+	Get(id ident.ID) ReaderIterator
 
 	// Put returns a ReaderIterator to the pool
 	Put(iter ReaderIterator)
@@ -309,7 +312,7 @@ type MultiReaderIteratorPool interface {
 	Init(alloc ReaderIteratorAllocate)
 
 	// Get provides a MultiReaderIterator from the pool
-	Get() MultiReaderIterator
+	Get(id ident.ID) MultiReaderIterator
 
 	// Put returns a MultiReaderIterator to the pool
 	Put(iter MultiReaderIterator)

--- a/src/dbnode/storage/block/block.go
+++ b/src/dbnode/storage/block/block.go
@@ -44,6 +44,7 @@ var (
 type dbBlock struct {
 	sync.RWMutex
 
+	nsID           ident.ID
 	opts           Options
 	startUnixNanos int64
 	segment        ts.Segment
@@ -94,6 +95,10 @@ func NewDatabaseBlock(
 		b.resetSegmentWithLock(segment)
 	}
 	return b
+}
+
+func (b *dbBlock) SetNamespace(id ident.ID) {
+	b.nsID = id
 }
 
 func (b *dbBlock) StartTime() time.Time {
@@ -303,7 +308,7 @@ func (b *dbBlock) forceMergeWithLock(ctx context.Context, stream xio.SegmentRead
 	mergedBlockReader := newDatabaseMergedBlockReader(start, b.blockSize,
 		mergeableStream{stream: stream, finalize: false},       // Should have been marked for finalization by the caller
 		mergeableStream{stream: targetStream, finalize: false}, // Already marked for finalization by the Stream() call above
-		b.opts)
+		b.opts, b.nsID)
 	mergedSegment, err := mergedBlockReader.Segment()
 	if err != nil {
 		return err

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -135,6 +135,9 @@ type NewDatabaseBlockFn func() DatabaseBlock
 
 // DatabaseBlock is the interface for a DatabaseBlock
 type DatabaseBlock interface {
+
+	SetNamespace(ident.ID)
+
 	// StartTime returns the start time of the block.
 	StartTime() time.Time
 

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -222,6 +222,12 @@ type database interface {
 	UpdateOwnedNamespaces(namespaces namespace.Map) error
 }
 
+type schemaRegistry interface {
+	GetLatestSchema(id ident.ID) namespace.SchemaDescr
+	GetSchemaHistory(id ident.ID) namespace.SchemaRegistry
+	SetSchemaHistory(id ident.ID, registry namespace.SchemaRegistry)
+}
+
 // Namespace is a time series database namespace
 type Namespace interface {
 	// Options returns the namespace options


### PR DESCRIPTION
just try the namespace aware encoding pool approach, where Get takes nsID. did not go too far.

for example: in storage/block/options.go, there are code like this that call Get in Init. 

	o.readerIteratorPool.Init(func(r io.Reader) encoding.ReaderIterator {
		return m3tsz.NewReaderIterator(r, m3tsz.DefaultIntOptimizationEnabled, encodingOpts)
	})
	o.multiReaderIteratorPool.Init(func(r io.Reader) encoding.ReaderIterator {
		it := o.readerIteratorPool.Get()
		it.Reset(r)
		return it
	})
