### PR TITLE
[dbnode] fix byte pool watermark log message

### DIFF
--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -1046,7 +1046,7 @@ func withEncodingAndPoolingOptions(
 		logger.Sugar().Infof("bytes pool registering bucket capacity=%d, size=%d, "+
 			"refillLowWatermark=%f, refillHighWatermark=%f",
 			bucket.Capacity, bucket.Size,
-			bucket.RefillLowWaterMark, bucket.RefillHighWaterMark)
+			bucket.RefillLowWaterMarkOrDefault(), bucket.RefillHighWaterMarkOrDefault())
 	}
 
 	var bytesPool pool.CheckedBytesPool


### PR DESCRIPTION
Seeing this in the logs has been driving me crazy:
```
bytes pool registering bucket capacity=842356189232, size=842356189240,
refillLowWatermark=%!f(*float64=0x26044d8),
refillHighWatermark=%!f(*float64=0x26044d0)
```