### PR TITLE
[dbnode] Filter out corrupt commit log files that were not present before the node started in the commit log bootstrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.8.5 (TBD)
+
+## Bug Fixes
+
+- **M3DB**: Prevent active commit log from appearing like a corrupt file during bootstrap.
+
 # 0.8.4 (2019-04-20)
 
 ## Performance

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -525,9 +525,9 @@ func TestCommitLogIteratorUsesPredicateFilterForNonCorruptFiles(t *testing.T) {
 	require.Equal(t, 4, len(files))
 
 	// This predicate should eliminate the first commitlog file.
-	commitLogPredicate := func(isCorrupt bool, f persist.CommitLogFile, _ ErrorWithPath) bool {
-		require.False(t, isCorrupt)
-		return f.Index > 0
+	commitLogPredicate := func(f FileFilterInfo) bool {
+		require.False(t, f.IsCorrupt)
+		return f.File.Index > 0
 	}
 
 	// Assert that the commitlog iterator honors the predicate and only uses
@@ -589,11 +589,8 @@ func TestCommitLogIteratorUsesPredicateFilterForCorruptFiles(t *testing.T) {
 	require.Equal(t, 1, len(iterStruct.files))
 
 	// Assert that the iterator ignores the corrupt file given an appropriate predicate.
-	ignoreCorruptPredicate := func(isCorrupt bool, f persist.CommitLogFile, err ErrorWithPath) bool {
-		if isCorrupt {
-			return false
-		}
-		return true
+	ignoreCorruptPredicate := func(f FileFilterInfo) bool {
+		return !f.IsCorrupt
 	}
 
 	iterOpts = IteratorOpts{

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -483,7 +483,7 @@ func TestCommitLogReaderIsNotReusable(t *testing.T) {
 	require.Equal(t, errCommitLogReaderIsNotReusable, err)
 }
 
-func TestCommitLogIteratorUsesPredicateFilter(t *testing.T) {
+func TestCommitLogIteratorUsesPredicateFilterForNonCorruptFiles(t *testing.T) {
 	clock := mclock.NewMock()
 	opts, scope := newTestOptions(t, overrides{
 		clock:    clock,
@@ -515,22 +515,23 @@ func TestCommitLogIteratorUsesPredicateFilter(t *testing.T) {
 		flushUntilDone(commitLog, wg)
 	}
 
-	// Close the commit log and consequently flush
+	// Close the commit log and consequently flush.
 	require.NoError(t, commitLog.Close())
 
-	// Make sure multiple commitlog files were generated
+	// Make sure multiple commitlog files were generated.
 	fsopts := opts.FilesystemOptions()
 	files, err := fs.SortedCommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
 	require.NoError(t, err)
 	require.Equal(t, 4, len(files))
 
-	// This predicate should eliminate the first commitlog file
-	commitLogPredicate := func(f persist.CommitLogFile) bool {
+	// This predicate should eliminate the first commitlog file.
+	commitLogPredicate := func(isCorrupt bool, f persist.CommitLogFile, _ ErrorWithPath) bool {
+		require.False(t, isCorrupt)
 		return f.Index > 0
 	}
 
 	// Assert that the commitlog iterator honors the predicate and only uses
-	// 2 of the 3 files
+	// 2 of the 3 files.
 	iterOpts := IteratorOpts{
 		CommitLogOptions:      opts,
 		FileFilterPredicate:   commitLogPredicate,
@@ -542,6 +543,70 @@ func TestCommitLogIteratorUsesPredicateFilter(t *testing.T) {
 
 	iterStruct := iter.(*iterator)
 	require.Equal(t, 3, len(iterStruct.files))
+}
+
+func TestCommitLogIteratorUsesPredicateFilterForCorruptFiles(t *testing.T) {
+	clock := mclock.NewMock()
+	opts, _ := newTestOptions(t, overrides{
+		clock:    clock,
+		strategy: StrategyWriteWait,
+	})
+	defer cleanup(t, opts)
+
+	commitLog := newTestCommitLog(t, opts)
+	// Close the commit log and consequently flush.
+	require.NoError(t, commitLog.Close())
+
+	// Make sure a valid commitlog was created.
+	fsopts := opts.FilesystemOptions()
+	files, err := fs.SortedCommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(files))
+
+	// Write out a corrupt commitlog file.
+	nextCommitlogFilePath, _, err := NextFile(opts)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(
+		nextCommitlogFilePath, []byte("not-a-valid-commitlog-file"), os.FileMode(0666))
+	require.NoError(t, err)
+
+	// Make sure the corrupt file is visibile.
+	files, err = fs.SortedCommitLogFiles(fs.CommitLogsDirPath(fsopts.FilePathPrefix()))
+	require.NoError(t, err)
+	require.Equal(t, 2, len(files))
+
+	// Assert that the corrupt file is returned from the iterator.
+	iterOpts := IteratorOpts{
+		CommitLogOptions:      opts,
+		FileFilterPredicate:   ReadAllPredicate(),
+		SeriesFilterPredicate: ReadAllSeriesPredicate(),
+	}
+	iter, corruptFiles, err := NewIterator(iterOpts)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(corruptFiles))
+
+	iterStruct := iter.(*iterator)
+	require.Equal(t, 1, len(iterStruct.files))
+
+	// Assert that the iterator ignores the corrupt file given an appropriate predicate.
+	ignoreCorruptPredicate := func(isCorrupt bool, f persist.CommitLogFile, err ErrorWithPath) bool {
+		if isCorrupt {
+			return false
+		}
+		return true
+	}
+
+	iterOpts = IteratorOpts{
+		CommitLogOptions:      opts,
+		FileFilterPredicate:   ignoreCorruptPredicate,
+		SeriesFilterPredicate: ReadAllSeriesPredicate(),
+	}
+	iter, corruptFiles, err = NewIterator(iterOpts)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(corruptFiles))
+
+	iterStruct = iter.(*iterator)
+	require.Equal(t, 1, len(iterStruct.files))
 }
 
 func TestCommitLogWriteBehind(t *testing.T) {

--- a/src/dbnode/persist/fs/commitlog/types.go
+++ b/src/dbnode/persist/fs/commitlog/types.go
@@ -186,11 +186,19 @@ type Options interface {
 	IdentifierPool() ident.Pool
 }
 
+// FileFilterInfo contains information about a commitog file that can be used to
+// determine whether the iterator should filter it out or not.
+type FileFilterInfo struct {
+	// If isCorrupt is true then File will contain a valid CommitLogFile, otherwise
+	// ErrorWithPath will contain an error and the path of the corrupt file.
+	File      persist.CommitLogFile
+	Err       ErrorWithPath
+	IsCorrupt bool
+}
+
 // FileFilterPredicate is a predicate that allows the caller to determine
-// which commitlogs the iterator should read from. If isCorrupt is true then f will contain
-// a valid CommitLogFile, otherwise ErrorWithPath will contain an error and the path of the
-// corrupt file.
-type FileFilterPredicate func(isCorrupt bool, f persist.CommitLogFile, err ErrorWithPath) bool
+// which commitlogs the iterator should read from.
+type FileFilterPredicate func(f FileFilterInfo) bool
 
 // SeriesFilterPredicate is a predicate that determines whether datapoints for a given series
 // should be returned from the Commit log reader. The predicate is pushed down to the

--- a/src/dbnode/persist/fs/commitlog/types.go
+++ b/src/dbnode/persist/fs/commitlog/types.go
@@ -187,8 +187,10 @@ type Options interface {
 }
 
 // FileFilterPredicate is a predicate that allows the caller to determine
-// which commitlogs the iterator should read from.
-type FileFilterPredicate func(f persist.CommitLogFile) bool
+// which commitlogs the iterator should read from. If isCorrupt is true then f will contain
+// a valid CommitLogFile, otherwise ErrorWithPath will contain an error and the path of the
+// corrupt file.
+type FileFilterPredicate func(isCorrupt bool, f persist.CommitLogFile, err ErrorWithPath) bool
 
 // SeriesFilterPredicate is a predicate that determines whether datapoints for a given series
 // should be returned from the Commit log reader. The predicate is pushed down to the

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -663,12 +663,27 @@ func (s *commitLogSource) newReadCommitlogPredAndMostRecentSnapshotByBlockShard(
 		}
 	}
 
-	return func(f persist.CommitLogFile) bool {
+	// TODO(rartoul): Refactor this to take the SnapshotMetadata files into account to reduce
+	// the number of commitlog files that need to be read.
+	return func(isCorrupt bool, f persist.CommitLogFile, err commitlog.ErrorWithPath) bool {
 		// Read all the commitlog files that were available on disk before the node started
 		// accepting writes.
-		// TODO(rartoul): Refactor this to take the SnapshotMetadata files into account to reduce
-		// the number of commitlog files that need to be read.
 		commitlogFilesPresentBeforeStart := s.inspection.CommitLogFilesSet()
+		if isCorrupt {
+			// Corrupt files that existed on disk before the node started should be included so
+			// that the commitlog bootstrapper can detect them and determine if it will return
+			// unfulfilled or ignore them.
+			//
+			// Corrupt files that did not exist on disk before the node started should always be
+			// ignored since they have no impact on the bootstrapping process and likely only
+			// appear corrupt because they were just created recently by the current node as
+			// its alreadying accepting writes at this point.
+			_, ok := commitlogFilesPresentBeforeStart[err.Path()]
+			return ok
+		}
+		// Only attempt to read commitlog files that were present on disk before the node started.
+		// If a commitlog file was not present when the node started then it was created once the
+		// node began accepting writes and the data is already in memory.
 		_, ok := commitlogFilesPresentBeforeStart[f.FilePath]
 		return ok
 	}, mostRecentCompleteSnapshotByBlockShard, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the commit log bootstrapper will only attempt to read commit log files that were present on disk before the node started to prevent it from trying to read the files that are currently being written to.

In addition to this check, we also need to add a guard against identifying the active file as corrupt. If the active file appears corrupt it will trigger logic in the commit log bootstrapper that makes configurable decisions about whether the commit log bootstrap should fail or whether the corrupt file should be ignored.

The existing code allowed callers to pass a predicate to the commit log iterator which could be used to filter out files that were not present before the node started, however, this filter was not being applied to files that appeared corrupt. In some rare scenarios, the active commit log file will appear corrupt because it hasn't been flushed yet and the commit log bootstrapper will thus think its encountered a corrupt file when in fact it should have never tried to read that file in the first place.

This P.R changes the iterator such that the predicate can be applied to files identified as corrupt as well, and modifies the commit log bootstrapper to take advantage of this new feature.
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
None
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
None
```
