### PR TITLE
[dbnode] Add support for bools in proto encoder/decoder

### DIFF
--- a/src/dbnode/encoding/proto/common.go
+++ b/src/dbnode/encoding/proto/common.go
@@ -64,8 +64,9 @@ const (
 	float64Field
 	float32Field
 	bytesField
+	boolField
 
-	numCustomTypes = 8
+	numCustomTypes = 9
 )
 
 // -1 because iota's are zero-indexed so the highest value will be the number of
@@ -102,6 +103,9 @@ const (
 
 	opCodeBitsetValueIsNotSet = 0
 	opCodeBitsetValueIsSet    = 1
+
+	opCodeBoolTrue  = 1
+	opCodeBoolFalse = 0
 )
 
 var (
@@ -132,6 +136,8 @@ var (
 
 		dpb.FieldDescriptorProto_TYPE_STRING: bytesField,
 		dpb.FieldDescriptorProto_TYPE_BYTES:  bytesField,
+
+		dpb.FieldDescriptorProto_TYPE_BOOL: boolField,
 	}
 )
 

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -459,6 +459,10 @@ func (enc *Encoder) encodeCustomValues(m *dynamic.Message) error {
 			if err := enc.encodeBytesValue(i, iVal); err != nil {
 				return err
 			}
+		case customField.fieldType == boolField:
+			if err := enc.encodeBoolValue(i, iVal); err != nil {
+				return err
+			}
 		default:
 			// This should never happen.
 			return fmt.Errorf(
@@ -617,6 +621,22 @@ func (enc *Encoder) encodeBytesValue(i int, iVal interface{}) error {
 		startPos: bytePos,
 		length:   length,
 	})
+	return nil
+}
+
+func (enc *Encoder) encodeBoolValue(i int, val interface{}) error {
+	boolVal, ok := val.(bool)
+	if !ok {
+		return fmt.Errorf(
+			"%s found unknown type in fieldNum %d", encErrPrefix, enc.customFields[i].fieldNum)
+	}
+
+	if boolVal {
+		enc.stream.WriteBit(opCodeBoolTrue)
+	} else {
+		enc.stream.WriteBit(opCodeBoolFalse)
+	}
+
 	return nil
 }
 

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -316,7 +316,7 @@ func (it *iterator) readCustomFieldsSchema() error {
 	}
 
 	for i := 1; i <= int(numCustomFields); i++ {
-		fieldTypeBits, err := it.stream.ReadBits(3)
+		fieldTypeBits, err := it.stream.ReadBits(numBitsToEncodeCustomType)
 		if err != nil {
 			return err
 		}
@@ -339,12 +339,16 @@ func (it *iterator) readCustomValues() error {
 			if err := it.readFloatValue(i); err != nil {
 				return err
 			}
+		case isCustomIntEncodedField(customField.fieldType):
+			if err := it.readIntValue(i); err != nil {
+				return err
+			}
 		case customField.fieldType == bytesField:
 			if err := it.readBytesValue(i, customField); err != nil {
 				return err
 			}
-		case isCustomIntEncodedField(customField.fieldType):
-			if err := it.readIntValue(i); err != nil {
+		case customField.fieldType == boolField:
+			if err := it.readBoolValue(i); err != nil {
 				return err
 			}
 		default:
@@ -457,7 +461,8 @@ func (it *iterator) readFloatValue(i int) error {
 		return err
 	}
 
-	return it.updateLastIteratedWithCustomValues(i, nil)
+	updateArg := updateLastIterArg{i: i}
+	return it.updateLastIteratedWithCustomValues(updateArg)
 }
 
 func (it *iterator) readBytesValue(i int, customField customFieldState) error {
@@ -533,7 +538,9 @@ func (it *iterator) readBytesValue(i int, customField customFieldState) error {
 	}
 
 	it.addToBytesDict(i, buf)
-	return it.updateLastIteratedWithCustomValues(i, buf)
+
+	updateArg := updateLastIterArg{i: i, bytesFieldBuf: buf}
+	return it.updateLastIteratedWithCustomValues(updateArg)
 }
 
 func (it *iterator) readIntValue(i int) error {
@@ -541,21 +548,41 @@ func (it *iterator) readIntValue(i int) error {
 		return err
 	}
 
-	return it.updateLastIteratedWithCustomValues(i, nil)
+	updateArg := updateLastIterArg{i: i}
+	return it.updateLastIteratedWithCustomValues(updateArg)
+}
+
+func (it *iterator) readBoolValue(i int) error {
+	boolOpCode, err := it.stream.ReadBit()
+	if err != nil {
+		return fmt.Errorf(
+			"%s: error trying to read bool value: %v",
+			itErrPrefix, err)
+	}
+
+	boolVal := boolOpCode == opCodeBoolTrue
+	updateArg := updateLastIterArg{i: i, boolVal: boolVal}
+	return it.updateLastIteratedWithCustomValues(updateArg)
+}
+
+type updateLastIterArg struct {
+	i             int
+	bytesFieldBuf []byte
+	boolVal       bool
 }
 
 // updateLastIteratedWithCustomValues updates lastIterated with the current
 // value of the custom field in it.customFields at index i. This ensures that
 // when we return it.lastIterated in the call to Current() that all the
 // most recent values are present.
-func (it *iterator) updateLastIteratedWithCustomValues(i int, bytesFieldBuf []byte) error {
+func (it *iterator) updateLastIteratedWithCustomValues(arg updateLastIterArg) error {
 	if it.lastIterated == nil {
 		it.lastIterated = dynamic.NewMessage(it.schema)
 	}
 
 	var (
-		fieldNum  = it.customFields[i].fieldNum
-		fieldType = it.customFields[i].fieldType
+		fieldNum  = it.customFields[arg.i].fieldNum
+		fieldType = it.customFields[arg.i].fieldType
 	)
 
 	if field := it.schema.FindFieldByNumber(int32(fieldNum)); field == nil {
@@ -568,7 +595,7 @@ func (it *iterator) updateLastIteratedWithCustomValues(i int, bytesFieldBuf []by
 	switch {
 	case isCustomFloatEncodedField(fieldType):
 		var (
-			val = math.Float64frombits(it.customFields[i].floatEncAndIter.PrevFloatBits)
+			val = math.Float64frombits(it.customFields[arg.i].floatEncAndIter.PrevFloatBits)
 			err error
 		)
 		if fieldType == float64Field {
@@ -581,19 +608,19 @@ func (it *iterator) updateLastIteratedWithCustomValues(i int, bytesFieldBuf []by
 	case isCustomIntEncodedField(fieldType):
 		switch fieldType {
 		case signedInt64Field:
-			val := int64(it.customFields[i].intEncAndIter.prevIntBits)
+			val := int64(it.customFields[arg.i].intEncAndIter.prevIntBits)
 			return it.lastIterated.TrySetFieldByNumber(fieldNum, val)
 
 		case unsignedInt64Field:
-			val := it.customFields[i].intEncAndIter.prevIntBits
+			val := it.customFields[arg.i].intEncAndIter.prevIntBits
 			return it.lastIterated.TrySetFieldByNumber(fieldNum, val)
 
 		case signedInt32Field:
-			val := int32(it.customFields[i].intEncAndIter.prevIntBits)
+			val := int32(it.customFields[arg.i].intEncAndIter.prevIntBits)
 			return it.lastIterated.TrySetFieldByNumber(fieldNum, val)
 
 		case unsignedInt32Field:
-			val := uint32(it.customFields[i].intEncAndIter.prevIntBits)
+			val := uint32(it.customFields[arg.i].intEncAndIter.prevIntBits)
 			return it.lastIterated.TrySetFieldByNumber(fieldNum, val)
 
 		default:
@@ -608,15 +635,15 @@ func (it *iterator) updateLastIteratedWithCustomValues(i int, bytesFieldBuf []by
 		schemaField := it.schema.FindFieldByNumber(int32(fieldNum))
 		schemaFieldType := schemaField.GetType()
 		if schemaFieldType == dpb.FieldDescriptorProto_TYPE_STRING {
-			return it.lastIterated.TrySetFieldByNumber(fieldNum, string(bytesFieldBuf))
+			return it.lastIterated.TrySetFieldByNumber(fieldNum, string(arg.bytesFieldBuf))
 		}
-		return it.lastIterated.TrySetFieldByNumber(fieldNum, bytesFieldBuf)
+		return it.lastIterated.TrySetFieldByNumber(fieldNum, arg.bytesFieldBuf)
+	case fieldType == boolField:
+		return it.lastIterated.TrySetFieldByNumber(fieldNum, arg.boolVal)
 	default:
 		return fmt.Errorf(
 			"%s unhandled fieldType: %v", itErrPrefix, fieldType)
 	}
-
-	return nil
 }
 
 // readBitset does the inverse of encodeBitset on the encoder struct.

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -139,7 +139,7 @@ func TestRoundTrip(t *testing.T) {
 		require.Equal(t, float64(0), lastEncoded.Value)
 	}
 	// Add some sanity to make sure that the string compression is working.
-	require.Equal(t, 368, enc.Stats().CompressedBytes)
+	require.Equal(t, 369, enc.Stats().CompressedBytes)
 
 	rawBytes, err := enc.Bytes()
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R adds support for boolean fields in the proto encoder / decoder so that the complex types feature can support efficiently compressing messages with boolean fields.

**Special notes for your reviewer**:

There are no added test cases because the existing property test already had logic for generating messages with boolean fields but the list of types of fields it would generate came from the map of support custom-encoded fields which was missing booleans. Now that booleans have been added to that map, the property test will now test against it as well (verified this behavior by adding the booleans to the map but not implementing the encoding/decoding and the property test started failing).

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```
NONE
```
