### PR TITLE
[dbnode] Make message name configurable when parsing proto schema + allocate if no byte pool

### DIFF
--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -282,6 +282,7 @@ type HashingConfiguration struct {
 // ProtoConfiguration is the configuration for running with ProtoDataMode enabled.
 type ProtoConfiguration struct {
 	SchemaFilePath string `yaml:"schemaFilePath"`
+	MessageName    string `yaml:"messageName"`
 }
 
 // Validate validates the ProtoConfiguration.
@@ -292,6 +293,10 @@ func (c *ProtoConfiguration) Validate() error {
 
 	if c.SchemaFilePath == "" {
 		return errors.New("schemaFilePath is required for Proto data mode")
+	}
+
+	if c.MessageName == "" {
+		return errors.New("messageName is required for Proto data mode")
 	}
 
 	return nil

--- a/src/dbnode/client/config.go
+++ b/src/dbnode/client/config.go
@@ -88,6 +88,7 @@ type Configuration struct {
 // ProtoConfiguration is the configuration for running with ProtoDataMode enabled.
 type ProtoConfiguration struct {
 	SchemaFilePath string `yaml:"schemaFilePath"`
+	MessageName    string `yaml:"messageName"`
 }
 
 // Validate validates the ProtoConfiguration.
@@ -98,6 +99,10 @@ func (c *ProtoConfiguration) Validate() error {
 
 	if c.SchemaFilePath == "" {
 		return errors.New("schemaFilePath is required for Proto data mode")
+	}
+
+	if c.MessageName == "" {
+		return errors.New("messageName is required for Proto data mode")
 	}
 
 	return nil
@@ -286,7 +291,7 @@ func (c Configuration) NewAdminClient(
 	})
 
 	if c.Proto != nil {
-		schema, err := proto.ParseProtoSchema(c.Proto.SchemaFilePath)
+		schema, err := proto.ParseProtoSchema(c.Proto.SchemaFilePath, c.Proto.MessageName)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"unable to parse protobuf schema: %s, err: %v",

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -751,7 +751,7 @@ func (it *iterator) resetUnmarshalProtoBuffer(n int) {
 	// If none exists (or one existed but it was too small) get a new one
 	// and IncRef(). DecRef() will never be called unless this one is
 	// replaced by a new one later.
-	it.unmarshalProtoBuf = it.opts.BytesPool().Get(n)
+	it.unmarshalProtoBuf = it.newBuffer(n)
 	it.unmarshalProtoBuf.IncRef()
 	it.unmarshalProtoBuf.Resize(n)
 }
@@ -770,4 +770,11 @@ func (it *iterator) isDone() bool {
 
 func (it *iterator) isClosed() bool {
 	return it.closed
+}
+
+func (it *iterator) newBuffer(capacity int) checked.Bytes {
+	if bytesPool := it.opts.BytesPool(); bytesPool != nil {
+		return bytesPool.Get(capacity)
+	}
+	return checked.NewBytes(make([]byte, 0, capacity), nil)
 }

--- a/src/dbnode/encoding/proto/parse_schema.go
+++ b/src/dbnode/encoding/proto/parse_schema.go
@@ -43,8 +43,6 @@ func ParseProtoSchema(filePath string, messageName string) (*desc.MessageDescrip
 			filePath, len(fds))
 	}
 
-	// TODO(rartoul): This will be more sophisticated later, but for now assume
-	// that the message will be called "Schema".
 	schema := fds[0].FindMessage(messageName)
 	if schema == nil {
 		return nil, fmt.Errorf(

--- a/src/dbnode/encoding/proto/parse_schema.go
+++ b/src/dbnode/encoding/proto/parse_schema.go
@@ -27,14 +27,10 @@ import (
 	"github.com/jhump/protoreflect/desc/protoparse"
 )
 
-const (
-	schemaMessageName = "Schema"
-)
-
 // ParseProtoSchema parses a Protobuf schema.
 // TODO(rartoul): This is temporary code that will eventually be replaced with
 // storing the schemas in etcd.
-func ParseProtoSchema(filePath string) (*desc.MessageDescriptor, error) {
+func ParseProtoSchema(filePath string, messageName string) (*desc.MessageDescriptor, error) {
 	fds, err := protoparse.Parser{}.ParseFiles(filePath)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -49,7 +45,7 @@ func ParseProtoSchema(filePath string) (*desc.MessageDescriptor, error) {
 
 	// TODO(rartoul): This will be more sophisticated later, but for now assume
 	// that the message will be called "Schema".
-	schema := fds[0].FindMessage(schemaMessageName)
+	schema := fds[0].FindMessage(messageName)
 	if schema == nil {
 		return nil, fmt.Errorf(
 			"expected to find message with name 'Schema' in %s, but did not",

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -178,7 +178,8 @@ func Run(runOpts RunOptions) {
 	var schema *desc.MessageDescriptor
 	if cfg.Proto != nil {
 		logger.Info("Probuf data mode enabled")
-		schema, err = proto.ParseProtoSchema(cfg.Proto.SchemaFilePath)
+		schema, err = proto.ParseProtoSchema(
+			cfg.Proto.SchemaFilePath, cfg.Proto.MessageName)
 		if err != nil {
 			logger.Fatal("error parsing protobuffer schema", zap.Error(err))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the message name configurable when parsing a proto schema + allow the proto iterator to operate even if the bytes pool is not configured.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
