### PR TITLE
[query] Add start and end time to tag values endpoint

### DIFF
--- a/src/query/api/v1/handler/graphite/find.go
+++ b/src/query/api/v1/handler/graphite/find.go
@@ -30,8 +30,8 @@ import (
 	"github.com/m3db/m3/src/query/graphite/graphite"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/util/logging"
-	"github.com/m3db/m3/src/x/net/http"
 	xerrors "github.com/m3db/m3/src/x/errors"
+	"github.com/m3db/m3/src/x/net/http"
 
 	"go.uber.org/zap"
 )

--- a/src/query/api/v1/handler/prometheus/common.go
+++ b/src/query/api/v1/handler/prometheus/common.go
@@ -241,6 +241,9 @@ func ParseTagValuesToQuery(
 
 	nameBytes := []byte(name)
 	return &storage.CompleteTagsQuery{
+		// NB: necessarily spans the entire timerange for the index.
+		Start:            time.Time{},
+		End:              time.Now(),
 		CompleteNameOnly: false,
 		FilterNameTags:   [][]byte{nameBytes},
 		TagMatchers: models.Matchers{

--- a/src/query/api/v1/handler/prometheus/common.go
+++ b/src/query/api/v1/handler/prometheus/common.go
@@ -37,13 +37,10 @@ import (
 	xhttp "github.com/m3db/m3/src/x/net/http"
 
 	"github.com/golang/snappy"
-	"github.com/gorilla/mux"
 	"github.com/prometheus/prometheus/promql"
 )
 
 const (
-	// NameReplace is the parameter that gets replaced.
-	NameReplace         = "name"
 	queryParam          = "query"
 	filterNameTagsParam = "tag"
 	errFormatStr        = "error parsing param: %s, error: %v"
@@ -52,8 +49,7 @@ const (
 )
 
 var (
-	matchValues = []byte(".*")
-	roleName    = []byte("role")
+	roleName = []byte("role")
 )
 
 // TimeoutOpts stores options related to various timeout configurations.
@@ -227,33 +223,6 @@ func ParseSeriesMatchQuery(
 	}
 
 	return queries, nil
-}
-
-// ParseTagValuesToQuery parses a tag values request to a complete tags query.
-func ParseTagValuesToQuery(
-	r *http.Request,
-) (*storage.CompleteTagsQuery, error) {
-	vars := mux.Vars(r)
-	name, ok := vars[NameReplace]
-	if !ok || len(name) == 0 {
-		return nil, errors.ErrNoName
-	}
-
-	nameBytes := []byte(name)
-	return &storage.CompleteTagsQuery{
-		// NB: necessarily spans the entire timerange for the index.
-		Start:            time.Time{},
-		End:              time.Now(),
-		CompleteNameOnly: false,
-		FilterNameTags:   [][]byte{nameBytes},
-		TagMatchers: models.Matchers{
-			models.Matcher{
-				Type:  models.MatchRegexp,
-				Name:  nameBytes,
-				Value: matchValues,
-			},
-		},
-	}, nil
 }
 
 func renderNameOnlyTagCompletionResultsJSON(

--- a/src/query/api/v1/handler/prometheus/native/list_tags.go
+++ b/src/query/api/v1/handler/prometheus/native/list_tags.go
@@ -25,6 +25,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/m3db/m3/src/x/clock"
+
 	"github.com/m3db/m3/src/query/api/v1/handler"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus"
 	"github.com/m3db/m3/src/query/models"
@@ -48,14 +50,17 @@ var (
 // ListTagsHandler represents a handler for list tags endpoint.
 type ListTagsHandler struct {
 	storage storage.Storage
+	nowFn   clock.NowFn
 }
 
 // NewListTagsHandler returns a new instance of handler.
 func NewListTagsHandler(
 	storage storage.Storage,
+	nowFn clock.NowFn,
 ) http.Handler {
 	return &ListTagsHandler{
 		storage: storage,
+		nowFn:   nowFn,
 	}
 }
 
@@ -70,7 +75,7 @@ func (h *ListTagsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// NB: necessarily spans entire possible query range.
 		Start: time.Time{},
-		End:   time.Now(),
+		End:   h.nowFn(),
 	}
 
 	opts := storage.NewFetchOptions()

--- a/src/query/api/v1/handler/prometheus/native/list_tags.go
+++ b/src/query/api/v1/handler/prometheus/native/list_tags.go
@@ -25,13 +25,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/m3db/m3/src/x/clock"
-
 	"github.com/m3db/m3/src/query/api/v1/handler"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/util/logging"
+	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/net/http"
 
 	"go.uber.org/zap"

--- a/src/query/api/v1/handler/prometheus/remote/tag_values.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values.go
@@ -23,28 +23,41 @@ package remote
 import (
 	"context"
 	"net/http"
+	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/m3db/m3/src/query/api/v1/handler"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus"
+	"github.com/m3db/m3/src/query/errors"
+	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/util/logging"
+	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/net/http"
 
 	"go.uber.org/zap"
 )
 
 const (
+	// NameReplace is the parameter that gets replaced.
+	NameReplace = "name"
+
 	// TagValuesURL is the url for tag values.
 	TagValuesURL = handler.RoutePrefixV1 +
-		"/label/{" + prometheus.NameReplace + "}/values"
+		"/label/{" + NameReplace + "}/values"
 
 	// TagValuesHTTPMethod is the HTTP method used with this resource.
 	TagValuesHTTPMethod = http.MethodGet
 )
 
+var (
+	matchValues = []byte(".*")
+)
+
 // TagValuesHandler represents a handler for search tags endpoint.
 type TagValuesHandler struct {
 	storage storage.Storage
+	nowFn   clock.NowFn
 }
 
 // TagValuesResponse is the response that gets returned to the user
@@ -55,9 +68,11 @@ type TagValuesResponse struct {
 // NewTagValuesHandler returns a new instance of handler.
 func NewTagValuesHandler(
 	storage storage.Storage,
+	nowFn clock.NowFn,
 ) http.Handler {
 	return &TagValuesHandler{
 		storage: storage,
+		nowFn:   nowFn,
 	}
 }
 
@@ -66,7 +81,7 @@ func (h *TagValuesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := logging.WithContext(ctx)
 	w.Header().Set("Content-Type", "application/json")
 
-	query, err := prometheus.ParseTagValuesToQuery(r)
+	query, err := h.parseTagValuesToQuery(r)
 	if err != nil {
 		logger.Error("unable to parse tag values to query", zap.Error(err))
 		xhttp.Error(w, err, http.StatusBadRequest)
@@ -87,4 +102,30 @@ func (h *TagValuesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logger.Error("unable to render tag values", zap.Error(err))
 		xhttp.Error(w, err, http.StatusBadRequest)
 	}
+}
+
+func (h *TagValuesHandler) parseTagValuesToQuery(
+	r *http.Request,
+) (*storage.CompleteTagsQuery, error) {
+	vars := mux.Vars(r)
+	name, ok := vars[NameReplace]
+	if !ok || len(name) == 0 {
+		return nil, errors.ErrNoName
+	}
+
+	nameBytes := []byte(name)
+	return &storage.CompleteTagsQuery{
+		// NB: necessarily spans the entire timerange for the index.
+		Start:            time.Time{},
+		End:              h.nowFn(),
+		CompleteNameOnly: false,
+		FilterNameTags:   [][]byte{nameBytes},
+		TagMatchers: models.Matchers{
+			models.Matcher{
+				Type:  models.MatchRegexp,
+				Name:  nameBytes,
+				Value: matchValues,
+			},
+		},
+	}, nil
 }

--- a/src/query/api/v1/handler/prometheus/remote/tag_values.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/m3db/m3/src/query/api/v1/handler"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus"
 	"github.com/m3db/m3/src/query/errors"
@@ -35,6 +34,7 @@ import (
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/net/http"
 
+	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
 

--- a/src/query/api/v1/handler/prometheus/remote/tag_values_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values_test.go
@@ -29,14 +29,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/util/logging"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type tagValuesMatcher struct {

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -162,6 +162,7 @@ func (h *Handler) RegisterRoutes() error {
 	// Wrap requests with response time logging as well as panic recovery.
 	wrapped := logging.WithResponseTimeAndPanicErrorLogging
 	panicOnly := logging.WithPanicErrorResponder
+	nowFn := time.Now
 
 	h.router.HandleFunc(openapi.URL,
 		wrapped(&openapi.DocHandler{}).ServeHTTP,
@@ -214,13 +215,13 @@ func (h *Handler) RegisterRoutes() error {
 		wrapped(native.NewCompleteTagsHandler(h.storage)).ServeHTTP,
 	).Methods(native.CompleteTagsHTTPMethod)
 	h.router.HandleFunc(remote.TagValuesURL,
-		wrapped(remote.NewTagValuesHandler(h.storage)).ServeHTTP,
+		wrapped(remote.NewTagValuesHandler(h.storage, nowFn)).ServeHTTP,
 	).Methods(remote.TagValuesHTTPMethod)
 
 	// List tag endpoints
 	for _, method := range native.ListTagsHTTPMethods {
 		h.router.HandleFunc(native.ListTagsURL,
-			wrapped(native.NewListTagsHandler(h.storage)).ServeHTTP,
+			wrapped(native.NewListTagsHandler(h.storage, nowFn)).ServeHTTP,
 		).Methods(method)
 	}
 

--- a/src/query/block/offset_test.go
+++ b/src/query/block/offset_test.go
@@ -25,10 +25,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/ts"
+
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/src/query/functions/fetch_test.go
+++ b/src/query/functions/fetch_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/executor/transform"
 	"github.com/m3db/m3/src/query/models"
@@ -34,6 +33,7 @@ import (
 	"github.com/m3db/m3/src/query/test"
 	"github.com/m3db/m3/src/query/test/executor"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/src/query/pools/query_pools.go
+++ b/src/query/pools/query_pools.go
@@ -26,11 +26,11 @@ import (
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
 	"github.com/m3db/m3/src/dbnode/x/xpool"
-	"github.com/m3db/m3/src/x/serialize"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
 	xsync "github.com/m3db/m3/src/x/sync"
 
 	"github.com/uber-go/tally"

--- a/src/query/test/mock_pools.go
+++ b/src/query/test/mock_pools.go
@@ -26,9 +26,9 @@ import (
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/x/xpool"
 	"github.com/m3db/m3/src/query/pools"
-	"github.com/m3db/m3/src/x/serialize"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
 )
 
 var (

--- a/src/query/tsdb/remote/compressed_codecs.go
+++ b/src/query/tsdb/remote/compressed_codecs.go
@@ -33,9 +33,9 @@ import (
 	"github.com/m3db/m3/src/dbnode/x/xpool"
 	"github.com/m3db/m3/src/query/errors"
 	rpc "github.com/m3db/m3/src/query/generated/proto/rpcpb"
-	"github.com/m3db/m3/src/x/serialize"
 	"github.com/m3db/m3/src/x/checked"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/serialize"
 	xtime "github.com/m3db/m3/src/x/time"
 )
 


### PR DESCRIPTION
Fixes an issue where the values endpoint, `/label/{name}/values` was not returning correct results. Issue was caused since the new optimized tag completion endpoint now considers query range params, and they were not being set correctly.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
Fixes a user-facing bug
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
