### PR TITLE
[query] Ignore name tags for matching binary functions

### DIFF
--- a/src/query/api/v1/handler/graphite/find_test.go
+++ b/src/query/api/v1/handler/graphite/find_test.go
@@ -68,12 +68,10 @@ func (m *completeTagQueryMatcher) Matches(x interface{}) bool {
 	}
 
 	if !q.Start.Equal(from.t) {
-		fmt.Println("Not equal start", q.Start, from.t)
 		return false
 	}
 
 	if !q.End.Equal(until.t) {
-		fmt.Println("Not equal end", q.End, until.t)
 		return false
 	}
 

--- a/src/query/functions/binary/binary.go
+++ b/src/query/functions/binary/binary.go
@@ -134,7 +134,9 @@ func processSingleBlock(
 		return nil, err
 	}
 
-	builder, err := controller.BlockBuilder(queryCtx, it.Meta(), it.SeriesMeta())
+	meta, metas := it.Meta(), it.SeriesMeta()
+	meta, metas = removeNameTags(meta, metas)
+	builder, err := controller.BlockBuilder(queryCtx, meta, metas)
 	if err != nil {
 		return nil, err
 	}
@@ -171,13 +173,16 @@ func processBothSeries(
 		return nil, errMismatchedStepCounts
 	}
 
-	lMeta, rMeta := lIter.Meta(), rIter.Meta()
+	lMeta, lSeriesMeta := lIter.Meta(), lIter.SeriesMeta()
+	lMeta, lSeriesMeta = removeNameTags(lMeta, lSeriesMeta)
 
-	lSeriesMeta := utils.FlattenMetadata(lMeta, lIter.SeriesMeta())
-	rSeriesMeta := utils.FlattenMetadata(rMeta, rIter.SeriesMeta())
+	rMeta, rSeriesMeta := rIter.Meta(), rIter.SeriesMeta()
+	rMeta, rSeriesMeta = removeNameTags(rMeta, rSeriesMeta)
+
+	lSeriesMeta = utils.FlattenMetadata(lMeta, lSeriesMeta)
+	rSeriesMeta = utils.FlattenMetadata(rMeta, rSeriesMeta)
 
 	takeLeft, correspondingRight, lSeriesMeta := intersect(matching, lSeriesMeta, rSeriesMeta)
-
 	lMeta.Tags, lSeriesMeta = utils.DedupeMetadata(lSeriesMeta)
 
 	// Use metas from only taken left series

--- a/src/query/functions/binary/binary_test.go
+++ b/src/query/functions/binary/binary_test.go
@@ -837,9 +837,11 @@ func TestBothSeries(t *testing.T) {
 
 			// Extract duped expected metas
 			expectedMeta := block.Metadata{Bounds: bounds}
-			expectedMeta.Tags, tt.expectedMetas = utils.DedupeMetadata(tt.expectedMetas)
+			var expectedMetas []block.SeriesMeta
+			expectedMeta.Tags, expectedMetas = utils.DedupeMetadata(tt.expectedMetas)
+			expectedMeta, expectedMetas = removeNameTags(expectedMeta, expectedMetas)
 			assert.Equal(t, expectedMeta, sink.Meta)
-			assert.Equal(t, tt.expectedMetas, sink.Metas)
+			assert.Equal(t, expectedMetas, sink.Metas)
 		})
 	}
 }

--- a/src/query/functions/binary/common.go
+++ b/src/query/functions/binary/common.go
@@ -168,3 +168,16 @@ func appendValuesAtIndices(idxArray []int, iter block.StepIter, builder block.Bu
 
 	return iter.Err()
 }
+
+// NB: binary functions should remove the name tag from relevant series.
+func removeNameTags(
+	meta block.Metadata,
+	metas []block.SeriesMeta,
+) (block.Metadata, []block.SeriesMeta) {
+	meta.Tags = meta.Tags.WithoutName()
+	for i, sm := range metas {
+		metas[i].Tags = sm.Tags.WithoutName()
+	}
+
+	return meta, metas
+}

--- a/src/query/models/tags_test.go
+++ b/src/query/models/tags_test.go
@@ -480,7 +480,6 @@ func BenchmarkIDs(b *testing.B) {
 				}
 			})
 		}
-		fmt.Println()
 	}
 }
 

--- a/src/query/test/block.go
+++ b/src/query/test/block.go
@@ -118,7 +118,7 @@ func NewBlockFromValuesWithSeriesMeta(
 	seriesMeta []block.SeriesMeta,
 	seriesValues [][]float64,
 ) block.Block {
-	blockMeta := block.Metadata{Bounds: bounds}
+	blockMeta := block.Metadata{Bounds: bounds, Tags: models.NewTags(0, models.NewTagOptions())}
 
 	return NewBlockFromValuesWithMetaAndSeriesMeta(blockMeta, seriesMeta, seriesValues)
 }


### PR DESCRIPTION
 **What this PR does / why we need it**:
Fixes #1520

**Special notes for your reviewer**:
Fixes an issue in binary functions; previously there was a requirement that series name tags matched to match series from left and right; this drops name tags from binary functions.

NB: this also drops the name tag from appearing in the output series for binary operations with a scalar argument; this is intentional to mirror the same behaviour as Prometheus 

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
Fixes an issue where binary functions would not match series correctly.
```

**Does this PR require updating code package or user-facing documentation?**: 
```documentation-note
NONE
```
