### PR TITLE
0.9.0 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 0.8.5
+# 0.9.0
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
 
-# 0.8.5 (TBD)
+# 0.8.5
+
+## Features
+
+- **M3Coordinator**: Emit caller I.P address in error logs (#1583)
+- **M3DB**: Add native support for running M3DB in "index-only" mode (#1596)
+- **M3DB**: Reduce M3DB log spam for normal operations like cleanup (#1592)
 
 ## Bug Fixes
 
-- **M3DB**: Prevent active commit log from appearing like a corrupt file during bootstrap.
+- **M3DB**: Filter out commit log files that were not present on disk before the process started when determining if files are corrupt in the commitlog bootstrapper. This will prevent a race in which the commitlog bootstrapper would interpret the current commitlog file as corrupt (#1581)
+- **M3Query**: Fixed binary arithmetic to properly ignore names when checking for matching series (#1604)
+
+## Performance
+
+- **M3DB**: Optimize some types aggregation queries in M3DB to not require materializing intermediary documents. This should substantially improve query performance for certain types of aggregation queries such as those used to perform auto-complete in Prometheus and Grafana (#1545)
+- **M3DB**: Open new commitlog files asynchronously. This should prevent large spikes in the commitlog queue during snapshotting / commitlog rotation for write-heavy workloads (#1576)
 
 # 0.8.4 (2019-04-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Features
 
 - **M3Coordinator**: Emit caller I.P address in error logs (#1583)
+- **M3Query**: Add a list tags endpoint that displays every unique tag name stored in M3DB to match the Prometheus [/labels endpoint](https://prometheus.io/docs/prometheus/latest/querying/api/#getting-label-names) (#1565)
 - **M3DB**: Add native support for running M3DB in "index-only" mode (#1596)
 - **M3DB**: Reduce M3DB log spam for normal operations like cleanup (#1592)
 
@@ -12,6 +13,7 @@
 
 - **M3DB**: Filter out commit log files that were not present on disk before the process started when determining if files are corrupt in the commitlog bootstrapper. This will prevent a race in which the commitlog bootstrapper would interpret the current commitlog file as corrupt (#1581)
 - **M3Query**: Fixed binary arithmetic to properly ignore names when checking for matching series (#1604)
+- **M3Query**: Add start and end time to tag values endpoint to fix an issue preventing Grafana tag completion (#1601)
 
 ## Performance
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Commit the changelog for 0.9.0 so we can cut a new release.