### PR TITLE
Update Stream() API and refactor/fix bugs in buffer.go

### DIFF
--- a/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
@@ -583,8 +583,8 @@ func (td testDatapoints) toRPCSegments(th testFetchTaggedHelper, start time.Time
 	for _, dp := range td {
 		require.NoError(th.t, enc.Encode(dp, testFetchTaggedTimeUnit, nil), fmt.Sprintf("%+v", dp))
 	}
-	reader := enc.Stream()
-	if reader == nil {
+	reader, ok := enc.Stream()
+	if !ok {
 		return nil
 	}
 	res, err := convert.ToSegments([]xio.BlockReader{

--- a/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
@@ -583,7 +583,7 @@ func (td testDatapoints) toRPCSegments(th testFetchTaggedHelper, start time.Time
 	for _, dp := range td {
 		require.NoError(th.t, enc.Encode(dp, testFetchTaggedTimeUnit, nil), fmt.Sprintf("%+v", dp))
 	}
-	reader, ok := enc.Stream(encoding.StreamOpts{})
+	reader, ok := enc.Stream(encoding.StreamOptions{})
 	if !ok {
 		return nil
 	}

--- a/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
@@ -583,7 +583,7 @@ func (td testDatapoints) toRPCSegments(th testFetchTaggedHelper, start time.Time
 	for _, dp := range td {
 		require.NoError(th.t, enc.Encode(dp, testFetchTaggedTimeUnit, nil), fmt.Sprintf("%+v", dp))
 	}
-	reader, ok := enc.Stream()
+	reader, ok := enc.Stream(encoding.StreamOpts{})
 	if !ok {
 		return nil
 	}

--- a/src/dbnode/client/session_fetch_bulk_blocks_test.go
+++ b/src/dbnode/client/session_fetch_bulk_blocks_test.go
@@ -43,12 +43,12 @@ import (
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"
-	"github.com/m3db/m3/src/x/serialize"
 	"github.com/m3db/m3/src/x/checked"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
 	xretry "github.com/m3db/m3/src/x/retry"
+	"github.com/m3db/m3/src/x/serialize"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
 
@@ -1269,8 +1269,8 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockErr(t *testing.T) {
 		Timestamp: start.Add(10 * time.Second),
 		Value:     42,
 	}, xtime.Second, nil))
-	reader := enc.Stream()
-	require.NotNil(t, reader)
+	reader, ok := enc.Stream()
+	require.True(t, ok)
 	segment, err := reader.Segment()
 	require.NoError(t, err)
 	rawBlockData := make([]byte, segment.Len())
@@ -1414,8 +1414,8 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockChecksum(t *testing.T) {
 		Timestamp: start.Add(10 * time.Second),
 		Value:     42,
 	}, xtime.Second, nil))
-	reader := enc.Stream()
-	require.NotNil(t, reader)
+	reader, ok := enc.Stream()
+	require.True(t, ok)
 	segment, err := reader.Segment()
 	require.NoError(t, err)
 	rawBlockData := make([]byte, segment.Len())

--- a/src/dbnode/client/session_fetch_bulk_blocks_test.go
+++ b/src/dbnode/client/session_fetch_bulk_blocks_test.go
@@ -1269,7 +1269,7 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockErr(t *testing.T) {
 		Timestamp: start.Add(10 * time.Second),
 		Value:     42,
 	}, xtime.Second, nil))
-	reader, ok := enc.Stream(encoding.StreamOpts{})
+	reader, ok := enc.Stream(encoding.StreamOptions{})
 	require.True(t, ok)
 	segment, err := reader.Segment()
 	require.NoError(t, err)
@@ -1414,7 +1414,7 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockChecksum(t *testing.T) {
 		Timestamp: start.Add(10 * time.Second),
 		Value:     42,
 	}, xtime.Second, nil))
-	reader, ok := enc.Stream(encoding.StreamOpts{})
+	reader, ok := enc.Stream(encoding.StreamOptions{})
 	require.True(t, ok)
 	segment, err := reader.Segment()
 	require.NoError(t, err)

--- a/src/dbnode/client/session_fetch_bulk_blocks_test.go
+++ b/src/dbnode/client/session_fetch_bulk_blocks_test.go
@@ -1269,7 +1269,7 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockErr(t *testing.T) {
 		Timestamp: start.Add(10 * time.Second),
 		Value:     42,
 	}, xtime.Second, nil))
-	reader, ok := enc.Stream()
+	reader, ok := enc.Stream(encoding.StreamOpts{})
 	require.True(t, ok)
 	segment, err := reader.Segment()
 	require.NoError(t, err)
@@ -1414,7 +1414,7 @@ func TestStreamBlocksBatchFromPeerVerifiesBlockChecksum(t *testing.T) {
 		Timestamp: start.Add(10 * time.Second),
 		Value:     42,
 	}, xtime.Second, nil))
-	reader, ok := enc.Stream()
+	reader, ok := enc.Stream(encoding.StreamOpts{})
 	require.True(t, ok)
 	segment, err := reader.Segment()
 	require.NoError(t, err)

--- a/src/dbnode/client/session_fetch_bulk_blocks_test.go
+++ b/src/dbnode/client/session_fetch_bulk_blocks_test.go
@@ -2292,8 +2292,8 @@ func (e *testEncoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, annotation ts
 	return fmt.Errorf("not implemented")
 }
 
-func (e *testEncoder) Stream() xio.SegmentReader {
-	return xio.NewSegmentReader(e.data)
+func (e *testEncoder) Stream(opts encoding.StreamOptions) (xio.SegmentReader, bool) {
+	return xio.NewSegmentReader(e.data), true
 }
 
 func (e *testEncoder) NumEncoded() int {

--- a/src/dbnode/encoding/encoding_mock.go
+++ b/src/dbnode/encoding/encoding_mock.go
@@ -79,7 +79,7 @@ func (mr *MockEncoderMockRecorder) Encode(dp, unit, annotation interface{}) *gom
 }
 
 // Stream mocks base method
-func (m *MockEncoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
+func (m *MockEncoder) Stream(opts StreamOptions) (xio.SegmentReader, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stream", opts)
 	ret0, _ := ret[0].(xio.SegmentReader)

--- a/src/dbnode/encoding/encoding_mock.go
+++ b/src/dbnode/encoding/encoding_mock.go
@@ -79,11 +79,12 @@ func (mr *MockEncoderMockRecorder) Encode(dp, unit, annotation interface{}) *gom
 }
 
 // Stream mocks base method
-func (m *MockEncoder) Stream() xio.SegmentReader {
+func (m *MockEncoder) Stream() (xio.SegmentReader, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stream")
 	ret0, _ := ret[0].(xio.SegmentReader)
-	return ret0
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 // Stream indicates an expected call of Stream

--- a/src/dbnode/encoding/encoding_mock.go
+++ b/src/dbnode/encoding/encoding_mock.go
@@ -79,18 +79,18 @@ func (mr *MockEncoderMockRecorder) Encode(dp, unit, annotation interface{}) *gom
 }
 
 // Stream mocks base method
-func (m *MockEncoder) Stream() (xio.SegmentReader, bool) {
+func (m *MockEncoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stream")
+	ret := m.ctrl.Call(m, "Stream", opts)
 	ret0, _ := ret[0].(xio.SegmentReader)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
 // Stream indicates an expected call of Stream
-func (mr *MockEncoderMockRecorder) Stream() *gomock.Call {
+func (mr *MockEncoderMockRecorder) Stream(opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stream", reflect.TypeOf((*MockEncoder)(nil).Stream))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stream", reflect.TypeOf((*MockEncoder)(nil).Stream), opts)
 }
 
 // NumEncoded mocks base method

--- a/src/dbnode/encoding/m3tsz/encoder.go
+++ b/src/dbnode/encoding/m3tsz/encoder.go
@@ -275,15 +275,14 @@ func (enc *encoder) reset(start time.Time, bytes checked.Bytes) {
 // Stream returns a copy of the underlying data stream.
 func (enc *encoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
 	segment := enc.segment(byCopyResultType)
-	if segment.Len() == 0 {
-		return xio.NewSegmentReader(ts.Segment{}), false
-	}
+	hasData := segment.Len() != 0
+
 	if readerPool := enc.opts.SegmentReaderPool(); readerPool != nil {
 		reader := readerPool.Get()
 		reader.Reset(segment)
-		return reader, true
+		return reader, hasData
 	}
-	return xio.NewSegmentReader(segment), true
+	return xio.NewSegmentReader(segment), hasData
 }
 
 // NumEncoded returns the number of encoded datapoints.

--- a/src/dbnode/encoding/m3tsz/encoder.go
+++ b/src/dbnode/encoding/m3tsz/encoder.go
@@ -273,7 +273,7 @@ func (enc *encoder) reset(start time.Time, bytes checked.Bytes) {
 }
 
 // Stream returns a copy of the underlying data stream.
-func (enc *encoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
+func (enc *encoder) Stream(opts encoding.StreamOptions) (xio.SegmentReader, bool) {
 	segment := enc.segment(byCopyResultType)
 	if segment.Len() == 0 {
 		return nil, false

--- a/src/dbnode/encoding/m3tsz/encoder.go
+++ b/src/dbnode/encoding/m3tsz/encoder.go
@@ -273,7 +273,7 @@ func (enc *encoder) reset(start time.Time, bytes checked.Bytes) {
 }
 
 // Stream returns a copy of the underlying data stream.
-func (enc *encoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
+func (enc *encoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
 	segment := enc.segment(byCopyResultType)
 	if segment.Len() == 0 {
 		return xio.NewSegmentReader(ts.Segment{}), false

--- a/src/dbnode/encoding/m3tsz/encoder.go
+++ b/src/dbnode/encoding/m3tsz/encoder.go
@@ -275,14 +275,16 @@ func (enc *encoder) reset(start time.Time, bytes checked.Bytes) {
 // Stream returns a copy of the underlying data stream.
 func (enc *encoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
 	segment := enc.segment(byCopyResultType)
-	hasData := segment.Len() != 0
+	if segment.Len() == 0 {
+		return nil, false
+	}
 
 	if readerPool := enc.opts.SegmentReaderPool(); readerPool != nil {
 		reader := readerPool.Get()
 		reader.Reset(segment)
-		return reader, hasData
+		return reader, true
 	}
-	return xio.NewSegmentReader(segment), hasData
+	return xio.NewSegmentReader(segment), true
 }
 
 // NumEncoded returns the number of encoded datapoints.

--- a/src/dbnode/encoding/m3tsz/encoder.go
+++ b/src/dbnode/encoding/m3tsz/encoder.go
@@ -276,7 +276,7 @@ func (enc *encoder) reset(start time.Time, bytes checked.Bytes) {
 func (enc *encoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
 	segment := enc.segment(byCopyResultType)
 	if segment.Len() == 0 {
-		return nil, false
+		return xio.NewSegmentReader(ts.Segment{}), false
 	}
 	if readerPool := enc.opts.SegmentReaderPool(); readerPool != nil {
 		reader := readerPool.Get()

--- a/src/dbnode/encoding/m3tsz/encoder.go
+++ b/src/dbnode/encoding/m3tsz/encoder.go
@@ -273,17 +273,17 @@ func (enc *encoder) reset(start time.Time, bytes checked.Bytes) {
 }
 
 // Stream returns a copy of the underlying data stream.
-func (enc *encoder) Stream() xio.SegmentReader {
+func (enc *encoder) Stream() (xio.SegmentReader, bool) {
 	segment := enc.segment(byCopyResultType)
 	if segment.Len() == 0 {
-		return nil
+		return nil, false
 	}
 	if readerPool := enc.opts.SegmentReaderPool(); readerPool != nil {
 		reader := readerPool.Get()
 		reader.Reset(segment)
-		return reader
+		return reader, true
 	}
-	return xio.NewSegmentReader(segment)
+	return xio.NewSegmentReader(segment), true
 }
 
 // NumEncoded returns the number of encoded datapoints.

--- a/src/dbnode/encoding/m3tsz/encoder.go
+++ b/src/dbnode/encoding/m3tsz/encoder.go
@@ -273,7 +273,7 @@ func (enc *encoder) reset(start time.Time, bytes checked.Bytes) {
 }
 
 // Stream returns a copy of the underlying data stream.
-func (enc *encoder) Stream() (xio.SegmentReader, bool) {
+func (enc *encoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
 	segment := enc.segment(byCopyResultType)
 	if segment.Len() == 0 {
 		return nil, false

--- a/src/dbnode/encoding/m3tsz/encoder_test.go
+++ b/src/dbnode/encoding/m3tsz/encoder_test.go
@@ -365,7 +365,7 @@ func TestEncoderResets(t *testing.T) {
 	defer enc.Close()
 
 	require.Equal(t, 0, enc.os.Len())
-	_, ok := encoder.Stream(encoding.StreamOpts{})
+	_, ok := enc.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 
 	enc.Encode(ts.Datapoint{testStartTime, 12}, xtime.Second, nil)
@@ -374,7 +374,7 @@ func TestEncoderResets(t *testing.T) {
 	now := time.Now()
 	enc.Reset(now, 0)
 	require.Equal(t, 0, enc.os.Len())
-	_, ok := encoder.Stream(encoding.StreamOpts{})
+	_, ok = enc.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 	b, _ := enc.os.Rawbytes()
 	require.Equal(t, []byte{}, b)
@@ -384,7 +384,7 @@ func TestEncoderResets(t *testing.T) {
 
 	enc.DiscardReset(now, 0)
 	require.Equal(t, 0, enc.os.Len())
-	_, ok := encoder.Stream(encoding.StreamOpts{})
+	_, ok = enc.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 	b, _ = enc.os.Rawbytes()
 	require.Equal(t, []byte{}, b)

--- a/src/dbnode/encoding/m3tsz/encoder_test.go
+++ b/src/dbnode/encoding/m3tsz/encoder_test.go
@@ -150,7 +150,7 @@ func TestWriteAnnotation(t *testing.T) {
 }
 
 func getBytes(t *testing.T, e encoding.Encoder) []byte {
-	r, ok := e.Stream()
+	r, ok := e.Stream(encoding.StreamOpts{})
 	if !ok {
 		return nil
 	}
@@ -197,7 +197,7 @@ func TestWriteTimeUnit(t *testing.T) {
 
 func TestEncodeNoAnnotation(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	_, ok := encoder.Stream()
+	_, ok := encoder.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
@@ -234,7 +234,7 @@ func TestEncodeNoAnnotation(t *testing.T) {
 
 func TestEncodeWithAnnotation(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	_, ok := encoder.Stream()
+	_, ok := encoder.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
@@ -275,7 +275,7 @@ func TestEncodeWithAnnotation(t *testing.T) {
 
 func TestEncodeWithTimeUnit(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	_, ok := encoder.Stream()
+	_, ok := encoder.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
@@ -310,7 +310,7 @@ func TestEncodeWithTimeUnit(t *testing.T) {
 
 func TestEncodeWithAnnotationAndTimeUnit(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	_, ok := encoder.Stream()
+	_, ok := encoder.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
@@ -365,7 +365,7 @@ func TestEncoderResets(t *testing.T) {
 	defer enc.Close()
 
 	require.Equal(t, 0, enc.os.Len())
-	_, ok := encoder.Stream()
+	_, ok := encoder.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 
 	enc.Encode(ts.Datapoint{testStartTime, 12}, xtime.Second, nil)
@@ -374,7 +374,7 @@ func TestEncoderResets(t *testing.T) {
 	now := time.Now()
 	enc.Reset(now, 0)
 	require.Equal(t, 0, enc.os.Len())
-	_, ok := encoder.Stream()
+	_, ok := encoder.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 	b, _ := enc.os.Rawbytes()
 	require.Equal(t, []byte{}, b)
@@ -384,7 +384,7 @@ func TestEncoderResets(t *testing.T) {
 
 	enc.DiscardReset(now, 0)
 	require.Equal(t, 0, enc.os.Len())
-	_, ok := encoder.Stream()
+	_, ok := encoder.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 	b, _ = enc.os.Rawbytes()
 	require.Equal(t, []byte{}, b)

--- a/src/dbnode/encoding/m3tsz/encoder_test.go
+++ b/src/dbnode/encoding/m3tsz/encoder_test.go
@@ -150,7 +150,7 @@ func TestWriteAnnotation(t *testing.T) {
 }
 
 func getBytes(t *testing.T, e encoding.Encoder) []byte {
-	r, ok := e.Stream(encoding.StreamOpts{})
+	r, ok := e.Stream(encoding.StreamOptions{})
 	if !ok {
 		return nil
 	}
@@ -197,7 +197,7 @@ func TestWriteTimeUnit(t *testing.T) {
 
 func TestEncodeNoAnnotation(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	_, ok := encoder.Stream(encoding.StreamOpts{})
+	_, ok := encoder.Stream(encoding.StreamOptions{})
 	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
@@ -234,7 +234,7 @@ func TestEncodeNoAnnotation(t *testing.T) {
 
 func TestEncodeWithAnnotation(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	_, ok := encoder.Stream(encoding.StreamOpts{})
+	_, ok := encoder.Stream(encoding.StreamOptions{})
 	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
@@ -275,7 +275,7 @@ func TestEncodeWithAnnotation(t *testing.T) {
 
 func TestEncodeWithTimeUnit(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	_, ok := encoder.Stream(encoding.StreamOpts{})
+	_, ok := encoder.Stream(encoding.StreamOptions{})
 	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
@@ -310,7 +310,7 @@ func TestEncodeWithTimeUnit(t *testing.T) {
 
 func TestEncodeWithAnnotationAndTimeUnit(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	_, ok := encoder.Stream(encoding.StreamOpts{})
+	_, ok := encoder.Stream(encoding.StreamOptions{})
 	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
@@ -365,7 +365,7 @@ func TestEncoderResets(t *testing.T) {
 	defer enc.Close()
 
 	require.Equal(t, 0, enc.os.Len())
-	_, ok := enc.Stream(encoding.StreamOpts{})
+	_, ok := enc.Stream(encoding.StreamOptions{})
 	require.False(t, ok)
 
 	enc.Encode(ts.Datapoint{testStartTime, 12}, xtime.Second, nil)
@@ -374,7 +374,7 @@ func TestEncoderResets(t *testing.T) {
 	now := time.Now()
 	enc.Reset(now, 0)
 	require.Equal(t, 0, enc.os.Len())
-	_, ok = enc.Stream(encoding.StreamOpts{})
+	_, ok = enc.Stream(encoding.StreamOptions{})
 	require.False(t, ok)
 	b, _ := enc.os.Rawbytes()
 	require.Equal(t, []byte{}, b)
@@ -384,7 +384,7 @@ func TestEncoderResets(t *testing.T) {
 
 	enc.DiscardReset(now, 0)
 	require.Equal(t, 0, enc.os.Len())
-	_, ok = enc.Stream(encoding.StreamOpts{})
+	_, ok = enc.Stream(encoding.StreamOptions{})
 	require.False(t, ok)
 	b, _ = enc.os.Rawbytes()
 	require.Equal(t, []byte{}, b)

--- a/src/dbnode/encoding/m3tsz/encoder_test.go
+++ b/src/dbnode/encoding/m3tsz/encoder_test.go
@@ -150,8 +150,8 @@ func TestWriteAnnotation(t *testing.T) {
 }
 
 func getBytes(t *testing.T, e encoding.Encoder) []byte {
-	r := e.Stream()
-	if r == nil {
+	r, ok := e.Stream()
+	if !ok {
 		return nil
 	}
 	var b [1000]byte
@@ -197,7 +197,8 @@ func TestWriteTimeUnit(t *testing.T) {
 
 func TestEncodeNoAnnotation(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	require.Nil(t, encoder.Stream())
+	_, ok := encoder.Stream()
+	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
 	inputs := []ts.Datapoint{
@@ -233,7 +234,8 @@ func TestEncodeNoAnnotation(t *testing.T) {
 
 func TestEncodeWithAnnotation(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	require.Nil(t, encoder.Stream())
+	_, ok := encoder.Stream()
+	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
 	inputs := []struct {
@@ -273,7 +275,8 @@ func TestEncodeWithAnnotation(t *testing.T) {
 
 func TestEncodeWithTimeUnit(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	require.Nil(t, encoder.Stream())
+	_, ok := encoder.Stream()
+	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
 	inputs := []struct {
@@ -307,7 +310,8 @@ func TestEncodeWithTimeUnit(t *testing.T) {
 
 func TestEncodeWithAnnotationAndTimeUnit(t *testing.T) {
 	encoder := getTestEncoder(testStartTime)
-	require.Nil(t, encoder.Stream())
+	_, ok := encoder.Stream()
+	require.False(t, ok)
 
 	startTime := time.Unix(1427162462, 0)
 	inputs := []struct {
@@ -361,7 +365,8 @@ func TestEncoderResets(t *testing.T) {
 	defer enc.Close()
 
 	require.Equal(t, 0, enc.os.Len())
-	require.Equal(t, nil, enc.Stream())
+	_, ok := encoder.Stream()
+	require.False(t, ok)
 
 	enc.Encode(ts.Datapoint{testStartTime, 12}, xtime.Second, nil)
 	require.True(t, enc.os.Len() > 0)
@@ -369,7 +374,8 @@ func TestEncoderResets(t *testing.T) {
 	now := time.Now()
 	enc.Reset(now, 0)
 	require.Equal(t, 0, enc.os.Len())
-	require.Equal(t, nil, enc.Stream())
+	_, ok := encoder.Stream()
+	require.False(t, ok)
 	b, _ := enc.os.Rawbytes()
 	require.Equal(t, []byte{}, b)
 
@@ -378,7 +384,8 @@ func TestEncoderResets(t *testing.T) {
 
 	enc.DiscardReset(now, 0)
 	require.Equal(t, 0, enc.os.Len())
-	require.Equal(t, nil, enc.Stream())
+	_, ok := encoder.Stream()
+	require.False(t, ok)
 	b, _ = enc.os.Rawbytes()
 	require.Equal(t, []byte{}, b)
 }

--- a/src/dbnode/encoding/m3tsz/roundtrip_test.go
+++ b/src/dbnode/encoding/m3tsz/roundtrip_test.go
@@ -118,7 +118,8 @@ func validateRoundTrip(t *testing.T, input []ts.Datapoint, intOpt bool) {
 		}
 	}
 	decoder := NewDecoder(intOpt, nil)
-	it := decoder.Decode(encoder.Stream())
+	it, ok := decoder.Decode(encoder.Stream())
+	require.True(t, ok)
 	defer it.Close()
 	var decompressed []ts.Datapoint
 	j := 0

--- a/src/dbnode/encoding/m3tsz/roundtrip_test.go
+++ b/src/dbnode/encoding/m3tsz/roundtrip_test.go
@@ -122,7 +122,7 @@ func validateRoundTrip(t *testing.T, input []ts.Datapoint, intOpt bool) {
 	stream, ok := encoder.Stream(encoding.StreamOpts{})
 	require.True(t, ok)
 
-	it, ok := decoder.Decode(stream)
+	it := decoder.Decode(stream)
 	require.True(t, ok)
 	defer it.Close()
 	var decompressed []ts.Datapoint

--- a/src/dbnode/encoding/m3tsz/roundtrip_test.go
+++ b/src/dbnode/encoding/m3tsz/roundtrip_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/testgen"
 	"github.com/m3db/m3/src/dbnode/ts"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -118,7 +119,10 @@ func validateRoundTrip(t *testing.T, input []ts.Datapoint, intOpt bool) {
 		}
 	}
 	decoder := NewDecoder(intOpt, nil)
-	it, ok := decoder.Decode(encoder.Stream())
+	stream, ok := encoder.Stream(encoding.StreamOpts{})
+	require.True(t, ok)
+
+	it, ok := decoder.Decode(stream)
 	require.True(t, ok)
 	defer it.Close()
 	var decompressed []ts.Datapoint

--- a/src/dbnode/encoding/m3tsz/roundtrip_test.go
+++ b/src/dbnode/encoding/m3tsz/roundtrip_test.go
@@ -119,7 +119,7 @@ func validateRoundTrip(t *testing.T, input []ts.Datapoint, intOpt bool) {
 		}
 	}
 	decoder := NewDecoder(intOpt, nil)
-	stream, ok := encoder.Stream(encoding.StreamOpts{})
+	stream, ok := encoder.Stream(encoding.StreamOptions{})
 	require.True(t, ok)
 
 	it := decoder.Decode(stream)

--- a/src/dbnode/encoding/null.go
+++ b/src/dbnode/encoding/null.go
@@ -42,8 +42,8 @@ func NewNullEncoder() Encoder {
 func (e *nullEncoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, annotation ts.Annotation) error {
 	return nil
 }
-func (e *nullEncoder) Stream() (xio.SegmentReader, bool) {
-	return nil, false
+func (e *nullEncoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
+	return xio.NewSegmentReader(ts.Segment{}), false
 }
 func (e *nullEncoder) NumEncoded() int { return 0 }
 func (e *nullEncoder) LastEncoded() (ts.Datapoint, error) {

--- a/src/dbnode/encoding/null.go
+++ b/src/dbnode/encoding/null.go
@@ -43,7 +43,7 @@ func (e *nullEncoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, annotation ts
 	return nil
 }
 func (e *nullEncoder) Stream() (xio.SegmentReader, bool) {
-	return xio.NewSegmentReader(ts.Segment{}), false
+	return nil, false
 }
 func (e *nullEncoder) NumEncoded() int { return 0 }
 func (e *nullEncoder) LastEncoded() (ts.Datapoint, error) {

--- a/src/dbnode/encoding/null.go
+++ b/src/dbnode/encoding/null.go
@@ -43,7 +43,7 @@ func (e *nullEncoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, annotation ts
 	return nil
 }
 func (e *nullEncoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
-	return xio.NewSegmentReader(ts.Segment{}), false
+	return nil, false
 }
 func (e *nullEncoder) NumEncoded() int { return 0 }
 func (e *nullEncoder) LastEncoded() (ts.Datapoint, error) {

--- a/src/dbnode/encoding/null.go
+++ b/src/dbnode/encoding/null.go
@@ -42,7 +42,7 @@ func NewNullEncoder() Encoder {
 func (e *nullEncoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, annotation ts.Annotation) error {
 	return nil
 }
-func (e *nullEncoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
+func (e *nullEncoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
 	return xio.NewSegmentReader(ts.Segment{}), false
 }
 func (e *nullEncoder) NumEncoded() int { return 0 }

--- a/src/dbnode/encoding/null.go
+++ b/src/dbnode/encoding/null.go
@@ -42,8 +42,8 @@ func NewNullEncoder() Encoder {
 func (e *nullEncoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, annotation ts.Annotation) error {
 	return nil
 }
-func (e *nullEncoder) Stream() xio.SegmentReader {
-	return xio.NewSegmentReader(ts.Segment{})
+func (e *nullEncoder) Stream() (xio.SegmentReader, bool) {
+	return xio.NewSegmentReader(ts.Segment{}), false
 }
 func (e *nullEncoder) NumEncoded() int { return 0 }
 func (e *nullEncoder) LastEncoded() (ts.Datapoint, error) {

--- a/src/dbnode/encoding/null.go
+++ b/src/dbnode/encoding/null.go
@@ -42,7 +42,7 @@ func NewNullEncoder() Encoder {
 func (e *nullEncoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, annotation ts.Annotation) error {
 	return nil
 }
-func (e *nullEncoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
+func (e *nullEncoder) Stream(opts StreamOptions) (xio.SegmentReader, bool) {
 	return nil, false
 }
 func (e *nullEncoder) NumEncoded() int { return 0 }

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -225,16 +225,14 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 // Stream returns a copy of the underlying data stream.
 func (enc *Encoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
 	seg := enc.segment(true)
-	if seg.Len() == 0 {
-		return xio.NewSegmentReader(ts.Segment{}), false
-	}
+	hasData := seg.Len() != 0
 
 	if readerPool := enc.opts.SegmentReaderPool(); readerPool != nil {
 		reader := readerPool.Get()
 		reader.Reset(seg)
-		return reader, true
+		return reader, hasData
 	}
-	return xio.NewSegmentReader(seg), true
+	return xio.NewSegmentReader(seg), hasData
 }
 
 func (enc *Encoder) segment(copy bool) ts.Segment {

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -226,7 +226,7 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 func (enc *Encoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
 	seg := enc.segment(true)
 	if seg.Len() == 0 {
-		return nil, false
+		return xio.NewSegmentReader(ts.Segment{}), false
 	}
 
 	if readerPool := enc.opts.SegmentReaderPool(); readerPool != nil {

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -223,7 +223,7 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 }
 
 // Stream returns a copy of the underlying data stream.
-func (enc *Encoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
+func (enc *Encoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
 	seg := enc.segment(true)
 	if seg.Len() == 0 {
 		return xio.NewSegmentReader(ts.Segment{}), false

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -223,18 +223,18 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 }
 
 // Stream returns a copy of the underlying data stream.
-func (enc *Encoder) Stream() xio.SegmentReader {
+func (enc *Encoder) Stream() (xio.SegmentReader, bool) {
 	seg := enc.segment(true)
 	if seg.Len() == 0 {
-		return nil
+		return nil, false
 	}
 
 	if readerPool := enc.opts.SegmentReaderPool(); readerPool != nil {
 		reader := readerPool.Get()
 		reader.Reset(seg)
-		return reader
+		return reader, true
 	}
-	return xio.NewSegmentReader(seg)
+	return xio.NewSegmentReader(seg), true
 }
 
 func (enc *Encoder) segment(copy bool) ts.Segment {

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -223,7 +223,7 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 }
 
 // Stream returns a copy of the underlying data stream.
-func (enc *Encoder) Stream() (xio.SegmentReader, bool) {
+func (enc *Encoder) Stream(opts StreamOpts) (xio.SegmentReader, bool) {
 	seg := enc.segment(true)
 	if seg.Len() == 0 {
 		return nil, false

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -225,14 +225,16 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 // Stream returns a copy of the underlying data stream.
 func (enc *Encoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
 	seg := enc.segment(true)
-	hasData := seg.Len() != 0
+	if seg.Len() == 0 {
+		return nil, false
+	}
 
 	if readerPool := enc.opts.SegmentReaderPool(); readerPool != nil {
 		reader := readerPool.Get()
 		reader.Reset(seg)
-		return reader, hasData
+		return reader, true
 	}
-	return xio.NewSegmentReader(seg), hasData
+	return xio.NewSegmentReader(seg), true
 }
 
 func (enc *Encoder) segment(copy bool) ts.Segment {

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -223,7 +223,7 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 }
 
 // Stream returns a copy of the underlying data stream.
-func (enc *Encoder) Stream(opts encoding.StreamOpts) (xio.SegmentReader, bool) {
+func (enc *Encoder) Stream(opts encoding.StreamOptions) (xio.SegmentReader, bool) {
 	seg := enc.segment(true)
 	if seg.Len() == 0 {
 		return nil, false

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -155,7 +155,7 @@ func TestRoundTripProp(t *testing.T) {
 			}
 		}
 
-		stream := enc.Stream()
+		stream, ok := enc.Stream()
 		if !ok {
 			return true, nil
 		}

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/ts"
 	xtime "github.com/m3db/m3/src/x/time"
 

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -156,7 +156,7 @@ func TestRoundTripProp(t *testing.T) {
 		}
 
 		stream := enc.Stream()
-		if stream == nil {
+		if !ok {
 			return true, nil
 		}
 

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -155,7 +155,7 @@ func TestRoundTripProp(t *testing.T) {
 			}
 		}
 
-		stream, ok := enc.Stream()
+		stream, ok := enc.Stream(encoding.StreamOpts{})
 		if !ok {
 			return true, nil
 		}

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -155,7 +155,7 @@ func TestRoundTripProp(t *testing.T) {
 			}
 		}
 
-		stream, ok := enc.Stream(encoding.StreamOpts{})
+		stream, ok := enc.Stream(encoding.StreamOptions{})
 		if !ok {
 			return true, nil
 		}

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -39,6 +39,8 @@ import (
 type StreamOpts struct {
 	// Optional bytes into which the stream should be copied. If left
 	// nil then the checked bytes pool on the encoder will be used instead.
+	// TODO(rartoul): Actually use this field in the Stream API() in a subsequent
+	// P.R.
 	Bytes checked.Bytes
 }
 

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -37,6 +37,8 @@ import (
 // StreamOpts is an options struct that can be passed to Encoder.Stream()
 // to modify its behavior.
 type StreamOpts struct {
+	// Optional bytes into which the stream should be copied. If left
+	// nil then the checked bytes pool on the encoder will be used instead.
 	Bytes checked.Bytes
 }
 

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -27,10 +27,10 @@ import (
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	"github.com/m3db/m3/src/dbnode/x/xpool"
-	"github.com/m3db/m3/src/x/serialize"
 	"github.com/m3db/m3/src/x/checked"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
@@ -40,7 +40,7 @@ type Encoder interface {
 	Encode(dp ts.Datapoint, unit xtime.Unit, annotation ts.Annotation) error
 
 	// Stream is the streaming interface for reading encoded bytes in the encoder.
-	Stream() xio.SegmentReader
+	Stream() (xio.SegmentReader, bool)
 
 	// NumEncoded returns the number of encoded datapoints.
 	NumEncoded() int

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -34,9 +34,9 @@ import (
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
-// StreamOpts is an options struct that can be passed to Encoder.Stream()
+// StreamOptions is an options struct that can be passed to Encoder.Stream()
 // to modify its behavior.
-type StreamOpts struct {
+type StreamOptions struct {
 	// Optional bytes into which the stream should be copied. If left
 	// nil then the checked bytes pool on the encoder will be used instead.
 	// TODO(rartoul): Actually use this field in the Stream API() in a subsequent
@@ -53,7 +53,7 @@ type Encoder interface {
 	// A boolean is returned indicating whether the returned xio.SegmentReader contains
 	// any data (true) or is empty (false) to encourage callers to remember to handle
 	// the special case where there is an empty stream.
-	Stream(opts StreamOpts) (xio.SegmentReader, bool)
+	Stream(opts StreamOptions) (xio.SegmentReader, bool)
 
 	// NumEncoded returns the number of encoded datapoints.
 	NumEncoded() int

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -48,6 +48,9 @@ type Encoder interface {
 	Encode(dp ts.Datapoint, unit xtime.Unit, annotation ts.Annotation) error
 
 	// Stream is the streaming interface for reading encoded bytes in the encoder.
+	// A boolean is returned indicating whether the returned xio.SegmentReader contains
+	// any data (true) or is empty (false) to encourage callers to remember to handle
+	// the special case where there is an empty stream.
 	Stream(opts StreamOpts) (xio.SegmentReader, bool)
 
 	// NumEncoded returns the number of encoded datapoints.

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -34,13 +34,19 @@ import (
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
+// StreamOpts is an options struct that can be passed to Encoder.Stream()
+// to modify its behavior.
+type StreamOpts struct {
+	Bytes checked.Bytes
+}
+
 // Encoder is the generic interface for different types of encoders.
 type Encoder interface {
 	// Encode encodes a datapoint and optionally an annotation.
 	Encode(dp ts.Datapoint, unit xtime.Unit, annotation ts.Annotation) error
 
 	// Stream is the streaming interface for reading encoded bytes in the encoder.
-	Stream() (xio.SegmentReader, bool)
+	Stream(opts StreamOpts) (xio.SegmentReader, bool)
 
 	// NumEncoded returns the number of encoded datapoints.
 	NumEncoded() int

--- a/src/dbnode/integration/generate/writer.go
+++ b/src/dbnode/integration/generate/writer.go
@@ -196,7 +196,7 @@ func writeToDiskWithPredicate(
 				}
 			}
 
-			stream, ok := encoder.Stream()
+			stream, ok := encoder.Stream(encoding.StreamOpts{})
 			if !ok {
 				// None of the datapoints passed the predicate.
 				continue

--- a/src/dbnode/integration/generate/writer.go
+++ b/src/dbnode/integration/generate/writer.go
@@ -196,7 +196,7 @@ func writeToDiskWithPredicate(
 				}
 			}
 
-			stream, ok := encoder.Stream(encoding.StreamOpts{})
+			stream, ok := encoder.Stream(encoding.StreamOptions{})
 			if !ok {
 				// None of the datapoints passed the predicate.
 				continue

--- a/src/dbnode/integration/generate/writer.go
+++ b/src/dbnode/integration/generate/writer.go
@@ -196,8 +196,8 @@ func writeToDiskWithPredicate(
 				}
 			}
 
-			stream := encoder.Stream()
-			if stream == nil {
+			stream, ok := encoder.Stream()
+			if !ok {
 				// None of the datapoints passed the predicate.
 				continue
 			}

--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -271,12 +271,13 @@ func TestServiceQuery(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		streams[id] = enc.Stream()
+		stream, _ := enc.Stream()
+		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).
 			Return([][]xio.BlockReader{{
 				xio.BlockReader{
-					SegmentReader: enc.Stream(),
+					SegmentReader: stream,
 				},
 			}}, nil)
 	}
@@ -519,12 +520,13 @@ func TestServiceFetch(t *testing.T) {
 		require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 	}
 
+	stream, _ := enc.Stream()
 	mockDB.EXPECT().
 		ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher("foo"), start, end).
 		Return([][]xio.BlockReader{
 			[]xio.BlockReader{
 				xio.BlockReader{
-					SegmentReader: enc.Stream(),
+					SegmentReader: stream,
 				},
 			},
 		}, nil)
@@ -689,14 +691,14 @@ func TestServiceFetchBatchRaw(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		streams[id] = enc.Stream()
-
+		stream, _ := enc.Stream()
+		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).
 			Return([][]xio.BlockReader{
 				[]xio.BlockReader{
 					xio.BlockReader{
-						SegmentReader: enc.Stream(),
+						SegmentReader: stream,
 					},
 				},
 			}, nil)
@@ -898,7 +900,8 @@ func TestServiceFetchBlocksRaw(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		streams[id] = enc.Stream()
+		stream, _ := enc.Stream()
+		streams[id] = stream
 
 		seg, err := streams[id].Segment()
 		require.NoError(t, err)
@@ -908,7 +911,7 @@ func TestServiceFetchBlocksRaw(t *testing.T) {
 
 		expectedBlockReader := []xio.BlockReader{
 			xio.BlockReader{
-				SegmentReader: enc.Stream(),
+				SegmentReader: stream,
 				Start:         start,
 			},
 		}
@@ -1314,12 +1317,13 @@ func TestServiceFetchTagged(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		streams[id] = enc.Stream()
+		stream, _ := enc.Stream()
+		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(gomock.Any(), ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).
 			Return([][]xio.BlockReader{{
 				xio.BlockReader{
-					SegmentReader: enc.Stream(),
+					SegmentReader: stream,
 				},
 			}}, nil)
 	}

--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -271,7 +271,7 @@ func TestServiceQuery(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		stream, _ := enc.Stream()
+		stream, _ := enc.Stream(encoding.StreamOpts{})
 		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).
@@ -520,7 +520,7 @@ func TestServiceFetch(t *testing.T) {
 		require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 	}
 
-	stream, _ := enc.Stream()
+	stream, _ := enc.Stream(encoding.StreamOpts{})
 	mockDB.EXPECT().
 		ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher("foo"), start, end).
 		Return([][]xio.BlockReader{
@@ -691,7 +691,7 @@ func TestServiceFetchBatchRaw(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		stream, _ := enc.Stream()
+		stream, _ := enc.Stream(encoding.StreamOpts{})
 		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).
@@ -900,7 +900,7 @@ func TestServiceFetchBlocksRaw(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		stream, _ := enc.Stream()
+		stream, _ := enc.Stream(encoding.StreamOpts{})
 		streams[id] = stream
 
 		seg, err := streams[id].Segment()
@@ -1317,7 +1317,7 @@ func TestServiceFetchTagged(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		stream, _ := enc.Stream()
+		stream, _ := enc.Stream(encoding.StreamOpts{})
 		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(gomock.Any(), ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).

--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -29,9 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3/src/dbnode/topology"
-
 	"github.com/m3db/m3/src/dbnode/digest"
+	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
 	"github.com/m3db/m3/src/dbnode/network/server/tchannelthrift"
 	"github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/convert"
@@ -41,6 +40,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/storage/namespace"
+	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/tracepoint"
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"

--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -271,7 +271,7 @@ func TestServiceQuery(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		stream, _ := enc.Stream(encoding.StreamOpts{})
+		stream, _ := enc.Stream(encoding.StreamOptions{})
 		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).
@@ -520,7 +520,7 @@ func TestServiceFetch(t *testing.T) {
 		require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 	}
 
-	stream, _ := enc.Stream(encoding.StreamOpts{})
+	stream, _ := enc.Stream(encoding.StreamOptions{})
 	mockDB.EXPECT().
 		ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher("foo"), start, end).
 		Return([][]xio.BlockReader{
@@ -691,7 +691,7 @@ func TestServiceFetchBatchRaw(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		stream, _ := enc.Stream(encoding.StreamOpts{})
+		stream, _ := enc.Stream(encoding.StreamOptions{})
 		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(ctx, ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).
@@ -900,7 +900,7 @@ func TestServiceFetchBlocksRaw(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		stream, _ := enc.Stream(encoding.StreamOpts{})
+		stream, _ := enc.Stream(encoding.StreamOptions{})
 		streams[id] = stream
 
 		seg, err := streams[id].Segment()
@@ -1317,7 +1317,7 @@ func TestServiceFetchTagged(t *testing.T) {
 			require.NoError(t, enc.Encode(dp, xtime.Second, nil))
 		}
 
-		stream, _ := enc.Stream(encoding.StreamOpts{})
+		stream, _ := enc.Stream(encoding.StreamOptions{})
 		streams[id] = stream
 		mockDB.EXPECT().
 			ReadEncoded(gomock.Any(), ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).

--- a/src/dbnode/storage/block/merged_block_reader.go
+++ b/src/dbnode/storage/block/merged_block_reader.go
@@ -129,7 +129,7 @@ func (r *dbMergedBlockReader) mergedReader() (xio.BlockReader, error) {
 		r.readers[i] = nil
 	}
 
-	stream, _ := r.encoder.Stream()
+	stream, _ := r.encoder.Stream(encoding.StreamOpts{})
 	r.merged = xio.BlockReader{
 		SegmentReader: stream,
 		Start:         r.blockStart,

--- a/src/dbnode/storage/block/merged_block_reader.go
+++ b/src/dbnode/storage/block/merged_block_reader.go
@@ -131,7 +131,7 @@ func (r *dbMergedBlockReader) mergedReader() (xio.BlockReader, error) {
 
 	// Can ignore OK here because BlockReader will handle nil streams
 	// properly.
-	stream, _ := r.encoder.Stream(encoding.StreamOpts{})
+	stream, _ := r.encoder.Stream(encoding.StreamOptions{})
 	r.merged = xio.BlockReader{
 		SegmentReader: stream,
 		Start:         r.blockStart,

--- a/src/dbnode/storage/block/merged_block_reader.go
+++ b/src/dbnode/storage/block/merged_block_reader.go
@@ -129,8 +129,9 @@ func (r *dbMergedBlockReader) mergedReader() (xio.BlockReader, error) {
 		r.readers[i] = nil
 	}
 
+	stream, _ := r.encoder.Stream()
 	r.merged = xio.BlockReader{
-		SegmentReader: r.encoder.Stream(),
+		SegmentReader: stream,
 		Start:         r.blockStart,
 		BlockSize:     r.blockSize,
 	}

--- a/src/dbnode/storage/block/merged_block_reader.go
+++ b/src/dbnode/storage/block/merged_block_reader.go
@@ -129,7 +129,16 @@ func (r *dbMergedBlockReader) mergedReader() (xio.BlockReader, error) {
 		r.readers[i] = nil
 	}
 
-	stream, _ := r.encoder.Stream(encoding.StreamOpts{})
+	var (
+		stream xio.SegmentReader
+		ok     bool
+	)
+	stream, ok = r.encoder.Stream(encoding.StreamOpts{})
+	if !ok {
+		// xio.BlockReader expect SegmentReader to be nil if there
+		// is no data.
+		stream = nil
+	}
 	r.merged = xio.BlockReader{
 		SegmentReader: stream,
 		Start:         r.blockStart,

--- a/src/dbnode/storage/block/merged_block_reader.go
+++ b/src/dbnode/storage/block/merged_block_reader.go
@@ -135,7 +135,7 @@ func (r *dbMergedBlockReader) mergedReader() (xio.BlockReader, error) {
 	)
 	stream, ok = r.encoder.Stream(encoding.StreamOpts{})
 	if !ok {
-		// xio.BlockReader expect SegmentReader to be nil if there
+		// xio.BlockReader expects SegmentReader to be nil if there
 		// is no data.
 		stream = nil
 	}

--- a/src/dbnode/storage/block/merged_block_reader.go
+++ b/src/dbnode/storage/block/merged_block_reader.go
@@ -129,16 +129,9 @@ func (r *dbMergedBlockReader) mergedReader() (xio.BlockReader, error) {
 		r.readers[i] = nil
 	}
 
-	var (
-		stream xio.SegmentReader
-		ok     bool
-	)
-	stream, ok = r.encoder.Stream(encoding.StreamOpts{})
-	if !ok {
-		// xio.BlockReader expects SegmentReader to be nil if there
-		// is no data.
-		stream = nil
-	}
+	// Can ignore OK here because BlockReader will handle nil streams
+	// properly.
+	stream, _ := r.encoder.Stream(encoding.StreamOpts{})
 	r.merged = xio.BlockReader{
 		SegmentReader: stream,
 		Start:         r.blockStart,

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -356,12 +356,17 @@ func TestItMergesSnapshotsAndCommitLogs(t *testing.T) {
 		}
 		encoder.Encode(dp, value.u, value.a)
 	}
-	reader := encoder.Stream()
+
+	reader, ok := encoder.Stream()
+	require.True(t, ok)
+
 	seg, err := reader.Segment()
 	require.NoError(t, err)
+
 	bytes := make([]byte, seg.Len())
 	_, err = reader.Read(bytes)
 	require.NoError(t, err)
+
 	mockReader.EXPECT().Read().Return(
 		foo.ID,
 		ident.EmptyTagIterator,

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -357,7 +357,7 @@ func TestItMergesSnapshotsAndCommitLogs(t *testing.T) {
 		encoder.Encode(dp, value.u, value.a)
 	}
 
-	reader, ok := encoder.Stream()
+	reader, ok := encoder.Stream(encoding.StreamOpts{})
 	require.True(t, ok)
 
 	seg, err := reader.Segment()

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -357,7 +357,7 @@ func TestItMergesSnapshotsAndCommitLogs(t *testing.T) {
 		encoder.Encode(dp, value.u, value.a)
 	}
 
-	reader, ok := encoder.Stream(encoding.StreamOpts{})
+	reader, ok := encoder.Stream(encoding.StreamOptions{})
 	require.True(t, ok)
 
 	seg, err := reader.Segment()

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -186,8 +186,8 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 						}
 					}
 
-					reader := encoder.Stream()
-					if reader != nil {
+					reader, ok := encoder.Stream()
+					if ok {
 						seg, err := reader.Segment()
 						if err != nil {
 							return false, err

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -186,7 +186,7 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 						}
 					}
 
-					reader, ok := encoder.Stream(encoding.StreamOpts{})
+					reader, ok := encoder.Stream(encoding.StreamOptions{})
 					if ok {
 						seg, err := reader.Segment()
 						if err != nil {

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -186,7 +186,7 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 						}
 					}
 
-					reader, ok := encoder.Stream()
+					reader, ok := encoder.Stream(encoding.StreamOpts{})
 					if ok {
 						seg, err := reader.Segment()
 						if err != nil {

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -962,7 +962,8 @@ func (b *BufferBucket) write(
 	// since an encoder is immutable.
 	// The encoders pushed later will surface their values first.
 	if idx != -1 {
-		return true, b.writeToEncoderIndex(idx, datapoint, unit, annotation)
+		err := b.writeToEncoderIndex(idx, datapoint, unit, annotation)
+		return err == nil, err
 	}
 
 	// Need a new encoder, we didn't find an encoder to write to

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -397,7 +397,7 @@ func (b *dbBuffer) Snapshot(
 		}
 
 		var ok bool
-		stream, ok = encoder.Stream(encoding.StreamOpts{})
+		stream, ok = encoder.Stream(encoding.StreamOptions{})
 		if !ok {
 			// Don't write out series with no data.
 			return nil
@@ -456,7 +456,7 @@ func (b *dbBuffer) Flush(
 			return FlushOutcomeErr, err
 		}
 
-		stream, ok = encoder.Stream(encoding.StreamOpts{})
+		stream, ok = encoder.Stream(encoding.StreamOptions{})
 		encoder.Close()
 	}
 
@@ -1019,7 +1019,7 @@ func (b *BufferBucket) streams(ctx context.Context) []xio.BlockReader {
 	}
 	for i := range b.encoders {
 		start := b.start
-		if s, ok := b.encoders[i].encoder.Stream(encoding.StreamOpts{}); ok {
+		if s, ok := b.encoders[i].encoder.Stream(encoding.StreamOptions{}); ok {
 			br := xio.BlockReader{
 				SegmentReader: s,
 				Start:         start,
@@ -1111,7 +1111,7 @@ func (b *BufferBucket) merge() (int, error) {
 	}
 
 	for i := range b.encoders {
-		if s, ok := b.encoders[i].encoder.Stream(encoding.StreamOpts{}); ok {
+		if s, ok := b.encoders[i].encoder.Stream(encoding.StreamOptions{}); ok {
 			merges++
 			readers = append(readers, s)
 			streams = append(streams, s)
@@ -1172,7 +1172,7 @@ func (b *BufferBucket) mergeToStream(ctx context.Context) (xio.SegmentReader, bo
 	if b.hasJustSingleEncoder() {
 		b.resetBootstrapped()
 		// Already merged as a single encoder.
-		stream, ok := b.encoders[0].encoder.Stream(encoding.StreamOpts{})
+		stream, ok := b.encoders[0].encoder.Stream(encoding.StreamOptions{})
 		if !ok {
 			return nil, false, nil
 		}
@@ -1205,7 +1205,7 @@ func (b *BufferBucket) mergeToStream(ctx context.Context) (xio.SegmentReader, bo
 		return nil, false, errIncompleteMerge
 	}
 
-	stream, ok := b.encoders[0].encoder.Stream(encoding.StreamOpts{})
+	stream, ok := b.encoders[0].encoder.Stream(encoding.StreamOptions{})
 	if !ok {
 		return nil, false, nil
 	}

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -388,7 +388,7 @@ func (b *dbBuffer) Snapshot(
 		return nil, false, err
 	}
 
-	stream, ok := encoder.Stream()
+	stream, ok := encoder.Stream(encoding.StreamOpts{})
 	return stream, ok, nil
 }
 
@@ -430,7 +430,7 @@ func (b *dbBuffer) Flush(
 			return FlushOutcomeErr, err
 		}
 
-		stream, ok = encoder.Stream()
+		stream, ok = encoder.Stream(encoding.StreamOpts{})
 		encoder.Close()
 	}
 
@@ -987,7 +987,7 @@ func (b *BufferBucket) streams(ctx context.Context) []xio.BlockReader {
 	}
 	for i := range b.encoders {
 		start := b.start
-		if s, ok := b.encoders[i].encoder.Stream(); ok {
+		if s, ok := b.encoders[i].encoder.Stream(encoding.StreamOpts{}); ok {
 			br := xio.BlockReader{
 				SegmentReader: s,
 				Start:         start,
@@ -1079,7 +1079,7 @@ func (b *BufferBucket) merge() (int, error) {
 	}
 
 	for i := range b.encoders {
-		if s, ok := b.encoders[i].encoder.Stream(); ok {
+		if s, ok := b.encoders[i].encoder.Stream(encoding.StreamOpts{}); ok {
 			merges++
 			readers = append(readers, s)
 			streams = append(streams, s)
@@ -1140,7 +1140,7 @@ func (b *BufferBucket) mergeToStream(ctx context.Context) (xio.SegmentReader, bo
 	if b.hasJustSingleEncoder() {
 		b.resetBootstrapped()
 		// Already merged as a single encoder.
-		stream, ok := b.encoders[0].encoder.Stream()
+		stream, ok := b.encoders[0].encoder.Stream(encoding.StreamOpts{})
 		if !ok {
 			return nil, false, nil
 		}
@@ -1173,7 +1173,7 @@ func (b *BufferBucket) mergeToStream(ctx context.Context) (xio.SegmentReader, bo
 		return nil, false, errIncompleteMerge
 	}
 
-	stream, ok := b.encoders[0].encoder.Stream()
+	stream, ok := b.encoders[0].encoder.Stream(encoding.StreamOpts{})
 	if !ok {
 		return nil, false, nil
 	}

--- a/src/dbnode/storage/series/buffer_mock.go
+++ b/src/dbnode/storage/series/buffer_mock.go
@@ -77,19 +77,17 @@ func (mr *MockdatabaseBufferMockRecorder) Write(ctx, timestamp, value, unit, ann
 }
 
 // Snapshot mocks base method
-func (m *MockdatabaseBuffer) Snapshot(ctx context.Context, blockStart time.Time) (xio.SegmentReader, bool, error) {
+func (m *MockdatabaseBuffer) Snapshot(ctx context.Context, blockStart time.Time, id ident.ID, tags ident.Tags, persistFn persist.DataFn) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Snapshot", ctx, blockStart)
-	ret0, _ := ret[0].(xio.SegmentReader)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "Snapshot", ctx, blockStart, id, tags, persistFn)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Snapshot indicates an expected call of Snapshot
-func (mr *MockdatabaseBufferMockRecorder) Snapshot(ctx, blockStart interface{}) *gomock.Call {
+func (mr *MockdatabaseBufferMockRecorder) Snapshot(ctx, blockStart, id, tags, persistFn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockdatabaseBuffer)(nil).Snapshot), ctx, blockStart)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockdatabaseBuffer)(nil).Snapshot), ctx, blockStart, id, tags, persistFn)
 }
 
 // Flush mocks base method

--- a/src/dbnode/storage/series/buffer_mock.go
+++ b/src/dbnode/storage/series/buffer_mock.go
@@ -77,12 +77,13 @@ func (mr *MockdatabaseBufferMockRecorder) Write(ctx, timestamp, value, unit, ann
 }
 
 // Snapshot mocks base method
-func (m *MockdatabaseBuffer) Snapshot(ctx context.Context, blockStart time.Time) (xio.SegmentReader, error) {
+func (m *MockdatabaseBuffer) Snapshot(ctx context.Context, blockStart time.Time) (xio.SegmentReader, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Snapshot", ctx, blockStart)
 	ret0, _ := ret[0].(xio.SegmentReader)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Snapshot indicates an expected call of Snapshot

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -340,7 +340,7 @@ func TestBufferBucketMergeNilEncoderStreams(t *testing.T) {
 	emptyEncoder.Reset(curr, 0)
 	b.encoders = append(b.encoders, inOrderEncoder{encoder: emptyEncoder})
 
-	_, ok := b.encoders[0].encoder.Stream(encoding.StreamOpts{})
+	_, ok := b.encoders[0].encoder.Stream(encoding.StreamOptions{})
 	require.False(t, ok)
 
 	encoder := opts.EncoderPool().Get()
@@ -717,7 +717,7 @@ func TestBufferTickReordersOutOfOrderBuffers(t *testing.T) {
 		for j := range bucket.encoders {
 			encoder := bucket.encoders[j].encoder
 
-			_, ok := encoder.Stream(encoding.StreamOpts{})
+			_, ok := encoder.Stream(encoding.StreamOptions{})
 			require.True(t, ok)
 
 			encoders = append(encoders, encoder)
@@ -756,7 +756,7 @@ func TestBufferTickReordersOutOfOrderBuffers(t *testing.T) {
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
 
-		_, ok := encoder.Stream(encoding.StreamOpts{})
+		_, ok := encoder.Stream(encoding.StreamOptions{})
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
@@ -876,7 +876,7 @@ func testBufferWithEmptyEncoder(t *testing.T, testSnapshot bool) {
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
 
-		_, ok := encoder.Stream(encoding.StreamOpts{})
+		_, ok := encoder.Stream(encoding.StreamOptions{})
 		require.True(t, ok)
 
 		// Reset the encoder to simulate the situation in which an encoder is present but
@@ -953,7 +953,7 @@ func TestBufferSnapshot(t *testing.T) {
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
 
-		_, ok := encoder.Stream(encoding.StreamOpts{})
+		_, ok := encoder.Stream(encoding.StreamOptions{})
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
@@ -993,7 +993,7 @@ func TestBufferSnapshot(t *testing.T) {
 	for i := range bucket.encoders {
 		encoder := bucket.encoders[i].encoder
 
-		_, ok := encoder.Stream(encoding.StreamOpts{})
+		_, ok := encoder.Stream(encoding.StreamOptions{})
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -297,8 +297,9 @@ func TestBufferBucketMerge(t *testing.T) {
 
 	ctx := context.NewContext()
 	defer ctx.Close()
-	sr, err := b.mergeToStream(ctx)
+	sr, ok, err := b.mergeToStream(ctx)
 	require.NoError(t, err)
+	require.True(t, ok)
 
 	assertValuesEqual(t, expected, [][]xio.BlockReader{[]xio.BlockReader{
 		xio.BlockReader{
@@ -403,8 +404,9 @@ func TestBufferBucketWriteDuplicateUpserts(t *testing.T) {
 	assertValuesEqual(t, expected, results, opts)
 
 	// Now assert that mergeToStream() returns same expected result.
-	stream, err := b.mergeToStream(ctx)
+	stream, ok, err := b.mergeToStream(ctx)
 	require.NoError(t, err)
+	require.True(t, ok)
 	assertSegmentValuesEqual(t, expected, []xio.SegmentReader{stream}, opts)
 }
 
@@ -891,7 +893,7 @@ func TestBufferSnapshot(t *testing.T) {
 	for i := range bucket.encoders {
 		encoder := bucket.encoders[i].encoder
 
-		_, ok := b.encoders[0].encoder.Stream()
+		_, ok := encoder.Stream()
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -317,7 +317,9 @@ func TestBufferBucketMergeNilEncoderStreams(t *testing.T) {
 	emptyEncoder := opts.EncoderPool().Get()
 	emptyEncoder.Reset(curr, 0)
 	b.encoders = append(b.encoders, inOrderEncoder{encoder: emptyEncoder})
-	require.Nil(t, b.encoders[0].encoder.Stream())
+
+	_, ok := b.encoders[0].encoder.Stream()
+	require.False(t, ok)
 
 	encoder := opts.EncoderPool().Get()
 	encoder.Reset(curr, 0)
@@ -690,7 +692,9 @@ func TestBufferTickReordersOutOfOrderBuffers(t *testing.T) {
 		// Current bucket encoders should all have data in them.
 		for j := range bucket.encoders {
 			encoder := bucket.encoders[j].encoder
-			assert.NotNil(t, encoder.Stream())
+
+			_, ok := b.encoders[0].encoder.Stream()
+			require.True(t, ok)
 
 			encoders = append(encoders, encoder)
 		}
@@ -727,7 +731,9 @@ func TestBufferTickReordersOutOfOrderBuffers(t *testing.T) {
 	// Current bucket encoders should all have data in them.
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
-		assert.NotNil(t, encoder.Stream())
+
+		_, ok := b.encoders[0].encoder.Stream()
+		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
 	}
@@ -848,7 +854,9 @@ func TestBufferSnapshot(t *testing.T) {
 	// Current bucket encoders should all have data in them.
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
-		assert.NotNil(t, encoder.Stream())
+
+		_, ok := b.encoders[0].encoder.Stream()
+		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
 	}
@@ -882,7 +890,9 @@ func TestBufferSnapshot(t *testing.T) {
 	// Current bucket encoders should all have data in them.
 	for i := range bucket.encoders {
 		encoder := bucket.encoders[i].encoder
-		assert.NotNil(t, encoder.Stream())
+
+		_, ok := b.encoders[0].encoder.Stream()
+		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
 	}

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -474,8 +474,9 @@ func TestBufferBucketDuplicatePointsNotWrittenButUpserted(t *testing.T) {
 	assertValuesEqual(t, expected, results, opts)
 
 	// Now assert that mergeToStream() returns same expected result.
-	stream, err := b.mergeToStream(ctx)
+	stream, ok, err := b.mergeToStream(ctx)
 	require.NoError(t, err)
+	require.True(t, ok)
 	assertSegmentValuesEqual(t, expected, []xio.SegmentReader{stream}, opts)
 }
 
@@ -695,7 +696,7 @@ func TestBufferTickReordersOutOfOrderBuffers(t *testing.T) {
 		for j := range bucket.encoders {
 			encoder := bucket.encoders[j].encoder
 
-			_, ok := b.encoders[0].encoder.Stream()
+			_, ok := encoder.Stream()
 			require.True(t, ok)
 
 			encoders = append(encoders, encoder)
@@ -734,7 +735,7 @@ func TestBufferTickReordersOutOfOrderBuffers(t *testing.T) {
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
 
-		_, ok := b.encoders[0].encoder.Stream()
+		_, ok := encoder.Stream()
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
@@ -857,7 +858,7 @@ func TestBufferSnapshot(t *testing.T) {
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
 
-		_, ok := b.encoders[0].encoder.Stream()
+		_, ok := encoder.Stream()
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
@@ -868,8 +869,9 @@ func TestBufferSnapshot(t *testing.T) {
 	// Perform a snapshot.
 	ctx := context.NewContext()
 	defer ctx.Close()
-	result, err := buffer.Snapshot(ctx, start)
+	result, ok, err := buffer.Snapshot(ctx, start)
 	assert.NoError(t, err)
+	require.True(t, ok)
 
 	// Check we got the right results.
 	expectedData := data[:len(data)-1] // -1 because we don't expect the last datapoint.

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -319,7 +319,7 @@ func TestBufferBucketMergeNilEncoderStreams(t *testing.T) {
 	emptyEncoder.Reset(curr, 0)
 	b.encoders = append(b.encoders, inOrderEncoder{encoder: emptyEncoder})
 
-	_, ok := b.encoders[0].encoder.Stream()
+	_, ok := b.encoders[0].encoder.Stream(encoding.StreamOpts{})
 	require.False(t, ok)
 
 	encoder := opts.EncoderPool().Get()
@@ -696,7 +696,7 @@ func TestBufferTickReordersOutOfOrderBuffers(t *testing.T) {
 		for j := range bucket.encoders {
 			encoder := bucket.encoders[j].encoder
 
-			_, ok := encoder.Stream()
+			_, ok := encoder.Stream(encoding.StreamOpts{})
 			require.True(t, ok)
 
 			encoders = append(encoders, encoder)
@@ -735,7 +735,7 @@ func TestBufferTickReordersOutOfOrderBuffers(t *testing.T) {
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
 
-		_, ok := encoder.Stream()
+		_, ok := encoder.Stream(encoding.StreamOpts{})
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
@@ -858,7 +858,7 @@ func TestBufferSnapshot(t *testing.T) {
 	for j := range bucket.encoders {
 		encoder := bucket.encoders[j].encoder
 
-		_, ok := encoder.Stream()
+		_, ok := encoder.Stream(encoding.StreamOpts{})
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)
@@ -895,7 +895,7 @@ func TestBufferSnapshot(t *testing.T) {
 	for i := range bucket.encoders {
 		encoder := bucket.encoders[i].encoder
 
-		_, ok := encoder.Stream()
+		_, ok := encoder.Stream(encoding.StreamOpts{})
 		require.True(t, ok)
 
 		encoders = append(encoders, encoder)

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/m3db/m3/src/dbnode/digest"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/ts"
@@ -544,26 +543,7 @@ func (s *dbSeries) Snapshot(
 		return errSeriesNotBootstrapped
 	}
 
-	var (
-		stream xio.SegmentReader
-		ok     bool
-		err    error
-	)
-
-	stream, ok, err = s.buffer.Snapshot(ctx, blockStart)
-	if err != nil {
-		return err
-	}
-	if !ok {
-		return nil
-	}
-
-	segment, err := stream.Segment()
-	if err != nil {
-		return err
-	}
-
-	return persistFn(s.id, s.tags, segment, digest.SegmentChecksum(segment))
+	return s.buffer.Snapshot(ctx, blockStart, s.id, s.tags, persistFn)
 }
 
 func (s *dbSeries) Close() {

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -546,15 +546,15 @@ func (s *dbSeries) Snapshot(
 
 	var (
 		stream xio.SegmentReader
+		ok     bool
 		err    error
 	)
 
-	stream, err = s.buffer.Snapshot(ctx, blockStart)
-
+	stream, ok, err = s.buffer.Snapshot(ctx, blockStart)
 	if err != nil {
 		return err
 	}
-	if stream == nil {
+	if !ok {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This P.R updates the Stream() API to be more difficult to misuse (returning a bool indicating if any data is present) as well as accept an options struct which will be used in a subsequent P.R.

In addition to the updated API, this P.R fixes two bugs in `buffer.go` and adds regression tests for them as well.
If there is an error during encoding its possible to end up with an encoder in the buffer that has no writes (an empty stream) which will cause the `Flush()` method to panic because it doesn't account for this possibility.

Additional changes included in this P.R:
- [X] Make Stream() API return a bool indicating if data is present in the stream. This makes the API more difficult to misuse. In addition, instead of returning nil segment readers the API now always returns a valid reader even if there is no data (the reader will just wrap an empty segment).
- [X] Make the Stream() API accept an options struct which will be used in a subsequent P.R.
- [X] Fix a panic in `buffer.go` that would occur if a series had an empty encoder for a given block.
- [X] Fix a bug in `buffer.go` in the Write() method that would return `true` for `wasWritten` even if the write failed.
- [X] Refactor the snapshotting logic out of `series.go` into `buffer.go` to be more consistent with the flush logic

Fixes #805