### PR TITLE
Make proto encoder prop test verify number of iterated messages

### DIFF
--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -41,8 +41,8 @@ import (
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
-	"github.com/stretchr/testify/require"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -198,6 +198,10 @@ func TestRoundTripProp(t *testing.T) {
 		if iter.Err() != nil {
 			return false, fmt.Errorf(
 				"iteration error: %v, schema: %s", iter.Err(), input.schema.String())
+		}
+
+		if i != len(input.messages) {
+			return false, fmt.Errorf("expected %d messages but got %d", len(input.messages), i)
 		}
 
 		return true, nil

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/ts"
 	xtime "github.com/m3db/m3/src/x/time"
 
@@ -41,7 +42,6 @@ import (
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/gen"
 	"github.com/leanovate/gopter/prop"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now if the iterator returns zero messages (even though it should have returned more than zero) the test will pass. This fixes it so the property test will catch issues that cause the iterator to return zero messages.