### PR TITLE
Optimize protobuf encoder and iterator for various workloads

### DIFF
--- a/src/dbnode/encoding/istream.go
+++ b/src/dbnode/encoding/istream.go
@@ -114,6 +114,8 @@ func (is *istream) ReadBits(numBits int) (uint64, error) {
 	}
 
 	for numBits > 0 {
+		// This is equivalent to calling is.ReadBit() in a loop but some manual inlining
+		// has been performed to optimize this loop as its heavily used in the hot path.
 		if is.remaining == 0 {
 			if err := is.readByteFromStream(); err != nil {
 				return 0, err

--- a/src/dbnode/encoding/istream.go
+++ b/src/dbnode/encoding/istream.go
@@ -102,6 +102,7 @@ func (is *istream) ReadBits(numBits int) (uint64, error) {
 	if is.err != nil {
 		return 0, is.err
 	}
+
 	var res uint64
 	for numBits >= 8 {
 		byteRead, err := is.ReadByte()
@@ -111,11 +112,14 @@ func (is *istream) ReadBits(numBits int) (uint64, error) {
 		res = (res << 8) | uint64(byteRead)
 		numBits -= 8
 	}
+
 	for numBits > 0 {
-		bitRead, err := is.ReadBit()
-		if err != nil {
-			return 0, err
+		if is.remaining == 0 {
+			if err := is.readByteFromStream(); err != nil {
+				return 0, err
+			}
 		}
+		bitRead := Bit(is.consumeBuffer(1))
 		res = (res << 1) | uint64(bitRead)
 		numBits--
 	}

--- a/src/dbnode/encoding/istream.go
+++ b/src/dbnode/encoding/istream.go
@@ -63,6 +63,7 @@ func (is *istream) Read(b []byte) (int, error) {
 	if is.remaining == 0 {
 		// Optimized path for when the iterator is already aligned on a byte boundary. Avoids
 		// all the bit manipulation and ReadByte() function calls.
+		// Use ReadFull because the bufferedReader may not return the requested number of bytes.
 		return io.ReadFull(is.r, b)
 	}
 

--- a/src/dbnode/encoding/istream.go
+++ b/src/dbnode/encoding/istream.go
@@ -121,9 +121,16 @@ func (is *istream) ReadBits(numBits int) (uint64, error) {
 				return 0, err
 			}
 		}
-		bitRead := Bit(is.consumeBuffer(1))
-		res = (res << 1) | uint64(bitRead)
-		numBits--
+
+		numToRead := numBits
+		if is.remaining < numToRead {
+			numToRead = is.remaining
+		}
+		bits := is.current >> uint(8-numToRead)
+		is.current <<= uint(numToRead)
+		is.remaining -= numToRead
+		res = (res << uint64(numToRead)) | uint64(bits)
+		numBits -= numToRead
 	}
 	return res, nil
 }

--- a/src/dbnode/encoding/istream.go
+++ b/src/dbnode/encoding/istream.go
@@ -60,6 +60,12 @@ func (is *istream) ReadBit() (Bit, error) {
 
 // Read reads len(b) bytes.
 func (is *istream) Read(b []byte) (int, error) {
+	if is.remaining == 0 {
+		// Optimized path for when the iterator is already aligned on a byte boundary. Avoids
+		// all the bit manipulation and ReadByte() function calls.
+		return io.ReadFull(is.r, b)
+	}
+
 	var (
 		i   int
 		err error

--- a/src/dbnode/encoding/m3tsz/float_encoder_iterator.go
+++ b/src/dbnode/encoding/m3tsz/float_encoder_iterator.go
@@ -140,16 +140,13 @@ func (eit *FloatEncoderAndIterator) readNextFloat(stream encoding.IStream) error
 		return nil
 	}
 
-	numLeadingZeros, err := stream.ReadBits(6)
+	numLeadingZeroesAndNumMeaningfulBits, err := stream.ReadBits(12)
 	if err != nil {
 		return err
 	}
 
-	numMeaningfulBits, err := stream.ReadBits(6)
-	if err != nil {
-		return err
-	}
-	numMeaningfulBits = numMeaningfulBits + 1
+	numLeadingZeros := (numLeadingZeroesAndNumMeaningfulBits & 4032) >> 6
+	numMeaningfulBits := (numLeadingZeroesAndNumMeaningfulBits & 63) + 1
 
 	meaningfulBits, err := stream.ReadBits(int(numMeaningfulBits))
 	if err != nil {

--- a/src/dbnode/encoding/m3tsz/float_encoder_iterator.go
+++ b/src/dbnode/encoding/m3tsz/float_encoder_iterator.go
@@ -26,6 +26,11 @@ import (
 	"github.com/m3db/m3/src/dbnode/encoding"
 )
 
+const (
+	bits12To6Mask = 4032 // 1111 1100 0000
+	bits6To0Mask  = 63   // 0011 1111
+)
+
 // FloatEncoderAndIterator encapsulates the state required for a logical stream of bits
 // that represent a stream of float values compressed with XOR.
 type FloatEncoderAndIterator struct {
@@ -145,8 +150,8 @@ func (eit *FloatEncoderAndIterator) readNextFloat(stream encoding.IStream) error
 		return err
 	}
 
-	numLeadingZeros := (numLeadingZeroesAndNumMeaningfulBits & 4032) >> 6
-	numMeaningfulBits := (numLeadingZeroesAndNumMeaningfulBits & 63) + 1
+	numLeadingZeros := (numLeadingZeroesAndNumMeaningfulBits & bits12To6Mask) >> 6
+	numMeaningfulBits := (numLeadingZeroesAndNumMeaningfulBits & bits6To0Mask) + 1
 
 	meaningfulBits, err := stream.ReadBits(int(numMeaningfulBits))
 	if err != nil {

--- a/src/dbnode/encoding/ostream.go
+++ b/src/dbnode/encoding/ostream.go
@@ -155,10 +155,6 @@ func (os *ostream) WriteByte(v byte) {
 
 // WriteBytes writes a byte slice.
 func (os *ostream) WriteBytes(bytes []byte) {
-	// Make sure we only have to grow the underlying buffer at most
-	// one time before we write one byte at a time in a loop.
-	os.ensureCapacityFor(len(bytes))
-
 	if !os.hasUnusedBits() {
 		// If the stream is aligned on a byte boundary then all of the WriteByte()
 		// function calls and bit-twiddling can be skipped in favor of a single
@@ -167,6 +163,9 @@ func (os *ostream) WriteBytes(bytes []byte) {
 		return
 	}
 
+	// Make sure we only have to grow the underlying buffer at most
+	// one time before we write one byte at a time in a loop.
+	os.ensureCapacityFor(len(bytes))
 	for i := 0; i < len(bytes); i++ {
 		os.WriteByte(bytes[i])
 	}

--- a/src/dbnode/encoding/ostream.go
+++ b/src/dbnode/encoding/ostream.go
@@ -159,6 +159,14 @@ func (os *ostream) WriteBytes(bytes []byte) {
 	// one time before we write one byte at a time in a loop.
 	os.ensureCapacityFor(len(bytes))
 
+	if !os.hasUnusedBits() {
+		// If the stream is aligned on a byte boundary then all of the WriteByte()
+		// function calls and bit-twiddling can be skipped in favor of a single
+		// memcopy.
+		os.rawBuffer = append(os.rawBuffer, bytes...)
+		return
+	}
+
 	for i := 0; i < len(bytes); i++ {
 		os.WriteByte(bytes[i])
 	}

--- a/src/dbnode/encoding/ostream.go
+++ b/src/dbnode/encoding/ostream.go
@@ -155,17 +155,23 @@ func (os *ostream) WriteByte(v byte) {
 
 // WriteBytes writes a byte slice.
 func (os *ostream) WriteBytes(bytes []byte) {
+	// Call ensureCapacityFor ahead of time to ensure that the bytes pool is used to
+	// grow the rawBuffer (as opposed to append possibly triggering an allocation if
+	// it wasn't) and that its only grown a maximum of one time regardless of the size
+	// of the []byte being written.
+	os.ensureCapacityFor(len(bytes))
+
 	if !os.hasUnusedBits() {
 		// If the stream is aligned on a byte boundary then all of the WriteByte()
 		// function calls and bit-twiddling can be skipped in favor of a single
-		// memcopy.
+		// copy operation.
 		os.rawBuffer = append(os.rawBuffer, bytes...)
+		// Position 8 indicates that the last byte of the buffer has been completely
+		// filled.
+		os.pos = 8
 		return
 	}
 
-	// Make sure we only have to grow the underlying buffer at most
-	// one time before we write one byte at a time in a loop.
-	os.ensureCapacityFor(len(bytes))
 	for i := 0; i < len(bytes); i++ {
 		os.WriteByte(bytes[i])
 	}

--- a/src/dbnode/encoding/ostream_test.go
+++ b/src/dbnode/encoding/ostream_test.go
@@ -89,7 +89,7 @@ func testWriteBytes(t *testing.T, o OStream) {
 	b, _ := os.Rawbytes()
 	require.Equal(t, rawBytes, b)
 
-	require.Equal(t, 8, os.pos)
+	require.Equal(t, 0, os.pos)
 }
 
 func TestResetOStream(t *testing.T) {

--- a/src/dbnode/encoding/ostream_test.go
+++ b/src/dbnode/encoding/ostream_test.go
@@ -86,10 +86,10 @@ func testWriteBytes(t *testing.T, o OStream) {
 
 	require.Equal(t, rawBytes, os.rawBuffer)
 
-	b, _ := os.Rawbytes()
+	b, pos := os.Rawbytes()
 	require.Equal(t, rawBytes, b)
-
-	require.Equal(t, 0, os.pos)
+	require.Equal(t, 8, pos)
+	require.Equal(t, 8, os.pos)
 }
 
 func TestResetOStream(t *testing.T) {

--- a/src/dbnode/encoding/proto/benchmarks_test.go
+++ b/src/dbnode/encoding/proto/benchmarks_test.go
@@ -35,7 +35,7 @@ import (
 
 func BenchmarkEncoder(b *testing.B) {
 	var (
-		_, messagesBytes = testMessages(100)
+		_, messagesBytes = testMessages(100, false)
 		start            = time.Now()
 		encoder          = NewEncoder(start, encoding.NewOptions())
 	)
@@ -53,7 +53,7 @@ func BenchmarkEncoder(b *testing.B) {
 
 func BenchmarkIterator(b *testing.B) {
 	var (
-		_, messagesBytes = testMessages(100)
+		_, messagesBytes = testMessages(100, false)
 		start            = time.Now()
 		encodingOpts     = encoding.NewOptions()
 		encoder          = NewEncoder(start, encodingOpts)
@@ -87,7 +87,7 @@ func BenchmarkIterator(b *testing.B) {
 	}
 }
 
-func testMessages(numMessages int) ([]*dynamic.Message, [][]byte) {
+func testMessages(numMessages int, includeAttributes bool) ([]*dynamic.Message, [][]byte) {
 	var (
 		messages      = make([]*dynamic.Message, 0, numMessages)
 		messagesBytes = make([][]byte, 0, numMessages)
@@ -97,11 +97,13 @@ func testMessages(numMessages int) ([]*dynamic.Message, [][]byte) {
 		m.SetFieldByName("latitude", float64(i))
 		m.SetFieldByName("longitude", float64(i))
 		m.SetFieldByName("deliveryID", []byte(fmt.Sprintf("some-really-really-really-really-long-id-%d", i)))
-		m.SetFieldByName("attributes", map[string]string{
-			fmt.Sprintf("key1_%d", i): fmt.Sprintf("val1_%d", i),
-			fmt.Sprintf("key2_%d", i): fmt.Sprintf("val2_%d", i),
-			fmt.Sprintf("key3_%d", i): fmt.Sprintf("val3_%d", i),
-		})
+		if includeAttributes {
+			m.SetFieldByName("attributes", map[string]string{
+				fmt.Sprintf("key1_%d", i): fmt.Sprintf("val1_%d", i),
+				fmt.Sprintf("key2_%d", i): fmt.Sprintf("val2_%d", i),
+				fmt.Sprintf("key3_%d", i): fmt.Sprintf("val3_%d", i),
+			})
+		}
 
 		bytes, err := m.Marshal()
 		handleErr(err)

--- a/src/dbnode/encoding/proto/benchmarks_test.go
+++ b/src/dbnode/encoding/proto/benchmarks_test.go
@@ -74,19 +74,15 @@ func BenchmarkIterator(b *testing.B) {
 	segment, err := stream.Segment()
 	handleErr(err)
 
-	fmt.Println("segment.Len()", segment.Len())
 	iterator := NewIterator(stream, schema, encodingOpts)
 	reader := xio.NewSegmentReader(segment)
 	for i := 0; i < b.N; i++ {
 		reader.Reset(segment)
 		iterator.Reset(reader, schema)
-		j := 0
 		for iterator.Next() {
 			iterator.Current()
-			j++
 		}
 		handleErr(iterator.Err())
-		panic(j)
 	}
 }
 

--- a/src/dbnode/encoding/proto/benchmarks_test.go
+++ b/src/dbnode/encoding/proto/benchmarks_test.go
@@ -34,8 +34,17 @@ import (
 )
 
 func BenchmarkEncoder(b *testing.B) {
+	b.Run("with non custom encoded fields enabled", func(b *testing.B) {
+		benchmarkEncoder(b, true)
+	})
+	b.Run("with non custom encoded fields disabled", func(b *testing.B) {
+		benchmarkEncoder(b, false)
+	})
+}
+
+func benchmarkEncoder(b *testing.B, nonCustomFieldsEnabled bool) {
 	var (
-		_, messagesBytes = testMessages(100, true)
+		_, messagesBytes = testMessages(100, nonCustomFieldsEnabled)
 		start            = time.Now()
 		encoder          = NewEncoder(start, encoding.NewOptions())
 	)
@@ -52,8 +61,17 @@ func BenchmarkEncoder(b *testing.B) {
 }
 
 func BenchmarkIterator(b *testing.B) {
+	b.Run("with non custom encoded fields enabled", func(b *testing.B) {
+		benchmarkIterator(b, true)
+	})
+	b.Run("with non custom encoded fields disabled", func(b *testing.B) {
+		benchmarkIterator(b, false)
+	})
+}
+
+func benchmarkIterator(b *testing.B, nonCustomFieldsEnabled bool) {
 	var (
-		_, messagesBytes = testMessages(100, true)
+		_, messagesBytes = testMessages(100, nonCustomFieldsEnabled)
 		start            = time.Now()
 		encodingOpts     = encoding.NewOptions()
 		encoder          = NewEncoder(start, encodingOpts)

--- a/src/dbnode/encoding/proto/benchmarks_test.go
+++ b/src/dbnode/encoding/proto/benchmarks_test.go
@@ -35,7 +35,7 @@ import (
 
 func BenchmarkEncode(b *testing.B) {
 	var (
-		_, messagesBytes = testMessages(4)
+		_, messagesBytes = testMessages(100)
 		start            = time.Now()
 		encoder          = NewEncoder(start, encoding.NewOptions())
 	)
@@ -43,9 +43,10 @@ func BenchmarkEncode(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		start = start.Add(time.Second)
-		protoBytes := messagesBytes[i%len(messagesBytes)]
-		if err := encoder.Encode(ts.Datapoint{Timestamp: start}, xtime.Second, protoBytes); err != nil {
-			panic(err)
+		for _, protoBytes := range messagesBytes {
+			if err := encoder.Encode(ts.Datapoint{Timestamp: start}, xtime.Second, protoBytes); err != nil {
+				panic(err)
+			}
 		}
 	}
 }

--- a/src/dbnode/encoding/proto/benchmarks_test.go
+++ b/src/dbnode/encoding/proto/benchmarks_test.go
@@ -52,7 +52,7 @@ func BenchmarkEncode(b *testing.B) {
 
 func BenchmarkIterator(b *testing.B) {
 	var (
-		_, messagesBytes = testMessages(4)
+		_, messagesBytes = testMessages(100)
 		start            = time.Now()
 		encodingOpts     = encoding.NewOptions()
 		encoder          = NewEncoder(start, encodingOpts)

--- a/src/dbnode/encoding/proto/benchmarks_test.go
+++ b/src/dbnode/encoding/proto/benchmarks_test.go
@@ -33,7 +33,7 @@ import (
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
-func BenchmarkEncode(b *testing.B) {
+func BenchmarkEncoder(b *testing.B) {
 	var (
 		_, messagesBytes = testMessages(100)
 		start            = time.Now()
@@ -97,6 +97,11 @@ func testMessages(numMessages int) ([]*dynamic.Message, [][]byte) {
 		m.SetFieldByName("latitude", float64(i))
 		m.SetFieldByName("longitude", float64(i))
 		m.SetFieldByName("deliveryID", []byte(fmt.Sprintf("some-really-really-really-really-long-id-%d", i)))
+		m.SetFieldByName("attributes", map[string]string{
+			fmt.Sprintf("key1_%d", i): fmt.Sprintf("val1_%d", i),
+			fmt.Sprintf("key2_%d", i): fmt.Sprintf("val2_%d", i),
+			fmt.Sprintf("key3_%d", i): fmt.Sprintf("val3_%d", i),
+		})
 
 		bytes, err := m.Marshal()
 		handleErr(err)

--- a/src/dbnode/encoding/proto/benchmarks_test.go
+++ b/src/dbnode/encoding/proto/benchmarks_test.go
@@ -52,7 +52,7 @@ func BenchmarkEncode(b *testing.B) {
 
 func BenchmarkIterator(b *testing.B) {
 	var (
-		_, messagesBytes = testMessages(1000)
+		_, messagesBytes = testMessages(4)
 		start            = time.Now()
 		encodingOpts     = encoding.NewOptions()
 		encoder          = NewEncoder(start, encodingOpts)

--- a/src/dbnode/encoding/proto/benchmarks_test.go
+++ b/src/dbnode/encoding/proto/benchmarks_test.go
@@ -35,7 +35,7 @@ import (
 
 func BenchmarkEncoder(b *testing.B) {
 	var (
-		_, messagesBytes = testMessages(100, false)
+		_, messagesBytes = testMessages(100, true)
 		start            = time.Now()
 		encoder          = NewEncoder(start, encoding.NewOptions())
 	)
@@ -53,7 +53,7 @@ func BenchmarkEncoder(b *testing.B) {
 
 func BenchmarkIterator(b *testing.B) {
 	var (
-		_, messagesBytes = testMessages(100, false)
+		_, messagesBytes = testMessages(100, true)
 		start            = time.Now()
 		encodingOpts     = encoding.NewOptions()
 		encoder          = NewEncoder(start, encodingOpts)

--- a/src/dbnode/encoding/proto/buffer_encode.go
+++ b/src/dbnode/encoding/proto/buffer_encode.go
@@ -66,14 +66,6 @@ func (cb *buffer) encodeFixed32(x uint32) {
 		uint8(x>>24))
 }
 
-func encodeZigZag64(v int64) uint64 {
-	return (uint64(v) << 1) ^ uint64(v>>63)
-}
-
-func encodeZigZag32(v int32) uint64 {
-	return uint64((uint32(v) << 1) ^ uint32((v >> 31)))
-}
-
 // EncodeRawBytes writes a count-delimited byte buffer to the Buffer.
 // This is the format used for the bytes protocol buffer
 // type and for embedded messages.
@@ -84,4 +76,12 @@ func (cb *buffer) encodeRawBytes(b []byte) {
 
 func (cb *buffer) append(b []byte) {
 	cb.buf = append(cb.buf, b...)
+}
+
+func encodeZigZag32(v int32) uint64 {
+	return uint64((uint32(v) << 1) ^ uint32((v >> 31)))
+}
+
+func encodeZigZag64(v int64) uint64 {
+	return (uint64(v) << 1) ^ uint64(v>>63)
 }

--- a/src/dbnode/encoding/proto/common.go
+++ b/src/dbnode/encoding/proto/common.go
@@ -153,21 +153,18 @@ type sortedMarshalledFields []marshalledField
 // customFieldState is used to track any required state for encoding / decoding a single
 // field in the encoder / iterator respectively.
 type customFieldState struct {
-	fieldNum       int
-	fieldType      customFieldType
-	protoFieldType dpb.FieldDescriptorProto_Type
-
+	fieldNum int
 	// Float state. Works as both an encoder and iterator (I.E the encoder calls
 	// the encode methods and the iterator calls the read methods).
 	floatEncAndIter m3tsz.FloatEncoderAndIterator
-
 	// Bytes State. TODO(rartoul): Wrap this up in an encoderAndIterator like
 	// the floats and ints.
 	bytesFieldDict         []encoderBytesFieldDictState
 	iteratorBytesFieldDict [][]byte
-
 	// Int state.
-	intEncAndIter intEncoderAndIterator
+	intEncAndIter  intEncoderAndIterator
+	protoFieldType dpb.FieldDescriptorProto_Type
+	fieldType      customFieldType
 }
 
 type encoderBytesFieldDictState struct {

--- a/src/dbnode/encoding/proto/common.go
+++ b/src/dbnode/encoding/proto/common.go
@@ -196,7 +196,11 @@ func newCustomFieldState(
 
 // TODO(rartoul): Improve this function to be less naive and actually explore nested messages
 // for fields that we can use our custom compression on: https://github.com/m3db/m3/issues/1471
-func customAndNonCustomFields(customFields []customFieldState, nonCustomFields []marshalledField, schema *desc.MessageDescriptor) ([]customFieldState, []marshalledField) {
+func customAndNonCustomFields(
+	customFields []customFieldState,
+	nonCustomFields []marshalledField,
+	schema *desc.MessageDescriptor,
+) ([]customFieldState, []marshalledField) {
 	fields := schema.GetFields()
 	numCustomFields := numCustomFields(schema)
 	numNonCustomFields := len(fields) - numCustomFields

--- a/src/dbnode/encoding/proto/common.go
+++ b/src/dbnode/encoding/proto/common.go
@@ -38,9 +38,9 @@ const (
 	// limitations, but we want some theoretical maximum so that in the case of data / memory
 	// corruption the iterator can avoid panicing due to trying to allocate a massive byte slice
 	// (MAX_UINT64 for example) and return a reasonable error message instead.
-	maxMarshaledProtoMessageSize = 2 << 29
+	maxMarshalledProtoMessageSize = 2 << 29
 
-	// maxCustomFieldNum is included for the same rationale as maxMarshaledProtoMessageSize.
+	// maxCustomFieldNum is included for the same rationale as maxMarshalledProtoMessageSize.
 	maxCustomFieldNum = 10000
 
 	protoFieldTypeNotFound dpb.FieldDescriptorProto_Type = -1
@@ -143,12 +143,12 @@ var (
 	}
 )
 
-type marshaledField struct {
-	fieldNum  int32
-	marshaled []byte
+type marshalledField struct {
+	fieldNum   int32
+	marshalled []byte
 }
 
-type marshaledFields []marshaledField
+type marshalledFields []marshalledField
 
 // customFieldState is used to track any required state for encoding / decoding a single
 // field in the encoder / iterator respectively.
@@ -198,7 +198,7 @@ func newCustomFieldState(
 
 // TODO(rartoul): Improve this function to be less naive and actually explore nested messages
 // for fields that we can use our custom compression on: https://github.com/m3db/m3/issues/1471
-func customAndNonCustomFields(customFields []customFieldState, nonCustomFields []marshaledField, schema *desc.MessageDescriptor) ([]customFieldState, []marshaledField) {
+func customAndNonCustomFields(customFields []customFieldState, nonCustomFields []marshalledField, schema *desc.MessageDescriptor) ([]customFieldState, []marshalledField) {
 	fields := schema.GetFields()
 	numCustomFields := numCustomFields(schema)
 	numNonCustomFields := len(fields) - numCustomFields
@@ -214,11 +214,11 @@ func customAndNonCustomFields(customFields []customFieldState, nonCustomFields [
 
 	if cap(nonCustomFields) >= numNonCustomFields {
 		for i := range nonCustomFields {
-			nonCustomFields[i] = marshaledField{}
+			nonCustomFields[i] = marshalledField{}
 		}
 		nonCustomFields = nonCustomFields[:0]
 	} else {
-		nonCustomFields = make([]marshaledField, 0, numNonCustomFields)
+		nonCustomFields = make([]marshalledField, 0, numNonCustomFields)
 	}
 
 	var (
@@ -236,7 +236,7 @@ func customAndNonCustomFields(customFields []customFieldState, nonCustomFields [
 
 		customFieldType, ok := isCustomField(fieldType, field.IsRepeated())
 		if !ok {
-			nonCustomFields = append(nonCustomFields, marshaledField{fieldNum: fieldNum})
+			nonCustomFields = append(nonCustomFields, marshalledField{fieldNum: fieldNum})
 			continue
 		}
 
@@ -322,14 +322,14 @@ func numBitsRequiredForNumUpToN(n int) int {
 	return count
 }
 
-func (m marshaledFields) Len() int {
+func (m marshalledFields) Len() int {
 	return len(m)
 }
 
-func (m marshaledFields) Less(i, j int) bool {
+func (m marshalledFields) Less(i, j int) bool {
 	return m[i].fieldNum < m[j].fieldNum
 }
 
-func (m marshaledFields) Swap(i, j int) {
+func (m marshalledFields) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }

--- a/src/dbnode/encoding/proto/common.go
+++ b/src/dbnode/encoding/proto/common.go
@@ -153,16 +153,17 @@ type sortedMarshalledFields []marshalledField
 // customFieldState is used to track any required state for encoding / decoding a single
 // field in the encoder / iterator respectively.
 type customFieldState struct {
-	fieldNum int
-	// Float state. Works as both an encoder and iterator (I.E the encoder calls
-	// the encode methods and the iterator calls the read methods).
-	floatEncAndIter m3tsz.FloatEncoderAndIterator
 	// Bytes State. TODO(rartoul): Wrap this up in an encoderAndIterator like
 	// the floats and ints.
 	bytesFieldDict         []encoderBytesFieldDictState
 	iteratorBytesFieldDict [][]byte
+	// Float state. Works as both an encoder and iterator (I.E the encoder calls
+	// the encode methods and the iterator calls the read methods).
+	floatEncAndIter m3tsz.FloatEncoderAndIterator
 	// Int state.
-	intEncAndIter  intEncoderAndIterator
+	intEncAndIter intEncoderAndIterator
+
+	fieldNum       int
 	protoFieldType dpb.FieldDescriptorProto_Type
 	fieldType      customFieldType
 }

--- a/src/dbnode/encoding/proto/common.go
+++ b/src/dbnode/encoding/proto/common.go
@@ -148,6 +148,8 @@ type marshaledField struct {
 	marshaled []byte
 }
 
+type marshaledFields []marshaledField
+
 // customFieldState is used to track any required state for encoding / decoding a single
 // field in the encoder / iterator respectively.
 type customFieldState struct {
@@ -315,4 +317,16 @@ func numBitsRequiredForNumUpToN(n int) int {
 		n = n >> 1
 	}
 	return count
+}
+
+func (m marshaledFields) Len() int {
+	return len(m)
+}
+
+func (m marshaledFields) Less(i, j int) bool {
+	return m[i].fieldNum < m[j].fieldNum
+}
+
+func (m marshaledFields) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
 }

--- a/src/dbnode/encoding/proto/common.go
+++ b/src/dbnode/encoding/proto/common.go
@@ -148,7 +148,7 @@ type marshalledField struct {
 	marshalled []byte
 }
 
-type sortedMarshaledFields []marshalledField
+type sortedMarshalledFields []marshalledField
 
 // customFieldState is used to track any required state for encoding / decoding a single
 // field in the encoder / iterator respectively.
@@ -322,14 +322,14 @@ func numBitsRequiredForNumUpToN(n int) int {
 	return count
 }
 
-func (m sortedMarshaledFields) Len() int {
+func (m sortedMarshalledFields) Len() int {
 	return len(m)
 }
 
-func (m sortedMarshaledFields) Less(i, j int) bool {
+func (m sortedMarshalledFields) Less(i, j int) bool {
 	return m[i].fieldNum < m[j].fieldNum
 }
 
-func (m sortedMarshaledFields) Swap(i, j int) {
+func (m sortedMarshalledFields) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }

--- a/src/dbnode/encoding/proto/common.go
+++ b/src/dbnode/encoding/proto/common.go
@@ -148,7 +148,7 @@ type marshalledField struct {
 	marshalled []byte
 }
 
-type marshalledFields []marshalledField
+type sortedMarshaledFields []marshalledField
 
 // customFieldState is used to track any required state for encoding / decoding a single
 // field in the encoder / iterator respectively.
@@ -322,14 +322,14 @@ func numBitsRequiredForNumUpToN(n int) int {
 	return count
 }
 
-func (m marshalledFields) Len() int {
+func (m sortedMarshaledFields) Len() int {
 	return len(m)
 }
 
-func (m marshalledFields) Less(i, j int) bool {
+func (m sortedMarshaledFields) Less(i, j int) bool {
 	return m[i].fieldNum < m[j].fieldNum
 }
 
-func (m marshalledFields) Swap(i, j int) {
+func (m sortedMarshaledFields) Swap(i, j int) {
 	m[i], m[j] = m[j], m[i]
 }

--- a/src/dbnode/encoding/proto/custom_marshal.go
+++ b/src/dbnode/encoding/proto/custom_marshal.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-type customFieldMarshaler interface {
+type customFieldMarshaller interface {
 	encFloat64(tag int32, x float64)
 	encFloat32(tag int32, x float32)
 	encInt32(tag int32, x int32)
@@ -45,17 +45,17 @@ type customFieldMarshaler interface {
 	reset()
 }
 
-type customMarshaler struct {
+type customMarshaller struct {
 	buf *buffer
 }
 
-func newCustomMarshaler() customFieldMarshaler {
-	return &customMarshaler{
+func newCustomMarshaller() customFieldMarshaller {
+	return &customMarshaller{
 		buf: newCodedBuffer(nil),
 	}
 }
 
-func (m *customMarshaler) encFloat64(tag int32, x float64) {
+func (m *customMarshaller) encFloat64(tag int32, x float64) {
 	if x == 0 {
 		// Default values are not included in the stream.
 		return
@@ -65,7 +65,7 @@ func (m *customMarshaler) encFloat64(tag int32, x float64) {
 	m.buf.encodeFixed64(math.Float64bits(x))
 }
 
-func (m *customMarshaler) encFloat32(tag int32, x float32) {
+func (m *customMarshaller) encFloat32(tag int32, x float32) {
 	if x == 0 {
 		// Default values are not included in the stream.
 		return
@@ -75,7 +75,7 @@ func (m *customMarshaler) encFloat32(tag int32, x float32) {
 	m.buf.encodeFixed32(math.Float32bits(x))
 }
 
-func (m *customMarshaler) encBool(tag int32, x bool) {
+func (m *customMarshaller) encBool(tag int32, x bool) {
 	if !x {
 		// Default values are not included in the stream.
 		return
@@ -84,37 +84,37 @@ func (m *customMarshaler) encBool(tag int32, x bool) {
 	m.encUInt64(tag, 1)
 }
 
-func (m *customMarshaler) encInt32(tag int32, x int32) {
+func (m *customMarshaller) encInt32(tag int32, x int32) {
 	m.encUInt64(tag, uint64(x))
 }
 
-func (m *customMarshaler) encSInt32(tag int32, x int32) {
+func (m *customMarshaller) encSInt32(tag int32, x int32) {
 	m.encUInt64(tag, encodeZigZag32(x))
 }
 
-func (m *customMarshaler) encSFixedInt32(tag int32, x int32) {
+func (m *customMarshaller) encSFixedInt32(tag int32, x int32) {
 	m.buf.encodeTagAndWireType(tag, proto.WireFixed32)
 	m.buf.encodeFixed32(uint32(x))
 }
 
-func (m *customMarshaler) encUInt32(tag int32, x uint32) {
+func (m *customMarshaller) encUInt32(tag int32, x uint32) {
 	m.encUInt64(tag, uint64(x))
 }
 
-func (m *customMarshaler) encInt64(tag int32, x int64) {
+func (m *customMarshaller) encInt64(tag int32, x int64) {
 	m.encUInt64(tag, uint64(x))
 }
 
-func (m *customMarshaler) encSInt64(tag int32, x int64) {
+func (m *customMarshaller) encSInt64(tag int32, x int64) {
 	m.encUInt64(tag, encodeZigZag64(x))
 }
 
-func (m *customMarshaler) encSFixedInt64(tag int32, x int64) {
+func (m *customMarshaller) encSFixedInt64(tag int32, x int64) {
 	m.buf.encodeTagAndWireType(tag, proto.WireFixed64)
 	m.buf.encodeFixed64(uint64(x))
 }
 
-func (m *customMarshaler) encUInt64(tag int32, x uint64) {
+func (m *customMarshaller) encUInt64(tag int32, x uint64) {
 	if x == 0 {
 		// Default values are not included in the stream.
 		return
@@ -124,7 +124,7 @@ func (m *customMarshaler) encUInt64(tag int32, x uint64) {
 	m.buf.encodeVarint(x)
 }
 
-func (m *customMarshaler) encBytes(tag int32, x []byte) {
+func (m *customMarshaller) encBytes(tag int32, x []byte) {
 	if len(x) == 0 {
 		// Default values are not included in the stream.
 		return
@@ -134,19 +134,19 @@ func (m *customMarshaler) encBytes(tag int32, x []byte) {
 	m.buf.encodeRawBytes(x)
 }
 
-func (m *customMarshaler) encPartialProto(tag int32, x []byte) {
+func (m *customMarshaller) encPartialProto(tag int32, x []byte) {
 	m.buf.append(x)
 }
 
-func (m *customMarshaler) bytes() []byte {
+func (m *customMarshaller) bytes() []byte {
 	return m.buf.buf
 }
 
-func (m *customMarshaler) setBytes(b []byte) {
+func (m *customMarshaller) setBytes(b []byte) {
 	m.buf.buf = b
 }
 
-func (m *customMarshaler) reset() {
+func (m *customMarshaller) reset() {
 	b := m.buf.buf
 	if b != nil {
 		b = b[:0]

--- a/src/dbnode/encoding/proto/custom_marshal.go
+++ b/src/dbnode/encoding/proto/custom_marshal.go
@@ -41,6 +41,7 @@ type customFieldMarshaler interface {
 	encBytes(tag int32, x []byte)
 	encPartialProto(tag int32, x []byte)
 	bytes() []byte
+	setBytes(b []byte)
 	reset()
 }
 
@@ -139,6 +140,10 @@ func (m *customMarshaler) encPartialProto(tag int32, x []byte) {
 
 func (m *customMarshaler) bytes() []byte {
 	return m.buf.buf
+}
+
+func (m *customMarshaler) setBytes(b []byte) {
+	m.buf.buf = b
 }
 
 func (m *customMarshaler) reset() {

--- a/src/dbnode/encoding/proto/custom_marshal.go
+++ b/src/dbnode/encoding/proto/custom_marshal.go
@@ -41,7 +41,12 @@ type customFieldMarshaller interface {
 	encUInt64(tag int32, x uint64)
 	encBool(tag int32, x bool)
 	encBytes(tag int32, x []byte)
-	encPartialProto(tag int32, x []byte)
+
+	// Used in cases where marshaled protobuf bytes have already been generated
+	// and need to be appended to the stream. Assumes that the <tag, wireType>
+	// tuple has already been included.
+	encPartialProto(x []byte)
+
 	bytes() []byte
 	setBytes(b []byte)
 	reset()
@@ -136,7 +141,7 @@ func (m *customMarshaller) encBytes(tag int32, x []byte) {
 	m.buf.encodeRawBytes(x)
 }
 
-func (m *customMarshaller) encPartialProto(tag int32, x []byte) {
+func (m *customMarshaller) encPartialProto(x []byte) {
 	m.buf.append(x)
 }
 

--- a/src/dbnode/encoding/proto/custom_marshal.go
+++ b/src/dbnode/encoding/proto/custom_marshal.go
@@ -48,7 +48,6 @@ type customFieldMarshaller interface {
 	encPartialProto(x []byte)
 
 	bytes() []byte
-	setBytes(b []byte)
 	reset()
 }
 
@@ -147,10 +146,6 @@ func (m *customMarshaller) encPartialProto(x []byte) {
 
 func (m *customMarshaller) bytes() []byte {
 	return m.buf.buf
-}
-
-func (m *customMarshaller) setBytes(b []byte) {
-	m.buf.buf = b
 }
 
 func (m *customMarshaller) reset() {

--- a/src/dbnode/encoding/proto/custom_marshal.go
+++ b/src/dbnode/encoding/proto/custom_marshal.go
@@ -62,7 +62,7 @@ func newCustomMarshaller() customFieldMarshaller {
 }
 
 func (m *customMarshaller) encFloat64(tag int32, x float64) {
-	if x == 0 {
+	if x == 0.0 {
 		// Default values are not included in the stream.
 		return
 	}
@@ -72,7 +72,7 @@ func (m *customMarshaller) encFloat64(tag int32, x float64) {
 }
 
 func (m *customMarshaller) encFloat32(tag int32, x float32) {
-	if x == 0 {
+	if x == 0.0 {
 		// Default values are not included in the stream.
 		return
 	}

--- a/src/dbnode/encoding/proto/custom_marshal.go
+++ b/src/dbnode/encoding/proto/custom_marshal.go
@@ -26,6 +26,8 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
+// encoding methods correspond to the scalar types defined in the protobuf 3
+// specificaiton: https://developers.google.com/protocol-buffers/docs/proto3#scalar
 type customFieldMarshaller interface {
 	encFloat64(tag int32, x float64)
 	encFloat32(tag int32, x float32)

--- a/src/dbnode/encoding/proto/custom_marshal.go
+++ b/src/dbnode/encoding/proto/custom_marshal.go
@@ -42,7 +42,7 @@ type customFieldMarshaller interface {
 	encBool(tag int32, x bool)
 	encBytes(tag int32, x []byte)
 
-	// Used in cases where marshaled protobuf bytes have already been generated
+	// Used in cases where marshalled protobuf bytes have already been generated
 	// and need to be appended to the stream. Assumes that the <tag, wireType>
 	// tuple has already been included.
 	encPartialProto(x []byte)

--- a/src/dbnode/encoding/proto/custom_marshal_test.go
+++ b/src/dbnode/encoding/proto/custom_marshal_test.go
@@ -43,25 +43,25 @@ func TestCustomMarshal(t *testing.T) {
 		},
 	}
 
-	marshaler := newCustomMarshaler()
+	marshaller := newCustomMarshaller()
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("test_case_%d", i), func(t *testing.T) {
-			marshaler.reset()
-			customMarshalVL(t, marshaler, tc.message)
+			marshaller.reset()
+			customMarshalVL(t, marshaller, tc.message)
 
 			unmarshalM := dynamic.NewMessage(testVLSchema)
-			require.NoError(t, unmarshalM.Unmarshal(marshaler.bytes()))
+			require.NoError(t, unmarshalM.Unmarshal(marshaller.bytes()))
 
 			require.True(t, dynamic.Equal(tc.message, unmarshalM))
 		})
 	}
 }
 
-func customMarshalVL(t *testing.T, marshaler customFieldMarshaler, m *dynamic.Message) {
-	marshaler.encFloat64(1, m.GetFieldByNumber(1).(float64))
-	marshaler.encFloat64(2, m.GetFieldByNumber(2).(float64))
-	marshaler.encInt64(3, m.GetFieldByNumber(3).(int64))
-	marshaler.encBytes(4, m.GetFieldByNumber(4).([]byte))
+func customMarshalVL(t *testing.T, marshaller customFieldMarshaller, m *dynamic.Message) {
+	marshaller.encFloat64(1, m.GetFieldByNumber(1).(float64))
+	marshaller.encFloat64(2, m.GetFieldByNumber(2).(float64))
+	marshaller.encInt64(3, m.GetFieldByNumber(3).(int64))
+	marshaller.encBytes(4, m.GetFieldByNumber(4).([]byte))
 
 	// Fields set to their default value are not marshalled in the Protobuf3 format so to generate
 	// the bytes that represent the attributes map we create a new VL message where every field is
@@ -74,7 +74,7 @@ func customMarshalVL(t *testing.T, marshaler customFieldMarshaler, m *dynamic.Me
 		attributeMapBytes, err = attributesM.Marshal()
 	)
 	require.NoError(t, err)
-	marshaler.encPartialProto(5, attributeMapBytes)
+	marshaller.encPartialProto(5, attributeMapBytes)
 }
 
 func mapInterfaceToMapString(ifaceMap map[interface{}]interface{}) map[string]string {

--- a/src/dbnode/encoding/proto/custom_marshal_test.go
+++ b/src/dbnode/encoding/proto/custom_marshal_test.go
@@ -63,7 +63,7 @@ func customMarshalVL(t *testing.T, marshaler customFieldMarshaler, m *dynamic.Me
 	marshaler.encInt64(3, m.GetFieldByNumber(3).(int64))
 	marshaler.encBytes(4, m.GetFieldByNumber(4).([]byte))
 
-	// Fields set to their default value are not marshaled in the Protobuf3 format so to generate
+	// Fields set to their default value are not marshalled in the Protobuf3 format so to generate
 	// the bytes that represent the attributes map we create a new VL message where every field is
 	// set to its default value except for the attributes map and then Marshal() it into a byte stream
 	// which will create a stream that only includes the attributes field.

--- a/src/dbnode/encoding/proto/custom_marshal_test.go
+++ b/src/dbnode/encoding/proto/custom_marshal_test.go
@@ -21,6 +21,7 @@
 package proto
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/jhump/protoreflect/dynamic"
@@ -43,14 +44,16 @@ func TestCustomMarshal(t *testing.T) {
 	}
 
 	marshaler := newCustomMarshaler()
-	for _, tc := range testCases {
-		marshaler.reset()
-		customMarshalVL(t, marshaler, tc.message)
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("test_case_%d", i), func(t *testing.T) {
+			marshaler.reset()
+			customMarshalVL(t, marshaler, tc.message)
 
-		unmarshalM := dynamic.NewMessage(testVLSchema)
-		require.NoError(t, unmarshalM.Unmarshal(marshaler.bytes()))
+			unmarshalM := dynamic.NewMessage(testVLSchema)
+			require.NoError(t, unmarshalM.Unmarshal(marshaler.bytes()))
 
-		require.True(t, dynamic.Equal(tc.message, unmarshalM))
+			require.True(t, dynamic.Equal(tc.message, unmarshalM))
+		})
 	}
 }
 

--- a/src/dbnode/encoding/proto/custom_marshal_test.go
+++ b/src/dbnode/encoding/proto/custom_marshal_test.go
@@ -74,7 +74,7 @@ func customMarshalVL(t *testing.T, marshaller customFieldMarshaller, m *dynamic.
 		attributeMapBytes, err = attributesM.Marshal()
 	)
 	require.NoError(t, err)
-	marshaller.encPartialProto(5, attributeMapBytes)
+	marshaller.encPartialProto(attributeMapBytes)
 }
 
 func mapInterfaceToMapString(ifaceMap map[interface{}]interface{}) map[string]string {

--- a/src/dbnode/encoding/proto/custom_unmarshal.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal.go
@@ -130,14 +130,14 @@ func (u *customUnmarshaler) unmarshal() error {
 				return err
 			}
 
-			fmt.Printf("%d unmarshaled into %s\n", fieldNum, u.nonCustomValues.String())
+			// fmt.Printf("%d unmarshaled into %s\n", fieldNum, u.nonCustomValues.String())
 			found := false
 			if fd.IsRepeated() {
 				for i := range u.nonCustomValues2 {
 					val := u.nonCustomValues2[i]
 					if fieldNum == val.fieldNum {
 						u.nonCustomValues2[i].marshaled = append(u.nonCustomValues2[i].marshaled, marshaled...)
-						fmt.Printf("(found) %d marshaled %v\n", fieldNum, u.nonCustomValues2[i].marshaled)
+						// fmt.Printf("(found) %d marshaled %v\n", fieldNum, u.nonCustomValues2[i].marshaled)
 						found = true
 						break
 					}
@@ -148,7 +148,7 @@ func (u *customUnmarshaler) unmarshal() error {
 					fieldNum:  fieldNum,
 					marshaled: marshaled,
 				})
-				fmt.Printf("(not found) %d marshaled %v\n", fieldNum, marshaled)
+				// fmt.Printf("(not found) %d marshaled %v\n", fieldNum, marshaled)
 			}
 
 			u.numNonCustom++

--- a/src/dbnode/encoding/proto/custom_unmarshal.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal.go
@@ -40,7 +40,7 @@ var (
 
 type customFieldUnmarshaler interface {
 	sortedCustomFieldValues() sortedCustomFieldValues
-	nonCustomFieldValues() []marshaledField
+	nonCustomFieldValues() []marshalledField
 	numNonCustomValues() int
 	resetAndUnmarshal(schema *desc.MessageDescriptor, buf []byte) error
 }
@@ -54,7 +54,7 @@ type customUnmarshaler struct {
 	decodeBuf    *buffer
 	customValues sortedCustomFieldValues
 
-	nonCustomValues marshaledFields
+	nonCustomValues marshalledFields
 	numNonCustom    int
 
 	opts customUnmarshalerOptions
@@ -75,7 +75,7 @@ func (u *customUnmarshaler) numNonCustomValues() int {
 	return u.numNonCustom
 }
 
-func (u *customUnmarshaler) nonCustomFieldValues() []marshaledField {
+func (u *customUnmarshaler) nonCustomFieldValues() []marshalledField {
 	return u.nonCustomValues
 }
 
@@ -114,19 +114,19 @@ func (u *customUnmarshaler) unmarshal() error {
 			}
 
 			var (
-				startIdx  = tagAndWireTypeStartOffset
-				endIdx    = u.decodeBuf.index
-				marshaled = u.decodeBuf.buf[startIdx:endIdx]
+				startIdx   = tagAndWireTypeStartOffset
+				endIdx     = u.decodeBuf.index
+				marshalled = u.decodeBuf.buf[startIdx:endIdx]
 			)
-			// A marshaled Protobuf message consists of a stream of <fieldNumber, wireType, value>
+			// A marshalled Protobuf message consists of a stream of <fieldNumber, wireType, value>
 			// tuples, all of which are optional, with no additional header or footer information.
 			// This means that each tuple within the stream can be thought of as its own complete
-			// marshaled message and as a result we can build up the []marshaledField one field at
+			// marshalled message and as a result we can build up the []marshalledField one field at
 			// a time.
 			updatedExisting := false
 			if fd.IsRepeated() {
 				// If the fd is a repeated type and not using `packed` encoding then their could be multiple
-				// entries in the stream with the same field number so their marshaled bytes needs to be all
+				// entries in the stream with the same field number so their marshalled bytes needs to be all
 				// concatenated together.
 				//
 				// NB(rartoul): This will have an adverse impact on the compression of map types because the
@@ -134,21 +134,21 @@ func (u *customUnmarshaler) unmarshal() error {
 				// maps to have different byte streams which will force the encoder to re-encode the field into
 				// the stream even though it hasn't changed. This naive solution should be good enough for now,
 				// but if it proves problematic in the future the issue could be resolved by accumulating the
-				// marshaled tuples into a slice and then sorting by field number to produce a deterministic
-				// result such that equivalent maps always result in equivalent marshaled bytes slices.
+				// marshalled tuples into a slice and then sorting by field number to produce a deterministic
+				// result such that equivalent maps always result in equivalent marshalled bytes slices.
 				for i := range u.nonCustomValues {
 					val := u.nonCustomValues[i]
 					if fieldNum == val.fieldNum {
-						u.nonCustomValues[i].marshaled = append(u.nonCustomValues[i].marshaled, marshaled...)
+						u.nonCustomValues[i].marshalled = append(u.nonCustomValues[i].marshalled, marshalled...)
 						updatedExisting = true
 						break
 					}
 				}
 			}
 			if !updatedExisting {
-				u.nonCustomValues = append(u.nonCustomValues, marshaledField{
-					fieldNum:  fieldNum,
-					marshaled: marshaled,
+				u.nonCustomValues = append(u.nonCustomValues, marshalledField{
+					fieldNum:   fieldNum,
+					marshalled: marshalled,
 				})
 			}
 
@@ -386,7 +386,7 @@ func (u *customUnmarshaler) resetAndUnmarshal(schema *desc.MessageDescriptor, bu
 	u.customValues = u.customValues[:0]
 
 	for i := range u.nonCustomValues {
-		u.nonCustomValues[i] = marshaledField{}
+		u.nonCustomValues[i] = marshalledField{}
 	}
 	u.nonCustomValues = u.nonCustomValues[:0]
 

--- a/src/dbnode/encoding/proto/custom_unmarshal.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal.go
@@ -40,7 +40,7 @@ var (
 
 type customFieldUnmarshaller interface {
 	sortedCustomFieldValues() sortedCustomFieldValues
-	nonCustomFieldValues() []marshalledField
+	sortedNonCustomFieldValues() sortedMarshaledFields
 	numNonCustomValues() int
 	resetAndUnmarshal(schema *desc.MessageDescriptor, buf []byte) error
 }
@@ -54,7 +54,7 @@ type customUnmarshaller struct {
 	decodeBuf    *buffer
 	customValues sortedCustomFieldValues
 
-	nonCustomValues marshalledFields
+	nonCustomValues sortedMarshaledFields
 	numNonCustom    int
 
 	opts customUnmarshallerOptions
@@ -75,7 +75,7 @@ func (u *customUnmarshaller) numNonCustomValues() int {
 	return u.numNonCustom
 }
 
-func (u *customUnmarshaller) nonCustomFieldValues() []marshalledField {
+func (u *customUnmarshaller) sortedNonCustomFieldValues() sortedMarshaledFields {
 	return u.nonCustomValues
 }
 

--- a/src/dbnode/encoding/proto/custom_unmarshal.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal.go
@@ -47,10 +47,8 @@ type customFieldUnmarshaler interface {
 }
 
 type customUnmarshaler struct {
-	schema *desc.MessageDescriptor
-
-	decodeBuf *buffer
-
+	schema       *desc.MessageDescriptor
+	decodeBuf    *buffer
 	customValues sortedCustomFieldValues
 
 	nonCustomValues *dynamic.Message
@@ -98,8 +96,7 @@ func (u *customUnmarshaler) unmarshal() error {
 			return fmt.Errorf("encountered unknown field with field number: %d", fieldNum)
 		}
 
-		isCustomField := u.isCustomField(fd)
-		if !isCustomField {
+		if !u.isCustomField(fd) {
 			if u.nonCustomValues == nil {
 				u.nonCustomValues = dynamic.NewMessage(u.schema)
 			}
@@ -120,7 +117,9 @@ func (u *customUnmarshaler) unmarshal() error {
 			// marshaled message and as a result we can build up the nonCustomValues *dynamic.Message
 			// one field at a time by calling UnmarshalMerge() on sub-slices that contain a complete
 			// tuple.
-			u.nonCustomValues.UnmarshalMerge(marshaledField)
+			if err := u.nonCustomValues.UnmarshalMerge(marshaledField); err != nil {
+				return err
+			}
 			u.numNonCustom++
 			continue
 		}
@@ -144,14 +143,18 @@ func (u *customUnmarshaler) unmarshal() error {
 
 	u.decodeBuf.reset(u.decodeBuf.buf)
 
+	// Avoid resorting if possible.
 	if !isSorted {
-		// Avoid resorting if possible.
 		sort.Sort(u.customValues)
 	}
 
 	return nil
 }
 
+// isCustomField checks whether the encoder would have custom encoded this field or left
+// it up to the `jhump/dynamic` package to handle the encoding. This is important because
+// it allows us to use the efficient unmarshal path only for fields that the encoder can
+// actually take advantage of.
 func (u *customUnmarshaler) isCustomField(fd *desc.FieldDescriptor) bool {
 	if fd.IsRepeated() || fd.IsMap() {
 		// Map should always be repeated but include the guard just in case.
@@ -171,45 +174,47 @@ func (u *customUnmarshaler) isCustomField(fd *desc.FieldDescriptor) bool {
 func (u *customUnmarshaler) skip(wireType int8) (int, error) {
 	switch wireType {
 	case proto.WireFixed32:
-		numSkipped := 4
-		u.decodeBuf.index += numSkipped
-		return numSkipped, nil
+		bytesSkipped := 4
+		u.decodeBuf.index += bytesSkipped
+		return bytesSkipped, nil
 
 	case proto.WireFixed64:
-		numSkipped := 8
-		u.decodeBuf.index += numSkipped
-		return numSkipped, nil
+		bytesSkipped := 8
+		u.decodeBuf.index += bytesSkipped
+		return bytesSkipped, nil
 
 	case proto.WireVarint:
 		var (
-			numSkipped               = 0
+			bytesSkipped             = 0
 			offsetBeforeDecodeVarInt = u.decodeBuf.index
 		)
 		_, err := u.decodeBuf.decodeVarint()
 		if err != nil {
-			return numSkipped, err
+			return 0, err
 		}
-		numSkipped += u.decodeBuf.index - offsetBeforeDecodeVarInt
-		return numSkipped, nil
+		bytesSkipped += u.decodeBuf.index - offsetBeforeDecodeVarInt
+		return bytesSkipped, nil
 
 	case proto.WireBytes:
 		var (
-			numSkipped                 = 0
+			bytesSkipped               = 0
 			offsetBeforeDecodeRawBytes = u.decodeBuf.index
 		)
 		// Bytes aren't copied because they're just being skipped over so
 		// copying would be wasteful.
 		_, err := u.decodeBuf.decodeRawBytes(false)
 		if err != nil {
-			return numSkipped, err
+			return 0, err
 		}
-		numSkipped += u.decodeBuf.index - offsetBeforeDecodeRawBytes
-		return numSkipped, nil
+		bytesSkipped += u.decodeBuf.index - offsetBeforeDecodeRawBytes
+		return bytesSkipped, nil
 
 	case proto.WireStartGroup:
 		return 0, errGroupsAreNotSupported
+
 	case proto.WireEndGroup:
 		return 0, errGroupsAreNotSupported
+
 	default:
 		return 0, proto.ErrInternalBadWireType
 	}
@@ -223,12 +228,14 @@ func (u *customUnmarshaler) unmarshalCustomField(fd *desc.FieldDescriptor, wireT
 			return zeroValue, err
 		}
 		return unmarshalSimpleField(fd, num)
+
 	case proto.WireFixed64:
 		num, err := u.decodeBuf.decodeFixed64()
 		if err != nil {
 			return zeroValue, err
 		}
 		return unmarshalSimpleField(fd, num)
+
 	case proto.WireVarint:
 		num, err := u.decodeBuf.decodeVarint()
 		if err != nil {
@@ -237,8 +244,8 @@ func (u *customUnmarshaler) unmarshalCustomField(fd *desc.FieldDescriptor, wireT
 		return unmarshalSimpleField(fd, num)
 
 	case proto.WireBytes:
-		if fd.GetType() != dpb.FieldDescriptorProto_TYPE_BYTES &&
-			fd.GetType() != dpb.FieldDescriptorProto_TYPE_STRING {
+		if t := fd.GetType(); t != dpb.FieldDescriptorProto_TYPE_BYTES &&
+			t != dpb.FieldDescriptorProto_TYPE_STRING {
 			// This should never happen since it means the skipping logic is not working
 			// correctly or the message is malformed since proto.WireBytes should only be
 			// used for fields of type bytes, string, group, or message. Groups/messages
@@ -261,6 +268,7 @@ func (u *customUnmarshaler) unmarshalCustomField(fd *desc.FieldDescriptor, wireT
 
 	case proto.WireStartGroup:
 		return zeroValue, errGroupsAreNotSupported
+
 	default:
 		return zeroValue, proto.ErrInternalBadWireType
 	}

--- a/src/dbnode/encoding/proto/custom_unmarshal.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal.go
@@ -129,10 +129,28 @@ func (u *customUnmarshaler) unmarshal() error {
 			if err := u.nonCustomValues.UnmarshalMerge(marshaled); err != nil {
 				return err
 			}
-			u.nonCustomValues2 = append(u.nonCustomValues2, marshaledField{
-				fieldNum:  fieldNum,
-				marshaled: marshaled,
-			})
+
+			fmt.Printf("%d unmarshaled into %s\n", fieldNum, u.nonCustomValues.String())
+			found := false
+			if fd.IsRepeated() {
+				for i := range u.nonCustomValues2 {
+					val := u.nonCustomValues2[i]
+					if fieldNum == val.fieldNum {
+						u.nonCustomValues2[i].marshaled = append(u.nonCustomValues2[i].marshaled, marshaled...)
+						fmt.Printf("(found) %d marshaled %v\n", fieldNum, u.nonCustomValues2[i].marshaled)
+						found = true
+						break
+					}
+				}
+			}
+			if !found {
+				u.nonCustomValues2 = append(u.nonCustomValues2, marshaledField{
+					fieldNum:  fieldNum,
+					marshaled: marshaled,
+				})
+				fmt.Printf("(not found) %d marshaled %v\n", fieldNum, marshaled)
+			}
+
 			u.numNonCustom++
 			continue
 		}

--- a/src/dbnode/encoding/proto/custom_unmarshal.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal.go
@@ -40,7 +40,7 @@ var (
 
 type customFieldUnmarshaller interface {
 	sortedCustomFieldValues() sortedCustomFieldValues
-	sortedNonCustomFieldValues() sortedMarshaledFields
+	sortedNonCustomFieldValues() sortedMarshalledFields
 	numNonCustomValues() int
 	resetAndUnmarshal(schema *desc.MessageDescriptor, buf []byte) error
 }
@@ -54,7 +54,7 @@ type customUnmarshaller struct {
 	decodeBuf    *buffer
 	customValues sortedCustomFieldValues
 
-	nonCustomValues sortedMarshaledFields
+	nonCustomValues sortedMarshalledFields
 	numNonCustom    int
 
 	opts customUnmarshallerOptions
@@ -75,7 +75,7 @@ func (u *customUnmarshaller) numNonCustomValues() int {
 	return u.numNonCustom
 }
 
-func (u *customUnmarshaller) sortedNonCustomFieldValues() sortedMarshaledFields {
+func (u *customUnmarshaller) sortedNonCustomFieldValues() sortedMarshalledFields {
 	return u.nonCustomValues
 }
 

--- a/src/dbnode/encoding/proto/custom_unmarshal.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal.go
@@ -387,7 +387,7 @@ func (u *customUnmarshaller) resetAndUnmarshal(schema *desc.MessageDescriptor, b
 
 func (u *customUnmarshaller) resetCustomAndNonCustomValues() {
 	for i := range u.customValues {
-		u.customValues[i] = marshalValue{}
+		u.customValues[i] = unmarshalValue{}
 	}
 	u.customValues = u.customValues[:0]
 

--- a/src/dbnode/encoding/proto/custom_unmarshal_test.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal_test.go
@@ -151,11 +151,11 @@ func TestCustomFieldUnmarshaler(t *testing.T) {
 
 		if len(tc.attributes) > 0 {
 			require.Equal(t, len(tc.attributes), unmarshaler.numNonCustomValues())
-			m := unmarshaler.nonCustomFieldValues()
-			assertAttributesEqual(
-				t,
-				tc.attributes,
-				m.GetFieldByName("attributes").(map[interface{}]interface{}))
+			// m := unmarshaler.nonCustomFieldValues()
+			// assertAttributesEqual(
+			// 	t,
+			// 	tc.attributes,
+			// 	m.GetFieldByName("attributes").(map[interface{}]interface{}))
 		} else {
 			require.Equal(t, 0, unmarshaler.numNonCustomValues())
 		}

--- a/src/dbnode/encoding/proto/custom_unmarshal_test.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal_test.go
@@ -79,7 +79,7 @@ func TestCustomFieldUnmarshaler(t *testing.T) {
 					v:           math.Float64bits(1.1),
 				},
 				// Note that epoch (field number 3) is not included here because default
-				// value are not included in a marshaled protobuf stream (their absence
+				// value are not included in a marshalled protobuf stream (their absence
 				// implies a default vlaue for a field) which means they're also not
 				// returned by the `sortedCustomFieldValues` method.
 				{
@@ -120,10 +120,10 @@ func TestCustomFieldUnmarshaler(t *testing.T) {
 	for _, tc := range testCases {
 		vl := newVL(
 			tc.latitude, tc.longitude, tc.epoch, tc.deliveryID, tc.attributes)
-		marshaledVL, err := vl.Marshal()
+		marshalledVL, err := vl.Marshal()
 		require.NoError(t, err)
 
-		unmarshaler.resetAndUnmarshal(testVLSchema, marshaledVL)
+		unmarshaler.resetAndUnmarshal(testVLSchema, marshalledVL)
 		sortedCustomFieldValues := unmarshaler.sortedCustomFieldValues()
 		require.Equal(t, len(tc.expectedSortedCustomFields), len(sortedCustomFieldValues))
 

--- a/src/dbnode/encoding/proto/custom_unmarshal_test.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal_test.go
@@ -156,7 +156,7 @@ func TestCustomFieldUnmarshaller(t *testing.T) {
 			require.Equal(t, 1, len(nonCustomFieldValues))
 			require.Equal(t, int32(5), nonCustomFieldValues[0].fieldNum)
 
-			assertAttributesEqualMarshaledBytes(
+			assertAttributesEqualMarshalledBytes(
 				t,
 				nonCustomFieldValues[0].marshalled,
 				tc.attributes)
@@ -166,7 +166,7 @@ func TestCustomFieldUnmarshaller(t *testing.T) {
 	}
 }
 
-func assertAttributesEqualMarshaledBytes(
+func assertAttributesEqualMarshalledBytes(
 	t *testing.T,
 	actualMarshalled []byte,
 	attrs map[string]string,

--- a/src/dbnode/encoding/proto/custom_unmarshal_test.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCustomFieldUnmarshaler(t *testing.T) {
+func TestCustomFieldUnmarshaller(t *testing.T) {
 	// Store in a var to prevent the compiler from complaining about overflow errors.
 	neg1 := -1
 
@@ -116,15 +116,15 @@ func TestCustomFieldUnmarshaler(t *testing.T) {
 		},
 	}
 
-	unmarshaler := newCustomFieldUnmarshaler(customUnmarshalerOptions{})
+	unmarshaller := newCustomFieldUnmarshaller(customUnmarshallerOptions{})
 	for _, tc := range testCases {
 		vl := newVL(
 			tc.latitude, tc.longitude, tc.epoch, tc.deliveryID, tc.attributes)
 		marshalledVL, err := vl.Marshal()
 		require.NoError(t, err)
 
-		unmarshaler.resetAndUnmarshal(testVLSchema, marshalledVL)
-		sortedCustomFieldValues := unmarshaler.sortedCustomFieldValues()
+		unmarshaller.resetAndUnmarshal(testVLSchema, marshalledVL)
+		sortedCustomFieldValues := unmarshaller.sortedCustomFieldValues()
 		require.Equal(t, len(tc.expectedSortedCustomFields), len(sortedCustomFieldValues))
 
 		lastFieldNum := -1
@@ -150,14 +150,14 @@ func TestCustomFieldUnmarshaler(t *testing.T) {
 		}
 
 		if len(tc.attributes) > 0 {
-			require.Equal(t, len(tc.attributes), unmarshaler.numNonCustomValues())
-			// m := unmarshaler.nonCustomFieldValues()
+			require.Equal(t, len(tc.attributes), unmarshaller.numNonCustomValues())
+			// m := unmarshaller.nonCustomFieldValues()
 			// assertAttributesEqual(
 			// 	t,
 			// 	tc.attributes,
 			// 	m.GetFieldByName("attributes").(map[interface{}]interface{}))
 		} else {
-			require.Equal(t, 0, unmarshaler.numNonCustomValues())
+			require.Equal(t, 0, unmarshaller.numNonCustomValues())
 		}
 	}
 }

--- a/src/dbnode/encoding/proto/custom_unmarshal_test.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal_test.go
@@ -152,7 +152,7 @@ func TestCustomFieldUnmarshaller(t *testing.T) {
 
 		if len(tc.attributes) > 0 {
 			require.Equal(t, len(tc.attributes), unmarshaller.numNonCustomValues())
-			nonCustomFieldValues := unmarshaller.nonCustomFieldValues()
+			nonCustomFieldValues := unmarshaller.sortedNonCustomFieldValues()
 			require.Equal(t, 1, len(nonCustomFieldValues))
 			require.Equal(t, int32(5), nonCustomFieldValues[0].fieldNum)
 

--- a/src/dbnode/encoding/proto/custom_unmarshal_test.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal_test.go
@@ -154,7 +154,7 @@ func TestCustomFieldUnmarshaller(t *testing.T) {
 			require.Equal(t, len(tc.attributes), unmarshaller.numNonCustomValues())
 			nonCustomFieldValues := unmarshaller.nonCustomFieldValues()
 			require.Equal(t, 1, len(nonCustomFieldValues))
-			require.Equal(t, 5, nonCustomFieldValues[0].fieldNum)
+			require.Equal(t, int32(5), nonCustomFieldValues[0].fieldNum)
 
 			assertAttributesEqualMarshaledBytes(
 				t,

--- a/src/dbnode/encoding/proto/custom_unmarshal_test.go
+++ b/src/dbnode/encoding/proto/custom_unmarshal_test.go
@@ -116,7 +116,7 @@ func TestCustomFieldUnmarshaler(t *testing.T) {
 		},
 	}
 
-	unmarshaler := newCustomFieldUnmarshaler()
+	unmarshaler := newCustomFieldUnmarshaler(customUnmarshalerOptions{})
 	for _, tc := range testCases {
 		vl := newVL(
 			tc.latitude, tc.longitude, tc.epoch, tc.deliveryID, tc.attributes)

--- a/src/dbnode/encoding/proto/docs/README.md
+++ b/src/dbnode/encoding/proto/docs/README.md
@@ -8,3 +8,4 @@ All compression is performed in an unbuffered manner such that the encoded strea
 
 Read [encoding.md](./encoding.md) for details on the encoding scheme.
 Read [unmarshal.md](./unmarshal.md) for details on the custom dynamic Protobuf unmarshaller.
+Read [marshal.md](./marshal.md) for details on the custom dynamic Protobuf marshaller.

--- a/src/dbnode/encoding/proto/docs/README.md
+++ b/src/dbnode/encoding/proto/docs/README.md
@@ -7,4 +7,4 @@ This package contains the encoder/decoder for compressing streams of Protobuf me
 All compression is performed in an unbuffered manner such that the encoded stream is updated with each write; there is no internal buffering or batching during which multiple writes are gathered before performing encoding.
 
 Read [encoding.md](./encoding.md) for details on the encoding scheme.
-Read [unmarshal.md](./unmarshal.md) for details on the custom dynamic Protobuf unmarshaler.
+Read [unmarshal.md](./unmarshal.md) for details on the custom dynamic Protobuf unmarshaller.

--- a/src/dbnode/encoding/proto/docs/encoding.md
+++ b/src/dbnode/encoding/proto/docs/encoding.md
@@ -95,7 +95,7 @@ In practice, a Protbuf message can have any number of different fields; for perf
 Instead, multiple "logical" streams are interleaved on a per-write basis within one physical stream.
 The remainder of this section outlines the binary format used to accomplish this interleaving.
 
-The binary format begins with a stream header and then the remainder of the stream is a sequence of tuples in the form: `<per-write header, compressed timestamp, compressed custom encoded fields, Protobuf marshalled fields>`
+The binary format begins with a stream header, and the the remainder of the stream is a sequence of tuples in the form: `<per-write header, compressed timestamp, compressed custom encoded fields, Protobuf marshalled fields>`
 
 ### Stream Header
 

--- a/src/dbnode/encoding/proto/docs/encoding.md
+++ b/src/dbnode/encoding/proto/docs/encoding.md
@@ -201,7 +201,7 @@ Compressing the Protobuf fields is broken into two stages:
 
 In the first phase, any eligible custom fields are compressed as described in the "Compression Techniques" section.
 
-In the second phase, the Protobuf marshaling format is used to encode and decode the data, with the caveat that fields are compared at the top level and re-encoding is avoided if they have not changed.
+In the second phase, the Protobuf marshalling format is used to encode and decode the data, with the caveat that fields are compared at the top level and re-encoding is avoided if they have not changed.
 
 #### Custom Compressed Protobuf Fields
 
@@ -226,14 +226,14 @@ Next, 6 bits would be used to encode the number of significant digits in the del
 
 Note that the values encoded for both fields are "self contained" in that they encode all the information required to determine when the end has been reached.
 
-#### Protobuf Marshalled Fields
+#### Protobuf Marshalled Fields (non custom encoded / compressed)
 
 We recommend reading the [Protocol Buffers Encoding](https://developers.google.com/protocol-buffers/docs/encoding) section of the official documentation before reading this section.
 Specifically, understanding how Protobuf messages are (basically) encoded as a stream of tuples in the form of `<field number, wire type, value>` will make understanding this section much easier.
 
 The Protobuf marshalled fields section of the encoding scheme contains all the values that don't currently support performing custom compression.
 For the most part, the output of this section is similar to the result of calling `Marshal()` on a message in which all the custom compressed fields have already been removed, and the only remaining fields are ones for which Protobuf will encode directly.
-This is possible because, as described in the Protobuf encoding section linked above, the Protobuf wire format does not encode **any** data for fields which are not set or are set to a default value, so by "clearing" the fields that have already been encoded, they can be omitted when marshaling the remainder of the Protobuf message.
+This is possible because, as described in the Protobuf encoding section linked above, the Protobuf wire format does not encode **any** data for fields which are not set or are set to a default value, so by "clearing" the fields that have already been encoded, they can be omitted when marshalling the remainder of the Protobuf message.
 
 While Protobuf's wire format is leaned upon heavily, there is specific attention given to re-encoding fields that haven't changed since the previous value, where "haven't changed" is defined at the top most level of the message.
 
@@ -259,7 +259,7 @@ However, if any of the fields have changed, like `nested.deeper.booly` for examp
 
 This top-level "only if it has changed" delta encoding can be used because, when the stream is decoded later, the original message can be reconstructed by merging the previously-decoded message with the current delta message, which contains only fields that have changed since the previous message.
 
-Only marshaling the fields that have changed since the previous message works for the most part, but there is one important edge case: because the Protobuf wire format does not encode **any** data for fields that are set to a default value (zero for `integers` and `floats`, empty array for `bytes` and `strings`, etc), using the standard Protobuf marshaling format with delta encoding works in every scenario *except* for the case where a field is changed from a non-default value to a default value because (because it is not possible to express explicitly setting a field to its default value).
+Only marshalling the fields that have changed since the previous message works for the most part, but there is one important edge case: because the Protobuf wire format does not encode **any** data for fields that are set to a default value (zero for `integers` and `floats`, empty array for `bytes` and `strings`, etc), using the standard Protobuf marshalling format with delta encoding works in every scenario *except* for the case where a field is changed from a non-default value to a default value because (because it is not possible to express explicitly setting a field to its default value).
 
 This issue is mitigated by encoding an additional optional (as in it is only encoded when necessary) bitset which indicates any field numbers that were set to the default value of the field's type.
 
@@ -274,4 +274,6 @@ If the previous control bit was set to `1`, indicating that there have been chan
 If so, then its value will be `1` and the subsequent bits should be interpreted as a `varint` encoding the length of the bitset followed by the actual bitset bits as discussed above.
 If the value is `0`, then there is no bitset to decode.
 
-Finally, this portion of the encoding will end with a final `varint` that encodes the length of the bytes that resulted from calling `Marshal()` on the message (where any custom-encoded or unchanged fields were cleared) followed by the actual marshalled bytes themselves.
+At this point, if the stream is not byte-aligned, it is passed with zeros up to the next byte boundary. This reduces compression slightly (a maximum of 7 bits per message that contains non-custom encoded fields), but significantly improves the speed at which large marshalled protobuf fields can be encoded and decoded.
+
+Finally, this portion of the encoding will end with a `varint` that encodes the length of the bytes that would be generated by calling `Marshal()` on the message (where any custom-encoded or unchanged fields were cleared) followed by the actual marshalled bytes themselves.

--- a/src/dbnode/encoding/proto/docs/marshal.md
+++ b/src/dbnode/encoding/proto/docs/marshal.md
@@ -1,0 +1,5 @@
+# Custom Dynamic Protobuf Marshaler
+
+## Overview
+
+The custom dynamic protobuf marshaler is more or less the inverse of the custom dynamic protobuf unmarshaler.

--- a/src/dbnode/encoding/proto/docs/unmarshal.md
+++ b/src/dbnode/encoding/proto/docs/unmarshal.md
@@ -14,7 +14,7 @@ For M3DB, a solution like this is prohibitively inefficient: unmarshalling into 
 It's especially inefficient for Protobuf schemas that are optimized for this package (specifically those that make heavy use of top-level scalar fields where allocating objects on the heap just to wrap primitive types is particularly wasteful).
 
 As a result, this package implements `customFieldUnmarshaller`, which accepts a marshalled Protobuf message (`[]byte`) and exposes methods for unmarshalling the top-level scalar fields (i.e the fields that the encoder can perform custom compression on) in an efficient and reusable manner such that in the general case there are no allocations.
-In addition, it also exposes a `nonCustomFieldValues` method which returns **the marshaled** bytes for every field non top-level scalar field that the unmarshaler couldn't unmarshal.
+In addition, it also exposes a `nonCustomFieldValues` method which returns **the marshalled** bytes for every field non top-level scalar field that the unmarshaler couldn't unmarshal.
 
 ## Implementation
 
@@ -24,7 +24,7 @@ The implementation is broken into two parts:
 
 1. The `buffer`, which is similar to [protoreflect's dynamic codex](https://github.com/jhump/protoreflect/blob/master/dynamic/codec.go) and provides an interface for iterating over a marshalled Protobuf message, one `<fieldNumber, wiretype, value>` tuple at a time.
 
-2. The `customFieldUnmarshaller`, which wraps the `buffer` and exposes an interface for efficiently unmarshalling top-level scalar fields with no allocations, as well as returning the marshaled bytes for any fields that the unmarshaller doesn't have an efficient unmarshalling codepath for (`maps`, `repeated` fields, and nested messages, etc).
+2. The `customFieldUnmarshaller`, which wraps the `buffer` and exposes an interface for efficiently unmarshalling top-level scalar fields with no allocations, as well as returning the marshalled bytes for any fields that the unmarshaller doesn't have an efficient unmarshalling codepath for (`maps`, `repeated` fields, and nested messages, etc).
 
 ### Buffer
 

--- a/src/dbnode/encoding/proto/docs/unmarshal.md
+++ b/src/dbnode/encoding/proto/docs/unmarshal.md
@@ -4,7 +4,7 @@
 
 It's recommended that readers familiarize themselves with the [proto3 encoding documentation](https://developers.google.com/protocol-buffers/docs/encoding) before reading the remainder of this document.
 
-The Encoder in this package is responsible for encoding an unbuffered stream of marshaled Protobuf messages into a new compressed stream one message at a time.
+The Encoder in this package is responsible for encoding an unbuffered stream of marshalled Protobuf messages into a new compressed stream one message at a time.
 
 In order to accomplish this, it needs to unmarshal the Protobuf messages so that it can re-encode their values.
 
@@ -13,7 +13,7 @@ Since the schemas for the Protobuf messages are provided dynamically (and thus e
 For M3DB, a solution like this is prohibitively inefficient: unmarshaling into a `*dynamic.Message` is expensive, as it involves `interface{}` magic and allocates a large number of short-lived objects that are difficult to reuse.
 It's especially inefficient for Protobuf schemas that are optimized for this package (specifically those that make heavy use of top-level scalar fields where allocating objects on the heap just to wrap primitive types is particularly wasteful).
 
-As a result, this package implements `customFieldUnmarshaler`, which accepts a marshaled Protobuf message (`[]byte`) and exposes methods for unmarshaling the top-level scalar fields (i.e the fields that the encoder can perform custom compression on) in an efficient and reusable manner such that in the general case there are no allocations.
+As a result, this package implements `customFieldUnmarshaler`, which accepts a marshalled Protobuf message (`[]byte`) and exposes methods for unmarshaling the top-level scalar fields (i.e the fields that the encoder can perform custom compression on) in an efficient and reusable manner such that in the general case there are no allocations.
 In addition, it uses the `jhump/protoreflect` library to unmarshal any other fields that it can't unmarshal efficiently (this has zero overhead if those fields are not present).
 
 
@@ -23,7 +23,7 @@ In addition, it uses the `jhump/protoreflect` library to unmarshal any other fie
 
 The implementation is broken into two parts:
 
-1. The `buffer`, which is similar to [protoreflect's dynamic codex](https://github.com/jhump/protoreflect/blob/master/dynamic/codec.go) and provides an interface for iterating over a marshaled Protobuf message, one `<fieldNumber, wiretype, value>` tuple at a time.
+1. The `buffer`, which is similar to [protoreflect's dynamic codex](https://github.com/jhump/protoreflect/blob/master/dynamic/codec.go) and provides an interface for iterating over a marshalled Protobuf message, one `<fieldNumber, wiretype, value>` tuple at a time.
 
 2. The `customFieldUnmarshaler`, which wraps the `buffer` and exposes an interface for efficiently unmarshaling top-level scalar fields with no allocations, as well as a fallback mechanism that relies on the `jhump/protoreflect` library for any fields that don't have an efficient unmarshaling codepath (`maps`, `repeated` fields, and nested messages, etc).
 
@@ -35,16 +35,16 @@ The code in the `buffer` is mostly self explanatory for anyone familiar with the
 
 The `customFieldUnmarshaler` has three primary responsibilities:
 
-1. Provide an interface for efficiently unmarshaling top-level scalar fields in a marshaled Protobuf message without allocating.
-2. Ensure that the values unmarshaled in #1 are sorted by field number.
-3. Provide a `*dynamic.Message` that contains *only* the fields that could not be unmarshaled efficiently in #1. This does not allocate / expend any resources at all in the case of optimized schemas that only contain fields that can be handled by #1.
+1. Provide an interface for efficiently unmarshaling top-level scalar fields in a marshalled Protobuf message without allocating.
+2. Ensure that the values unmarshalled in #1 are sorted by field number.
+3. Provide a `*dynamic.Message` that contains *only* the fields that could not be unmarshalled efficiently in #1. This does not allocate / expend any resources at all in the case of optimized schemas that only contain fields that can be handled by #1.
 
-The `customFieldUnmarshaler` works by iterating through all the `<fieldNumber, wireType, value>` tuples in the marshaled Protobuf and checking if they are supported by the efficient code path.
+The `customFieldUnmarshaler` works by iterating through all the `<fieldNumber, wireType, value>` tuples in the marshalled Protobuf and checking if they are supported by the efficient code path.
 If they are, it unmarshals the value into an `unmarshalValue` which is a space-optimized type that can be reused without any allocations.
-If the tuple cannot be unmarshaled efficiently, the unmarshaler falls back to the `jhump/protoreflect` library and uses `UnmarshalMerge` to iteratively unmarshal each field sequentially to avoid rewriting the message. This approach supports both any combination of custom and non-custom fields, and in any order.
+If the tuple cannot be unmarshalled efficiently, the unmarshaler falls back to the `jhump/protoreflect` library and uses `UnmarshalMerge` to iteratively unmarshal each field sequentially to avoid rewriting the message. This approach supports both any combination of custom and non-custom fields, and in any order.
 
-The output of unmarshaling is a slice of `unmarshalValue`s (sorted by field number) containing all custom-encoded values and a `*dynamic.Message` containing any complex fields that cannot be unmarshaled or compressed efficiently. This value slice is reused to mitigate allocation costs for subsequent unmarshaling.
+The output of unmarshaling is a slice of `unmarshalValue`s (sorted by field number) containing all custom-encoded values and a `*dynamic.Message` containing any complex fields that cannot be unmarshalled or compressed efficiently. This value slice is reused to mitigate allocation costs for subsequent unmarshaling.
 
-Note that the `customFieldUnmarshaler` only returns an `unmarshalValue` for fields that were actually encoded into the stream. According to the [Proto3 encoding format](https://developers.google.com/protocol-buffers/docs/encoding), fields set to their default values are omitted from the marshaled stream.
+Note that the `customFieldUnmarshaler` only returns an `unmarshalValue` for fields that were actually encoded into the stream. According to the [Proto3 encoding format](https://developers.google.com/protocol-buffers/docs/encoding), fields set to their default values are omitted from the marshalled stream.
 Thus, if an `unmarshalValue` is not present for a field (and the given field would nominally unmarshal to an `unmarshalValue`), then that value is the type's default value.
 

--- a/src/dbnode/encoding/proto/docs/unmarshal.md
+++ b/src/dbnode/encoding/proto/docs/unmarshal.md
@@ -1,4 +1,4 @@
-# Top Level Scalar Unmarshaler
+# Top Level Scalar Unmarshaller
 
 ## Overview
 
@@ -13,7 +13,7 @@ Since the schemas for the Protobuf messages are provided dynamically (and thus e
 For M3DB, a solution like this is prohibitively inefficient: unmarshaling into a `*dynamic.Message` is expensive, as it involves `interface{}` magic and allocates a large number of short-lived objects that are difficult to reuse.
 It's especially inefficient for Protobuf schemas that are optimized for this package (specifically those that make heavy use of top-level scalar fields where allocating objects on the heap just to wrap primitive types is particularly wasteful).
 
-As a result, this package implements `customFieldUnmarshaler`, which accepts a marshalled Protobuf message (`[]byte`) and exposes methods for unmarshaling the top-level scalar fields (i.e the fields that the encoder can perform custom compression on) in an efficient and reusable manner such that in the general case there are no allocations.
+As a result, this package implements `customFieldUnmarshaller`, which accepts a marshalled Protobuf message (`[]byte`) and exposes methods for unmarshaling the top-level scalar fields (i.e the fields that the encoder can perform custom compression on) in an efficient and reusable manner such that in the general case there are no allocations.
 In addition, it uses the `jhump/protoreflect` library to unmarshal any other fields that it can't unmarshal efficiently (this has zero overhead if those fields are not present).
 
 
@@ -25,26 +25,26 @@ The implementation is broken into two parts:
 
 1. The `buffer`, which is similar to [protoreflect's dynamic codex](https://github.com/jhump/protoreflect/blob/master/dynamic/codec.go) and provides an interface for iterating over a marshalled Protobuf message, one `<fieldNumber, wiretype, value>` tuple at a time.
 
-2. The `customFieldUnmarshaler`, which wraps the `buffer` and exposes an interface for efficiently unmarshaling top-level scalar fields with no allocations, as well as a fallback mechanism that relies on the `jhump/protoreflect` library for any fields that don't have an efficient unmarshaling codepath (`maps`, `repeated` fields, and nested messages, etc).
+2. The `customFieldUnmarshaller`, which wraps the `buffer` and exposes an interface for efficiently unmarshaling top-level scalar fields with no allocations, as well as a fallback mechanism that relies on the `jhump/protoreflect` library for any fields that don't have an efficient unmarshaling codepath (`maps`, `repeated` fields, and nested messages, etc).
 
 ### Buffer
 
 The code in the `buffer` is mostly self explanatory for anyone familiar with the [proto3 encoding format](https://developers.google.com/protocol-buffers/docs/encoding).
 
-### CustomFieldUnmarshaler
+### CustomFieldUnmarshaller
 
-The `customFieldUnmarshaler` has three primary responsibilities:
+The `customFieldUnmarshaller` has three primary responsibilities:
 
 1. Provide an interface for efficiently unmarshaling top-level scalar fields in a marshalled Protobuf message without allocating.
 2. Ensure that the values unmarshalled in #1 are sorted by field number.
 3. Provide a `*dynamic.Message` that contains *only* the fields that could not be unmarshalled efficiently in #1. This does not allocate / expend any resources at all in the case of optimized schemas that only contain fields that can be handled by #1.
 
-The `customFieldUnmarshaler` works by iterating through all the `<fieldNumber, wireType, value>` tuples in the marshalled Protobuf and checking if they are supported by the efficient code path.
+The `customFieldUnmarshaller` works by iterating through all the `<fieldNumber, wireType, value>` tuples in the marshalled Protobuf and checking if they are supported by the efficient code path.
 If they are, it unmarshals the value into an `unmarshalValue` which is a space-optimized type that can be reused without any allocations.
-If the tuple cannot be unmarshalled efficiently, the unmarshaler falls back to the `jhump/protoreflect` library and uses `UnmarshalMerge` to iteratively unmarshal each field sequentially to avoid rewriting the message. This approach supports both any combination of custom and non-custom fields, and in any order.
+If the tuple cannot be unmarshalled efficiently, the unmarshaller falls back to the `jhump/protoreflect` library and uses `UnmarshalMerge` to iteratively unmarshal each field sequentially to avoid rewriting the message. This approach supports both any combination of custom and non-custom fields, and in any order.
 
 The output of unmarshaling is a slice of `unmarshalValue`s (sorted by field number) containing all custom-encoded values and a `*dynamic.Message` containing any complex fields that cannot be unmarshalled or compressed efficiently. This value slice is reused to mitigate allocation costs for subsequent unmarshaling.
 
-Note that the `customFieldUnmarshaler` only returns an `unmarshalValue` for fields that were actually encoded into the stream. According to the [Proto3 encoding format](https://developers.google.com/protocol-buffers/docs/encoding), fields set to their default values are omitted from the marshalled stream.
+Note that the `customFieldUnmarshaller` only returns an `unmarshalValue` for fields that were actually encoded into the stream. According to the [Proto3 encoding format](https://developers.google.com/protocol-buffers/docs/encoding), fields set to their default values are omitted from the marshalled stream.
 Thus, if an `unmarshalValue` is not present for a field (and the given field would nominally unmarshal to an `unmarshalValue`), then that value is the type's default value.
 

--- a/src/dbnode/encoding/proto/docs/unmarshal.md
+++ b/src/dbnode/encoding/proto/docs/unmarshal.md
@@ -8,14 +8,13 @@ The Encoder in this package is responsible for encoding an unbuffered stream of 
 
 In order to accomplish this, it needs to unmarshal the Protobuf messages so that it can re-encode their values.
 
-Since the schemas for the Protobuf messages are provided dynamically (and thus efficient unmarshaling code can not be generated ahead of time) the easiest way to accomplish the unmarshaling is to rely on a dynamic Protobuf package like `jhump/protoreflect` to perform the heavy lfting.
+Since the schemas for the Protobuf messages are provided dynamically (and thus efficient unmarshalling code can not be generated ahead of time) the easiest way to accomplish the unmarshalling is to rely on a dynamic Protobuf package like `jhump/protoreflect` to perform the heavy lfting.
 
-For M3DB, a solution like this is prohibitively inefficient: unmarshaling into a `*dynamic.Message` is expensive, as it involves `interface{}` magic and allocates a large number of short-lived objects that are difficult to reuse.
+For M3DB, a solution like this is prohibitively inefficient: unmarshalling into a `*dynamic.Message` is expensive, as it involves `interface{}` magic and allocates a large number of short-lived objects that are difficult to reuse.
 It's especially inefficient for Protobuf schemas that are optimized for this package (specifically those that make heavy use of top-level scalar fields where allocating objects on the heap just to wrap primitive types is particularly wasteful).
 
-As a result, this package implements `customFieldUnmarshaller`, which accepts a marshalled Protobuf message (`[]byte`) and exposes methods for unmarshaling the top-level scalar fields (i.e the fields that the encoder can perform custom compression on) in an efficient and reusable manner such that in the general case there are no allocations.
-In addition, it uses the `jhump/protoreflect` library to unmarshal any other fields that it can't unmarshal efficiently (this has zero overhead if those fields are not present).
-
+As a result, this package implements `customFieldUnmarshaller`, which accepts a marshalled Protobuf message (`[]byte`) and exposes methods for unmarshalling the top-level scalar fields (i.e the fields that the encoder can perform custom compression on) in an efficient and reusable manner such that in the general case there are no allocations.
+In addition, it also exposes a `nonCustomFieldValues` method which returns **the marshaled** bytes for every field non top-level scalar field that the unmarshaler couldn't unmarshal.
 
 ## Implementation
 
@@ -25,7 +24,7 @@ The implementation is broken into two parts:
 
 1. The `buffer`, which is similar to [protoreflect's dynamic codex](https://github.com/jhump/protoreflect/blob/master/dynamic/codec.go) and provides an interface for iterating over a marshalled Protobuf message, one `<fieldNumber, wiretype, value>` tuple at a time.
 
-2. The `customFieldUnmarshaller`, which wraps the `buffer` and exposes an interface for efficiently unmarshaling top-level scalar fields with no allocations, as well as a fallback mechanism that relies on the `jhump/protoreflect` library for any fields that don't have an efficient unmarshaling codepath (`maps`, `repeated` fields, and nested messages, etc).
+2. The `customFieldUnmarshaller`, which wraps the `buffer` and exposes an interface for efficiently unmarshalling top-level scalar fields with no allocations, as well as returning the marshaled bytes for any fields that the unmarshaller doesn't have an efficient unmarshalling codepath for (`maps`, `repeated` fields, and nested messages, etc).
 
 ### Buffer
 
@@ -35,15 +34,15 @@ The code in the `buffer` is mostly self explanatory for anyone familiar with the
 
 The `customFieldUnmarshaller` has three primary responsibilities:
 
-1. Provide an interface for efficiently unmarshaling top-level scalar fields in a marshalled Protobuf message without allocating.
+1. Provide an interface for efficiently unmarshalling top-level scalar fields in a marshalled Protobuf message without allocating.
 2. Ensure that the values unmarshalled in #1 are sorted by field number.
-3. Provide a `*dynamic.Message` that contains *only* the fields that could not be unmarshalled efficiently in #1. This does not allocate / expend any resources at all in the case of optimized schemas that only contain fields that can be handled by #1.
+3. Return a slice of `marshalledField` that contains *only* the fields that could not be unmarshalled efficiently in #1. This does not allocate / expend any resources at all in the case of optimized schemas that only contain fields that can be handled by #1.
 
 The `customFieldUnmarshaller` works by iterating through all the `<fieldNumber, wireType, value>` tuples in the marshalled Protobuf and checking if they are supported by the efficient code path.
 If they are, it unmarshals the value into an `unmarshalValue` which is a space-optimized type that can be reused without any allocations.
-If the tuple cannot be unmarshalled efficiently, the unmarshaller falls back to the `jhump/protoreflect` library and uses `UnmarshalMerge` to iteratively unmarshal each field sequentially to avoid rewriting the message. This approach supports both any combination of custom and non-custom fields, and in any order.
+If the tuple cannot be unmarshalled efficiently, the unmarshaller keeps track of the bytes that represent that tuple and will return them as part of the (sorted) `[]marshalledField` when unmarshalling is complete. This approach supports both any combination of custom and non-custom fields, and in any order.
 
-The output of unmarshaling is a slice of `unmarshalValue`s (sorted by field number) containing all custom-encoded values and a `*dynamic.Message` containing any complex fields that cannot be unmarshalled or compressed efficiently. This value slice is reused to mitigate allocation costs for subsequent unmarshaling.
+The output of unmarshalling is a slice of `unmarshalValue`s (sorted by field number) containing all custom-encoded values and a `[]marshalledField` containing any complex fields that cannot be unmarshalled or compressed efficiently. This value slice is reused to mitigate allocation costs for subsequent unmarshalling.
 
 Note that the `customFieldUnmarshaller` only returns an `unmarshalValue` for fields that were actually encoded into the stream. According to the [Proto3 encoding format](https://developers.google.com/protocol-buffers/docs/encoding), fields set to their default values are omitted from the marshalled stream.
 Thus, if an `unmarshalValue` is not present for a field (and the given field would nominally unmarshal to an `unmarshalValue`), then that value is the type's default value.

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -67,7 +67,7 @@ type Encoder struct {
 	lastEncodedDP ts.Datapoint
 	lastEncoded   *dynamic.Message
 	customFields  []customFieldState
-	protoFields   []int32
+	protoFields   []marshaledField
 
 	// Fields that are reused between function calls to
 	// avoid allocations.
@@ -683,8 +683,26 @@ func (enc *Encoder) encodeProtoValues(m *dynamic.Message) error {
 		enc.lastEncoded = dynamic.NewMessage(enc.schema)
 	}
 
-	for _, fieldNum := range enc.protoFields {
+	// currProtoFields := enc.unmarshaler.nonCustomFieldValues2()
+	// for _, fieldNum := range enc.protoFields {
+	// 	var curVal []byte
+	// 	for _, val := range currProtoFields {
+	// 		if fielNum == val.fieldNum {
+	// 			curVal = val.marshaled
+	// 		}
+	// 	}
+
+	// 	prevVal :=
+
+	// 	if curVal == nil {
+	// 		// Interpret as default value.
+	// 		fieldsChangedToDefault = append(fieldsChangedToDefault, fieldNum)
+	// 	}
+
+	// }
+	for _, marshaledField := range enc.protoFields {
 		var (
+			fieldNum    = marshaledField.fieldNum
 			field       = enc.schema.FindFieldByNumber(fieldNum)
 			fieldNumInt = int(fieldNum)
 			prevVal     = enc.lastEncoded.GetFieldByNumber(fieldNumInt)

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -692,21 +692,21 @@ func (enc *Encoder) encodeProtoValues(m *dynamic.Message) error {
 			}
 		}
 
-		fmt.Println("curVal", curVal)
+		// fmt.Println("curVal", curVal)
 		prevVal := protoField.marshaled
 		if bytes.Equal(prevVal, curVal) {
-			fmt.Println(protoField.fieldNum, "same as previous, skipping")
+			// fmt.Println(protoField.fieldNum, "same as previous, skipping")
 			// No change, nothing to encode.
 			continue
 		}
 
 		if curVal == nil {
-			fmt.Println(protoField.fieldNum, "changed to default")
+			// fmt.Println(protoField.fieldNum, "changed to default")
 			// Interpret as default value.
 			fieldsChangedToDefault = append(fieldsChangedToDefault, protoField.fieldNum)
 		}
 
-		fmt.Println(protoField.fieldNum, "changed")
+		// fmt.Println(protoField.fieldNum, "changed")
 		changedFields = append(changedFields, protoField.fieldNum)
 		// Need to copy since the encoder no longer owns the original source of the bytes once
 		// this function returns.

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -131,7 +131,7 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 
 	if enc.unmarshaler == nil {
 		// Lazy init.
-		enc.unmarshaler = newCustomFieldUnmarshaler()
+		enc.unmarshaler = newCustomFieldUnmarshaler(customUnmarshalerOptions{})
 	}
 	// resetAndUnmarshal before any data is written so that the marshaled message can be validated
 	// upfront, otherwise errors could be encountered mid-write leaving the stream in a corrupted state.

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -469,7 +469,7 @@ func (enc *Encoder) reset(start time.Time, capacity int) {
 	enc.marshalBuf = nil
 
 	if enc.schema != nil {
-		enc.customFields, enc.nonCustomFields = customAndProtoFields(enc.customFields, enc.nonCustomFields, enc.schema)
+		enc.customFields, enc.nonCustomFields = customAndNonCustomFields(enc.customFields, enc.nonCustomFields, enc.schema)
 	}
 
 	enc.closed = false
@@ -482,7 +482,7 @@ func (enc *Encoder) resetSchema(schema *desc.MessageDescriptor) {
 		enc.nonCustomFields = nil
 		enc.customFields = nil
 	} else {
-		enc.customFields, enc.nonCustomFields = customAndProtoFields(enc.customFields, enc.nonCustomFields, enc.schema)
+		enc.customFields, enc.nonCustomFields = customAndNonCustomFields(enc.customFields, enc.nonCustomFields, enc.schema)
 		enc.hasEncodedSchema = false
 	}
 }

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -671,7 +671,7 @@ func (enc *Encoder) encodeNonCustomValues() error {
 		// track of the last index at which a match was found so that subsequent inner loops can start
 		// at the next index.
 		lastMatchIdx     = -1
-		numChangedFields = 0
+		numChangedValues = 0
 	)
 	enc.marshalBuf = enc.marshalBuf[:0] // Reset buf for reuse.
 
@@ -692,7 +692,7 @@ func (enc *Encoder) encodeNonCustomValues() error {
 			continue
 		}
 
-		numChangedFields++
+		numChangedValues++
 		if curVal == nil {
 			// Interpret as default value.
 			enc.fieldsChangedToDefault = append(enc.fieldsChangedToDefault, existingField.fieldNum)
@@ -704,7 +704,7 @@ func (enc *Encoder) encodeNonCustomValues() error {
 		enc.nonCustomFields[i].marshalled = append(enc.nonCustomFields[i].marshalled[:0], curVal...)
 	}
 
-	if numChangedFields > 0 {
+	if numChangedValues <= 0 {
 		// Only want to skip encoding if nothing has changed AND we've already
 		// encoded the first message.
 		enc.stream.WriteBit(opCodeNoChange)

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -141,16 +141,6 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 		return fmt.Errorf(
 			"%s error unmarshaling message: %v", encErrPrefix, err)
 	}
-	// resetAndUnmarshal before any data is written so that the marshaled message can be validated
-	// upfront, otherwise errors could be encountered mid-write leaving the stream in a corrupted state.
-	if err := enc.unmarshaler.resetAndUnmarshal(enc.schema, protoBytes); err != nil {
-		return fmt.Errorf(
-			"%s error unmarshaling message: %v", encErrPrefix, err)
-	}
-
-	if enc.numEncoded == 0 {
-		enc.encodeStreamHeader()
-	}
 
 	if enc.numEncoded == 0 {
 		enc.encodeStreamHeader()

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -647,8 +647,8 @@ func (enc *Encoder) encodeBytesValue(i int, val []byte) error {
 
 	enc.addToBytesDict(i, encoderBytesFieldDictState{
 		hash:     hash,
-		startPos: bytePos,
-		length:   length,
+		startPos: uint32(bytePos),
+		length:   uint32(length),
 	})
 	return nil
 }
@@ -767,7 +767,7 @@ func (enc *Encoder) bytesMatchEncodedDictionaryValue(
 		prevEncodedBytesEnd   = prevEncodedBytesStart + dictState.length
 	)
 
-	if prevEncodedBytesEnd > len(streamBytes) {
+	if prevEncodedBytesEnd > uint32(len(streamBytes)) {
 		// Should never happen.
 		return false, fmt.Errorf(
 			"bytes position in LRU is outside of stream bounds, streamSize: %d, startPos: %d, length: %d",

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -632,6 +632,10 @@ func (enc *Encoder) encodeBytesValue(i int, val []byte) error {
 	// which is acceptable for now, but in the future we may want to make the code able
 	// to do the comparison even if the bytes aren't aligned on a byte boundary in order
 	// to improve the compression.
+	//
+	// Also this implementation had the side-effect of making decoding much faster because
+	// for long []byte the iterator can avoid bit manipulation and calling ReadByte() in a
+	// loop and can instead read the entire []byte in one go.
 	enc.padToNextByte()
 
 	// Track the byte position we're going to start at so we can store it in the LRU after.

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -669,6 +669,7 @@ func (enc *Encoder) encodeNonCustomValues() error {
 
 	currProtoFields := enc.unmarshaller.sortedNonCustomFieldValues()
 	for i, protoField := range enc.nonCustomFields {
+		// TODO: Fix this loop.
 		var curVal []byte
 		for _, val := range currProtoFields {
 			if protoField.fieldNum == val.fieldNum {
@@ -702,6 +703,7 @@ func (enc *Encoder) encodeNonCustomValues() error {
 
 	enc.marshalBuf = enc.marshalBuf[:0]
 	for _, fieldNum := range enc.changedValues {
+		// TODO: Fix this loop.
 		for _, field := range currProtoFields {
 			if field.fieldNum == fieldNum {
 				enc.marshalBuf = append(enc.marshalBuf, field.marshalled...)

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -137,7 +137,7 @@ func (enc *Encoder) Encode(dp ts.Datapoint, timeUnit xtime.Unit, protoBytes ts.A
 	// upfront, otherwise errors could be encountered mid-write leaving the stream in a corrupted state.
 	if err := enc.unmarshaller.resetAndUnmarshal(enc.schema, protoBytes); err != nil {
 		return fmt.Errorf(
-			"%s error unmarshaling message: %v", encErrPrefix, err)
+			"%s error unmarshalling message: %v", encErrPrefix, err)
 	}
 
 	if enc.numEncoded == 0 {

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -667,7 +667,7 @@ func (enc *Encoder) encodeNonCustomValues() error {
 	enc.changedValues = enc.changedValues[:0]
 	enc.fieldsChangedToDefault = enc.fieldsChangedToDefault[:0]
 
-	currProtoFields := enc.unmarshaller.nonCustomFieldValues()
+	currProtoFields := enc.unmarshaller.sortedNonCustomFieldValues()
 	for i, protoField := range enc.nonCustomFields {
 		var curVal []byte
 		for _, val := range currProtoFields {

--- a/src/dbnode/encoding/proto/encoder.go
+++ b/src/dbnode/encoding/proto/encoder.go
@@ -438,7 +438,7 @@ func (enc *Encoder) Reset(
 	capacity int,
 	descr namespace.SchemaDescr,
 ) {
-	enc.resetSchema(descr)
+	enc.SetSchema(descr)
 	enc.reset(start, capacity)
 }
 
@@ -454,42 +454,8 @@ func (enc *Encoder) SetSchema(descr namespace.SchemaDescr) {
 		return
 	}
 
-	enc.schema = descr.Get().MessageDescriptor
 	enc.schemaDesc = descr
-
-	// If the schema is being changed by a call to SetSchema() (I.E the encoder itself isn't being reset) then
-	// the existing state in the customFields and nonCustomFields needs to be maintained otherwise an incorrect
-	// stream will be generated since much of the compression relies upon deltas between individual messages.
-	oldCustomFields, oldNonCustomFields := enc.customFields, enc.nonCustomFields
-	enc.customFields, enc.nonCustomFields = customAndNonCustomFields(nil, nil, enc.schema)
-
-	// Matching values in two sorted lists where each list only contains unique values so use lastMatchIdx to
-	// start the inner loop at the next index after finding a previous match to prevent iterating over the same
-	// values over and over again.
-	lastMatchIdx := -1
-	for i, customField := range enc.customFields {
-		for j := lastMatchIdx + 1; j < len(oldCustomFields); j++ {
-			oldCustomField := oldCustomFields[j]
-			if oldCustomField.fieldNum == customField.fieldNum {
-				enc.customFields[i] = oldCustomField
-				lastMatchIdx = j
-				break
-			}
-		}
-	}
-
-	// Same comment as above.
-	lastMatchIdx = -1
-	for i, nonCustomField := range enc.nonCustomFields {
-		for j := lastMatchIdx + 1; j < len(oldNonCustomFields); j++ {
-			oldNonCustomField := oldNonCustomFields[j]
-			if nonCustomField.fieldNum == oldNonCustomField.fieldNum {
-				enc.nonCustomFields[i] = oldNonCustomField
-				lastMatchIdx = j
-				break
-			}
-		}
-	}
+	enc.resetSchema(descr.Get().MessageDescriptor)
 }
 
 func (enc *Encoder) reset(start time.Time, capacity int) {
@@ -501,18 +467,16 @@ func (enc *Encoder) reset(start time.Time, capacity int) {
 	// Prevent this from growing too large and remaining in the pools.
 	enc.marshalBuf = nil
 
+	if enc.schema != nil {
+		enc.customFields, enc.nonCustomFields = customAndNonCustomFields(enc.customFields, enc.nonCustomFields, enc.schema)
+	}
+
 	enc.closed = false
 	enc.numEncoded = 0
 }
 
-func (enc *Encoder) resetSchema(descr namespace.SchemaDescr) {
-	enc.schemaDesc = descr
-	if descr != nil {
-		enc.schema = descr.Get().MessageDescriptor
-	} else {
-		enc.schema = nil
-	}
-
+func (enc *Encoder) resetSchema(schema *desc.MessageDescriptor) {
+	enc.schema = schema
 	if enc.schema == nil {
 		enc.nonCustomFields = nil
 		enc.customFields = nil

--- a/src/dbnode/encoding/proto/encoder_test.go
+++ b/src/dbnode/encoding/proto/encoder_test.go
@@ -38,7 +38,7 @@ func TestCustomAndProtoFields(t *testing.T) {
 	testCases := []struct {
 		schema                  *desc.MessageDescriptor
 		expectedCustomFields    []customFieldState
-		expectedNonCustomFields []marshaledField
+		expectedNonCustomFields []marshalledField
 	}{
 		{
 			schema: newVLMessageDescriptor(),
@@ -68,7 +68,7 @@ func TestCustomAndProtoFields(t *testing.T) {
 					protoFieldType: dpb.FieldDescriptorProto_TYPE_BYTES,
 				},
 			},
-			expectedNonCustomFields: []marshaledField{{fieldNum: 5}},
+			expectedNonCustomFields: []marshalledField{{fieldNum: 5}},
 		},
 	}
 

--- a/src/dbnode/encoding/proto/encoder_test.go
+++ b/src/dbnode/encoding/proto/encoder_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/ts"
@@ -42,10 +43,30 @@ func TestCustomAndProtoFields(t *testing.T) {
 		{
 			schema: newVLMessageDescriptor(),
 			expectedCustomFields: []customFieldState{
-				{fieldNum: 1, fieldType: float64Field},     // latitude
-				{fieldNum: 2, fieldType: float64Field},     // longitude
-				{fieldNum: 3, fieldType: signedInt64Field}, // numTrips
-				{fieldNum: 4, fieldType: bytesField},       // deliveryID
+				// latitude
+				{
+					fieldNum:       1,
+					fieldType:      float64Field,
+					protoFieldType: dpb.FieldDescriptorProto_TYPE_DOUBLE,
+				},
+				// longitude
+				{
+					fieldNum:       2,
+					fieldType:      float64Field,
+					protoFieldType: dpb.FieldDescriptorProto_TYPE_DOUBLE,
+				},
+				// numTrips
+				{
+					fieldNum:       3,
+					fieldType:      signedInt64Field,
+					protoFieldType: dpb.FieldDescriptorProto_TYPE_INT64,
+				},
+				// deliveryID
+				{
+					fieldNum:       4,
+					fieldType:      bytesField,
+					protoFieldType: dpb.FieldDescriptorProto_TYPE_BYTES,
+				},
 			},
 			expectedProtoFields: []int32{5},
 		},

--- a/src/dbnode/encoding/proto/encoder_test.go
+++ b/src/dbnode/encoding/proto/encoder_test.go
@@ -100,6 +100,7 @@ func getCurrEncoderBytes(t *testing.T, enc *Encoder) []byte {
 
 	currSeg, err := stream.Segment()
 	require.NoError(t, err)
+
 	if currSeg.Tail != nil {
 		require.Equal(t, 0, currSeg.Tail.Len())
 	}

--- a/src/dbnode/encoding/proto/encoder_test.go
+++ b/src/dbnode/encoding/proto/encoder_test.go
@@ -36,9 +36,9 @@ import (
 
 func TestCustomAndProtoFields(t *testing.T) {
 	testCases := []struct {
-		schema               *desc.MessageDescriptor
-		expectedCustomFields []customFieldState
-		expectedProtoFields  []int32
+		schema                  *desc.MessageDescriptor
+		expectedCustomFields    []customFieldState
+		expectedNonCustomFields []marshaledField
 	}{
 		{
 			schema: newVLMessageDescriptor(),
@@ -68,14 +68,14 @@ func TestCustomAndProtoFields(t *testing.T) {
 					protoFieldType: dpb.FieldDescriptorProto_TYPE_BYTES,
 				},
 			},
-			expectedProtoFields: []int32{5},
+			expectedNonCustomFields: []marshaledField{{fieldNum: 5}},
 		},
 	}
 
 	for _, tc := range testCases {
-		tszFields, protoFields := customAndProtoFields(nil, nil, tc.schema)
+		tszFields, nonCustomFields := customAndNonCustomFields(nil, nil, tc.schema)
 		require.Equal(t, tc.expectedCustomFields, tszFields)
-		require.Equal(t, tc.expectedProtoFields, protoFields)
+		require.Equal(t, tc.expectedNonCustomFields, nonCustomFields)
 	}
 }
 

--- a/src/dbnode/encoding/proto/encoder_test.go
+++ b/src/dbnode/encoding/proto/encoder_test.go
@@ -24,12 +24,12 @@ import (
 	"testing"
 	"time"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/ts"
 	xtime "github.com/m3db/m3/src/x/time"
 
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/stretchr/testify/require"
 )

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -544,15 +544,16 @@ func (it *iterator) readBytesValue(i int, customField customFieldState) error {
 			itErrPrefix, err)
 	}
 
-	buf := make([]byte, 0, bytesLen)
-	for j := 0; j < int(bytesLen); j++ {
-		b, err := it.stream.ReadByte()
-		if err != nil {
-			return fmt.Errorf(
-				"%s error trying to read byte in readBytes: %v",
-				itErrPrefix, err)
-		}
-		buf = append(buf, b)
+	buf := make([]byte, bytesLen)
+	n, err := it.stream.Read(buf)
+	if err != nil {
+		return fmt.Errorf(
+			"%s error trying to read byte in readBytes: %v",
+			itErrPrefix, err)
+	}
+	if bytesLen != uint64(n) {
+		return fmt.Errorf(
+			"%s tried to read %d bytes but only read: %d", itErrPrefix, bytesLen, n)
 	}
 
 	it.addToBytesDict(i, buf)

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -628,8 +628,6 @@ func (it *iterator) updateLastIteratedWithCustomValues(arg updateLastIterArg) er
 	case isCustomIntEncodedField(fieldType):
 		switch fieldType {
 		case signedInt64Field:
-			// val := int64(it.customFields[arg.i].intEncAndIter.prevIntBits)
-			// return it.lastIterated.TrySetFieldByNumber(int(fieldNum), val)
 			var (
 				val   = int64(it.customFields[arg.i].intEncAndIter.prevIntBits)
 				field = it.schema.FindFieldByNumber(fieldNum)
@@ -656,7 +654,6 @@ func (it *iterator) updateLastIteratedWithCustomValues(arg updateLastIterArg) er
 			val := it.customFields[arg.i].intEncAndIter.prevIntBits
 			it.marshaler.encUInt64(fieldNum, val)
 			return nil
-			// return it.lastIterated.TrySetFieldByNumber(int(fieldNum), val)
 
 		case signedInt32Field:
 			var (
@@ -680,11 +677,9 @@ func (it *iterator) updateLastIteratedWithCustomValues(arg updateLastIterArg) er
 				it.marshaler.encInt32(fieldNum, val)
 			}
 			return nil
-			// return it.lastIterated.TrySetFieldByNumber(int(fieldNum), val)
 
 		case unsignedInt32Field:
 			val := uint32(it.customFields[arg.i].intEncAndIter.prevIntBits)
-			// return it.lastIterated.TrySetFieldByNumber(int(fieldNum), val)
 			it.marshaler.encUInt32(fieldNum, val)
 			return nil
 
@@ -695,19 +690,12 @@ func (it *iterator) updateLastIteratedWithCustomValues(arg updateLastIterArg) er
 		}
 
 	case fieldType == bytesField:
-		// schemaField := it.schema.FindFieldByNumber(int32(fieldNum))
-		// schemaFieldType := schemaField.GetType()
-		// if schemaFieldType == dpb.FieldDescriptorProto_TYPE_STRING {
-		// 	return it.lastIterated.TrySetFieldByNumber(int(fieldNum), string(arg.bytesFieldBuf))
-		// }
-		// return it.lastIterated.TrySetFieldByNumber(int(fieldNum), arg.bytesFieldBuf)
 		it.marshaler.encBytes(fieldNum, arg.bytesFieldBuf)
 		return nil
 
 	case fieldType == boolField:
 		it.marshaler.encBool(fieldNum, arg.boolVal)
 		return nil
-		// return it.lastIterated.TrySetFieldByNumber(int(fieldNum), arg.boolVal)
 
 	default:
 		return fmt.Errorf(

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -427,8 +427,13 @@ func (it *iterator) readProtoValues() error {
 
 	if it.unmarshaler == nil {
 		// Lazy init.
-		it.unmarshaler = newCustomFieldUnmarshaler()
+		it.unmarshaler = newCustomFieldUnmarshaler(customUnmarshalerOptions{
+			// Skip over unknown fields when unmarshaling because its possible that the stream was
+			// encoded with a newer schema.
+			skipUnknownFields: true,
+		})
 	}
+
 	if err := it.unmarshaler.resetAndUnmarshal(it.schema, unmarshalBytes); err != nil {
 		return fmt.Errorf(
 			"%s error unmarshaling message: %v", itErrPrefix, err)

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -451,7 +451,7 @@ func (it *iterator) readProtoValues() error {
 		}
 	}
 
-	if fieldsSetToDefaultControlBit == 1 {
+	if fieldsSetToDefaultControlBit == opCodeFieldsSetToDefaultProtoMarshal {
 		for _, fieldNum := range it.bitsetValues {
 			for i, protoField := range it.protoFields {
 				if fieldNum == int(protoField.fieldNum) {

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -463,6 +463,7 @@ func (it *iterator) readNonCustomValues() error {
 				nonCustomField.marshalled...)
 
 			lastMatchIdx = i
+			break
 		}
 	}
 
@@ -481,6 +482,7 @@ func (it *iterator) readNonCustomValues() error {
 				// Resize slice to zero so that the existing capacity can be reused later if required.
 				it.nonCustomFields[i].marshalled = it.nonCustomFields[i].marshalled[:0]
 				lastMatchIdx = i
+				break
 			}
 		}
 	}

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -475,7 +475,7 @@ func (it *iterator) readFloatValue(i int) error {
 	}
 
 	updateArg := updateLastIterArg{i: i}
-	return it.updateLastIteratedWithCustomValues(updateArg)
+	return it.updateMarshalerWithCustomValues(updateArg)
 }
 
 func (it *iterator) readBytesValue(i int, customField customFieldState) error {
@@ -489,7 +489,7 @@ func (it *iterator) readBytesValue(i int, customField customFieldState) error {
 	if bytesChangedControlBit == opCodeNoChange {
 		// No changes to the bytes value.
 		updateArg := updateLastIterArg{i: i, bytesFieldBuf: it.lastValueBytesDict(i)}
-		return it.updateLastIteratedWithCustomValues(updateArg)
+		return it.updateMarshalerWithCustomValues(updateArg)
 	}
 
 	// Bytes have changed since the previous value.
@@ -520,7 +520,7 @@ func (it *iterator) readBytesValue(i int, customField customFieldState) error {
 		it.moveToEndOfBytesDict(i, dictIdx)
 
 		updateArg := updateLastIterArg{i: i, bytesFieldBuf: bytesVal}
-		return it.updateLastIteratedWithCustomValues(updateArg)
+		return it.updateMarshalerWithCustomValues(updateArg)
 	}
 
 	// New value that was not in the dict already.
@@ -558,7 +558,7 @@ func (it *iterator) readBytesValue(i int, customField customFieldState) error {
 	it.addToBytesDict(i, buf)
 
 	updateArg := updateLastIterArg{i: i, bytesFieldBuf: buf}
-	return it.updateLastIteratedWithCustomValues(updateArg)
+	return it.updateMarshalerWithCustomValues(updateArg)
 }
 
 func (it *iterator) readIntValue(i int) error {
@@ -567,7 +567,7 @@ func (it *iterator) readIntValue(i int) error {
 	}
 
 	updateArg := updateLastIterArg{i: i}
-	return it.updateLastIteratedWithCustomValues(updateArg)
+	return it.updateMarshalerWithCustomValues(updateArg)
 }
 
 func (it *iterator) readBoolValue(i int) error {
@@ -580,7 +580,7 @@ func (it *iterator) readBoolValue(i int) error {
 
 	boolVal := boolOpCode == opCodeBoolTrue
 	updateArg := updateLastIterArg{i: i, boolVal: boolVal}
-	return it.updateLastIteratedWithCustomValues(updateArg)
+	return it.updateMarshalerWithCustomValues(updateArg)
 }
 
 type updateLastIterArg struct {
@@ -589,12 +589,10 @@ type updateLastIterArg struct {
 	boolVal       bool
 }
 
-// TODO: Rename this method and fix comment.
-// updateLastIteratedWithCustomValues updates lastIterated with the current
-// value of the custom field in it.customFields at index i. This ensures that
-// when we return it.lastIterated in the call to Current() that all the
-// most recent values are present.
-func (it *iterator) updateLastIteratedWithCustomValues(arg updateLastIterArg) error {
+// updateMarshalerWithCustomValues updates the marshaled stream with the current
+// value of the custom field at index i. This ensures that marshaled protobuf stream
+// returned by Current() contains the most recent value for all of the custom fields.
+func (it *iterator) updateMarshalerWithCustomValues(arg updateLastIterArg) error {
 	var (
 		fieldNum       = int32(it.customFields[arg.i].fieldNum)
 		fieldType      = it.customFields[arg.i].fieldType

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -185,6 +185,14 @@ func (it *iterator) Next() bool {
 				it.err = fmt.Errorf("%s error reading custom fields schema: %v", itErrPrefix, err)
 				return false
 			}
+
+			// When the encoder changes its schema it will reset all of its nonCustomFields state
+			// which means that the iterator needs to do the same to keep them synchronized at
+			// each point in the stream.
+			for i := range it.nonCustomFields {
+				// Reslice instead of setting to nil to reuse existing capacity if possible.
+				it.nonCustomFields[i].marshalled = it.nonCustomFields[i].marshalled[:0]
+			}
 		}
 	}
 

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -646,8 +646,8 @@ func (it *iterator) updateMarshallerWithCustomValues(arg updateLastIterArg) erro
 			val := int64(it.customFields[arg.i].intEncAndIter.prevIntBits)
 			if protoFieldType == dpb.FieldDescriptorProto_TYPE_SINT64 {
 				// The encoding / compression schema in this package treats Protobuf int32 and sint32 the same,
-				// however, Protobuf unmarshallers assume that fields of type sint are zigzag. As a result, the
-				// iterator needs to check the fields protobuf type so that it can perform the correct encoding.
+				// however, Protobuf unmarshallers assume that fields of type sint are zigzag encoded. As a result,
+				// the iterator needs to check the fields protobuf type so that it can perform the correct encoding.
 				it.marshaller.encSInt64(fieldNum, val)
 			} else if protoFieldType == dpb.FieldDescriptorProto_TYPE_SFIXED64 {
 				it.marshaller.encSFixedInt64(fieldNum, val)
@@ -674,8 +674,8 @@ func (it *iterator) updateMarshallerWithCustomValues(arg updateLastIterArg) erro
 			fieldType := field.GetType()
 			if fieldType == dpb.FieldDescriptorProto_TYPE_SINT32 {
 				// The encoding / compression schema in this package treats Protobuf int32 and sint32 the same,
-				// however, Protobuf unmarshallers assume that fields of type sint are zigzag. As a result, the
-				// iterator needs to check the fields protobuf type so that it can perform the correct encoding.
+				// however, Protobuf unmarshallers assume that fields of type sint are zigzag encoded. As a result,
+				// the iterator needs to check the fields protobuf type so that it can perform the correct encoding.
 				it.marshaller.encSInt32(fieldNum, val)
 			} else if fieldType == dpb.FieldDescriptorProto_TYPE_SFIXED32 {
 				it.marshaller.encSFixedInt32(fieldNum, val)

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -411,6 +411,7 @@ func (it *iterator) readProtoValues() error {
 		}
 	}
 
+	it.skipToNextByte()
 	marshalLen, err := it.readVarInt()
 	if err != nil {
 		return fmt.Errorf("%s err reading proto length varint: %v", itErrPrefix, err)

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -440,9 +440,9 @@ func (it *iterator) readNonCustomValues() error {
 			"%s encoded protobuf portion of message had custom fields", itErrPrefix)
 	}
 
-	// Update any non custom fields that have explicitly changed (since they were including in the
-	// marshaled stream).
-	unmarshalledProtoFields := it.unmarshaller.nonCustomFieldValues()
+	// Update any non custom fields that have explicitly changed (they were explicitly included
+	// in the marshaled stream).
+	unmarshalledProtoFields := it.unmarshaller.sortedNonCustomFieldValues()
 	for _, unmarshalledProtoField := range unmarshalledProtoFields {
 		for i, existingProtoField := range it.nonCustomFields {
 			if unmarshalledProtoField.fieldNum != existingProtoField.fieldNum {

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"math"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
 	"github.com/m3db/m3/src/dbnode/namespace"
@@ -36,6 +35,7 @@ import (
 	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
 
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 )
 

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -428,7 +428,7 @@ func (it *iterator) readProtoValues() error {
 	if it.unmarshaller == nil {
 		// Lazy init.
 		it.unmarshaller = newCustomFieldUnmarshaller(customUnmarshallerOptions{
-			// Skip over unknown fields when unmarshaling because its possible that the stream was
+			// Skip over unknown fields when unmarshalling because its possible that the stream was
 			// encoded with a newer schema.
 			skipUnknownFields: true,
 		})
@@ -436,7 +436,7 @@ func (it *iterator) readProtoValues() error {
 
 	if err := it.unmarshaller.resetAndUnmarshal(it.schema, unmarshalBytes); err != nil {
 		return fmt.Errorf(
-			"%s error unmarshaling message: %v", itErrPrefix, err)
+			"%s error unmarshalling message: %v", itErrPrefix, err)
 	}
 	customFieldValues := it.unmarshaller.sortedCustomFieldValues()
 	if len(customFieldValues) > 0 {

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -61,7 +61,7 @@ type iterator struct {
 	// TODO(rartoul): Update these as we traverse the stream if we encounter
 	// a mid-stream schema change: https://github.com/m3db/m3/issues/1471
 	customFields    []customFieldState
-	nonCustomFields []marshaledField
+	nonCustomFields []marshalledField
 
 	tsIterator m3tsz.TimestampIterator
 
@@ -224,14 +224,14 @@ func (it *iterator) Current() (ts.Datapoint, xtime.Unit, ts.Annotation) {
 	marshalerBytes := it.marshaler.bytes()
 	numBytes := len(marshalerBytes)
 	for _, protoField := range it.nonCustomFields {
-		numBytes += len(protoField.marshaled)
+		numBytes += len(protoField.marshalled)
 	}
 
 	it.resetUnmarshalProtoBuffer(numBytes)
 	buf := it.unmarshalProtoBuf.Bytes()[:0]
 	buf = append(buf, it.marshaler.bytes()...)
 	for _, protoField := range it.nonCustomFields {
-		buf = append(buf, protoField.marshaled...)
+		buf = append(buf, protoField.marshalled...)
 	}
 	return dp, unit, buf
 }
@@ -407,21 +407,21 @@ func (it *iterator) readProtoValues() error {
 		return fmt.Errorf("%s err reading proto length varint: %v", itErrPrefix, err)
 	}
 
-	if marshalLen > maxMarshaledProtoMessageSize {
+	if marshalLen > maxMarshalledProtoMessageSize {
 		return fmt.Errorf(
-			"%s marshaled protobuf size was %d which is larger than the maximum of %d",
-			itErrPrefix, marshalLen, maxMarshaledProtoMessageSize)
+			"%s marshalled protobuf size was %d which is larger than the maximum of %d",
+			itErrPrefix, marshalLen, maxMarshalledProtoMessageSize)
 	}
 
 	it.resetUnmarshalProtoBuffer(int(marshalLen))
 	unmarshalBytes := it.unmarshalProtoBuf.Bytes()
 	n, err := it.stream.Read(unmarshalBytes)
 	if err != nil {
-		return fmt.Errorf("%s: error reading marshaled proto bytes: %v", itErrPrefix, err)
+		return fmt.Errorf("%s: error reading marshalled proto bytes: %v", itErrPrefix, err)
 	}
 	if n != int(marshalLen) {
 		return fmt.Errorf(
-			"%s tried to read %d marshaled proto bytes but only read %d",
+			"%s tried to read %d marshalled proto bytes but only read %d",
 			itErrPrefix, int(marshalLen), n)
 	}
 
@@ -446,12 +446,12 @@ func (it *iterator) readProtoValues() error {
 			"%s encoded protobuf portion of message had custom fields", itErrPrefix)
 	}
 
-	unmarshaledProtoFields := it.unmarshaler.nonCustomFieldValues()
-	for _, unmarshaledProtoField := range unmarshaledProtoFields {
+	unmarshalledProtoFields := it.unmarshaler.nonCustomFieldValues()
+	for _, unmarshalledProtoField := range unmarshalledProtoFields {
 		for i, existingProtoField := range it.nonCustomFields {
-			if unmarshaledProtoField.fieldNum == existingProtoField.fieldNum {
+			if unmarshalledProtoField.fieldNum == existingProtoField.fieldNum {
 				// Copy because the underlying bytes get reused between reads.
-				it.nonCustomFields[i].marshaled = append(it.nonCustomFields[i].marshaled[:0], unmarshaledProtoField.marshaled...)
+				it.nonCustomFields[i].marshalled = append(it.nonCustomFields[i].marshalled[:0], unmarshalledProtoField.marshalled...)
 			}
 		}
 	}
@@ -460,7 +460,7 @@ func (it *iterator) readProtoValues() error {
 		for _, fieldNum := range it.bitsetValues {
 			for i, protoField := range it.nonCustomFields {
 				if fieldNum == int(protoField.fieldNum) {
-					it.nonCustomFields[i].marshaled = it.nonCustomFields[i].marshaled[:0]
+					it.nonCustomFields[i].marshalled = it.nonCustomFields[i].marshalled[:0]
 				}
 			}
 		}
@@ -589,8 +589,8 @@ type updateLastIterArg struct {
 	boolVal       bool
 }
 
-// updateMarshalerWithCustomValues updates the marshaled stream with the current
-// value of the custom field at index i. This ensures that marshaled protobuf stream
+// updateMarshalerWithCustomValues updates the marshalled stream with the current
+// value of the custom field at index i. This ensures that marshalled protobuf stream
 // returned by Current() contains the most recent value for all of the custom fields.
 func (it *iterator) updateMarshalerWithCustomValues(arg updateLastIterArg) error {
 	var (

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -542,7 +542,7 @@ func (it *iterator) readBytesValue(i int, customField customFieldState) error {
 			itErrPrefix, err)
 	}
 
-	// Reuse the byte slices that about to be evicted (if any) to read into instead of
+	// Reuse the byte slice that is about to be evicted (if any) to read into instead of
 	// allocating if possible.
 	buf := it.nextToBeEvicted(i)
 	if cap(buf) < int(bytesLen) {

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -443,15 +443,6 @@ func (it *iterator) readProtoValues() error {
 
 	unmarshaledProtoFields := it.unmarshaler.nonCustomFieldValues()
 	for _, unmarshaledProtoField := range unmarshaledProtoFields {
-		var (
-			field       = it.schema.FindFieldByNumber(unmarshaledProtoField.fieldNum)
-			messageType = field.GetMessageType()
-		)
-		// TODO: Do I need this?
-		if messageType == nil && !field.IsRepeated() {
-			continue
-		}
-
 		for i, existingProtoField := range it.protoFields {
 			if unmarshaledProtoField.fieldNum == existingProtoField.fieldNum {
 				// Copy because the underlying bytes get reused between reads.

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -319,6 +319,9 @@ func (it *iterator) readCustomFieldsSchema() error {
 	}
 
 	if it.customFields != nil {
+		for i := range it.customFields {
+			it.customFields[i] = customFieldState{}
+		}
 		it.customFields = it.customFields[:0]
 	} else {
 		it.customFields = make([]customFieldState, 0, numCustomFields)

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -63,7 +63,7 @@ type iterator struct {
 	// TODO(rartoul): Update these as we traverse the stream if we encounter
 	// a mid-stream schema change: https://github.com/m3db/m3/issues/1471
 	customFields []customFieldState
-	protoFields  []int32
+	protoFields  []marshaledField
 
 	tsIterator m3tsz.TimestampIterator
 
@@ -441,9 +441,9 @@ func (it *iterator) readProtoValues() error {
 		return fmt.Errorf("error unmarshaling protobuf: %v", err)
 	}
 
-	for _, fieldNum := range it.protoFields {
+	for _, marshaledField := range it.protoFields {
 		var (
-			field       = it.schema.FindFieldByNumber(fieldNum)
+			field       = it.schema.FindFieldByNumber(marshaledField.fieldNum)
 			messageType = field.GetMessageType()
 			fieldNumInt = int(field.GetNumber())
 		)

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -452,7 +452,7 @@ func (it *iterator) readNonCustomValues() error {
 	}
 
 	// Update any non custom fields that have explicitly changed (they were explicitly included
-	// in the marshaled stream).
+	// in the marshalled stream).
 	var (
 		unmarshalledNonCustomFields = it.unmarshaller.sortedNonCustomFieldValues()
 		// Matching entries in two sorted lists in which every element in each list is unique so keep

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -612,7 +612,8 @@ func (it *iterator) updateLastIteratedWithCustomValues(arg updateLastIterArg) er
 
 	// TODO: Can delete this?
 	// Cant delete but might be able to optimize away.
-	if field := it.schema.FindFieldByNumber(fieldNum); field == nil {
+	field := it.schema.FindFieldByNumber(fieldNum)
+	if field == nil {
 		// This can happen when the field being decoded does not exist (or is reserved)
 		// in the current schema, but the message was encoded with a schema in which the
 		// field number did exist.
@@ -636,15 +637,9 @@ func (it *iterator) updateLastIteratedWithCustomValues(arg updateLastIterArg) er
 		switch fieldType {
 		case signedInt64Field:
 			var (
-				val   = int64(it.customFields[arg.i].intEncAndIter.prevIntBits)
-				field = it.schema.FindFieldByNumber(fieldNum)
+				val       = int64(it.customFields[arg.i].intEncAndIter.prevIntBits)
+				fieldType = field.GetType()
 			)
-			if field == nil {
-				return fmt.Errorf(
-					"updating last iterated with value, could not find field number %d in schema", fieldNum)
-			}
-
-			fieldType := field.GetType()
 			if fieldType == dpb.FieldDescriptorProto_TYPE_SINT64 {
 				// The encoding / compression schema in this package treats Protobuf int32 and sint32 the same,
 				// however, Protobuf unmarshalers assume that fields of type sint are zigzag. As a result, the

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -1,3 +1,5 @@
+// +build big
+//
 // Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -1,5 +1,3 @@
-// +build big
-//
 // Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -1,4 +1,3 @@
-// +build big
 //
 // Copyright (c) 2019 Uber Technologies, Inc.
 //

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -1,3 +1,4 @@
+// +build big
 //
 // Copyright (c) 2019 Uber Technologies, Inc.
 //

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -76,7 +76,7 @@ const (
 	maxNumMessages   = 100
 	maxNumEnumValues = 10
 
-	debugLogs = false
+	debugLogs = true
 )
 
 type fieldModifierProp int
@@ -143,7 +143,7 @@ func TestRoundTripProp(t *testing.T) {
 			}
 
 			if debugLogs {
-				printMessage("encoding", m.message)
+				printMessage(fmt.Sprintf("encoding %d", i), m.message)
 			}
 			err = enc.Encode(ts.Datapoint{Timestamp: times[i]}, xtime.Nanosecond, cloneBytes)
 			if err != nil {
@@ -168,7 +168,7 @@ func TestRoundTripProp(t *testing.T) {
 			decodedM := dynamic.NewMessage(input.schema)
 			require.NoError(t, decodedM.Unmarshal(annotation))
 			if debugLogs {
-				printMessage("decoding", decodedM)
+				printMessage(fmt.Sprintf("decoding %d", i), decodedM)
 			}
 
 			require.Equal(t, unit, xtime.Nanosecond)

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -76,7 +76,7 @@ const (
 	maxNumMessages   = 100
 	maxNumEnumValues = 10
 
-	debugLogs = true
+	debugLogs = false
 )
 
 type fieldModifierProp int

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -139,7 +139,7 @@ func TestRoundTripProp(t *testing.T) {
 			clone.MergeFrom(m.message)
 			cloneBytes, err := clone.Marshal()
 			if err != nil {
-				return false, fmt.Errorf("error marshaling proto message: %v", err)
+				return false, fmt.Errorf("error marshalling proto message: %v", err)
 			}
 
 			if debugLogs {

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -173,8 +173,6 @@ func TestRoundTripProp(t *testing.T) {
 				m                    = input.messages[i].message
 				dp, unit, annotation = iter.Current()
 			)
-			fmt.Println("m:", m.String())
-			fmt.Println("schema:", input.schema.String())
 			decodedM := dynamic.NewMessage(input.schema)
 			require.NoError(t, decodedM.Unmarshal(annotation))
 			if debugLogs {

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -1,4 +1,3 @@
-// +build big
 //
 // Copyright (c) 2019 Uber Technologies, Inc.
 //
@@ -93,7 +92,7 @@ const (
 func TestRoundTripProp(t *testing.T) {
 	var (
 		parameters = gopter.DefaultTestParameters()
-		seed       = time.Now().UnixNano0()
+		seed       = time.Now().UnixNano()
 		props      = gopter.NewProperties(parameters)
 		reporter   = gopter.NewFormatedReporter(true, 160, os.Stdout)
 	)

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -67,6 +67,12 @@ var (
 
 func init() {
 	for key := range mapProtoTypeToCustomFieldType {
+		// if key == dpb.FieldDescriptorProto_TYPE_SINT32 {
+		// 	continue
+		// }
+		// if key == dpb.FieldDescriptorProto_TYPE_SFIXED32 {
+		// 	continue
+		// }
 		allowedProtoTypesSliceIface = append(allowedProtoTypesSliceIface, key)
 	}
 }
@@ -92,15 +98,16 @@ const (
 func TestRoundTripProp(t *testing.T) {
 	var (
 		parameters = gopter.DefaultTestParameters()
-		seed       = time.Now().UnixNano()
-		props      = gopter.NewProperties(parameters)
-		reporter   = gopter.NewFormatedReporter(true, 160, os.Stdout)
+		// seed       = time.Now().UnixNano0()
+		seed     = int64(1558117541928586000)
+		props    = gopter.NewProperties(parameters)
+		reporter = gopter.NewFormatedReporter(true, 160, os.Stdout)
 	)
 	parameters.MinSuccessfulTests = 300
 	parameters.Rng.Seed(seed)
 
 	enc := NewEncoder(time.Time{}, testEncodingOptions)
-	iter := NewIterator(nil, nil, testEncodingOptions).(*iterator)
+	// iter := NewIterator(nil, nil, testEncodingOptions).(*iterator)
 	props.Property("Encoded data should be readable", prop.ForAll(func(input propTestInput) (bool, error) {
 		if debugLogs {
 			fmt.Println("---------------------------------------------------")
@@ -157,6 +164,7 @@ func TestRoundTripProp(t *testing.T) {
 			return true, nil
 		}
 
+		iter := NewIterator(nil, nil, testEncodingOptions).(*iterator)
 		iter.Reset(stream, namespace.GetTestSchemaDescr(input.schema))
 
 		i := 0
@@ -165,6 +173,8 @@ func TestRoundTripProp(t *testing.T) {
 				m                    = input.messages[i].message
 				dp, unit, annotation = iter.Current()
 			)
+			fmt.Println("m:", m.String())
+			fmt.Println("schema:", input.schema.String())
 			decodedM := dynamic.NewMessage(input.schema)
 			require.NoError(t, decodedM.Unmarshal(annotation))
 			if debugLogs {

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -376,17 +376,17 @@ func newMessageWithValues(schema *desc.MessageDescriptor, input generatedWrite) 
 
 	// Basic sanity test to protect against bugs in the underlying library:
 	// https://github.com/jhump/protoreflect/issues/181
-	marshaled, err := message.Marshal()
+	marshalled, err := message.Marshal()
 	if err != nil {
 		panic(err)
 	}
-	unmarshaled := dynamic.NewMessage(schema)
-	err = unmarshaled.Unmarshal(marshaled)
+	unmarshalled := dynamic.NewMessage(schema)
+	err = unmarshalled.Unmarshal(marshalled)
 	if err != nil {
 		panic(err)
 	}
-	if !dynamic.MessagesEqual(message, unmarshaled) {
-		panic("generated message that is not equal after being marshaled and unmarshaled")
+	if !dynamic.MessagesEqual(message, unmarshalled) {
+		panic("generated message that is not equal after being marshalled and unmarshalled")
 	}
 
 	return messageAndTimeUnit{

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -1,3 +1,4 @@
+// +build big
 //
 // Copyright (c) 2019 Uber Technologies, Inc.
 //
@@ -67,12 +68,6 @@ var (
 
 func init() {
 	for key := range mapProtoTypeToCustomFieldType {
-		// if key == dpb.FieldDescriptorProto_TYPE_SINT32 {
-		// 	continue
-		// }
-		// if key == dpb.FieldDescriptorProto_TYPE_SFIXED32 {
-		// 	continue
-		// }
 		allowedProtoTypesSliceIface = append(allowedProtoTypesSliceIface, key)
 	}
 }
@@ -98,16 +93,15 @@ const (
 func TestRoundTripProp(t *testing.T) {
 	var (
 		parameters = gopter.DefaultTestParameters()
-		// seed       = time.Now().UnixNano0()
-		seed     = int64(1558117541928586000)
-		props    = gopter.NewProperties(parameters)
-		reporter = gopter.NewFormatedReporter(true, 160, os.Stdout)
+		seed       = time.Now().UnixNano0()
+		props      = gopter.NewProperties(parameters)
+		reporter   = gopter.NewFormatedReporter(true, 160, os.Stdout)
 	)
 	parameters.MinSuccessfulTests = 300
 	parameters.Rng.Seed(seed)
 
 	enc := NewEncoder(time.Time{}, testEncodingOptions)
-	// iter := NewIterator(nil, nil, testEncodingOptions).(*iterator)
+	iter := NewIterator(nil, nil, testEncodingOptions).(*iterator)
 	props.Property("Encoded data should be readable", prop.ForAll(func(input propTestInput) (bool, error) {
 		if debugLogs {
 			fmt.Println("---------------------------------------------------")
@@ -164,7 +158,6 @@ func TestRoundTripProp(t *testing.T) {
 			return true, nil
 		}
 
-		iter := NewIterator(nil, nil, testEncodingOptions).(*iterator)
 		iter.Reset(stream, namespace.GetTestSchemaDescr(input.schema))
 
 		i := 0

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -215,7 +215,7 @@ func TestRoundTripMidStreamSchemaChanges(t *testing.T) {
 	buff := bytes.NewBuffer(rawBytes)
 	iter := NewIterator(buff, namespace.GetTestSchemaDescr(testVLSchema), testEncodingOptions)
 
-	require.True(t, iter.Next())
+	require.True(t, iter.Next(), "iter err: %v", iter.Err())
 	dp, unit, annotation := iter.Current()
 	m := dynamic.NewMessage(testVLSchema)
 	require.NoError(t, m.Unmarshal(annotation))
@@ -228,7 +228,7 @@ func TestRoundTripMidStreamSchemaChanges(t *testing.T) {
 	require.Equal(t, vl1Write.GetFieldByName("deliveryID"), m.GetFieldByName("deliveryID"))
 	require.Equal(t, vl1Write.GetFieldByName("attributes"), m.GetFieldByName("attributes"))
 
-	require.True(t, iter.Next())
+	require.True(t, iter.Next(), "iter err: %v", iter.Err())
 	dp, unit, annotation = iter.Current()
 	m = dynamic.NewMessage(testVLSchema)
 	require.NoError(t, m.Unmarshal(annotation))
@@ -251,7 +251,7 @@ func TestRoundTripMidStreamSchemaChanges(t *testing.T) {
 	buff = bytes.NewBuffer(rawBytes)
 	iter = NewIterator(buff, namespace.GetTestSchemaDescr(testVL2Schema), testEncodingOptions)
 
-	require.True(t, iter.Next())
+	require.True(t, iter.Next(), "iter err: %v", iter.Err())
 	dp, unit, annotation = iter.Current()
 	m = dynamic.NewMessage(testVL2Schema)
 	require.NoError(t, m.Unmarshal(annotation))
@@ -271,7 +271,7 @@ func TestRoundTripMidStreamSchemaChanges(t *testing.T) {
 	_, err = m.TryGetFieldByName("deliveryID")
 	require.Error(t, err)
 
-	require.True(t, iter.Next())
+	require.True(t, iter.Next(), "iter err: %v", iter.Err())
 	dp, unit, annotation = iter.Current()
 	m = dynamic.NewMessage(testVL2Schema)
 	require.NoError(t, m.Unmarshal(annotation))

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -143,12 +143,12 @@ func TestRoundTrip(t *testing.T) {
 
 	// Add some sanity to make sure that the compression (especially string compression)
 	// is working properly.
-	numExpectedBytes := 231
-	require.Equal(t, numExpectedBytes, enc.Stats().CompressedBytes)
+	// numExpectedBytes := 231
+	// require.Equal(t, numExpectedBytes, enc.Stats().CompressedBytes)
 
 	rawBytes, err := enc.Bytes()
 	require.NoError(t, err)
-	require.Equal(t, numExpectedBytes, len(rawBytes))
+	// require.Equal(t, numExpectedBytes, len(rawBytes))
 
 	buff := bytes.NewBuffer(rawBytes)
 	iter := NewIterator(buff, namespace.GetTestSchemaDescr(testVLSchema), testEncodingOptions)

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -23,6 +23,7 @@ package proto
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -162,6 +163,7 @@ func TestRoundTrip(t *testing.T) {
 		m := dynamic.NewMessage(testVLSchema)
 		require.NoError(t, m.Unmarshal(annotation))
 
+		fmt.Println(m.String())
 		require.Equal(t, unit, xtime.Second)
 		require.True(t, tc.timestamp.Equal(dp.Timestamp))
 		// Value is meaningless for proto so should always be zero

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -143,12 +143,12 @@ func TestRoundTrip(t *testing.T) {
 
 	// Add some sanity to make sure that the compression (especially string compression)
 	// is working properly.
-	// numExpectedBytes := 231
-	// require.Equal(t, numExpectedBytes, enc.Stats().CompressedBytes)
+	numExpectedBytes := 233
+	require.Equal(t, numExpectedBytes, enc.Stats().CompressedBytes)
 
 	rawBytes, err := enc.Bytes()
 	require.NoError(t, err)
-	// require.Equal(t, numExpectedBytes, len(rawBytes))
+	require.Equal(t, numExpectedBytes, len(rawBytes))
 
 	buff := bytes.NewBuffer(rawBytes)
 	iter := NewIterator(buff, namespace.GetTestSchemaDescr(testVLSchema), testEncodingOptions)

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -125,13 +125,13 @@ func TestRoundTrip(t *testing.T) {
 	for i, tc := range testCases {
 		vl := newVL(
 			tc.latitude, tc.longitude, tc.epoch, tc.deliveryID, tc.attributes)
-		marshaledVL, err := vl.Marshal()
+		marshalledVL, err := vl.Marshal()
 		require.NoError(t, err)
 
 		currTime := curr.Add(time.Duration(i) * time.Second)
 		testCases[i].timestamp = currTime
 		// Encoder should ignore value so we set it to make sure it gets ignored.
-		err = enc.Encode(ts.Datapoint{Timestamp: currTime, Value: float64(i)}, xtime.Second, marshaledVL)
+		err = enc.Encode(ts.Datapoint{Timestamp: currTime, Value: float64(i)}, xtime.Second, marshalledVL)
 		require.NoError(t, err)
 
 		lastEncoded, err := enc.LastEncoded()
@@ -185,25 +185,25 @@ func TestRoundTripMidStreamSchemaChanges(t *testing.T) {
 
 	attrs := map[string]string{"key1": "val1"}
 	vl1Write := newVL(26.0, 27.0, 10, []byte("some_delivery_id"), attrs)
-	marshaledVL, err := vl1Write.Marshal()
+	marshalledVL, err := vl1Write.Marshal()
 	require.NoError(t, err)
 
 	vl1WriteTime := time.Now().Truncate(time.Second)
-	err = enc.Encode(ts.Datapoint{Timestamp: vl1WriteTime}, xtime.Second, marshaledVL)
+	err = enc.Encode(ts.Datapoint{Timestamp: vl1WriteTime}, xtime.Second, marshalledVL)
 	require.NoError(t, err)
 
 	vl2Write := newVL2(28.0, 29.0, attrs, "some_new_custom_field", map[int]int{1: 2})
-	marshaledVL, err = vl2Write.Marshal()
+	marshalledVL, err = vl2Write.Marshal()
 	require.NoError(t, err)
 
 	vl2WriteTime := vl1WriteTime.Add(time.Second)
-	err = enc.Encode(ts.Datapoint{Timestamp: vl2WriteTime}, xtime.Second, marshaledVL)
+	err = enc.Encode(ts.Datapoint{Timestamp: vl2WriteTime}, xtime.Second, marshalledVL)
 	require.Equal(t,
 		"proto encoder: error unmarshaling message: encountered unknown field with field number: 6",
 		err.Error())
 
 	enc.SetSchema(namespace.GetTestSchemaDescr(testVL2Schema))
-	err = enc.Encode(ts.Datapoint{Timestamp: vl2WriteTime}, xtime.Second, marshaledVL)
+	err = enc.Encode(ts.Datapoint{Timestamp: vl2WriteTime}, xtime.Second, marshalledVL)
 	require.NoError(t, err)
 
 	rawBytes, err := enc.Bytes()

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -199,7 +199,7 @@ func TestRoundTripMidStreamSchemaChanges(t *testing.T) {
 	vl2WriteTime := vl1WriteTime.Add(time.Second)
 	err = enc.Encode(ts.Datapoint{Timestamp: vl2WriteTime}, xtime.Second, marshalledVL)
 	require.Equal(t,
-		"proto encoder: error unmarshaling message: encountered unknown field with field number: 6",
+		"proto encoder: error unmarshalling message: encountered unknown field with field number: 6",
 		err.Error())
 
 	enc.SetSchema(namespace.GetTestSchemaDescr(testVL2Schema))

--- a/src/dbnode/namespace/schema.go
+++ b/src/dbnode/namespace/schema.go
@@ -22,6 +22,7 @@ package namespace
 
 import (
 	"errors"
+
 	nsproto "github.com/m3db/m3/src/dbnode/generated/proto/namespace"
 	xerrors "github.com/m3db/m3/src/x/errors"
 
@@ -321,4 +322,8 @@ func GenTestSchemaOptions(protoFile string, importPathPrefix ...string) *nsproto
 
 func GetTestSchemaDescr(md *desc.MessageDescriptor) SchemaDescr {
 	return &schemaDescr{md: MessageDescriptor{md}}
+}
+
+func GetTestSchemaDescrWithDeployID(md *desc.MessageDescriptor, deployID string) SchemaDescr {
+	return &schemaDescr{md: MessageDescriptor{md}, deployId: deployID}
 }

--- a/src/m3ninx/postings/pilosa/codec_test.go
+++ b/src/m3ninx/postings/pilosa/codec_test.go
@@ -37,8 +37,8 @@ func TestEncodeDecode(t *testing.T) {
 	bytes, err := e.Encode(b)
 	require.NoError(t, err)
 
-	unmarshaled, err := Unmarshal(bytes)
+	unmarshalled, err := Unmarshal(bytes)
 	require.NoError(t, err)
 
-	require.True(t, b.Equal(unmarshaled))
+	require.True(t, b.Equal(unmarshalled))
 }

--- a/src/msg/protocol/proto/types.go
+++ b/src/msg/protocol/proto/types.go
@@ -26,16 +26,16 @@ import (
 	"github.com/m3db/m3/src/x/pool"
 )
 
-// Marshaler can be marshaled.
+// Marshaler can be marshalled.
 type Marshaler interface {
-	// Size returns the size of the marshaled bytes.
+	// Size returns the size of the marshalled bytes.
 	Size() int
 
 	// MarshalTo marshals the marshaler into the given byte slice.
 	MarshalTo(data []byte) (int, error)
 }
 
-// Unmarshaler can be unmarshaled from bytes.
+// Unmarshaler can be unmarshalled from bytes.
 type Unmarshaler interface {
 	// Unmarshal unmarshals the unmarshaler from the given byte slice.
 	Unmarshal(data []byte) error


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `jhump/protoreflect` from the hot path as much as possible, plus some other optimizations and cleanup.

Results:

1. 10x improvement in encoding and decoding for non-custom fields.
2. 2x improvement in encoding for custom fields.
3. 4x improvement in decoding for custom fields (original goal).

before
```
goos: darwin
goarch: amd64
pkg: github.com/m3db/m3/src/dbnode/encoding/proto
BenchmarkEncoder/with_non_custom_encoded_fields_enabled-8         	    1000	   1432754 ns/op	  374435 B/op	    8177 allocs/op
BenchmarkEncoder/with_non_custom_encoded_fields_disabled-8        	   10000	    111547 ns/op	   13430 B/op	       0 allocs/op
BenchmarkIterator/with_non_custom_encoded_fields_enabled-8        	    1000	   1274402 ns/op	  323059 B/op	    8196 allocs/op
BenchmarkIterator/with_non_custom_encoded_fields_disabled-8       	   10000	    203996 ns/op	   21603 B/op	     910 allocs/op
```

after
```
goos: darwin
goarch: amd64
pkg: github.com/m3db/m3/src/dbnode/encoding/proto
BenchmarkEncoder/with_non_custom_encoded_fields_enabled-8         	   10000	    119435 ns/op	   66221 B/op	       0 allocs/op
BenchmarkEncoder/with_non_custom_encoded_fields_disabled-8        	   20000	     67853 ns/op	   21176 B/op	       0 allocs/op
BenchmarkIterator/with_non_custom_encoded_fields_enabled-8        	   20000	     90630 ns/op	     671 B/op	      13 allocs/op
BenchmarkIterator/with_non_custom_encoded_fields_disabled-8       	   30000	     46309 ns/op	     595 B/op	      12 allocs/op
```