### PR TITLE
[query] Add support for unary expressions

### DIFF
--- a/src/query/block/lazy.go
+++ b/src/query/block/lazy.go
@@ -236,13 +236,13 @@ func (s unconsolidatedStep) Values() []ts.Datapoints {
 
 func (it *ucLazyStepIter) Current() UnconsolidatedStep {
 	var (
-		c       = it.it.Current()
-		stepDPs = c.Values()
-		dpList  = make([]ts.Datapoints, 0, len(stepDPs))
-		tt, vt  = it.opts.TimeTransform(), it.opts.ValueTransform()
+		c      = it.it.Current()
+		values = c.Values()
+		dpList = make([]ts.Datapoints, 0, len(values))
+		tt, vt = it.opts.TimeTransform(), it.opts.ValueTransform()
 	)
 
-	for _, val := range stepDPs {
+	for _, val := range values {
 		dps := make([]ts.Datapoint, 0, len(val))
 		for _, dp := range val.Datapoints() {
 			dps = append(dps, ts.Datapoint{
@@ -285,13 +285,13 @@ func (it *ucLazySeriesIter) Next() bool               { return it.it.Next() }
 
 func (it *ucLazySeriesIter) Current() UnconsolidatedSeries {
 	var (
-		c         = it.it.Current()
-		seriesDPs = c.datapoints
-		dpList    = make([]ts.Datapoints, 0, len(seriesDPs))
-		tt, vt    = it.opts.TimeTransform(), it.opts.ValueTransform()
+		c      = it.it.Current()
+		values = c.datapoints
+		dpList = make([]ts.Datapoints, 0, len(values))
+		tt, vt = it.opts.TimeTransform(), it.opts.ValueTransform()
 	)
 
-	for _, val := range seriesDPs {
+	for _, val := range values {
 		dps := make([]ts.Datapoint, 0, len(val))
 		for _, dp := range val.Datapoints() {
 			dps = append(dps, ts.Datapoint{

--- a/src/query/block/lazy.go
+++ b/src/query/block/lazy.go
@@ -89,9 +89,9 @@ func (it *lazyStepIter) Current() Step {
 		stepVals = c.Values()
 	)
 
-	vals := make([]float64, len(stepVals))
-	for i, val := range stepVals {
-		vals[i] = vt(val)
+	vals := make([]float64, 0, len(stepVals))
+	for _, val := range stepVals {
+		vals = append(vals, vt(val))
 	}
 
 	return ColStep{
@@ -128,16 +128,17 @@ func (it *lazySeriesIter) Current() Series {
 	var (
 		c    = it.it.Current()
 		vt   = it.opts.ValueTransform()
-		vals = make([]float64, len(c.values))
+		vals = make([]float64, 0, len(c.values))
 	)
 
-	for i, val := range c.values {
-		vals[i] = vt(val)
+	for _, val := range c.values {
+		vals = append(vals, vt(val))
 	}
 
 	c.values = vals
 	return c
 }
+
 func (it *lazySeriesIter) Meta() Metadata {
 	mt := it.opts.MetaTransform()
 	return mt(it.it.Meta())
@@ -237,19 +238,20 @@ func (it *ucLazyStepIter) Current() UnconsolidatedStep {
 	var (
 		c       = it.it.Current()
 		stepDPs = c.Values()
-		dpList  = make([]ts.Datapoints, len(stepDPs))
+		dpList  = make([]ts.Datapoints, 0, len(stepDPs))
 		tt, vt  = it.opts.TimeTransform(), it.opts.ValueTransform()
 	)
 
-	for j, val := range stepDPs {
-		dps := make([]ts.Datapoint, len(val))
-		for i, dp := range val.Datapoints() {
-
-			dps[i].Timestamp = tt(dp.Timestamp)
-			dps[i].Value = vt(dp.Value)
+	for _, val := range stepDPs {
+		dps := make([]ts.Datapoint, 0, len(val))
+		for _, dp := range val.Datapoints() {
+			dps = append(dps, ts.Datapoint{
+				Timestamp: tt(dp.Timestamp),
+				Value:     vt(dp.Value),
+			})
 		}
 
-		dpList[j] = dps
+		dpList = append(dpList, dps)
 	}
 
 	return unconsolidatedStep{
@@ -285,18 +287,20 @@ func (it *ucLazySeriesIter) Current() UnconsolidatedSeries {
 	var (
 		c         = it.it.Current()
 		seriesDPs = c.datapoints
-		dpList    = make([]ts.Datapoints, len(seriesDPs))
+		dpList    = make([]ts.Datapoints, 0, len(seriesDPs))
+		tt, vt    = it.opts.TimeTransform(), it.opts.ValueTransform()
 	)
 
-	for i, val := range seriesDPs {
-		dps := make([]ts.Datapoint, len(val))
-		for j, dp := range val.Datapoints() {
-			tt, vt := it.opts.TimeTransform(), it.opts.ValueTransform()
-			dps[j].Timestamp = tt(dp.Timestamp)
-			dps[j].Value = vt(dp.Value)
+	for _, val := range seriesDPs {
+		dps := make([]ts.Datapoint, 0, len(val))
+		for _, dp := range val.Datapoints() {
+			dps = append(dps, ts.Datapoint{
+				Timestamp: tt(dp.Timestamp),
+				Value:     vt(dp.Value),
+			})
 		}
 
-		dpList[i] = dps
+		dpList = append(dpList, dps)
 	}
 
 	c.datapoints = dpList

--- a/src/query/block/lazy.go
+++ b/src/query/block/lazy.go
@@ -293,6 +293,7 @@ func (it *ucLazySeriesIter) Current() UnconsolidatedSeries {
 			dps[j].Timestamp = tt(dp.Timestamp)
 			dps[j].Value = vt(dp.Value)
 		}
+
 		dpList[i] = dps
 	}
 

--- a/src/query/block/lazy.go
+++ b/src/query/block/lazy.go
@@ -123,6 +123,7 @@ func (it *lazySeriesIter) Err() error               { return it.it.Err() }
 func (it *lazySeriesIter) SeriesCount() int         { return it.it.SeriesCount() }
 func (it *lazySeriesIter) SeriesMeta() []SeriesMeta { return it.it.SeriesMeta() }
 func (it *lazySeriesIter) Next() bool               { return it.it.Next() }
+
 func (it *lazySeriesIter) Current() Series {
 	var (
 		c    = it.it.Current()
@@ -279,6 +280,7 @@ func (it *ucLazySeriesIter) Err() error               { return it.it.Err() }
 func (it *ucLazySeriesIter) SeriesCount() int         { return it.it.SeriesCount() }
 func (it *ucLazySeriesIter) SeriesMeta() []SeriesMeta { return it.it.SeriesMeta() }
 func (it *ucLazySeriesIter) Next() bool               { return it.it.Next() }
+
 func (it *ucLazySeriesIter) Current() UnconsolidatedSeries {
 	var (
 		c         = it.it.Current()

--- a/src/query/block/lazy_test.go
+++ b/src/query/block/lazy_test.go
@@ -420,7 +420,7 @@ func TestUnconsolidatedSeriesIter(t *testing.T) {
 	assert.Equal(t, expected, actual.Datapoints())
 }
 
-// negative value offset
+// negative value offset tests
 
 func TestStepIterWithNegativeValueOffset(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/src/query/functions/fetch.go
+++ b/src/query/functions/fetch.go
@@ -30,7 +30,7 @@ import (
 	"github.com/m3db/m3/src/query/parser"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/util/logging"
-	"github.com/m3db/m3/src/query/util/opentracing"
+	opentracingutil "github.com/m3db/m3/src/query/util/opentracing"
 
 	"go.uber.org/zap"
 )

--- a/src/query/functions/lazy/base.go
+++ b/src/query/functions/lazy/base.go
@@ -37,11 +37,6 @@ const (
 	UnaryType = "unary"
 )
 
-const (
-	ItemAdd = "+"
-	ItemSub = "-"
-)
-
 // NewLazyOp creates a new lazy operation
 func NewLazyOp(
 	opType string,

--- a/src/query/functions/lazy/base.go
+++ b/src/query/functions/lazy/base.go
@@ -32,6 +32,14 @@ import (
 const (
 	// OffsetType offsets incoming data point timestamps and metadata by the given offset.
 	OffsetType = "offset"
+
+	// UnaryType offsets incoming data point values by the given operator.
+	UnaryType = "unary"
+)
+
+const (
+	ItemAdd = "+"
+	ItemSub = "-"
 )
 
 // NewLazyOp creates a new lazy operation

--- a/src/query/parser/promql/parse.go
+++ b/src/query/parser/promql/parse.go
@@ -285,8 +285,6 @@ func (p *parseState) walk(node pql.Node) error {
 			return fmt.Errorf("only + and - operators allowed for unary expressions, received: %s", n.Op.String())
 		}
 
-		fmt.Println(unaryType)
-
 		return p.addLazyTransform(0, lazy.UnaryType, unaryType)
 
 	default:

--- a/src/query/parser/promql/parse_test.go
+++ b/src/query/parser/promql/parse_test.go
@@ -77,7 +77,7 @@ func TestInvalidOffset(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestUnary(t *testing.T) {
+func TestNegativeUnary(t *testing.T) {
 	q := "-up"
 	p, err := Parse(q, models.NewTagOptions())
 	require.NoError(t, err)
@@ -91,6 +91,18 @@ func TestUnary(t *testing.T) {
 	assert.Len(t, edges, 1)
 	assert.Equal(t, edges[0].ParentID, parser.NodeID("0"))
 	assert.Equal(t, edges[0].ChildID, parser.NodeID("1"))
+}
+
+func TestPositiveUnary(t *testing.T) {
+	q := "+up"
+	p, err := Parse(q, models.NewTagOptions())
+	require.NoError(t, err)
+	transforms, edges, err := p.DAG()
+	require.NoError(t, err)
+	assert.Len(t, transforms, 1) // "+" defaults to just a fetch operation
+	assert.Equal(t, transforms[0].Op.OpType(), functions.FetchType)
+	assert.Equal(t, transforms[0].ID, parser.NodeID("0"))
+	assert.Len(t, edges, 0)
 }
 
 func TestInvalidUnary(t *testing.T) {

--- a/src/query/parser/promql/parse_test.go
+++ b/src/query/parser/promql/parse_test.go
@@ -76,6 +76,22 @@ func TestInvalidOffset(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUnary(t *testing.T) {
+	q := "-up"
+	p, err := Parse(q, models.NewTagOptions())
+	require.NoError(t, err)
+	transforms, edges, err := p.DAG()
+	require.NoError(t, err)
+	assert.Len(t, transforms, 2)
+	assert.Equal(t, transforms[0].Op.OpType(), functions.FetchType)
+	assert.Equal(t, transforms[0].ID, parser.NodeID("0"))
+	assert.Equal(t, transforms[1].Op.OpType(), lazy.UnaryType)
+	assert.Equal(t, transforms[1].ID, parser.NodeID("1"))
+	assert.Len(t, edges, 1)
+	assert.Equal(t, edges[0].ParentID, parser.NodeID("0"))
+	assert.Equal(t, edges[0].ChildID, parser.NodeID("1"))
+}
+
 func TestDAGWithEmptyExpression(t *testing.T) {
 	q := ""
 	_, err := Parse(q, models.NewTagOptions())

--- a/src/query/parser/promql/parse_test.go
+++ b/src/query/parser/promql/parse_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/m3db/m3/src/query/functions/temporal"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/parser"
+	"github.com/prometheus/prometheus/promql"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,6 +96,17 @@ func TestUnary(t *testing.T) {
 func TestInvalidUnary(t *testing.T) {
 	q := "*up"
 	_, err := Parse(q, models.NewTagOptions())
+	require.Error(t, err)
+}
+
+func TestGetUnaryOpType(t *testing.T) {
+	promOpType := promql.ItemType(itemADD)
+	unaryOpType, err := getUnaryOpType(promOpType)
+	require.NoError(t, err)
+	assert.Equal(t, binary.PlusType, unaryOpType)
+
+	promOpType = promql.ItemType(itemEQL)
+	_, err = getUnaryOpType(promOpType)
 	require.Error(t, err)
 }
 

--- a/src/query/parser/promql/parse_test.go
+++ b/src/query/parser/promql/parse_test.go
@@ -92,6 +92,12 @@ func TestUnary(t *testing.T) {
 	assert.Equal(t, edges[0].ChildID, parser.NodeID("1"))
 }
 
+func TestInvalidUnary(t *testing.T) {
+	q := "*up"
+	_, err := Parse(q, models.NewTagOptions())
+	require.Error(t, err)
+}
+
 func TestDAGWithEmptyExpression(t *testing.T) {
 	q := ""
 	_, err := Parse(q, models.NewTagOptions())

--- a/src/query/parser/promql/types.go
+++ b/src/query/parser/promql/types.go
@@ -293,6 +293,7 @@ func getBinaryOpType(opType promql.ItemType) string {
 	}
 }
 
+// GetUnaryOpType returns the M3 unary op type based on the Prom op type
 func GetUnaryOpType(opType promql.ItemType) (string, bool) {
 	switch opType {
 	case promql.ItemType(itemADD):

--- a/src/query/parser/promql/types.go
+++ b/src/query/parser/promql/types.go
@@ -293,6 +293,17 @@ func getBinaryOpType(opType promql.ItemType) string {
 	}
 }
 
+func GetUnaryOpType(opType promql.ItemType) (string, bool) {
+	switch opType {
+	case promql.ItemType(itemADD):
+		return binary.PlusType, true
+	case promql.ItemType(itemSUB):
+		return binary.MinusType, true
+	default:
+		return common.UnknownOpType, false
+	}
+}
+
 const promDefaultName = "__name__"
 
 // LabelMatchersToModelMatcher parses promql matchers to model matchers

--- a/src/query/parser/promql/types.go
+++ b/src/query/parser/promql/types.go
@@ -40,7 +40,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 )
 
-// NewSelectorFromVector creates a new fetchop
+// NewSelectorFromVector creates a new fetchop.
 func NewSelectorFromVector(
 	n *promql.VectorSelector,
 	tagOpts models.TagOptions,
@@ -57,7 +57,7 @@ func NewSelectorFromVector(
 	}, nil
 }
 
-// NewSelectorFromMatrix creates a new fetchop
+// NewSelectorFromMatrix creates a new fetchop.
 func NewSelectorFromMatrix(
 	n *promql.MatrixSelector,
 	tagOpts models.TagOptions,
@@ -75,7 +75,7 @@ func NewSelectorFromMatrix(
 	}, nil
 }
 
-// NewAggregationOperator creates a new aggregation operator based on the type
+// NewAggregationOperator creates a new aggregation operator based on the type.
 func NewAggregationOperator(expr *promql.AggregateExpr) (parser.Params, error) {
 	opType := expr.Op
 	byteMatchers := make([][]byte, len(expr.Grouping))
@@ -141,7 +141,7 @@ func getAggOpType(opType promql.ItemType) string {
 	}
 }
 
-// NewScalarOperator creates a new scalar operator
+// NewScalarOperator creates a new scalar operator.
 func NewScalarOperator(expr *promql.NumberLiteral) (parser.Params, error) {
 	return scalar.NewScalarOp(
 		func(_ time.Time) float64 { return expr.Val },
@@ -149,7 +149,7 @@ func NewScalarOperator(expr *promql.NumberLiteral) (parser.Params, error) {
 	)
 }
 
-// NewBinaryOperator creates a new binary operator based on the type
+// NewBinaryOperator creates a new binary operator based on the type.
 func NewBinaryOperator(expr *promql.BinaryExpr, lhs, rhs parser.NodeID) (parser.Params, error) {
 	matching := promMatchingToM3(expr.VectorMatching)
 
@@ -166,7 +166,7 @@ func NewBinaryOperator(expr *promql.BinaryExpr, lhs, rhs parser.NodeID) (parser.
 	return binary.NewOp(op, nodeParams)
 }
 
-// NewFunctionExpr creates a new function expr based on the type
+// NewFunctionExpr creates a new function expr based on the type.
 func NewFunctionExpr(
 	name string,
 	argValues []interface{},
@@ -248,7 +248,7 @@ func NewFunctionExpr(
 		return p, true, err
 
 	default:
-		// TODO: handle other types
+		// TODO: handle other types.
 		return nil, false, fmt.Errorf("function not supported: %s", name)
 	}
 }
@@ -293,21 +293,21 @@ func getBinaryOpType(opType promql.ItemType) string {
 	}
 }
 
-// GetUnaryOpType returns the M3 unary op type based on the Prom op type
-func GetUnaryOpType(opType promql.ItemType) (string, bool) {
+// getUnaryOpType returns the M3 unary op type based on the Prom op type.
+func getUnaryOpType(opType promql.ItemType) (string, error) {
 	switch opType {
 	case promql.ItemType(itemADD):
-		return binary.PlusType, true
+		return binary.PlusType, nil
 	case promql.ItemType(itemSUB):
-		return binary.MinusType, true
+		return binary.MinusType, nil
 	default:
-		return common.UnknownOpType, false
+		return "", fmt.Errorf("only + and - operators allowed for unary expressions, received: %s", opType.String())
 	}
 }
 
 const promDefaultName = "__name__"
 
-// LabelMatchersToModelMatcher parses promql matchers to model matchers
+// LabelMatchersToModelMatcher parses promql matchers to model matchers.
 func LabelMatchersToModelMatcher(
 	lMatchers []*labels.Matcher,
 	tagOpts models.TagOptions,
@@ -337,8 +337,8 @@ func LabelMatchersToModelMatcher(
 	return matchers, nil
 }
 
-// promTypeToM3 converts a prometheus label type to m3 matcher type
-//TODO(nikunj): Consider merging with prompb code
+// promTypeToM3 converts a prometheus label type to m3 matcher type.
+// TODO(nikunj): Consider merging with prompb code.
 func promTypeToM3(labelType labels.MatchType) (models.MatchType, error) {
 	switch labelType {
 	case labels.MatchEqual:
@@ -371,7 +371,7 @@ func promVectorCardinalityToM3(card promql.VectorMatchCardinality) binary.Vector
 }
 
 func promMatchingToM3(vectorMatching *promql.VectorMatching) *binary.VectorMatching {
-	// vectorMatching can be nil iff at least one of the sides is a scalar
+	// vectorMatching can be nil iff at least one of the sides is a scalar.
 	if vectorMatching == nil {
 		return nil
 	}

--- a/src/query/parser/promql/types.go
+++ b/src/query/parser/promql/types.go
@@ -248,7 +248,6 @@ func NewFunctionExpr(
 		return p, true, err
 
 	default:
-		// TODO: handle other types.
 		return nil, false, fmt.Errorf("function not supported: %s", name)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR fixes #1619. It introduces support for unary expressions -- specifically `+` and `-`. For example, this query is now supported: 

```
-sum(up)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Yes, this PR adds support for Prometheus unary expressions (`+` and `-`).
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
