### PR TITLE
[dbnode] Remove coldwrites error message until feature is ready

### DIFF
--- a/src/dbnode/storage/errors/types.go
+++ b/src/dbnode/storage/errors/types.go
@@ -35,9 +35,10 @@ var (
 	ErrTooPast = xerrors.NewInvalidParamsError(errors.New("datapoint is too far in the past"))
 
 	// ErrColdWritesNotEnabled is returned when cold writes are disabled
-	// and a write is too far in the past or future.
+	// and a write is too far in the past or future. Note, the error intentionally
+	// excludes anything regarding the cold writes feature until it's release.
 	ErrColdWritesNotEnabled = xerrors.NewInvalidParamsError(errors.New(
-		"cold writes not enabled and datapoint is too far in the past or future"))
+		"datapoint is too far in the past or future"))
 )
 
 // NewUnknownNamespaceError returns a new error indicating an unknown namespace parameter.

--- a/src/dbnode/storage/errors/types.go
+++ b/src/dbnode/storage/errors/types.go
@@ -36,7 +36,7 @@ var (
 
 	// ErrColdWritesNotEnabled is returned when cold writes are disabled
 	// and a write is too far in the past or future. Note, the error intentionally
-	// excludes anything regarding the cold writes feature until it's release.
+	// excludes anything regarding the cold writes feature until its release.
 	ErrColdWritesNotEnabled = xerrors.NewInvalidParamsError(errors.New(
 		"datapoint is too far in the past or future"))
 )

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -29,10 +29,10 @@ import (
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/digest"
 	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	m3dberrors "github.com/m3db/m3/src/dbnode/storage/errors"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	"github.com/m3db/m3/src/x/context"
@@ -79,7 +79,7 @@ type databaseBuffer interface {
 		id ident.ID,
 		tags ident.Tags,
 		persistFn persist.DataFn,
-                nsCtx namespace.Context,
+		nsCtx namespace.Context,
 	) error
 
 	Flush(
@@ -246,9 +246,12 @@ func (b *dbBuffer) Write(
 	writeType := b.ResolveWriteType(timestamp, now)
 
 	if writeType == ColdWrite {
-		if !b.coldWritesEnabled {
-			return false, m3dberrors.ErrColdWritesNotEnabled
-		}
+		/*
+			Disable until cold writes is ready as this is confusing to users
+			if !b.coldWritesEnabled {
+				return false, m3dberrors.ErrColdWritesNotEnabled
+			}
+		*/
 
 		if now.Add(-b.retentionPeriod).After(timestamp) {
 			return false, m3dberrors.ErrTooPast

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -247,7 +247,7 @@ func (b *dbBuffer) Write(
 
 	if writeType == ColdWrite {
 		/*
-			Disable until cold writes is ready as this is confusing to users
+			Disable until cold writes is ready as this is confusing to users.
 			if !b.coldWritesEnabled {
 				return false, m3dberrors.ErrColdWritesNotEnabled
 			}

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -246,7 +246,6 @@ func (b *dbBuffer) Write(
 	writeType := b.ResolveWriteType(timestamp, now)
 
 	if writeType == ColdWrite {
-
 		if !b.coldWritesEnabled {
 			return false, m3dberrors.ErrColdWritesNotEnabled
 		}

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -246,12 +246,10 @@ func (b *dbBuffer) Write(
 	writeType := b.ResolveWriteType(timestamp, now)
 
 	if writeType == ColdWrite {
-		/*
-			Disable until cold writes is ready as this is confusing to users.
-			if !b.coldWritesEnabled {
-				return false, m3dberrors.ErrColdWritesNotEnabled
-			}
-		*/
+
+		if !b.coldWritesEnabled {
+			return false, m3dberrors.ErrColdWritesNotEnabled
+		}
 
 		if now.Add(-b.retentionPeriod).After(timestamp) {
 			return false, m3dberrors.ErrTooPast


### PR DESCRIPTION
**What this PR does / why we need it**:
When any datapoint outside of the buffer is currently written, the user gets back a msg saying that the coldWrites feature (which is not ready) is not enabled. This causes a lot of confusion.
