### PR TITLE
[dbnode] add schema registry to client configuration

### DIFF
--- a/src/dbnode/client/config.go
+++ b/src/dbnode/client/config.go
@@ -87,16 +87,42 @@ type Configuration struct {
 
 // ProtoConfiguration is the configuration for running with ProtoDataMode enabled.
 type ProtoConfiguration struct {
-	// Whether proto is enabled.
+	// Enabled specifies whether proto is enabled.
 	Enabled bool `yaml:"enabled"`
+	// load user schema from client configuration into schema registry
+	// at startup/initialization time.
+	SchemaRegistry map[string]NamespaceProtoSchema `yaml:"schema_registry"`
+}
+
+type NamespaceProtoSchema struct {
+	SchemaFilePath string `yaml:"schemaFilePath"`
+	MessageName    string `yaml:"messageName"`
+}
+
+// Validate validates the NamespaceProtoSchema.
+func (c NamespaceProtoSchema) Validate() error {
+	if c.SchemaFilePath == "" {
+		return errors.New("schemaFilePath is required for Proto data mode")
+	}
+
+	if c.MessageName == "" {
+		return errors.New("messageName is required for Proto data mode")
+	}
+
+	return nil
 }
 
 // Validate validates the ProtoConfiguration.
 func (c *ProtoConfiguration) Validate() error {
-	if c == nil {
+	if c == nil || !c.Enabled {
 		return nil
 	}
 
+	for _, schema := range c.SchemaRegistry {
+		if err := schema.Validate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/src/dbnode/client/config_test.go
+++ b/src/dbnode/client/config_test.go
@@ -56,6 +56,15 @@ backgroundHealthCheckFailLimit: 4
 backgroundHealthCheckFailThrottleFactor: 0.5
 hashing:
   seed: 42
+proto:
+  enabled: false
+  schema_registry:
+    "ns1:2d":
+      schemaFilePath: "file/path/to/ns1/schema"
+      messageName: "ns1_msg_name"
+    ns2:
+      schemaFilePath: "file/path/to/ns2/schema"
+      messageName: "ns2_msg_name"
 `
 
 	fd, err := ioutil.TempFile("", "config.yaml")
@@ -107,6 +116,13 @@ hashing:
 		BackgroundHealthCheckFailThrottleFactor: &numHalf,
 		HashingConfiguration: &HashingConfiguration{
 			Seed: 42,
+		},
+		Proto: &ProtoConfiguration{
+			Enabled: false,
+			SchemaRegistry: map[string]NamespaceProtoSchema{
+				"ns1:2d": {SchemaFilePath: "file/path/to/ns1/schema", MessageName: "ns1_msg_name"},
+				"ns2": {SchemaFilePath: "file/path/to/ns2/schema", MessageName: "ns2_msg_name"},
+			},
 		},
 	}
 


### PR DESCRIPTION
Allow client configuration to load schema from file.
The code is the same as in cmd/services/m3dbnode/config