### PR TITLE
Support repair config in server.go

### DIFF
--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -612,7 +612,7 @@ func Run(runOpts RunOptions) {
 		repairOpts := opts.RepairOptions().
 			SetRepairInterval(cfg.Repair.Interval).
 			SetRepairTimeOffset(cfg.Repair.Offset).
-			SetRepairJitter(cfg.Repair.Jitter).
+			SetRepairTimeJitter(cfg.Repair.Jitter).
 			SetRepairThrottle(cfg.Repair.Throttle).
 			SetRepairCheckInterval(cfg.Repair.CheckInterval).
 			SetAdminClient(m3dbClient)

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -608,6 +608,7 @@ func Run(runOpts RunOptions) {
 	kvWatchClientConsistencyLevels(envCfg.KVStore, logger,
 		clientAdminOpts, runtimeOptsMgr)
 
+	opts = opts.SetRepairEnabled(false)
 	if cfg.Repair != nil {
 		repairOpts := opts.RepairOptions().
 			SetRepairInterval(cfg.Repair.Interval).
@@ -620,9 +621,6 @@ func Run(runOpts RunOptions) {
 		opts = opts.
 			SetRepairEnabled(cfg.Repair.Enabled).
 			SetRepairOptions(repairOpts)
-	} else {
-		opts = opts.
-			SetRepairEnabled(false)
 	}
 
 	// Set bootstrap options - We need to create a topology map provider from the

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -611,7 +611,7 @@ func Run(runOpts RunOptions) {
 	if cfg.Repair != nil {
 		repairOpts := opts.RepairOptions().
 			SetRepairInterval(cfg.Repair.Interval).
-			SetRepairOffset(cfg.Repair.Offset).
+			SetRepairTimeOffset(cfg.Repair.Offset).
 			SetRepairJitter(cfg.Repair.Jitter).
 			SetRepairThrottle(cfg.Repair.Throttle).
 			SetRepairCheckInterval(cfg.Repair.CheckInterval).

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -614,7 +614,8 @@ func Run(runOpts RunOptions) {
 			SetRepairOffset(cfg.Repair.Offset).
 			SetRepairJitter(cfg.Repair.Jitter).
 			SetRepairThrottle(cfg.Repair.Throttle).
-			SetRepairCheckInterval(cfg.Repair.CheckInterval)
+			SetRepairCheckInterval(cfg.Repair.CheckInterval).
+			SetAdminClient(m3dbClient)
 
 		opts = opts.
 			SetRepairEnabled(cfg.Repair.Enabled).

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -64,7 +64,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/ts"
-	"github.com/m3db/m3/src/dbnode/x/tchannel"
+	xtchannel "github.com/m3db/m3/src/dbnode/x/tchannel"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	"github.com/m3db/m3/src/m3ninx/postings"
 	"github.com/m3db/m3/src/m3ninx/postings/roaring"
@@ -608,9 +608,21 @@ func Run(runOpts RunOptions) {
 	kvWatchClientConsistencyLevels(envCfg.KVStore, logger,
 		clientAdminOpts, runtimeOptsMgr)
 
-	opts = opts.
-		// Feature currently not working.
-		SetRepairEnabled(false)
+	if cfg.Repair != nil {
+		repairOpts := opts.RepairOptions().
+			SetRepairInterval(cfg.Repair.Interval).
+			SetRepairOffset(cfg.Repair.Offset).
+			SetRepairJitter(cfg.Repair.Jitter).
+			SetRepairThrottle(cfg.Repair.Throttle).
+			SetRepairCheckInterval(cfg.Repair.CheckInterval)
+
+		opts = opts.
+			SetRepairEnabled(cfg.Repair.Enabled).
+			SetRepairOptions(repairOpts)
+	} else {
+		opts = opts.
+			SetRepairEnabled(false)
+	}
 
 	// Set bootstrap options - We need to create a topology map provider from the
 	// same topology that will be passed to the cluster so that when we make


### PR DESCRIPTION
**What this PR does / why we need it**:

Reading the repair config from YAML was disabled because we weren't using this feature at all. As we begin to invest into M3DB's repair functionality we want to be able to test the existing code.