### PR TITLE
Flow NS Context into shard repairer

### DIFF
--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1165,6 +1165,11 @@ func (n *dbNamespace) Repair(
 
 	workers := xsync.NewWorkerPool(repairer.Options().RepairShardConcurrency())
 	workers.Init()
+
+	n.RLock()
+	nsCtx := n.nsContextWithRLock()
+	n.RUnlock()
+
 	for _, shard := range shards {
 		shard := shard
 
@@ -1175,7 +1180,7 @@ func (n *dbNamespace) Repair(
 			ctx := n.opts.ContextPool().Get()
 			defer ctx.Close()
 
-			metadataRes, err := shard.Repair(ctx, tr, repairer)
+			metadataRes, err := shard.Repair(ctx, nsCtx, tr, repairer)
 
 			mutex.Lock()
 			if err != nil {

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/clock"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/sharding"
@@ -36,7 +37,6 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/index"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3/src/dbnode/tracepoint"
 	"github.com/m3db/m3/src/dbnode/ts"
@@ -302,8 +302,8 @@ func newDatabaseNamespace(
 
 	scope := iops.MetricsScope().SubScope("database").
 		Tagged(map[string]string{
-		"namespace": id.String(),
-	})
+			"namespace": id.String(),
+		})
 
 	tickWorkersConcurrency := int(math.Max(1, float64(runtime.NumCPU())/8))
 	tickWorkers := xsync.NewWorkerPool(tickWorkersConcurrency)
@@ -355,8 +355,8 @@ func newDatabaseNamespace(
 	// If proto is disabled, err will always be nil.
 	if err != nil {
 		return nil, fmt.Errorf(
-		"unable to register schema listener for namespace %v, error: %v",
-		metadata.ID().String(), err)
+			"unable to register schema listener for namespace %v, error: %v",
+			metadata.ID().String(), err)
 	}
 	n.schemaListener = sl
 	n.initShards(nopts.BootstrapEnabled())
@@ -509,7 +509,7 @@ func (n *dbNamespace) Tick(c context.Cancellable, tickStart time.Time) error {
 	}
 
 	n.RLock()
-	nsCtx := namespace.Context{ID: n.id, Schema: n.schemaDescr}
+	nsCtx := n.nsContextWithRLock()
 	n.RUnlock()
 
 	// Tick through the shards at a capped level of concurrency
@@ -902,7 +902,7 @@ func (n *dbNamespace) Flush(
 		n.metrics.flush.ReportError(n.nowFn().Sub(callStart))
 		return errNamespaceNotBootstrapped
 	}
-	nsCtx := namespace.Context{Schema: n.schemaDescr}
+	nsCtx := n.nsContextWithRLock()
 	n.RUnlock()
 
 	if !n.nopts.FlushEnabled() {
@@ -994,7 +994,7 @@ func (n *dbNamespace) Snapshot(
 		n.metrics.snapshot.ReportError(n.nowFn().Sub(callStart))
 		return errNamespaceNotBootstrapped
 	}
-	nsCtx = namespace.Context{Schema: n.schemaDescr}
+	nsCtx = n.nsContextWithRLock()
 	n.RUnlock()
 
 	if !n.nopts.SnapshotEnabled() {
@@ -1236,7 +1236,7 @@ func (n *dbNamespace) GetIndex() (namespaceIndex, error) {
 
 func (n *dbNamespace) shardFor(id ident.ID) (databaseShard, namespace.Context, error) {
 	n.RLock()
-	nsCtx := namespace.Context{ID: n.id, Schema: n.schemaDescr}
+	nsCtx := n.nsContextWithRLock()
 	shardID := n.shardSet.Lookup(id)
 	shard, err := n.shardAtWithRLock(shardID)
 	n.RUnlock()
@@ -1245,7 +1245,7 @@ func (n *dbNamespace) shardFor(id ident.ID) (databaseShard, namespace.Context, e
 
 func (n *dbNamespace) readableShardFor(id ident.ID) (databaseShard, namespace.Context, error) {
 	n.RLock()
-	nsCtx := namespace.Context{ID: n.id, Schema: n.schemaDescr}
+	nsCtx := n.nsContextWithRLock()
 	shardID := n.shardSet.Lookup(id)
 	shard, err := n.readableShardAtWithRLock(shardID)
 	n.RUnlock()
@@ -1254,7 +1254,7 @@ func (n *dbNamespace) readableShardFor(id ident.ID) (databaseShard, namespace.Co
 
 func (n *dbNamespace) readableShardAt(shardID uint32) (databaseShard, namespace.Context, error) {
 	n.RLock()
-	nsCtx := namespace.Context{Schema: n.schemaDescr}
+	nsCtx := n.nsContextWithRLock()
 	shard, err := n.readableShardAtWithRLock(shardID)
 	n.RUnlock()
 	return shard, nsCtx, err
@@ -1333,4 +1333,8 @@ func (n *dbNamespace) BootstrapState() ShardBootstrapStates {
 	}
 	n.RUnlock()
 	return shardStates
+}
+
+func (n *dbNamespace) nsContextWithRLock() namespace.Context {
+	return namespace.Context{ID: n.id, Schema: n.schemaDescr}
 }

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -651,7 +651,7 @@ func TestNamespaceRepair(t *testing.T) {
 			}
 		}
 		shard.EXPECT().
-			Repair(gomock.Any(), repairTimeRange, repairer).
+			Repair(gomock.Any(), gomock.Any(), repairTimeRange, repairer).
 			Return(res, errs[i])
 		ns.shards[testShardIDs[i].ID()] = shard
 	}

--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -86,7 +86,6 @@ func (r shardRepairer) Options() repair.Options {
 func (r shardRepairer) Repair(
 	ctx context.Context,
 	nsCtx namespace.Context,
-	namespace ident.ID,
 	tr xtime.Range,
 	shard databaseShard,
 ) (repair.MetadataComparisonResult, error) {
@@ -124,7 +123,7 @@ func (r shardRepairer) Repair(
 
 	// Add peer metadata
 	level := r.rpopts.RepairConsistencyLevel()
-	peerIter, err := session.FetchBlocksMetadataFromPeers(namespace, shard.ID(), start, end,
+	peerIter, err := session.FetchBlocksMetadataFromPeers(nsCtx.ID, shard.ID(), start, end,
 		level, result.NewOptions())
 	if err != nil {
 		return repair.MetadataComparisonResult{}, err
@@ -135,7 +134,7 @@ func (r shardRepairer) Repair(
 
 	metadataRes := metadata.Compare()
 
-	r.recordFn(namespace, shard, metadataRes)
+	r.recordFn(nsCtx.ID, shard, metadataRes)
 
 	return metadataRes, nil
 }

--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/clock"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/repair"
@@ -84,6 +85,7 @@ func (r shardRepairer) Options() repair.Options {
 
 func (r shardRepairer) Repair(
 	ctx context.Context,
+	nsCtx namespace.Context,
 	namespace ident.ID,
 	tr xtime.Range,
 	shard databaseShard,

--- a/src/dbnode/storage/repair_test.go
+++ b/src/dbnode/storage/repair_test.go
@@ -311,7 +311,7 @@ func TestDatabaseShardRepairerRepair(t *testing.T) {
 
 	ctx := context.NewContext()
 	nsCtx := namespace.Context{ID: namespaceID}
-	repairer.Repair(ctx, nsCtx, namespaceID, repairTimeRange, shard)
+	repairer.Repair(ctx, nsCtx, repairTimeRange, shard)
 	require.Equal(t, namespaceID, resNamespace)
 	require.Equal(t, resShard, shard)
 	require.Equal(t, int64(2), resDiff.NumSeries)

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/generated/proto/pagetoken"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/retention"
@@ -39,7 +40,6 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/storage/index/convert"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/storage/repair"
 	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3/src/dbnode/storage/series/lookup"
@@ -2072,10 +2072,11 @@ func (s *dbShard) CleanupExpiredFileSets(earliestToRetain time.Time) error {
 
 func (s *dbShard) Repair(
 	ctx context.Context,
+	nsCtx namespace.Context,
 	tr xtime.Range,
 	repairer databaseShardRepairer,
 ) (repair.MetadataComparisonResult, error) {
-	return repairer.Repair(ctx, s.namespace.ID(), tr, s)
+	return repairer.Repair(ctx, nsCtx, s.namespace.ID(), tr, s)
 }
 
 func (s *dbShard) BootstrapState() BootstrapState {

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -2076,7 +2076,7 @@ func (s *dbShard) Repair(
 	tr xtime.Range,
 	repairer databaseShardRepairer,
 ) (repair.MetadataComparisonResult, error) {
-	return repairer.Repair(ctx, nsCtx, s.namespace.ID(), tr, s)
+	return repairer.Repair(ctx, nsCtx, tr, s)
 }
 
 func (s *dbShard) BootstrapState() BootstrapState {

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2341,18 +2341,18 @@ func (mr *MockdatabaseShardRepairerMockRecorder) Options() *gomock.Call {
 }
 
 // Repair mocks base method
-func (m *MockdatabaseShardRepairer) Repair(ctx context.Context, nsCtx namespace.Context, namespace ident.ID, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
+func (m *MockdatabaseShardRepairer) Repair(ctx context.Context, nsCtx namespace.Context, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Repair", ctx, nsCtx, namespace, tr, shard)
+	ret := m.ctrl.Call(m, "Repair", ctx, nsCtx, tr, shard)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Repair indicates an expected call of Repair
-func (mr *MockdatabaseShardRepairerMockRecorder) Repair(ctx, nsCtx, namespace, tr, shard interface{}) *gomock.Call {
+func (mr *MockdatabaseShardRepairerMockRecorder) Repair(ctx, nsCtx, tr, shard interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShardRepairer)(nil).Repair), ctx, nsCtx, namespace, tr, shard)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShardRepairer)(nil).Repair), ctx, nsCtx, tr, shard)
 }
 
 // MockdatabaseRepairer is a mock of databaseRepairer interface

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -1732,18 +1732,18 @@ func (mr *MockdatabaseShardMockRecorder) CleanupExpiredFileSets(earliestToRetain
 }
 
 // Repair mocks base method
-func (m *MockdatabaseShard) Repair(ctx context.Context, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
+func (m *MockdatabaseShard) Repair(ctx context.Context, nsCtx namespace.Context, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Repair", ctx, tr, repairer)
+	ret := m.ctrl.Call(m, "Repair", ctx, nsCtx, tr, repairer)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Repair indicates an expected call of Repair
-func (mr *MockdatabaseShardMockRecorder) Repair(ctx, tr, repairer interface{}) *gomock.Call {
+func (mr *MockdatabaseShardMockRecorder) Repair(ctx, nsCtx, tr, repairer interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShard)(nil).Repair), ctx, tr, repairer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShard)(nil).Repair), ctx, nsCtx, tr, repairer)
 }
 
 // MocknamespaceIndex is a mock of namespaceIndex interface
@@ -2341,18 +2341,18 @@ func (mr *MockdatabaseShardRepairerMockRecorder) Options() *gomock.Call {
 }
 
 // Repair mocks base method
-func (m *MockdatabaseShardRepairer) Repair(ctx context.Context, namespace ident.ID, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
+func (m *MockdatabaseShardRepairer) Repair(ctx context.Context, nsCtx namespace.Context, namespace ident.ID, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Repair", ctx, namespace, tr, shard)
+	ret := m.ctrl.Call(m, "Repair", ctx, nsCtx, namespace, tr, shard)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Repair indicates an expected call of Repair
-func (mr *MockdatabaseShardRepairerMockRecorder) Repair(ctx, namespace, tr, shard interface{}) *gomock.Call {
+func (mr *MockdatabaseShardRepairerMockRecorder) Repair(ctx, nsCtx, namespace, tr, shard interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShardRepairer)(nil).Repair), ctx, namespace, tr, shard)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShardRepairer)(nil).Repair), ctx, nsCtx, namespace, tr, shard)
 }
 
 // MockdatabaseRepairer is a mock of databaseRepairer interface

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -643,7 +643,6 @@ type databaseShardRepairer interface {
 	Repair(
 		ctx context.Context,
 		nsCtx namespace.Context,
-		namespace ident.ID,
 		tr xtime.Range,
 		shard databaseShard,
 	) (repair.MetadataComparisonResult, error)

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/runtime"
@@ -35,7 +36,6 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/index"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/storage/repair"
 	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3/src/dbnode/ts"
@@ -475,6 +475,7 @@ type databaseShard interface {
 	// Repair repairs the shard data for a given time.
 	Repair(
 		ctx context.Context,
+		nsCtx namespace.Context,
 		tr xtime.Range,
 		repairer databaseShardRepairer,
 	) (repair.MetadataComparisonResult, error)
@@ -641,6 +642,7 @@ type databaseShardRepairer interface {
 	// Repair repairs the data for a given namespace and shard.
 	Repair(
 		ctx context.Context,
+		nsCtx namespace.Context,
 		namespace ident.ID,
 		tr xtime.Range,
 		shard databaseShard,


### PR DESCRIPTION
**What this PR does / why we need it**:
Repair logic needs access to the nsctx long term so that it can perform remote reads / merges.
