### PR TITLE
[query] Drop series with no values in the given range

### DIFF
--- a/src/query/api/v1/handler/prometheus/native/common.go
+++ b/src/query/api/v1/handler/prometheus/native/common.go
@@ -240,9 +240,10 @@ func parseQuery(r *http.Request) (string, error) {
 	return queries[0], nil
 }
 
-func filterNaNSeries(series []*ts.Series,
-	start time.Time,
-	end time.Time,
+func filterNaNSeries(
+	series []*ts.Series,
+	startInclusive time.Time,
+	endInclusive time.Time,
 ) []*ts.Series {
 	filtered := series[:0]
 	for _, s := range series {
@@ -251,7 +252,7 @@ func filterNaNSeries(series []*ts.Series,
 		for _, dp := range dps {
 			if !math.IsNaN(dp.Value) {
 				ts := dp.Timestamp
-				if ts.Before(start) || ts.After(end) {
+				if ts.Before(startInclusive) || ts.After(endInclusive) {
 					continue
 				}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Follows on from #1682 to also remove series with no NaN-values in the given range, as they were still appearing as empty series.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
Will no longer add series with no non-NaN points in the given range
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
