### PR TITLE
[query] Propagate Limit settings for remote reads

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/read.go
+++ b/src/query/api/v1/handler/prometheus/remote/read.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/api/v1/handler"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus"
 	"github.com/m3db/m3/src/query/executor"
@@ -50,17 +51,24 @@ const (
 
 // PromReadHandler represents a handler for prometheus read endpoint.
 type PromReadHandler struct {
-	engine          *executor.Engine
-	promReadMetrics promReadMetrics
-	timeoutOpts     *prometheus.TimeoutOpts
+	engine              *executor.Engine
+	promReadMetrics     promReadMetrics
+	timeoutOpts         *prometheus.TimeoutOpts
+	fetchOptionsBuilder handler.FetchOptionsBuilder
 }
 
 // NewPromReadHandler returns a new instance of handler.
-func NewPromReadHandler(engine *executor.Engine, scope tally.Scope, timeoutOpts *prometheus.TimeoutOpts) http.Handler {
+func NewPromReadHandler(
+	engine *executor.Engine,
+	fetchOptionsBuilder handler.FetchOptionsBuilder,
+	scope tally.Scope,
+	timeoutOpts *prometheus.TimeoutOpts,
+) http.Handler {
 	return &PromReadHandler{
-		engine:          engine,
-		promReadMetrics: newPromReadMetrics(scope),
-		timeoutOpts:     timeoutOpts,
+		engine:              engine,
+		promReadMetrics:     newPromReadMetrics(scope),
+		timeoutOpts:         timeoutOpts,
+		fetchOptionsBuilder: fetchOptionsBuilder,
 	}
 }
 
@@ -72,9 +80,12 @@ type promReadMetrics struct {
 
 func newPromReadMetrics(scope tally.Scope) promReadMetrics {
 	return promReadMetrics{
-		fetchSuccess:      scope.Counter("fetch.success"),
-		fetchErrorsServer: scope.Tagged(map[string]string{"code": "5XX"}).Counter("fetch.errors"),
-		fetchErrorsClient: scope.Tagged(map[string]string{"code": "4XX"}).Counter("fetch.errors"),
+		fetchSuccess: scope.
+			Counter("fetch.success"),
+		fetchErrorsServer: scope.Tagged(map[string]string{"code": "5XX"}).
+			Counter("fetch.errors"),
+		fetchErrorsClient: scope.Tagged(map[string]string{"code": "4XX"}).
+			Counter("fetch.errors"),
 	}
 }
 
@@ -97,7 +108,13 @@ func (h *PromReadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.read(ctx, w, req, timeout)
+	fetchOpts, rErr := h.fetchOptionsBuilder.NewFetchOptions(r)
+	if rErr != nil {
+		xhttp.Error(w, rErr.Inner(), rErr.Code())
+		return
+	}
+
+	result, err := h.read(ctx, w, req, timeout, fetchOpts.Limit)
 	if err != nil {
 		h.promReadMetrics.fetchErrorsServer.Inc(1)
 		logger.Error("unable to fetch data", zap.Error(err))
@@ -153,10 +170,11 @@ func (h *PromReadHandler) read(
 	w http.ResponseWriter,
 	r *prompb.ReadRequest,
 	timeout time.Duration,
+	limit int,
 ) ([]*prompb.QueryResult, error) {
 	// TODO: Handle multi query use case
 	if len(r.Queries) != 1 {
-		return nil, fmt.Errorf("prometheus read endpoint currently only supports one query at a time")
+		return nil, fmt.Errorf("only one query at a time is currently supported")
 	}
 
 	ctx, cancel := context.WithTimeout(reqCtx, timeout)
@@ -169,8 +187,12 @@ func (h *PromReadHandler) read(
 
 	// Results is closed by execute
 	results := make(chan *storage.QueryResult)
+	opts := &executor.EngineOptions{
+		QueryContextOptions: models.QueryContextOptions{
+			LimitMaxTimeseries: limit,
+		},
+	}
 
-	opts := &executor.EngineOptions{}
 	// Detect clients closing connections
 	handler.CloseWatcher(ctx, cancel, w)
 	go h.engine.Execute(ctx, query, opts, results)

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -176,7 +176,7 @@ func (h *Handler) RegisterRoutes() error {
 
 	// Prometheus remote read/write endpoints
 	promRemoteReadHandler := remote.NewPromReadHandler(h.engine,
-		h.scope.Tagged(remoteSource), h.timeoutOpts)
+		h.fetchOptionsBuilder, h.scope.Tagged(remoteSource), h.timeoutOpts)
 	promRemoteWriteHandler, err := remote.NewPromWriteHandler(
 		h.downsamplerAndWriter,
 		h.tagOptions,


### PR DESCRIPTION
**What this PR does / why we need it**:

Limit was not correctly propagated for remote reads, which could OOM clusters when using the Prometheus remote read endpoints.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
Users who set a low limit but relied on the prom read endpoints may see less data returned, but this is unlikely, and is easily fixed by updating the limit in coordinator settings.
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
