### PR TITLE
update namespace metadata dynamically

### DIFF
--- a/src/dbnode/namespace/namespace_mock.go
+++ b/src/dbnode/namespace/namespace_mock.go
@@ -658,16 +658,16 @@ func (m *MockSchemaListener) EXPECT() *MockSchemaListenerMockRecorder {
 	return m.recorder
 }
 
-// SetSchema mocks base method
-func (m *MockSchemaListener) SetSchema(value SchemaDescr) {
+// SetSchemaHistory mocks base method
+func (m *MockSchemaListener) SetSchemaHistory(value SchemaHistory) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSchema", value)
+	m.ctrl.Call(m, "SetSchemaHistory", value)
 }
 
-// SetSchema indicates an expected call of SetSchema
-func (mr *MockSchemaListenerMockRecorder) SetSchema(value interface{}) *gomock.Call {
+// SetSchemaHistory indicates an expected call of SetSchemaHistory
+func (mr *MockSchemaListenerMockRecorder) SetSchemaHistory(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSchema", reflect.TypeOf((*MockSchemaListener)(nil).SetSchema), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSchemaHistory", reflect.TypeOf((*MockSchemaListener)(nil).SetSchemaHistory), value)
 }
 
 // MockSchemaRegistry is a mock of SchemaRegistry interface

--- a/src/dbnode/namespace/schema_registry.go
+++ b/src/dbnode/namespace/schema_registry.go
@@ -154,21 +154,13 @@ func (sr *schemaRegistry) RegisterListener(
 	<-watch.C()
 
 	// Deliver the current schema
-	if schema, ok := watchable.Get().(SchemaHistory).GetLatest(); ok {
-		listener.SetSchema(schema)
-	} else if sr.logger != nil {
-		sr.logger.Error("can not update schema listener with empty schema history")
-	}
+	listener.SetSchemaHistory(watchable.Get().(SchemaHistory))
 
 	// Spawn a new goroutine that will terminate when the
 	// watchable terminates on the close of the runtime options manager
 	go func() {
 		for range watch.C() {
-			if schema, ok := watchable.Get().(SchemaHistory).GetLatest(); ok {
-				listener.SetSchema(schema)
-			} else if sr.logger != nil {
-				sr.logger.Error("can not update schema listener with empty schema history")
-			}
+			listener.SetSchemaHistory(watchable.Get().(SchemaHistory))
 		}
 	}()
 

--- a/src/dbnode/namespace/schema_registry_test.go
+++ b/src/dbnode/namespace/schema_registry_test.go
@@ -37,10 +37,12 @@ type mockListener struct {
 	value SchemaDescr
 }
 
-func (l *mockListener) SetSchema(value SchemaDescr) {
+func (l *mockListener) SetSchemaHistory(value SchemaHistory) {
 	l.Lock()
 	defer l.Unlock()
-	l.value = value
+	if s, ok := value.GetLatest(); ok {
+		l.value = s
+	}
 }
 
 func (l *mockListener) Schema() SchemaDescr {

--- a/src/dbnode/namespace/types.go
+++ b/src/dbnode/namespace/types.go
@@ -148,9 +148,9 @@ type SchemaHistory interface {
 
 // SchemaListener listens for updates to schema registry for a namespace.
 type SchemaListener interface {
-	// SetSchema is called when the listener is registered
+	// SetSchemaHistory is called when the listener is registered
 	// and when any updates occurred passing the new schema history.
-	SetSchema(value SchemaDescr)
+	SetSchemaHistory(value SchemaHistory)
 }
 
 // SchemaRegistry represents the schema registry for a database.

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -370,18 +370,19 @@ func (n *dbNamespace) SetSchemaHistory(value namespace.SchemaHistory) {
 	n.Lock()
 	defer n.Unlock()
 
+	schema, ok := value.GetLatest()
+	if !ok {
+		n.log.Error("can not update namespace schema to empty", zap.Stringer("namespace", n.ID()))
+	}
+
 	metadata, err := namespace.NewMetadata(n.ID(), n.nopts.SetSchemaHistory(value))
 	if err != nil {
 		n.log.Error("can not update namespace metadata with empty schema history", zap.Stringer("namespace", n.ID()), zap.Error(err))
 		return
 	}
 
-	if schema, ok := value.GetLatest(); ok {
-		n.schemaDescr = schema
-		n.metadata = metadata
-	} else {
-		n.log.Error("can not update namespace schema to empty", zap.Stringer("namespace", n.ID()))
-	}
+	n.schemaDescr = schema
+	n.metadata = metadata
 }
 
 func (n *dbNamespace) reportStatusLoop() {


### PR DESCRIPTION
namespace bootstrap depends on namespace.metadata for schema.

We need to deliver dynamic schema to namespace metadata as well, since bootstrap can be invoked when new shards are assigned to a node.