### PR TITLE
[api] placement delete: return 404 if not found

### DIFF
--- a/src/query/api/v1/handler/placement/delete_all_test.go
+++ b/src/query/api/v1/handler/placement/delete_all_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
+	"github.com/m3db/m3/src/cluster/kv"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -64,5 +65,15 @@ func TestPlacementDeleteAllHandler(t *testing.T) {
 
 		resp = w.Result()
 		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+		// Test delete not found error
+		w = httptest.NewRecorder()
+		req = httptest.NewRequest(DeleteAllHTTPMethod, M3DBDeleteAllURL, nil)
+		require.NotNil(t, req)
+		mockPlacementService.EXPECT().Delete().Return(kv.ErrNotFound)
+		handler.ServeHTTP(serviceName, w, req)
+
+		resp = w.Result()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**: Returns a 404 rather than 500 from the coordinator if we attempt to delete a nonexistent placement.
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
