### PR TITLE
[coordinator] Use table based approach for aggregation tile buffer past calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+# 0.10.0
+
+## Features
+
+- **M3Query**: Add multi-zone and multi-region configuration for coordinator (#1687)
+- **M3Query**: Add debug param to `GET` `/api/v1/namespace` endpoint for better readability (#1698)
+- **M3Coordinator**: Add "ingest_latency" histogram metric and return datapoint too old/new errors with offending timestamps (#1716)
+
+## Performance
+
+- **M3DB**: Add forward index write capability which eases index pressure at block boundaries (#1613)
+- **M3Query**: Drop empty series from appearing in output when `keepNaNs` option is set to disabled (#1682, #1684)
+- **M3DB**: Build and release M3DB with Go 1.12 (#1674)
+
+## Bug Fixes
+
+- **M3DB**: Fix a bug where peer bootstrapping would sometimes get stuck for a short period of time due to other M3DB nodes (temporarily) returning more than one block of data for a given time period (#1707)
+- **M3DB**: Fix a bug that would cause multiple orders of magnitude slow-down in peer bootstrapping / node replacements when one of the nodes in the cluster was hard down (#1677)
+- **M3Query**: Fix a bug with parsing Graphite find queries by adding `MatchField` and `MatchNotField` match types, and explicitly making use of them in graphite queries (#1676)
+- **M3Query**: Propagate limit settings when using Prometheus Remote Read (#1685)
+- **M3Coordinator**: Return a 404 rather than a 500 if we attempt to delete a nonexistent placement (#1701)
+- **M3Coordinator**: Return HTTP 400 if all sent samples encounter too old/new or other bad request error (#1692)
+
 # 0.9.6
 
 ## Bug Fixes

--- a/integrations/grafana/m3coordinator_dashboard.json
+++ b/integrations/grafana/m3coordinator_dashboard.json
@@ -89,7 +89,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(coordinator_fetch_success{source=\"remote\"}[1m])",
+          "expr": "rate(coordinator_fetch_success{}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "queries_per_second",
@@ -175,7 +175,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(coordinator_fetch_errors{source=\"remote\"}[1m])) by (code)",
+          "expr": "sum(rate(coordinator_fetch_errors{}[1m])) by (code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{code}}",
@@ -274,7 +274,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(coordinator_write_success{source=\"remote\"}[1m])",
+          "expr": "sum(irate(coordinator_m3db_client_write_success{}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "write_per_second",
@@ -285,7 +285,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Writes Per Second",
+      "title": "Remote Writes Per Second",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -360,7 +360,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(coordinator_write_errors{source=\"remote\"}[1m])) by (code)",
+          "expr": "sum(rate(coordinator_write_success{}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "2XX",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(coordinator_write_errors{}[1m])) by (code)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{code}}",
@@ -371,7 +378,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Write Errors Per Second",
+      "title": "Remote Write Batch Requests Per Second",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -388,6 +395,114 @@
       "yaxes": [
         {
           "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "This is the measurement of the difference between the server's relative time now() and the datapoint's timestamp after it is persisted (or fails) to be written.",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "paceLength": 10,
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(coordinator_ingest_latency_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p99 latency",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(coordinator_ingest_latency_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p95 latency",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.75, sum(rate(coordinator_ingest_latency_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p75 latency",
+          "refId": "C"
+        },
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(coordinator_ingest_latency_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "p50 latency",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Write Ingest Latency (Relative to datapoint timestamp)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -56,15 +56,12 @@ import (
 )
 
 const (
-	instanceID                         = "downsampler_local"
-	placementKVKey                     = "/placement"
-	replicationFactor                  = 1
-	defaultStorageFlushConcurrency     = 20000
-	defaultOpenTimeout                 = 10 * time.Second
-	minBufferPast                      = 5 * time.Second
-	maxBufferPast                      = 10 * time.Minute
-	defaultBufferPastTimedMetricFactor = 0.5
-	defaultBufferFutureTimedMetric     = time.Minute
+	instanceID                     = "downsampler_local"
+	placementKVKey                 = "/placement"
+	replicationFactor              = 1
+	defaultStorageFlushConcurrency = 20000
+	defaultOpenTimeout             = 10 * time.Second
+	defaultBufferFutureTimedMetric = time.Minute
 )
 
 var (

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -48,10 +48,10 @@ import (
 	"github.com/m3db/m3/src/metrics/rules"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
-	"github.com/m3db/m3/src/x/serialize"
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
 	xsync "github.com/m3db/m3/src/x/sync"
 )
 
@@ -63,7 +63,7 @@ const (
 	defaultOpenTimeout                 = 10 * time.Second
 	minBufferPast                      = 5 * time.Second
 	maxBufferPast                      = 10 * time.Minute
-	defaultBufferPastTimedMetricFactor = 0.1
+	defaultBufferPastTimedMetricFactor = 0.5
 	defaultBufferFutureTimedMetric     = time.Minute
 )
 

--- a/src/cmd/services/m3coordinator/downsample/options_test.go
+++ b/src/cmd/services/m3coordinator/downsample/options_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package downsample
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferForPastTimedMetric(t *testing.T) {
+	tests := []struct {
+		value    time.Duration
+		expected time.Duration
+	}{
+		{value: -1 * time.Second, expected: 15 * time.Second},
+		{value: 0, expected: 15 * time.Second},
+		{value: 1 * time.Second, expected: 15 * time.Second},
+		{value: 29 * time.Second, expected: 15 * time.Second},
+		{value: 30 * time.Second, expected: 30 * time.Second},
+		{value: 59 * time.Second, expected: 30 * time.Second},
+		{value: 60 * time.Second, expected: time.Minute},
+		{value: 59 * time.Minute, expected: time.Minute},
+		{value: 61 * time.Minute, expected: time.Minute},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("test_value_%v", test.value), func(t *testing.T) {
+			result := bufferForPastTimedMetric(test.value)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This fixes a relatively unreasonable default of only 10% of tile size for the aggregation buffer past value.  Table based approach allows for some reasonable defaults, the observed delay from Prometheus remote write seems to be under 15seconds when it's healthy (not 5s like the current clamp minimum).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
