### PR TITLE
Add tests for block leaser

### DIFF
--- a/src/dbnode/storage/block/lease.go
+++ b/src/dbnode/storage/block/lease.go
@@ -31,7 +31,6 @@ var (
 	errLeaserNotRegistered     = errors.New("leaser not registered")
 )
 
-// TODO: This needs tests!
 type leaseManager struct {
 	sync.Mutex
 	leasers  []Leaser

--- a/src/dbnode/storage/block/lease_test.go
+++ b/src/dbnode/storage/block/lease_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package block
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterLeaserPreventsDuplicates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	leaser := NewMockLeaser(ctrl)
+	leaseMgr := NewLeaseManager(nil)
+
+	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
+	require.Equal(t, errLeaserAlreadyRegistered, leaseMgr.RegisterLeaser(leaser))
+}

--- a/src/dbnode/storage/block/lease_test.go
+++ b/src/dbnode/storage/block/lease_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegisterLeaserPreventsDuplicates(t *testing.T) {
+func TestRegisterLeaser(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -36,4 +36,18 @@ func TestRegisterLeaserPreventsDuplicates(t *testing.T) {
 
 	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
 	require.Equal(t, errLeaserAlreadyRegistered, leaseMgr.RegisterLeaser(leaser))
+}
+
+func TestUnregisterLeaser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	leaser := NewMockLeaser(ctrl)
+	leaseMgr := NewLeaseManager(nil)
+
+	require.Equal(t, errLeaserNotRegistered, leaseMgr.UnregisterLeaser(leaser))
+	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
+	require.Equal(t, errLeaserAlreadyRegistered, leaseMgr.RegisterLeaser(leaser))
+	require.NoError(t, leaseMgr.UnregisterLeaser(leaser))
+	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
 }

--- a/src/dbnode/storage/block/lease_test.go
+++ b/src/dbnode/storage/block/lease_test.go
@@ -48,15 +48,29 @@ func TestUnregisterLeaser(t *testing.T) {
 	defer ctrl.Finish()
 
 	var (
-		leaser   = NewMockLeaser(ctrl)
+		leaser1  = NewMockLeaser(ctrl)
+		leaser2  = NewMockLeaser(ctrl)
 		leaseMgr = NewLeaseManager(nil)
 	)
 
-	require.Equal(t, errLeaserNotRegistered, leaseMgr.UnregisterLeaser(leaser))
-	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
-	require.Equal(t, errLeaserAlreadyRegistered, leaseMgr.RegisterLeaser(leaser))
-	require.NoError(t, leaseMgr.UnregisterLeaser(leaser))
-	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
+	// Cant unregister if not registered.
+	require.Equal(t, errLeaserNotRegistered, leaseMgr.UnregisterLeaser(leaser1))
+	require.Equal(t, errLeaserNotRegistered, leaseMgr.UnregisterLeaser(leaser2))
+
+	// Register.
+	require.NoError(t, leaseMgr.RegisterLeaser(leaser1))
+	require.NoError(t, leaseMgr.RegisterLeaser(leaser2))
+
+	// Ensure registered.
+	require.Equal(t, errLeaserAlreadyRegistered, leaseMgr.RegisterLeaser(leaser1))
+	require.Equal(t, errLeaserAlreadyRegistered, leaseMgr.RegisterLeaser(leaser2))
+
+	// Ensure unregistering works.
+	require.NoError(t, leaseMgr.UnregisterLeaser(leaser1))
+	require.NoError(t, leaseMgr.RegisterLeaser(leaser1))
+
+	// Ensure unregistering leaser1 does not unregister leaser2.
+	require.Equal(t, errLeaserAlreadyRegistered, leaseMgr.RegisterLeaser(leaser2))
 }
 
 func TestOpenLease(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R adds test for the block.LeaseManager interface.