### PR TITLE
[DBNode] - Add Block Lease Verifier Implementation

### DIFF
--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -951,6 +951,18 @@ func (d *db) BootstrapState() DatabaseBootstrapState {
 	}
 }
 
+func (d *db) FlushState(
+	namespace ident.ID,
+	shardID uint32,
+	blockStart time.Time,
+) (fileOpState, error) {
+	n, err := d.namespaceFor(namespace)
+	if err != nil {
+		return fileOpState{}, err
+	}
+	return n.FlushState(shardID, blockStart)
+}
+
 func (d *db) namespaceFor(namespace ident.ID) (databaseNamespace, error) {
 	d.RLock()
 	n, exists := d.namespaces.Get(namespace)

--- a/src/dbnode/storage/lease_verifier.go
+++ b/src/dbnode/storage/lease_verifier.go
@@ -58,6 +58,10 @@ func (v *leaseVerifier) VerifyLease(
 		// The cold flush version and volume correspond 1:1 so a lease should only
 		// be permitted if the requested volume is equal to the highest flushed
 		// volume (the current cold flush version).
+		//
+		// This logic also holds in situations where the cold flush feature is not
+		// enabled because even in that case the volume number for the first warm
+		// flush should be 0 and the cold version should also be 0.
 		return fmt.Errorf(
 			"cannot permit lease for ns: %s, shard: %d, blockStart: %s, volume: %d when latest volume is %d",
 			descriptor.Namespace.String(), descriptor.Shard, descriptor.BlockStart.String(), state.Volume, flushState.ColdVersion)

--- a/src/dbnode/storage/lease_verifier.go
+++ b/src/dbnode/storage/lease_verifier.go
@@ -25,11 +25,18 @@ import (
 )
 
 type leaseVerifier struct {
+	db database
 }
 
 func (v *leaseVerifier) VerifyLease(
 	descriptor block.LeaseDescriptor,
 	state block.LeaseState,
 ) error {
+	// namespaces, err := m.database.GetOwnedNamespaces()
+	// if err != nil {
+	// 	return err
+	// }
+
+	// var matchingNS
 	return nil
 }

--- a/src/dbnode/storage/lease_verifier.go
+++ b/src/dbnode/storage/lease_verifier.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package storage
+
+import (
+	"github.com/m3db/m3/src/dbnode/storage/block"
+)
+
+type leaseVerifier struct {
+}
+
+func (v *leaseVerifier) VerifyLease(
+	descriptor block.LeaseDescriptor,
+	state block.LeaseState,
+) error {
+	return nil
+}

--- a/src/dbnode/storage/lease_verifier_test.go
+++ b/src/dbnode/storage/lease_verifier_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package storage
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/m3db/m3/src/dbnode/storage/block"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testBlockDescriptor = block.LeaseDescriptor{
+		Namespace:  ident.StringID("test-ns"),
+		Shard:      0,
+		BlockStart: time.Now().Truncate(2 * time.Hour),
+	}
+	testBlockLeaseState = block.LeaseState{Volume: 0}
+)
+
+func TestLeaseVerifierHandlesErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		mockDB        = NewMockDatabase(ctrl)
+		leaseVerifier = newLeaseVerifier(mockDB)
+	)
+	mockDB.EXPECT().FlushState(
+		testBlockDescriptor.Namespace,
+		uint32(testBlockDescriptor.Shard),
+		testBlockDescriptor.BlockStart,
+	).Return(fileOpState{}, errors.New("some-error"))
+
+	err := leaseVerifier.VerifyLease(testBlockDescriptor, testBlockLeaseState)
+	require.Error(t, err)
+}
+
+func TestLeaseVerifierReturnsErrorIfNotLatestVolume(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		mockDB        = NewMockDatabase(ctrl)
+		leaseVerifier = newLeaseVerifier(mockDB)
+	)
+	mockDB.EXPECT().FlushState(
+		testBlockDescriptor.Namespace,
+		uint32(testBlockDescriptor.Shard),
+		testBlockDescriptor.BlockStart,
+	).Return(fileOpState{ColdVersion: testBlockLeaseState.Volume + 1}, nil)
+
+	err := leaseVerifier.VerifyLease(testBlockDescriptor, testBlockLeaseState)
+	require.Error(t, err)
+}
+
+func TestLeaseVerifierSuccessIfVolumeIsLatest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		volumeNum     = 1
+		state         = block.LeaseState{Volume: volumeNum}
+		mockDB        = NewMockDatabase(ctrl)
+		leaseVerifier = newLeaseVerifier(mockDB)
+	)
+	mockDB.EXPECT().FlushState(
+		testBlockDescriptor.Namespace,
+		uint32(testBlockDescriptor.Shard),
+		testBlockDescriptor.BlockStart,
+	).Return(fileOpState{ColdVersion: volumeNum}, nil)
+
+	require.NoError(t, leaseVerifier.VerifyLease(testBlockDescriptor, state))
+}

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1401,6 +1401,16 @@ func (n *dbNamespace) BootstrapState() ShardBootstrapStates {
 	return shardStates
 }
 
+func (n *dbNamespace) FlushState(shardID uint32, blockStart time.Time) (fileOpState, error) {
+	n.RLock()
+	defer n.RUnlock()
+	shard, err := n.shardAtWithRLock(shardID)
+	if err != nil {
+		return fileOpState{}, err
+	}
+	return shard.FlushState(blockStart), nil
+}
+
 func (n *dbNamespace) nsContextWithRLock() namespace.Context {
 	return namespace.Context{ID: n.id, Schema: n.schemaDescr}
 }

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -469,6 +469,21 @@ func (mr *MockDatabaseMockRecorder) BootstrapState() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BootstrapState", reflect.TypeOf((*MockDatabase)(nil).BootstrapState))
 }
 
+// FlushState mocks base method
+func (m *MockDatabase) FlushState(namespace ident.ID, shardID uint32, blockStart time.Time) (fileOpState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FlushState", namespace, shardID, blockStart)
+	ret0, _ := ret[0].(fileOpState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FlushState indicates an expected call of FlushState
+func (mr *MockDatabaseMockRecorder) FlushState(namespace, shardID, blockStart interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushState", reflect.TypeOf((*MockDatabase)(nil).FlushState), namespace, shardID, blockStart)
+}
+
 // Mockdatabase is a mock of database interface
 type Mockdatabase struct {
 	ctrl     *gomock.Controller
@@ -847,6 +862,21 @@ func (m *Mockdatabase) BootstrapState() DatabaseBootstrapState {
 func (mr *MockdatabaseMockRecorder) BootstrapState() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BootstrapState", reflect.TypeOf((*Mockdatabase)(nil).BootstrapState))
+}
+
+// FlushState mocks base method
+func (m *Mockdatabase) FlushState(namespace ident.ID, shardID uint32, blockStart time.Time) (fileOpState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FlushState", namespace, shardID, blockStart)
+	ret0, _ := ret[0].(fileOpState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FlushState indicates an expected call of FlushState
+func (mr *MockdatabaseMockRecorder) FlushState(namespace, shardID, blockStart interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushState", reflect.TypeOf((*Mockdatabase)(nil).FlushState), namespace, shardID, blockStart)
 }
 
 // GetOwnedNamespaces mocks base method

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -1368,6 +1368,21 @@ func (mr *MockdatabaseNamespaceMockRecorder) BootstrapState() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BootstrapState", reflect.TypeOf((*MockdatabaseNamespace)(nil).BootstrapState))
 }
 
+// FlushState mocks base method
+func (m *MockdatabaseNamespace) FlushState(shardID uint32, blockStart time.Time) (fileOpState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FlushState", shardID, blockStart)
+	ret0, _ := ret[0].(fileOpState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FlushState indicates an expected call of FlushState
+func (mr *MockdatabaseNamespaceMockRecorder) FlushState(shardID, blockStart interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushState", reflect.TypeOf((*MockdatabaseNamespace)(nil).FlushState), shardID, blockStart)
+}
+
 // MockShard is a mock of Shard interface
 type MockShard struct {
 	ctrl     *gomock.Controller

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -210,6 +210,9 @@ type Database interface {
 	// BootstrapState captures and returns a snapshot of the databases'
 	// bootstrap state.
 	BootstrapState() DatabaseBootstrapState
+
+	// FlushState returns the flush state for the specified shard and block start.
+	FlushState(namespace ident.ID, shardID uint32, blockStart time.Time) (fileOpState, error)
 }
 
 // database is the internal database interface

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -366,6 +366,9 @@ type databaseNamespace interface {
 	// BootstrapState captures and returns a snapshot of the namespaces'
 	// bootstrap state.
 	BootstrapState() ShardBootstrapStates
+
+	// FlushState returns the flush state for the specified shard and block start.
+	FlushState(shardID uint32, blockStart time.Time) (fileOpState, error)
 }
 
 // Shard is a time series database shard.


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R adds a `block.LeaseVerifier` implementation that wraps `storage.Database`. This will be used by the `block.Leaser` to verify requests from the `SeekManager` to lease blocks are valid and for the latest volume.