### PR TITLE
[DBNode] Add LeaseLatest() API to block.LeaseManager

### DIFF
--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -1386,19 +1386,19 @@ func (mr *MockLeaseManagerMockRecorder) OpenLease(leaser, descriptor, state inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenLease", reflect.TypeOf((*MockLeaseManager)(nil).OpenLease), leaser, descriptor, state)
 }
 
-// OpenLeaseForLatest mocks base method
-func (m *MockLeaseManager) OpenLeaseForLatest(leaser Leaser, descriptor LeaseDescriptor) (LeaseState, error) {
+// OpenLatestLease mocks base method
+func (m *MockLeaseManager) OpenLatestLease(leaser Leaser, descriptor LeaseDescriptor) (LeaseState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "OpenLeaseForLatest", leaser, descriptor)
+	ret := m.ctrl.Call(m, "OpenLatestLease", leaser, descriptor)
 	ret0, _ := ret[0].(LeaseState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// OpenLeaseForLatest indicates an expected call of OpenLeaseForLatest
-func (mr *MockLeaseManagerMockRecorder) OpenLeaseForLatest(leaser, descriptor interface{}) *gomock.Call {
+// OpenLatestLease indicates an expected call of OpenLatestLease
+func (mr *MockLeaseManagerMockRecorder) OpenLatestLease(leaser, descriptor interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenLeaseForLatest", reflect.TypeOf((*MockLeaseManager)(nil).OpenLeaseForLatest), leaser, descriptor)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenLatestLease", reflect.TypeOf((*MockLeaseManager)(nil).OpenLatestLease), leaser, descriptor)
 }
 
 // UpdateOpenLeases mocks base method

--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -1386,6 +1386,21 @@ func (mr *MockLeaseManagerMockRecorder) OpenLease(leaser, descriptor, state inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenLease", reflect.TypeOf((*MockLeaseManager)(nil).OpenLease), leaser, descriptor, state)
 }
 
+// OpenLeaseForLatest mocks base method
+func (m *MockLeaseManager) OpenLeaseForLatest(leaser Leaser, descriptor LeaseDescriptor) (LeaseState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenLeaseForLatest", leaser, descriptor)
+	ret0, _ := ret[0].(LeaseState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenLeaseForLatest indicates an expected call of OpenLeaseForLatest
+func (mr *MockLeaseManagerMockRecorder) OpenLeaseForLatest(leaser, descriptor interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenLeaseForLatest", reflect.TypeOf((*MockLeaseManager)(nil).OpenLeaseForLatest), leaser, descriptor)
+}
+
 // UpdateOpenLeases mocks base method
 func (m *MockLeaseManager) UpdateOpenLeases(descriptor LeaseDescriptor, state LeaseState) (UpdateLeasesResult, error) {
 	m.ctrl.T.Helper()
@@ -1450,6 +1465,21 @@ func (m *MockLeaseVerifier) VerifyLease(descriptor LeaseDescriptor, state LeaseS
 func (mr *MockLeaseVerifierMockRecorder) VerifyLease(descriptor, state interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyLease", reflect.TypeOf((*MockLeaseVerifier)(nil).VerifyLease), descriptor, state)
+}
+
+// LatestState mocks base method
+func (m *MockLeaseVerifier) LatestState(descriptor LeaseDescriptor) (LeaseState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestState", descriptor)
+	ret0, _ := ret[0].(LeaseState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestState indicates an expected call of LatestState
+func (mr *MockLeaseVerifierMockRecorder) LatestState(descriptor interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestState", reflect.TypeOf((*MockLeaseVerifier)(nil).LatestState), descriptor)
 }
 
 // MockLeaser is a mock of Leaser interface

--- a/src/dbnode/storage/block/lease.go
+++ b/src/dbnode/storage/block/lease.go
@@ -52,12 +52,9 @@ func (m *leaseManager) RegisterLeaser(leaser Leaser) error {
 	m.Lock()
 	defer m.Unlock()
 
-	for _, l := range m.leasers {
-		if l == leaser {
-			return errLeaserAlreadyRegistered
-		}
+	if m.isRegistered(leaser) {
+		return errLeaserAlreadyRegistered
 	}
-
 	m.leasers = append(m.leasers, leaser)
 
 	return nil
@@ -97,15 +94,7 @@ func (m *leaseManager) OpenLease(
 		return errOpenLeaseVerifierNotSet
 	}
 
-	registered := false
-	for _, l := range m.leasers {
-		if l == leaser {
-			registered = true
-			break
-		}
-	}
-
-	if !registered {
+	if !m.isRegistered(leaser) {
 		return errLeaserNotRegistered
 	}
 
@@ -125,15 +114,7 @@ func (m *leaseManager) OpenLeaseForLatest(
 		return LeaseState{}, errOpenLeaseVerifierNotSet
 	}
 
-	registered := false
-	for _, l := range m.leasers {
-		if l == leaser {
-			registered = true
-			break
-		}
-	}
-
-	if !registered {
+	if !m.isRegistered(leaser) {
 		return LeaseState{}, errLeaserNotRegistered
 	}
 
@@ -185,4 +166,13 @@ func (m *leaseManager) SetLeaseVerifier(leaseVerifier LeaseVerifier) error {
 
 	m.verifier = leaseVerifier
 	return nil
+}
+
+func (m *leaseManager) isRegistered(leaser Leaser) bool {
+	for _, l := range m.leasers {
+		if l == leaser {
+			return true
+		}
+	}
+	return false
 }

--- a/src/dbnode/storage/block/lease.go
+++ b/src/dbnode/storage/block/lease.go
@@ -101,7 +101,7 @@ func (m *leaseManager) OpenLease(
 	return m.verifier.VerifyLease(descriptor, state)
 }
 
-func (m *leaseManager) OpenLeaseForLatest(
+func (m *leaseManager) OpenLatestLease(
 	leaser Leaser,
 	descriptor LeaseDescriptor,
 ) (LeaseState, error) {

--- a/src/dbnode/storage/block/lease_noop.go
+++ b/src/dbnode/storage/block/lease_noop.go
@@ -39,7 +39,7 @@ func (n *NoopLeaseManager) OpenLease(
 	return nil
 }
 
-func (n *NoopLeaseManager) OpenLeaseForLatest(
+func (n *NoopLeaseManager) OpenLatestLease(
 	leaser Leaser,
 	descriptor LeaseDescriptor,
 ) (LeaseState, error) {

--- a/src/dbnode/storage/block/lease_noop.go
+++ b/src/dbnode/storage/block/lease_noop.go
@@ -39,6 +39,13 @@ func (n *NoopLeaseManager) OpenLease(
 	return nil
 }
 
+func (n *NoopLeaseManager) OpenLeaseForLatest(
+	leaser Leaser,
+	descriptor LeaseDescriptor,
+) (LeaseState, error) {
+	return LeaseState{}, nil
+}
+
 func (n *NoopLeaseManager) UpdateOpenLeases(
 	descriptor LeaseDescriptor,
 	state LeaseState,

--- a/src/dbnode/storage/block/lease_test.go
+++ b/src/dbnode/storage/block/lease_test.go
@@ -123,7 +123,7 @@ func TestOpenLeaseErrorIfNoVerifier(t *testing.T) {
 	require.NoError(t, leaseMgr.OpenLease(leaser, leaseDesc, leaseState))
 }
 
-func TestOpenLeaseForLatest(t *testing.T) {
+func TestOpenLatestLease(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -144,12 +144,12 @@ func TestOpenLeaseForLatest(t *testing.T) {
 
 	require.Equal(t, errLeaserNotRegistered, leaseMgr.OpenLease(leaser, leaseDesc, leaseState))
 	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
-	latestState, err := leaseMgr.OpenLeaseForLatest(leaser, leaseDesc)
+	latestState, err := leaseMgr.OpenLatestLease(leaser, leaseDesc)
 	require.NoError(t, err)
 	require.Equal(t, leaseState, latestState)
 }
 
-func TestOpenLeaseForLatestErrorIfNoVerifier(t *testing.T) {
+func TestOpenLatestLeaseErrorIfNoVerifier(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -166,13 +166,13 @@ func TestOpenLeaseForLatestErrorIfNoVerifier(t *testing.T) {
 		}
 	)
 	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
-	_, err := leaseMgr.OpenLeaseForLatest(leaser, leaseDesc)
+	_, err := leaseMgr.OpenLatestLease(leaser, leaseDesc)
 	require.Equal(t, errOpenLeaseVerifierNotSet, err)
 
 	verifier := NewMockLeaseVerifier(ctrl)
 	verifier.EXPECT().LatestState(leaseDesc).Return(leaseState, nil)
 	require.NoError(t, leaseMgr.SetLeaseVerifier(verifier))
-	latestState, err := leaseMgr.OpenLeaseForLatest(leaser, leaseDesc)
+	latestState, err := leaseMgr.OpenLatestLease(leaser, leaseDesc)
 	require.NoError(t, err)
 	require.Equal(t, leaseState, latestState)
 }

--- a/src/dbnode/storage/block/lease_test.go
+++ b/src/dbnode/storage/block/lease_test.go
@@ -123,6 +123,60 @@ func TestOpenLeaseErrorIfNoVerifier(t *testing.T) {
 	require.NoError(t, leaseMgr.OpenLease(leaser, leaseDesc, leaseState))
 }
 
+func TestOpenLeaseForLatest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		leaser    = NewMockLeaser(ctrl)
+		verifier  = NewMockLeaseVerifier(ctrl)
+		leaseMgr  = NewLeaseManager(verifier)
+		leaseDesc = LeaseDescriptor{
+			Namespace:  ident.StringID("test-ns"),
+			Shard:      1,
+			BlockStart: time.Now().Truncate(2 * time.Hour),
+		}
+		leaseState = LeaseState{
+			Volume: 1,
+		}
+	)
+	verifier.EXPECT().LatestState(leaseDesc).Return(leaseState, nil)
+
+	require.Equal(t, errLeaserNotRegistered, leaseMgr.OpenLease(leaser, leaseDesc, leaseState))
+	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
+	latestState, err := leaseMgr.OpenLeaseForLatest(leaser, leaseDesc)
+	require.NoError(t, err)
+	require.Equal(t, leaseState, latestState)
+}
+
+func TestOpenLeaseForLatestErrorIfNoVerifier(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		leaser    = NewMockLeaser(ctrl)
+		leaseMgr  = NewLeaseManager(nil)
+		leaseDesc = LeaseDescriptor{
+			Namespace:  ident.StringID("test-ns"),
+			Shard:      1,
+			BlockStart: time.Now().Truncate(2 * time.Hour),
+		}
+		leaseState = LeaseState{
+			Volume: 1,
+		}
+	)
+	require.NoError(t, leaseMgr.RegisterLeaser(leaser))
+	_, err := leaseMgr.OpenLeaseForLatest(leaser, leaseDesc)
+	require.Equal(t, errOpenLeaseVerifierNotSet, err)
+
+	verifier := NewMockLeaseVerifier(ctrl)
+	verifier.EXPECT().LatestState(leaseDesc).Return(leaseState, nil)
+	require.NoError(t, leaseMgr.SetLeaseVerifier(verifier))
+	latestState, err := leaseMgr.OpenLeaseForLatest(leaser, leaseDesc)
+	require.NoError(t, err)
+	require.Equal(t, leaseState, latestState)
+}
+
 func TestUpdateOpenLeases(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -416,6 +416,8 @@ type LeaseVerifier interface {
 		descriptor LeaseDescriptor,
 		state LeaseState,
 	) error
+
+	LatestState(descriptor LeaseDescriptor) (LeaseState, error)
 }
 
 // UpdateOpenLeaseResult is the result of processing an update lease.

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -446,7 +446,11 @@ const (
 // Leaser is a block leaser.
 type Leaser interface {
 	// UpdateOpenLease is called on the Leaser when the latest state
-	// has changed and the leaser needs to update their lease.
+	// has changed and the leaser needs to update their lease. The leaser
+	// should update its state (releasing any resources as necessary and
+	// optionally acquiring new ones related to the updated lease) accordingly,
+	// but it should *not* call LeaseManager.OpenLease() with the provided
+	// descriptor and state.
 	UpdateOpenLease(
 		descriptor LeaseDescriptor,
 		state LeaseState,

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -384,6 +384,7 @@ type LeaseManager interface {
 		descriptor LeaseDescriptor,
 		state LeaseState,
 	) error
+	OpenLeaseForLatest(leaser Leaser, descriptor LeaseDescriptor) (LeaseState, error)
 	UpdateOpenLeases(
 		descriptor LeaseDescriptor,
 		state LeaseState,

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -377,18 +377,28 @@ type FetchBlocksMetadataResultsPool interface {
 
 // LeaseManager is a manager of block leases and leasers.
 type LeaseManager interface {
+	// RegisterLeaser registers the leaser to receive UpdateOpenLease()
+	// calls when leases need to be updated.
 	RegisterLeaser(leaser Leaser) error
+	// UnregisterLeaser unregisters the leaser from receiving UpdateOpenLease()
+	// calls.
 	UnregisterLeaser(leaser Leaser) error
+	// OpenLease opens a lease.
 	OpenLease(
 		leaser Leaser,
 		descriptor LeaseDescriptor,
 		state LeaseState,
 	) error
-	OpenLeaseForLatest(leaser Leaser, descriptor LeaseDescriptor) (LeaseState, error)
+	// OpenLatestLease opens a lease for the latest LeaseState for a given
+	// LeaseDescriptor.
+	OpenLatestLease(leaser Leaser, descriptor LeaseDescriptor) (LeaseState, error)
+	// UpdateOpenLeases propagate a call to UpdateOpenLease() to each registered
+	// leaser.
 	UpdateOpenLeases(
 		descriptor LeaseDescriptor,
 		state LeaseState,
 	) (UpdateLeasesResult, error)
+	// SetLeaseVerifier sets the LeaseVerifier (for delayed initialization).
 	SetLeaseVerifier(leaseVerifier LeaseVerifier) error
 }
 
@@ -413,11 +423,13 @@ type LeaseState struct {
 
 // LeaseVerifier verifies that a lease is valid.
 type LeaseVerifier interface {
+	// VerifyLease is called to determine if the requested lease is valid.
 	VerifyLease(
 		descriptor LeaseDescriptor,
 		state LeaseState,
 	) error
 
+	// LatestState returns the latest LeaseState for a given descriptor.
 	LatestState(descriptor LeaseDescriptor) (LeaseState, error)
 }
 
@@ -433,6 +445,8 @@ const (
 
 // Leaser is a block leaser.
 type Leaser interface {
+	// UpdateOpenLease is called on the Leaser when the latest state
+	// has changed and the leaser needs to update their lease.
 	UpdateOpenLease(
 		descriptor LeaseDescriptor,
 		state LeaseState,

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -451,6 +451,9 @@ type Leaser interface {
 	// optionally acquiring new ones related to the updated lease) accordingly,
 	// but it should *not* call LeaseManager.OpenLease() with the provided
 	// descriptor and state.
+	//
+	// UpdateOpenLease will never be called concurrently on the same Leaser. Each
+	// call to UpdateOpenLease() must return before the next one will begin.
 	UpdateOpenLease(
 		descriptor LeaseDescriptor,
 		state LeaseState,

--- a/src/dbnode/storage/lease_verifier.go
+++ b/src/dbnode/storage/lease_verifier.go
@@ -70,3 +70,15 @@ func (v *leaseVerifier) VerifyLease(
 
 	return nil
 }
+
+func (v *leaseVerifier) LatestState(descriptor block.LeaseDescriptor) (block.LeaseState, error) {
+	flushState, err := v.flushStateRetriever.FlushState(
+		descriptor.Namespace, uint32(descriptor.Shard), descriptor.BlockStart)
+	if err != nil {
+		return false, block.LeaseState{}, fmt.Errorf(
+			"err retrieving flushState for LatestState, ns: %s, shard: %d, blockStart: %s, err: %v",
+			descriptor.Namespace.String(), descriptor.Shard, descriptor.BlockStart.String(), err)
+	}
+
+	return block.LeaseState{Volume: flushState.ColdVersion}, nil
+}

--- a/src/dbnode/storage/lease_verifier.go
+++ b/src/dbnode/storage/lease_verifier.go
@@ -75,7 +75,7 @@ func (v *leaseVerifier) LatestState(descriptor block.LeaseDescriptor) (block.Lea
 	flushState, err := v.flushStateRetriever.FlushState(
 		descriptor.Namespace, uint32(descriptor.Shard), descriptor.BlockStart)
 	if err != nil {
-		return false, block.LeaseState{}, fmt.Errorf(
+		return block.LeaseState{}, fmt.Errorf(
 			"err retrieving flushState for LatestState, ns: %s, shard: %d, blockStart: %s, err: %v",
 			descriptor.Namespace.String(), descriptor.Shard, descriptor.BlockStart.String(), err)
 	}

--- a/src/dbnode/storage/lease_verifier_test.go
+++ b/src/dbnode/storage/lease_verifier_test.go
@@ -40,7 +40,7 @@ var (
 	testBlockLeaseState = block.LeaseState{Volume: 0}
 )
 
-func TestLeaseVerifierHandlesErrors(t *testing.T) {
+func TestLeaseVerifierVerifyLeaseHandlesErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -58,7 +58,7 @@ func TestLeaseVerifierHandlesErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLeaseVerifierReturnsErrorIfNotLatestVolume(t *testing.T) {
+func TestLeaseVerifierVerifyLeaseReturnsErrorIfNotLatestVolume(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -76,7 +76,7 @@ func TestLeaseVerifierReturnsErrorIfNotLatestVolume(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLeaseVerifierSuccessIfVolumeIsLatest(t *testing.T) {
+func TestLeaseVerifierVerifyLeaseSuccessIfVolumeIsLatest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -93,4 +93,41 @@ func TestLeaseVerifierSuccessIfVolumeIsLatest(t *testing.T) {
 	).Return(fileOpState{ColdVersion: volumeNum}, nil)
 
 	require.NoError(t, leaseVerifier.VerifyLease(testBlockDescriptor, state))
+}
+
+func TestLeaseVerifierLatestStateHandlesErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		mockDB        = NewMockDatabase(ctrl)
+		leaseVerifier = NewLeaseVerifier(mockDB)
+	)
+	mockDB.EXPECT().FlushState(
+		testBlockDescriptor.Namespace,
+		uint32(testBlockDescriptor.Shard),
+		testBlockDescriptor.BlockStart,
+	).Return(fileOpState{}, errors.New("some-error"))
+
+	_, err := leaseVerifier.LatestState(testBlockDescriptor, testBlockLeaseState)
+	require.Error(t, err)
+}
+
+func TestLeaseVerifierLatestStateSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		mockDB        = NewMockDatabase(ctrl)
+		leaseVerifier = NewLeaseVerifier(mockDB)
+	)
+	mockDB.EXPECT().FlushState(
+		testBlockDescriptor.Namespace,
+		uint32(testBlockDescriptor.Shard),
+		testBlockDescriptor.BlockStart,
+	).Return(fileOpState{ColdVersion: 1}, nil)
+
+	state, err := leaseVerifier.LatestState(testBlockDescriptor, testBlockLeaseState)
+	require.NoError(t, err)
+	require.Equal(t, block.LeaseState{Volume: 1}, state)
 }

--- a/src/dbnode/storage/lease_verifier_test.go
+++ b/src/dbnode/storage/lease_verifier_test.go
@@ -109,7 +109,7 @@ func TestLeaseVerifierLatestStateHandlesErrors(t *testing.T) {
 		testBlockDescriptor.BlockStart,
 	).Return(fileOpState{}, errors.New("some-error"))
 
-	_, err := leaseVerifier.LatestState(testBlockDescriptor, testBlockLeaseState)
+	_, err := leaseVerifier.LatestState(testBlockDescriptor)
 	require.Error(t, err)
 }
 
@@ -127,7 +127,7 @@ func TestLeaseVerifierLatestStateSuccess(t *testing.T) {
 		testBlockDescriptor.BlockStart,
 	).Return(fileOpState{ColdVersion: 1}, nil)
 
-	state, err := leaseVerifier.LatestState(testBlockDescriptor, testBlockLeaseState)
+	state, err := leaseVerifier.LatestState(testBlockDescriptor)
 	require.NoError(t, err)
 	require.Equal(t, block.LeaseState{Volume: 1}, state)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R adds a `OpenLeaseForLatest()` API to the block.LeaseManager so that when the SeekManager is opening seekers of its own accord (as opposed to as the result of receiving an `UpdateOpenLeases()` notification, it can determine which volume to open for a given block.