### PR TITLE
[DBNode] Register/unregister leaser outside of locks in SeekManager and make UpdateOpenLeases() concurrency safe

### DIFF
--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -157,20 +157,23 @@ func (m *seekerManager) Open(
 	nsMetadata namespace.Metadata,
 ) error {
 	m.Lock()
-	defer m.Unlock()
-
 	if m.status != seekerManagerNotOpen {
+		m.Unlock()
 		return errSeekerManagerAlreadyOpenOrClosed
 	}
-
-	// Register for updates to block leases.
-	m.blockRetrieverOpts.BlockLeaseManager().RegisterLeaser(m)
 
 	m.namespace = nsMetadata.ID()
 	m.namespaceMetadata = nsMetadata
 	m.status = seekerManagerOpen
-
 	go m.openCloseLoop()
+	m.Unlock()
+
+	// Register for updates to block leases.
+	// NB(rartoul): This should be safe to do within the context of the lock
+	// because the block.LeaseManager does not yet have a handle on the SeekerManager
+	// so they can't deadlock trying to acquire each other's locks, but do it otuside
+	// of the lock just to be safe.
+	m.blockRetrieverOpts.BlockLeaseManager().RegisterLeaser(m)
 
 	return nil
 }
@@ -288,6 +291,8 @@ func (m *seekerManager) UpdateOpenLease(
 	state block.LeaseState,
 ) (block.UpdateOpenLeaseResult, error) {
 	// TODO(rartoul): This is a no-op for now until the logic for swapping out seekers is written.
+	// Also make sure that this function is a proper no-op if the SeekerManager state has been
+	// been switched to closed.
 	return block.NoOpenLease, nil
 }
 
@@ -478,9 +483,6 @@ func (m *seekerManager) Close() error {
 		return errSeekerManagerAlreadyClosed
 	}
 
-	// Unregister for lease updates since all the seekers are going to be closed.
-	m.blockRetrieverOpts.BlockLeaseManager().UnregisterLeaser(m)
-
 	// Make sure all seekers are returned before allowing the SeekerManager to be closed.
 	// Actual cleanup of the seekers themselves will be handled by the openCloseLoop.
 	for _, byTime := range m.seekersByShardIdx {
@@ -500,6 +502,14 @@ func (m *seekerManager) Close() error {
 	m.status = seekerManagerClosed
 
 	m.Unlock()
+
+	// Unregister for lease updates since all the seekers are going to be closed.
+	// NB(rartoul): Perform this outside the lock to prevent deadlock issues where
+	// the block.LeaseManager is trying to acquire the SeekerManager's lock (via
+	// a call to UpdateOpenLease) and the SeekerManager is trying to acquire the
+	// block.LeaseManager's lock (via a call to UnregisterLeaser).
+	m.blockRetrieverOpts.BlockLeaseManager().UnregisterLeaser(m)
+
 	<-m.openCloseLoopDoneCh
 	return nil
 }

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -171,7 +171,7 @@ func (m *seekerManager) Open(
 	// Register for updates to block leases.
 	// NB(rartoul): This should be safe to do within the context of the lock
 	// because the block.LeaseManager does not yet have a handle on the SeekerManager
-	// so they can't deadlock trying to acquire each other's locks, but do it otuside
+	// so they can't deadlock trying to acquire each other's locks, but do it outside
 	// of the lock just to be safe.
 	m.blockRetrieverOpts.BlockLeaseManager().RegisterLeaser(m)
 

--- a/src/dbnode/storage/block/lease.go
+++ b/src/dbnode/storage/block/lease.go
@@ -125,14 +125,13 @@ func (m *leaseManager) UpdateOpenLeases(
 	descriptor LeaseDescriptor,
 	state LeaseState,
 ) (UpdateLeasesResult, error) {
-	// NB(r): Take exclusive lock so that add lease can't be called
-	// while we are notifying existing
+	// NB(rartoul): Take exclusive
 	m.Lock()
-	defer m.Unlock()
-
 	if m.verifier == nil {
+		m.Unlock()
 		return UpdateLeasesResult{}, errUpdateOpenLeasesVerifierNotSet
 	}
+	m.Unlock()
 
 	var result UpdateLeasesResult
 	for _, l := range m.leasers {

--- a/src/dbnode/storage/block/lease.go
+++ b/src/dbnode/storage/block/lease.go
@@ -125,12 +125,14 @@ func (m *leaseManager) UpdateOpenLeases(
 	descriptor LeaseDescriptor,
 	state LeaseState,
 ) (UpdateLeasesResult, error) {
-	// NB(rartoul): Take exclusive
 	m.Lock()
 	if m.verifier == nil {
 		m.Unlock()
 		return UpdateLeasesResult{}, errUpdateOpenLeasesVerifierNotSet
 	}
+	// NB(rartoul): Release lock while calling UpdateOpenLease() so that
+	// calls to OpenLease() and OpenLatestLease() are not blocked (which
+	// would subsequently block reads).
 	m.Unlock()
 
 	var result UpdateLeasesResult

--- a/src/dbnode/storage/block/lease.go
+++ b/src/dbnode/storage/block/lease.go
@@ -145,17 +145,18 @@ func (m *leaseManager) UpdateOpenLeases(
 	}
 
 	m.updateOpenLeasesInProgress = true
-	defer func() {
-		m.Lock()
-		m.updateOpenLeasesInProgress = false
-		m.Unlock()
-	}()
 	// NB(rartoul): Release lock while calling UpdateOpenLease() so that
 	// calls to OpenLease() and OpenLatestLease() are not blocked which
 	// would blocks reads and could cause deadlocks if those calls were
 	// made while holding locks that would not allow UpdateOpenLease() to
 	// return before being released.
 	m.Unlock()
+
+	defer func() {
+		m.Lock()
+		m.updateOpenLeasesInProgress = false
+		m.Unlock()
+	}()
 
 	var result UpdateLeasesResult
 	for _, l := range m.leasers {

--- a/src/dbnode/storage/block/lease_test.go
+++ b/src/dbnode/storage/block/lease_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"code.uber.internal/infra/m3db-client/dep/github.com/stretchr/testify/require"
-
 	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/stretchr/testify/require"
@@ -286,9 +284,10 @@ func TestUpdateOpenLeasesDoesNotDeadlockIfLeasersCallsBack(t *testing.T) {
 		leaseMgr = NewLeaseManager(verifier)
 	)
 	verifier.EXPECT().VerifyLease(gomock.Any(), gomock.Any()).AnyTimes()
+	verifier.EXPECT().LatestState(gomock.Any()).AnyTimes()
 	leaser.EXPECT().UpdateOpenLease(gomock.Any(), gomock.Any()).Do(func(_ LeaseDescriptor, _ LeaseState) {
 		require.NoError(t, leaseMgr.OpenLease(leaser, LeaseDescriptor{}, LeaseState{}))
-		_, err := leaseMgr.OpenLatestLease(leaser)
+		_, err := leaseMgr.OpenLatestLease(leaser, LeaseDescriptor{})
 		require.NoError(t, err)
 	})
 

--- a/src/dbnode/storage/block/lease_test.go
+++ b/src/dbnode/storage/block/lease_test.go
@@ -325,6 +325,8 @@ func TestUpdateOpenLeasesConcurrentNotAllowed(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestUpdateOpenLeasesConcurrencyTest spins up a number of goroutines to call UpdateOpenLeases(),
+// OpenLease(), and OpenLatestLease() concurrently and ensure there are no deadlocks.
 func TestUpdateOpenLeasesConcurrencyTest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
**What this PR does / why we need it**:
The existing implementation has a potential to deadlock(although not an actual bug in master since this is "dead" / feature-flagged code) when the SeekManager is being closed as described in the comments in the P.R.