### PR TITLE
[DBNode] Use OpenLatestLease() in SeekManager and move CacheShardIndices() to namespace bootstrap

### DIFF
--- a/scripts/docker-integration-tests/common.sh
+++ b/scripts/docker-integration-tests/common.sh
@@ -62,6 +62,7 @@ function wait_for_db_init {
     "type": "cluster",
     "namespaceName": "agg",
     "retentionTime": "6h",
+    "num_shards": 4,
     "replicationFactor": 1,
     "hosts": [
       {

--- a/scripts/docker-integration-tests/simple/test.sh
+++ b/scripts/docker-integration-tests/simple/test.sh
@@ -115,7 +115,7 @@ ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | jq .placement.instances.m3db_local.id)" == \"m3db_local\" ]'
 
 echo "Sleep until bootstrapped"
-ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
+ATTEMPTS=7 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
 
 echo "Waiting until shards are marked as available"

--- a/scripts/docker-integration-tests/simple/test.sh
+++ b/scripts/docker-integration-tests/simple/test.sh
@@ -12,17 +12,19 @@ docker create --name "${CONTAINER_NAME}" -p 9000:9000 -p 9001:9001 -p 9002:9002 
 
 # think of this as a defer func() in golang
 function defer {
+  if [ $? -ne 0 ]; then
+    echo "Tested failed, dumping logs"
+    echo "---------------------------"
+    docker logs "${CONTAINER_NAME}"
+    exit 1
+  fi
+
   echo "Remove docker container"
   docker rm --force "${CONTAINER_NAME}"
 }
 trap defer EXIT
 
 docker start "${CONTAINER_NAME}"
-if [ $? -ne 0 ]; then
-  echo "m3dbnode docker failed to start"
-  docker logs "${CONTAINER_NAME}"
-  exit 1
-fi
 
 # TODO(rartoul): Rewrite this test to use a docker-compose file like the others so that we can share all the
 # DB initialization logic with the setup_single_m3db_node command in common.sh like the other files. Right now

--- a/scripts/docker-integration-tests/simple/test.sh
+++ b/scripts/docker-integration-tests/simple/test.sh
@@ -12,14 +12,12 @@ docker create --name "${CONTAINER_NAME}" -p 9000:9000 -p 9001:9001 -p 9002:9002 
 
 # think of this as a defer func() in golang
 function defer {
-  if [ $? -ne 0 ]; then
-    echo "Tested failed, dumping logs"
-    echo "---------------------------"
-    docker logs "${CONTAINER_NAME}"
-    exit 1
-  fi
+  echo "Test complete, dumping logs"
+  echo "---------------------------"
+  docker logs "${CONTAINER_NAME}"
+  echo "---------------------------"
 
-  echo "Remove docker container"
+  echo "Removing docker container"
   docker rm --force "${CONTAINER_NAME}"
 }
 trap defer EXIT
@@ -117,7 +115,7 @@ ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:7201/api/v1/placement | jq .placement.instances.m3db_local.id)" == \"m3db_local\" ]'
 
 echo "Sleep until bootstrapped"
-ATTEMPTS=10 TIMEOUT=2 retry_with_backoff  \
+ATTEMPTS=6 TIMEOUT=2 retry_with_backoff  \
   '[ "$(curl -sSf 0.0.0.0:9002/health | jq .bootstrapped)" == true ]'
 
 echo "Waiting until shards are marked as available"

--- a/scripts/docker-integration-tests/simple/test.sh
+++ b/scripts/docker-integration-tests/simple/test.sh
@@ -75,7 +75,7 @@ curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/namespace -d '{
     "snapshotEnabled": true,
     "repairEnabled": false,
     "retentionOptions": {
-      "retentionPeriodDuration": "48h",
+      "retentionPeriodDuration": "8h",
       "blockSizeDuration": "2h",
       "bufferFutureDuration": "10m",
       "bufferPastDuration": "10m",
@@ -95,7 +95,7 @@ ATTEMPTS=4 TIMEOUT=1 retry_with_backoff  \
 
 echo "Placement initialization"
 curl -vvvsSf -X POST 0.0.0.0:7201/api/v1/placement/init -d '{
-    "num_shards": 64,
+    "num_shards": 4,
     "replication_factor": 1,
     "instances": [
         {

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -135,16 +135,20 @@ func TestIndexEnabledServer(t *testing.T) {
 	placementSvc, err := svcs.PlacementService(serviceID, placementOpts)
 	require.NoError(t, err)
 
-	instance := placement.NewInstance().
-		SetID(hostID).
-		SetEndpoint(endpoint("127.0.0.1", servicePort)).
-		SetPort(servicePort).
-		SetIsolationGroup("local").
-		SetWeight(1).
-		SetZone(serviceZone)
-	instances := []placement.Instance{instance}
-	shards := 256
-	replicas := 1
+	var (
+		instance = placement.NewInstance().
+				SetID(hostID).
+				SetEndpoint(endpoint("127.0.0.1", servicePort)).
+				SetPort(servicePort).
+				SetIsolationGroup("local").
+				SetWeight(1).
+				SetZone(serviceZone)
+		instances = []placement.Instance{instance}
+		// Keep number of shards low to avoid having to tune F.D limits.
+		shards   = 4
+		replicas = 1
+	)
+
 	_, err = placementSvc.BuildInitialPlacement(instances, shards, replicas)
 	require.NoError(t, err)
 

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -127,16 +127,20 @@ func TestConfig(t *testing.T) {
 	placementSvc, err := svcs.PlacementService(serviceID, placementOpts)
 	require.NoError(t, err)
 
-	instance := placement.NewInstance().
-		SetID(hostID).
-		SetEndpoint(endpoint("127.0.0.1", servicePort)).
-		SetPort(servicePort).
-		SetIsolationGroup("local").
-		SetWeight(1).
-		SetZone(serviceZone)
-	instances := []placement.Instance{instance}
-	shards := 256
-	replicas := 1
+	var (
+		instance = placement.NewInstance().
+				SetID(hostID).
+				SetEndpoint(endpoint("127.0.0.1", servicePort)).
+				SetPort(servicePort).
+				SetIsolationGroup("local").
+				SetWeight(1).
+				SetZone(serviceZone)
+		instances = []placement.Instance{instance}
+		// Reduce number of shards to avoid having to tune F.D limits.
+		shards   = 4
+		replicas = 1
+	)
+
 	_, err = placementSvc.BuildInitialPlacement(instances, shards, replicas)
 	require.NoError(t, err)
 

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -342,16 +342,20 @@ func TestEmbeddedConfig(t *testing.T) {
 	placementSvc, err := svcs.PlacementService(serviceID, placementOpts)
 	require.NoError(t, err)
 
-	instance := placement.NewInstance().
-		SetID(hostID).
-		SetEndpoint(endpoint("127.0.0.1", servicePort)).
-		SetPort(servicePort).
-		SetIsolationGroup("local").
-		SetWeight(1).
-		SetZone(serviceZone)
-	instances := []placement.Instance{instance}
-	shards := 256
-	replicas := 1
+	var (
+		instance = placement.NewInstance().
+				SetID(hostID).
+				SetEndpoint(endpoint("127.0.0.1", servicePort)).
+				SetPort(servicePort).
+				SetIsolationGroup("local").
+				SetWeight(1).
+				SetZone(serviceZone)
+		instances = []placement.Instance{instance}
+		// Use a low number of shards to avoid having to tune F.D limits.
+		shards   = 4
+		replicas = 1
+	)
+
 	_, err = placementSvc.BuildInitialPlacement(instances, shards, replicas)
 	require.NoError(t, err)
 

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -557,7 +557,9 @@ func (ts *testSetup) startServerBase(waitForBootstrap bool) error {
 	}
 
 	leaseVerifier := storage.NewLeaseVerifier(ts.db)
-	ts.blockLeaseManager.SetLeaseVerifier(leaseVerifier)
+	if err := ts.blockLeaseManager.SetLeaseVerifier(leaseVerifier); err != nil {
+		return err
+	}
 
 	// Check if clients were closed by stopServer and need to be re-created.
 	ts.maybeResetClients()

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -437,7 +437,7 @@ func (m *seekerManager) newOpenSeeker(
 		return nil, fmt.Errorf("err opening latest lease: %v", err)
 	}
 
-	// TODO(rartoul): Pass volume obtained from OpenLatestLease here.
+	// TODO_OUT_OF_ORDER_WRITES(rartoul): Pass volume obtained from OpenLatestLease here.
 	err = seeker.Open(m.namespace, shard, blockStart, resources)
 	m.putSeekerResources(resources)
 	if err != nil {

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -22,6 +22,7 @@ package fs
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -423,7 +424,20 @@ func (m *seekerManager) newOpenSeeker(
 	// Set the unread buffer to reuse it amongst all seekers.
 	seeker.setUnreadBuffer(m.unreadBuf.value)
 
-	resources := m.getSeekerResources()
+	var (
+		resources = m.getSeekerResources()
+		blm       = m.blockRetrieverOpts.BlockLeaseManager()
+	)
+	_, err = blm.OpenLatestLease(m, block.LeaseDescriptor{
+		Namespace:  m.namespace,
+		Shard:      shard,
+		BlockStart: blockStart,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("err opening latest lease: %v", err)
+	}
+
+	// TODO(rartoul): Pass volume obtained from OpenLatestLease here.
 	err = seeker.Open(m.namespace, shard, blockStart, resources)
 	m.putSeekerResources(resources)
 	if err != nil {

--- a/src/dbnode/storage/block/lease.go
+++ b/src/dbnode/storage/block/lease.go
@@ -29,7 +29,6 @@ import (
 var (
 	errLeaserAlreadyRegistered        = errors.New("leaser already registered")
 	errLeaserNotRegistered            = errors.New("leaser not registered")
-	errLeaseVerifierAlreadySet        = errors.New("lease verifier already set")
 	errOpenLeaseVerifierNotSet        = errors.New("cannot open leases while verifier is not set")
 	errUpdateOpenLeasesVerifierNotSet = errors.New("cannot update open leases while verifier is not set")
 	errConcurrentUpdateOpenLeases     = errors.New("cannot call updateOpenLeases() concurrently")
@@ -181,13 +180,6 @@ func (m *leaseManager) UpdateOpenLeases(
 func (m *leaseManager) SetLeaseVerifier(leaseVerifier LeaseVerifier) error {
 	m.Lock()
 	defer m.Unlock()
-
-	if m.verifier != nil {
-		// SetLeaseVerifier is used for delayed initialization so calling it more
-		// than once means there is an initialization bug.
-		return errLeaseVerifierAlreadySet
-	}
-
 	m.verifier = leaseVerifier
 	return nil
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -105,7 +105,6 @@ func (s *peersSource) ReadData(
 
 	var (
 		namespace         = nsMetadata.ID()
-		blockRetriever    block.DatabaseBlockRetriever
 		shardRetrieverMgr block.DatabaseShardBlockRetrieverManager
 		persistFlush      persist.FlushPreparer
 		shouldPersist     = false

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -28,12 +28,12 @@ import (
 	"github.com/m3db/m3/src/cluster/shard"
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/clock"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/index/convert"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/x/context"
@@ -197,14 +197,6 @@ func (s *peersSource) ReadData(
 	if shouldPersist {
 		// Wait for the persistenceQueueWorker to finish flushing everything
 		<-persistenceWorkerDoneCh
-	}
-
-	if shouldPersist {
-		// Now cache the flushed results
-		err := s.cacheShardIndices(shardsTimeRanges, blockRetriever)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return result, nil
@@ -506,19 +498,6 @@ func (s *peersSource) flush(
 	}
 
 	return nil
-}
-
-func (s *peersSource) cacheShardIndices(
-	shardsTimeRanges result.ShardTimeRanges,
-	blockRetriever block.DatabaseBlockRetriever,
-) error {
-	// Now cache the flushed results
-	shards := make([]uint32, 0, len(shardsTimeRanges))
-	for shard := range shardsTimeRanges {
-		shards = append(shards, shard)
-	}
-
-	return blockRetriever.CacheShardIndices(shards)
 }
 
 func (s *peersSource) AvailableIndex(

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -140,7 +140,6 @@ func (s *peersSource) ReadData(
 		defer persist.DoneFlush()
 
 		shouldPersist = true
-		blockRetriever = r
 		shardRetrieverMgr = block.NewDatabaseShardBlockRetrieverManager(r)
 		persistFlush = persist
 	}

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
@@ -26,12 +26,12 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	m3dbruntime "github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/ts"
@@ -289,10 +289,6 @@ func TestPeersSourceRunWithPersist(t *testing.T) {
 		opts = opts.SetAdminClient(mockAdminClient)
 
 		mockRetriever := block.NewMockDatabaseBlockRetriever(ctrl)
-		// The shard indices are computed from iterating over a map, they can
-		// come in any order
-		mockRetriever.EXPECT().CacheShardIndices([]uint32{0, 1}).AnyTimes()
-		mockRetriever.EXPECT().CacheShardIndices([]uint32{1, 0}).AnyTimes()
 
 		mockRetrieverMgr := block.NewMockDatabaseBlockRetrieverManager(ctrl)
 		mockRetrieverMgr.EXPECT().
@@ -522,8 +518,6 @@ func TestPeersSourceMarksUnfulfilledOnPersistenceErrors(t *testing.T) {
 	opts = opts.SetAdminClient(mockAdminClient)
 
 	mockRetriever := block.NewMockDatabaseBlockRetriever(ctrl)
-	mockRetriever.EXPECT().CacheShardIndices(gomock.Any()).AnyTimes()
-
 	mockRetrieverMgr := block.NewMockDatabaseBlockRetrieverManager(ctrl)
 	mockRetrieverMgr.EXPECT().
 		Retriever(namespace.NewMetadataMatcher(testNsMd)).

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -362,7 +362,7 @@ func newDatabaseNamespace(
 	}
 	n.schemaListener = sl
 	n.initShards(nopts.BootstrapEnabled())
-	go n.reportStatusLoop()
+	go n.reportStatusLoop(opts.InstrumentOptions().ReportInterval())
 
 	return n, nil
 }
@@ -388,8 +388,7 @@ func (n *dbNamespace) SetSchemaHistory(value namespace.SchemaHistory) {
 	n.metadata = metadata
 }
 
-func (n *dbNamespace) reportStatusLoop() {
-	reportInterval := n.opts.InstrumentOptions().ReportInterval()
+func (n *dbNamespace) reportStatusLoop(reportInterval time.Duration) {
 	ticker := time.NewTicker(reportInterval)
 	defer ticker.Stop()
 	for {

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -891,7 +891,15 @@ func (n *dbNamespace) Bootstrap(start time.Time, process bootstrap.Process) erro
 			for _, shard := range shards {
 				shardIDs = append(shardIDs, shard.ID())
 			}
-			retriever.CacheShardIndices(shardIDs)
+			n.log.Info("Caching shard indices",
+				zap.Int("numShards", len(shardIDs)),
+			)
+			if err := retriever.CacheShardIndices(shardIDs); err != nil {
+				multiErr = multiErr.Add(err)
+				n.log.Error("Caching shard indices error", zap.Error(err))
+			} else {
+				n.log.Info("Caching shard indices completed successfully")
+			}
 		}
 	}
 

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -369,7 +369,9 @@ func TestNamespaceBootstrapAllShards(t *testing.T) {
 
 	mockRetrieverMgr := block.NewMockDatabaseBlockRetrieverManager(ctrl)
 	mockRetrieverMgr.EXPECT().Retriever(ns.metadata).Return(mockRetriever, nil)
+	ns.Lock()
 	ns.opts = ns.opts.SetDatabaseBlockRetrieverManager(mockRetrieverMgr)
+	ns.Unlock()
 
 	require.Equal(t, "foo", ns.Bootstrap(start, bs).Error())
 	require.Equal(t, BootstrapNotStarted, ns.bootstrapState)
@@ -426,7 +428,9 @@ func TestNamespaceBootstrapOnlyNonBootstrappedShards(t *testing.T) {
 
 	mockRetrieverMgr := block.NewMockDatabaseBlockRetrieverManager(ctrl)
 	mockRetrieverMgr.EXPECT().Retriever(ns.metadata).Return(mockRetriever, nil)
+	ns.Lock()
 	ns.opts = ns.opts.SetDatabaseBlockRetrieverManager(mockRetrieverMgr)
+	ns.Unlock()
 
 	require.NoError(t, ns.Bootstrap(start, bs))
 	require.Equal(t, Bootstrapped, ns.bootstrapState)

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/sharding"
+	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/index"
@@ -352,13 +353,23 @@ func TestNamespaceBootstrapAllShards(t *testing.T) {
 			DataResult:  result.NewDataBootstrapResult(),
 			IndexResult: result.NewIndexBootstrapResult(),
 		}, nil)
+
+	shardIDs := make([]uint32, 0, len(errs))
 	for i := range errs {
+		shardID := uint32(i)
 		shard := NewMockdatabaseShard(ctrl)
 		shard.EXPECT().IsBootstrapped().Return(false)
-		shard.EXPECT().ID().Return(uint32(i)).AnyTimes()
+		shard.EXPECT().ID().Return(shardID).AnyTimes()
 		shard.EXPECT().Bootstrap(gomock.Any()).Return(errs[i])
 		ns.shards[testShardIDs[i].ID()] = shard
+		shardIDs = append(shardIDs, shardID)
 	}
+	mockRetriever := block.NewMockDatabaseBlockRetriever(ctrl)
+	mockRetriever.EXPECT().CacheShardIndices(shardIDs).Return(nil)
+
+	mockRetrieverMgr := block.NewMockDatabaseBlockRetrieverManager(ctrl)
+	mockRetrieverMgr.EXPECT().Retriever(ns.metadata).Return(mockRetriever, nil)
+	ns.opts = ns.opts.SetDatabaseBlockRetrieverManager(mockRetrieverMgr)
 
 	require.Equal(t, "foo", ns.Bootstrap(start, bs).Error())
 	require.Equal(t, BootstrapNotStarted, ns.bootstrapState)
@@ -368,10 +379,14 @@ func TestNamespaceBootstrapOnlyNonBootstrappedShards(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	var needsBootstrap, alreadyBootstrapped []shard.Shard
+	var (
+		needsBootstrap, alreadyBootstrapped []shard.Shard
+		needsBootstrapShardIDs              []uint32
+	)
 	for i, shard := range testShardIDs {
 		if i%2 == 0 {
 			needsBootstrap = append(needsBootstrap, shard)
+			needsBootstrapShardIDs = append(needsBootstrapShardIDs, shard.ID())
 		} else {
 			alreadyBootstrapped = append(alreadyBootstrapped, shard)
 		}
@@ -405,6 +420,13 @@ func TestNamespaceBootstrapOnlyNonBootstrappedShards(t *testing.T) {
 		shard.EXPECT().IsBootstrapped().Return(true)
 		ns.shards[testShard.ID()] = shard
 	}
+
+	mockRetriever := block.NewMockDatabaseBlockRetriever(ctrl)
+	mockRetriever.EXPECT().CacheShardIndices(needsBootstrapShardIDs).Return(nil)
+
+	mockRetrieverMgr := block.NewMockDatabaseBlockRetrieverManager(ctrl)
+	mockRetrieverMgr.EXPECT().Retriever(ns.metadata).Return(mockRetriever, nil)
+	ns.opts = ns.opts.SetDatabaseBlockRetrieverManager(mockRetrieverMgr)
 
 	require.NoError(t, ns.Bootstrap(start, bs))
 	require.Equal(t, Bootstrapped, ns.bootstrapState)


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R calls `OpenLatestLease()` before opening a new seeker in the seek manager to ensure that the seek manager is always opening the latest volume for a given file. This is required for correct behavior of the cold write feature.

In addition, this change means that `CacheShardIndices` cannot be called before shards complete bootstrapping (since they cannot perform lease verification until they are bootstrapped). As a result, `CacheShardIndices` cannot be called in the F.S and peers bootstrapper as it is currently. Instead, this P.R moves the call to `CacheShardIndices` into the namespace `Bootstrap()` method immediately after all the shards are marked as bootstrapped (and as a result can perform lease verification).