### PR TITLE
[docker] dual-publish setcap; default raise limits

### DIFF
--- a/docker/images.json
+++ b/docker/images.json
@@ -1,15 +1,24 @@
 {
   "images": {
     "m3dbnode": {
+      "name": "m3dbnode",
       "dockerfile": "docker/m3dbnode/Dockerfile"
     },
+    "m3dbnode-setcap": {
+      "name": "m3dbnode",
+      "dockerfile": "docker/m3dbnode/Dockerfile",
+      "tag_suffix": "setcap"
+    },
     "m3coordinator": {
+      "name": "m3coordinator",
       "dockerfile": "docker/m3coordinator/Dockerfile"
     },
     "m3query": {
+      "name": "m3query",
       "dockerfile": "docker/m3query/Dockerfile"
     },
     "m3nsch": {
+      "name": "m3nsch",
       "dockerfile": "docker/m3nsch/Dockerfile"
     }
   }

--- a/docker/images.json
+++ b/docker/images.json
@@ -1,25 +1,29 @@
 {
   "images": {
-    "m3dbnode": {
-      "name": "m3dbnode",
-      "dockerfile": "docker/m3dbnode/Dockerfile"
-    },
-    "m3dbnode-setcap": {
-      "name": "m3dbnode",
-      "dockerfile": "docker/m3dbnode/Dockerfile",
-      "tag_suffix": "setcap"
+    "m3aggregator": {
+      "dockerfile": "docker/m3aggregator/Dockerfile",
+      "name": "m3aggregator"
     },
     "m3coordinator": {
-      "name": "m3coordinator",
-      "dockerfile": "docker/m3coordinator/Dockerfile"
+      "dockerfile": "docker/m3coordinator/Dockerfile",
+      "name": "m3coordinator"
     },
-    "m3query": {
-      "name": "m3query",
-      "dockerfile": "docker/m3query/Dockerfile"
+    "m3dbnode": {
+      "dockerfile": "docker/m3dbnode/Dockerfile",
+      "name": "m3dbnode"
+    },
+    "m3dbnode-setcap": {
+      "dockerfile": "docker/m3dbnode/Dockerfile-setcap",
+      "name": "m3dbnode",
+      "tag_suffix": "setcap"
     },
     "m3nsch": {
-      "name": "m3nsch",
-      "dockerfile": "docker/m3nsch/Dockerfile"
+      "dockerfile": "docker/m3nsch/Dockerfile",
+      "name": "m3nsch"
+    },
+    "m3query": {
+      "dockerfile": "docker/m3query/Dockerfile",
+      "name": "m3query"
     }
   }
 }

--- a/docker/m3dbnode/Dockerfile
+++ b/docker/m3dbnode/Dockerfile
@@ -26,9 +26,10 @@ EXPOSE 2379/tcp 2380/tcp 7201/tcp 7203/tcp 9000-9004/tcp
 
 RUN apk add --no-cache curl jq
 
-COPY --from=builder /go/src/github.com/m3db/m3/bin/m3dbnode /bin/
 COPY --from=builder /go/src/github.com/m3db/m3/src/dbnode/config/m3dbnode-local-etcd.yml /etc/m3dbnode/m3dbnode.yml
-COPY --from=builder /go/src/github.com/m3db/m3/scripts/m3dbnode_bootstrapped.sh /bin/
+COPY --from=builder /go/src/github.com/m3db/m3/bin/m3dbnode \
+  /go/src/github.com/m3db/m3/scripts/m3dbnode_bootstrapped.sh \
+  /bin/
 
 ENTRYPOINT [ "/bin/m3dbnode" ]
 CMD [ "-f", "/etc/m3dbnode/m3dbnode.yml" ]

--- a/docker/m3dbnode/Dockerfile-setcap
+++ b/docker/m3dbnode/Dockerfile-setcap
@@ -1,0 +1,34 @@
+# stage 1: build
+FROM golang:1.12-alpine AS builder
+LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
+
+# Install Glide
+RUN apk add --update glide git make bash
+
+# Add source code
+RUN mkdir -p /go/src/github.com/m3db/m3
+ADD . /go/src/github.com/m3db/m3
+
+# Build m3dbnode binary
+RUN cd /go/src/github.com/m3db/m3/ && \
+    git submodule update --init      && \
+    make m3dbnode-linux-amd64
+
+# Stage 2: lightweight "release"
+FROM alpine:latest
+LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
+
+EXPOSE 2379/tcp 2380/tcp 7201/tcp 7203/tcp 9000-9004/tcp
+
+COPY --from=builder /go/src/github.com/m3db/m3/src/dbnode/config/m3dbnode-local-etcd.yml /etc/m3dbnode/m3dbnode.yml
+COPY --from=builder /go/src/github.com/m3db/m3/bin/m3dbnode \
+  /go/src/github.com/m3db/m3/scripts/m3dbnode_bootstrapped.sh \
+  /bin/
+
+# Use setcap to set +e "effective" and +p "permitted" to adjust the SYS_RESOURCE
+# so the process can raise the hard file limit with setrlimit.
+RUN apk add --no-cache curl jq libcap && \
+  setcap cap_sys_resource=+ep /bin/m3dbnode
+
+ENTRYPOINT [ "/bin/m3dbnode" ]
+CMD [ "-f", "/etc/m3dbnode/m3dbnode.yml" ]

--- a/docs/operational_guide/kernel_configuration.md
+++ b/docs/operational_guide/kernel_configuration.md
@@ -7,14 +7,14 @@ values for you. Please read the comment in that manifest to understand the impli
 
 ## Running with Docker
 
-If running M3DB under Docker it is recommended to give M3DB the `SYS_RESOURCE` capability so that it may raise its file
-limits. If running directly with Docker this can be accomplished using:
+When running M3DB inside Docker, it is recommended to add the `SYS_RESOURCE` capability to the container (using the
+`--cap-add` argument to `docker run`) so that it can raise its file limits:
 
 ```
 docker run --cap-add SYS_RESOURCE quay.io/m3/m3dbnode:latest
 ```
 
-If you wish to run M3DB as a non-root user, you will need to use our `setcap` images:
+If M3DB is being run as a non-root user, M3's `setcap` images are required:
 ```
 docker run --cap-add SYS_RESOURCE -u 1000:1000 quay.io/m3/m3dbnode:latest-setcap
 ```
@@ -81,7 +81,7 @@ Before running the process make sure the limits are set, if running manually you
 
 ## Automatic Limit Raising
 
-When M3DB first starts up it will attempt to raise its open file limit to the current value of `fs.nr_open`. This is a
-benign operation and if it fails M3DB will simply emit a warning.
+During startup, M3DB will attempt to raise its open file limit to the current value of `fs.nr_open`. This is a benign
+operation; if it fails M3DB, will simply emit a warning.
 
 [docker-caps]: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities

--- a/docs/operational_guide/kernel_configuration.md
+++ b/docs/operational_guide/kernel_configuration.md
@@ -1,9 +1,25 @@
-Kernel Configuration
+Docker & Kernel Configuration
 ====================
 
 This document lists the Kernel tweaks M3DB needs to run well. If you are running on Kubernetes, you may use our
 `sysctl-setter` [DaemonSet](https://github.com/m3db/m3/blob/master/kube/sysctl-daemonset.yaml) that will set these
 values for you. Please read the comment in that manifest to understand the implications of applying it.
+
+## Running with Docker
+
+If running M3DB under Docker it is recommended to give M3DB the `SYS_RESOURCE` capability so that it may raise its file
+limits. If running directly with Docker this can be accomplished using:
+
+```
+docker run --cap-add SYS_RESOURCE quay.io/m3/m3dbnode:latest
+```
+
+If you wish to run M3DB as a non-root user, you will need to use our `setcap` images:
+```
+docker run --cap-add SYS_RESOURCE -u 1000:1000 quay.io/m3/m3dbnode:latest-setcap
+```
+
+More information on Docker's capability settings can be found [here][docker-caps].
 
 ## vm.max_map_count
 M3DB uses a lot of mmap-ed files for performance, as a result, you might need to bump `vm.max_map_count`. We suggest setting this value to `3000000`, so you don’t have to come back and debug issues later.
@@ -62,3 +78,10 @@ Also note that systemd has a `system.conf` file and a `user.conf` file which may
 Be sure to check that those files aren't configured with values lower than the value you configure at the service level.
 
 Before running the process make sure the limits are set, if running manually you can raise the limit for the current user with `ulimit -n 3000000`.
+
+## Automatic Limit Raising
+
+When M3DB first starts up it will attempt to raise its open file limit to the current value of `fs.nr_open`. This is a
+benign operation and if it fails M3DB will simply emit a warning.
+
+[docker-caps]: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 105536886b45a56d0e59ffc500254941bbe3d0ca9355e32bd94fb2d7a4deb9f8
-updated: 2019-06-12T15:04:52.880394+10:00
+updated: 2019-06-14T18:40:46.052161434Z
 imports:
 - name: github.com/apache/thrift
   version: c2fb1c4e8c931d22617bebb0bf388cb4d5e6fcff
@@ -353,7 +353,7 @@ imports:
   subpackages:
   - fs
 - name: github.com/RoaringBitmap/roaring
-  version: 8d778e47dd84f169ef4436abb474b0e0101a6dae
+  version: df298267d3e5c232b8b7bdf28d891d0b57253843
 - name: github.com/russross/blackfriday
   version: d3b5b032dc8e8927d31a5071b56e14c89f045135
 - name: github.com/satori/go.uuid
@@ -381,7 +381,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 4f9190456aed1c2113ca51ea9b89219747458dc1
 - name: github.com/spf13/viper
-  version: 9e56dacc08fbbf8c9ee2dbc717553c758ce42bc9
+  version: b5bf975e5823809fb22c7644d008757f78a4259e
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,7 @@ pages:
     - "Placement/Topology Configuration": "operational_guide/placement_configuration.md"
     - "Namespace Configuration": "operational_guide/namespace_configuration.md"
     - "Bootstrapping": "operational_guide/bootstrapping.md"
-    - "Kernel Configuration": "operational_guide/kernel_configuration.md"
+    - "Docker & Kernel Configuration": "operational_guide/kernel_configuration.md"
     - "etcd": "operational_guide/etcd.md"
   - "Integrations":
     - "Prometheus": "integrations/prometheus.md"

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -30,6 +30,7 @@ import (
 	"path"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	clusterclient "github.com/m3db/m3/src/cluster/client"
@@ -93,6 +94,8 @@ const (
 	cpuProfileDuration               = 5 * time.Second
 	filePathPrefixLockFile           = ".lock"
 	defaultServiceName               = "m3dbnode"
+	skipRaiseProcessLimitsEnvVar     = "SKIP_PROCESS_LIMITS_RAISE"
+	skipRaiseProcessLimitsEnvVarTrue = "true"
 )
 
 // RunOptions provides options for running the server
@@ -153,17 +156,20 @@ func Run(runOpts RunOptions) {
 
 	xconfig.WarnOnDeprecation(cfg, logger)
 
-	// Raise fd limits to nr_open system limit
-	result, err := xos.RaiseProcessNoFileToNROpen()
-	if err != nil {
-		logger.Warn("unable to raise rlimit to no file fds limit",
-			zap.Error(err))
-	} else {
-		logger.Info("raised rlimit no file fds limit",
-			zap.Bool("required", result.RaisePerformed),
-			zap.Uint64("sysNROpenValue", result.NROpenValue),
-			zap.Uint64("noFileMaxValue", result.NoFileMaxValue),
-			zap.Uint64("noFileCurrValue", result.NoFileCurrValue))
+	// By default attempt to raise process limits, which is a benign operation.
+	skipRaiseLimits := strings.TrimSpace(os.Getenv(skipRaiseProcessLimitsEnvVar))
+	if skipRaiseLimits != skipRaiseProcessLimitsEnvVarTrue {
+		// Raise fd limits to nr_open system limit
+		result, err := xos.RaiseProcessNoFileToNROpen()
+		if err != nil {
+			logger.Warn("unable to raise rlimit", zap.Error(err))
+		} else {
+			logger.Info("raised rlimit no file fds limit",
+				zap.Bool("required", result.RaisePerformed),
+				zap.Uint64("sysNROpenValue", result.NROpenValue),
+				zap.Uint64("noFileMaxValue", result.NoFileMaxValue),
+				zap.Uint64("noFileCurrValue", result.NoFileCurrValue))
+		}
 	}
 
 	// Parse file and directory modes


### PR DESCRIPTION
TODO:
- [x] docs

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1671

**Special notes for your reviewer**:

- Default to attempting to raise FD limits rather than opt in: raising
  the limits is benign if it fails.
- Dual-publish Docker images with a setcap'd binary for users running as
  non-root that want to raise limits.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Dual-publish Docker images with SYS_RESOURCE capabilities on the m3dbnode binary for users running as non-root with added capabilities that wish to raise process limits.

- Default to attempting to raise FD limits to max possible, with an environment variable to skip doing so.
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
YES: Included
```
