### PR TITLE
[DBNode][WIP] Dont block database initialization on namespace initialization

### DIFF
--- a/src/dbnode/namespace/dynamic_test.go
+++ b/src/dbnode/namespace/dynamic_test.go
@@ -95,6 +95,7 @@ func TestInitializerNoTimeout(t *testing.T) {
 
 	rw, err := reg.Watch()
 	require.NoError(t, err)
+	<-rw.C()
 	rMap := rw.Get()
 	mds := rMap.Metadatas()
 	require.Len(t, mds, 1)
@@ -140,6 +141,8 @@ func TestInitializerUpdateWithBadProto(t *testing.T) {
 
 	rmap, err := reg.Watch()
 	require.NoError(t, err)
+
+	<-rmap.C()
 	require.Len(t, rmap.Get().Metadatas(), 1)
 	require.Equal(t, int64(0), numInvalidUpdates(opts))
 
@@ -179,6 +182,8 @@ func TestInitializerUpdateWithOlderVersion(t *testing.T) {
 
 	rmap, err := reg.Watch()
 	require.NoError(t, err)
+	<-rmap.C()
+
 	require.Len(t, rmap.Get().Metadatas(), 1)
 	require.Equal(t, int64(0), numInvalidUpdates(opts))
 
@@ -212,6 +217,7 @@ func TestInitializerUpdateWithNilValue(t *testing.T) {
 
 	rmap, err := reg.Watch()
 	require.NoError(t, err)
+	<-rmap.C()
 	require.Len(t, rmap.Get().Metadatas(), 1)
 	require.Equal(t, int64(0), numInvalidUpdates(opts))
 
@@ -223,23 +229,6 @@ func TestInitializerUpdateWithNilValue(t *testing.T) {
 
 	require.Len(t, rmap.Get().Metadatas(), 1)
 	require.NoError(t, reg.Close())
-}
-
-func TestInitializerUpdateWithNilInitialValue(t *testing.T) {
-	defer leaktest.CheckTimeout(t, time.Second)()
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	w := newTestWatchable(t, nil)
-	defer w.Close()
-
-	opts := newTestOpts(t, ctrl, w)
-	init := NewDynamicInitializer(opts)
-
-	require.NoError(t, w.Update(nil))
-	_, err := init.Init()
-	require.Error(t, err)
 }
 
 func TestInitializerUpdateWithIdenticalValue(t *testing.T) {
@@ -260,6 +249,7 @@ func TestInitializerUpdateWithIdenticalValue(t *testing.T) {
 
 	rmap, err := reg.Watch()
 	require.NoError(t, err)
+	<-rmap.C()
 	require.Len(t, rmap.Get().Metadatas(), 1)
 	require.Equal(t, int64(0), numInvalidUpdates(opts))
 
@@ -294,6 +284,7 @@ func TestInitializerUpdateSuccess(t *testing.T) {
 
 	rmap, err := reg.Watch()
 	require.NoError(t, err)
+	<-rmap.C()
 	require.Len(t, rmap.Get().Metadatas(), 1)
 	require.Equal(t, int64(0), numInvalidUpdates(opts))
 	require.Equal(t, 0., currentVersionMetrics(opts))

--- a/src/dbnode/namespace/namespace_mock.go
+++ b/src/dbnode/namespace/namespace_mock.go
@@ -1012,6 +1012,22 @@ func (mr *MockRegistryMockRecorder) Watch() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockRegistry)(nil).Watch))
 }
 
+// ForceGet mocks base method
+func (m *MockRegistry) ForceGet() (Map, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForceGet")
+	ret0, _ := ret[0].(Map)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ForceGet indicates an expected call of ForceGet
+func (mr *MockRegistryMockRecorder) ForceGet() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceGet", reflect.TypeOf((*MockRegistry)(nil).ForceGet))
+}
+
 // Close mocks base method
 func (m *MockRegistry) Close() error {
 	m.ctrl.T.Helper()

--- a/src/dbnode/namespace/static.go
+++ b/src/dbnode/namespace/static.go
@@ -41,6 +41,7 @@ func (i *staticInit) Init() (Registry, error) {
 
 type staticReg struct {
 	xwatch.Watchable
+	m Map
 }
 
 func newStaticRegistry(metadatas []Metadata) (Registry, error) {
@@ -48,7 +49,7 @@ func newStaticRegistry(metadatas []Metadata) (Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	reg := &staticReg{xwatch.NewWatchable()}
+	reg := &staticReg{Watchable: xwatch.NewWatchable(), m: m}
 	if err := reg.Update(m); err != nil {
 		return nil, err
 	}
@@ -61,6 +62,10 @@ func (r *staticReg) Watch() (Watch, error) {
 		return nil, err
 	}
 	return NewWatch(w), nil
+}
+
+func (r *staticReg) ForceGet() (Map, bool, error) {
+	return r.m, true, nil
 }
 
 func (r *staticReg) Close() error {

--- a/src/dbnode/namespace/types.go
+++ b/src/dbnode/namespace/types.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/dbnode/retention"
+	xclose "github.com/m3db/m3/src/x/close"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
-	xclose "github.com/m3db/m3/src/x/close"
 )
 
 // Options controls namespace behavior
@@ -220,6 +220,11 @@ type Watch interface {
 type Registry interface {
 	// Watch for the Registry changes
 	Watch() (Watch, error)
+
+	// ForceGet bypasses the watch and issues a get request against KV directly.
+	// This can be used in situations where the caller wants to get the current
+	// value, if any, without potentially waiting for an initial value to be set.
+	ForceGet() (Map, bool, error)
 
 	// Close closes the registry
 	Close() error

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -107,6 +107,7 @@ func newMockNsInitializer(
 
 	nsWatch := namespace.NewWatch(w)
 	reg := namespace.NewMockRegistry(ctrl)
+	reg.EXPECT().ForceGet().Return(nil, true, nil)
 	reg.EXPECT().Watch().Return(nsWatch, nil).AnyTimes()
 
 	return &mockNsInitializer{


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R allows M3DB to come up and mark itself as bootstrapped without any configured namespaces.