### PR TITLE
[DBNode][Draft] Make SeekerManager update seekers based on calls to UpdateOpenLease()

### DIFF
--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -307,6 +307,7 @@ func (m *seekerManager) UpdateOpenLease(
 	m.Unlock()
 
 	// First open a new seeker outside the context of any locks.
+	// TODO(rartoul): Use the volume number from the LeaseState.
 	seeker, err := m.newOpenSeekerFn(descriptor.Shard, descriptor.BlockStart)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R is required for the out of order writes feature. After a new volume for a given namespace/shard/blockstart is written out, the SeekerManager will be notified via a call to UpdateOpenLease(). This function imlpements UpdateOpenLease such that the SeekerManager "hot swaps" its old seekers for the old volume with new seekers for the new volume.

TODO(rartoul): Tests, specifically concurrency tests.