### PR TITLE
[metrics] rules: reject timertype tag in filters

### DIFF
--- a/src/metrics/rules/validator/config.go
+++ b/src/metrics/rules/validator/config.go
@@ -48,6 +48,7 @@ type Configuration struct {
 	MetricTypes                      metricTypesValidationConfiguration `yaml:"metricTypes"`
 	Policies                         policiesValidationConfiguration    `yaml:"policies"`
 	TagNameInvalidChars              string                             `yaml:"tagNameInvalidChars"`
+	FilterInvalidTagNames            []string                           `yaml:"filterInvalidTagNames"`
 	MetricNameInvalidChars           string                             `yaml:"metricNameInvalidChars"`
 }
 
@@ -71,7 +72,8 @@ func (c Configuration) newValidatorOptions(
 		SetRequiredRollupTags(c.RequiredRollupTags).
 		SetMetricTypesFn(c.MetricTypes.NewMetricTypesFn()).
 		SetTagNameInvalidChars(toRunes(c.TagNameInvalidChars)).
-		SetMetricNameInvalidChars(toRunes(c.MetricNameInvalidChars))
+		SetMetricNameInvalidChars(toRunes(c.MetricNameInvalidChars)).
+		SetFilterInvalidTagNames(c.FilterInvalidTagNames)
 	if c.MetricTypes.MultiAggregationTypesEnabledFor != nil {
 		opts = opts.SetMultiAggregationTypesEnabledFor(*c.MetricTypes.MultiAggregationTypesEnabledFor)
 	}

--- a/src/metrics/rules/validator/config_test.go
+++ b/src/metrics/rules/validator/config_test.go
@@ -94,6 +94,8 @@ requiredRollupTags:
   - tag2
 maxTransformationDerivativeOrder: 2
 maxRollupLevels: 1
+filterInvalidTagNames:
+- foobar
 metricTypes:
   typeTag: type
   allowed:
@@ -236,6 +238,8 @@ policies:
 			require.False(t, opts.IsAllowedNonFirstLevelAggregationTypeFor(input.metricType, aggregationType))
 		}
 	}
+
+	require.Error(t, opts.CheckFilterTagNameValid("foobar"))
 }
 
 func TestNamespaceValidatorConfigurationStatic(t *testing.T) {

--- a/src/metrics/rules/validator/options.go
+++ b/src/metrics/rules/validator/options.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/metrics/filters"
@@ -276,9 +277,10 @@ func (o *options) CheckInvalidCharactersForTagName(tagName string) error {
 }
 
 func (o *options) CheckTimertypeFilterForTagName(tagName string) error {
-	if tagName == tagTimerType {
+	if strings.ToLower(tagName) == tagTimerType {
 		return errors.New("tag name cannot be timertype; timertype is not added at the client layer")
 	}
+
 	return nil
 }
 

--- a/src/metrics/rules/validator/options.go
+++ b/src/metrics/rules/validator/options.go
@@ -21,6 +21,7 @@
 package validator
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -39,6 +40,8 @@ const (
 
 	// By default we allow at most one level of rollup in a pipeline.
 	defaultMaxRollupLevels = 1
+
+	tagTimerType = "timertype"
 )
 
 // MetricTypesFn determines the possible metric types based on a set of tag based filters.
@@ -110,6 +113,11 @@ type Options interface {
 	// CheckInvalidCharactersForTagName checks if the given tag name contains invalid characters
 	// returning an error if invalid character(s) present.
 	CheckInvalidCharactersForTagName(tagName string) error
+
+	// CheckTimertypeFilterForTagName checks if the given tag name is "timertype"
+	// and returns an error if so, as timertype is added at the aggregation tier
+	// and not the client.
+	CheckTimertypeFilterForTagName(tagName string) error
 
 	// SetMetricNameInvalidChars sets the list of invalid chars for a metric name.
 	SetMetricNameInvalidChars(value []rune) Options
@@ -265,6 +273,13 @@ func (o *options) SetTagNameInvalidChars(values []rune) Options {
 
 func (o *options) CheckInvalidCharactersForTagName(tagName string) error {
 	return validateChars(tagName, o.tagNameInvalidChars)
+}
+
+func (o *options) CheckTimertypeFilterForTagName(tagName string) error {
+	if tagName == tagTimerType {
+		return errors.New("tag name cannot be timertype; timertype is not added at the client layer")
+	}
+	return nil
 }
 
 func (o *options) SetMetricNameInvalidChars(values []rune) Options {

--- a/src/metrics/rules/validator/options_test.go
+++ b/src/metrics/rules/validator/options_test.go
@@ -23,8 +23,8 @@ package validator
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateChars(t *testing.T) {
@@ -38,5 +38,6 @@ func TestValidateChars(t *testing.T) {
 func TestCheckTimertypeFilterForTagName(t *testing.T) {
 	o := NewOptions()
 	assert.Error(t, o.CheckTimertypeFilterForTagName("timertype"))
+	assert.Error(t, o.CheckTimertypeFilterForTagName("timerType"))
 	assert.NoError(t, o.CheckTimertypeFilterForTagName("service"))
 }

--- a/src/metrics/rules/validator/options_test.go
+++ b/src/metrics/rules/validator/options_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateChars(t *testing.T) {
@@ -32,4 +33,10 @@ func TestValidateChars(t *testing.T) {
 	}
 	require.Error(t, validateChars("test$", invalidChars))
 	require.NoError(t, validateChars("test", invalidChars))
+}
+
+func TestCheckTimertypeFilterForTagName(t *testing.T) {
+	o := NewOptions()
+	assert.Error(t, o.CheckTimertypeFilterForTagName("timertype"))
+	assert.NoError(t, o.CheckTimertypeFilterForTagName("service"))
 }

--- a/src/metrics/rules/validator/options_test.go
+++ b/src/metrics/rules/validator/options_test.go
@@ -35,9 +35,11 @@ func TestValidateChars(t *testing.T) {
 	require.NoError(t, validateChars("test", invalidChars))
 }
 
-func TestCheckTimertypeFilterForTagName(t *testing.T) {
+func TestCheckFilterTagNameValid(t *testing.T) {
 	o := NewOptions()
-	assert.Error(t, o.CheckTimertypeFilterForTagName("timertype"))
-	assert.Error(t, o.CheckTimertypeFilterForTagName("timerType"))
-	assert.NoError(t, o.CheckTimertypeFilterForTagName("service"))
+	assert.NoError(t, o.CheckFilterTagNameValid("timertype"))
+	assert.NoError(t, o.CheckFilterTagNameValid("timerType"))
+	o = o.SetFilterInvalidTagNames([]string{"timertype"})
+	assert.Error(t, o.CheckFilterTagNameValid("timertype"))
+	assert.Error(t, o.CheckFilterTagNameValid("timerType"))
 }

--- a/src/metrics/rules/validator/validator.go
+++ b/src/metrics/rules/validator/validator.go
@@ -206,6 +206,9 @@ func (v *validator) validateFilter(f string) (filters.TagFilterValueMap, error) 
 		if err := v.opts.CheckInvalidCharactersForTagName(tag); err != nil {
 			return nil, fmt.Errorf("tag name '%s' contains invalid character, err: %v", tag, err)
 		}
+		if err := v.opts.CheckTimertypeFilterForTagName(tag); err != nil {
+			return nil, err
+		}
 	}
 	return filterValues, nil
 }

--- a/src/metrics/rules/validator/validator.go
+++ b/src/metrics/rules/validator/validator.go
@@ -206,7 +206,7 @@ func (v *validator) validateFilter(f string) (filters.TagFilterValueMap, error) 
 		if err := v.opts.CheckInvalidCharactersForTagName(tag); err != nil {
 			return nil, fmt.Errorf("tag name '%s' contains invalid character, err: %v", tag, err)
 		}
-		if err := v.opts.CheckTimertypeFilterForTagName(tag); err != nil {
+		if err := v.opts.CheckFilterTagNameValid(tag); err != nil {
 			return nil, err
 		}
 	}

--- a/src/metrics/rules/validator/validator_test.go
+++ b/src/metrics/rules/validator/validator_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/m3db/m3/src/metrics/transformation"
 
 	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1113,6 +1114,44 @@ func TestValidatorValidateRollupRuleRollupOpWithValidTagName(t *testing.T) {
 
 	validator := NewValidator(testValidatorOptions().SetMetricNameInvalidChars(invalidChars))
 	require.NoError(t, validator.ValidateSnapshot(view))
+}
+
+func TestValidatorValidateNoTimertypeFilter(t *testing.T) {
+	for _, test := range []string{
+		"rollup",
+		"mapping",
+	} {
+		t.Run(test, func(t *testing.T) {
+			ruleView := view.RuleSet{}
+			if test == "rollup" {
+				ruleView.RollupRules = []view.RollupRule{
+					{
+						Name:   "foo",
+						Filter: "service:bar timertype:count",
+					},
+				}
+			} else {
+				ruleView.MappingRules = []view.MappingRule{
+					{
+						Name:       "foo",
+						Filter:     "service:bar timertype:count",
+						DropPolicy: policy.DropMust,
+					},
+				}
+			}
+
+			validator := NewValidator(testValidatorOptions())
+			assert.Error(t, validator.ValidateSnapshot(ruleView))
+
+			if test == "rollup" {
+				ruleView.RollupRules = ruleView.RollupRules[:0]
+			} else {
+				ruleView.MappingRules = ruleView.MappingRules[:0]
+			}
+
+			assert.NoError(t, validator.ValidateSnapshot(ruleView))
+		})
+	}
 }
 
 func TestValidatorValidateRollupRuleRollupOpMultipleAggregationTypes(t *testing.T) {

--- a/src/metrics/rules/validator/validator_test.go
+++ b/src/metrics/rules/validator/validator_test.go
@@ -1140,7 +1140,7 @@ func TestValidatorValidateNoTimertypeFilter(t *testing.T) {
 				}
 			}
 
-			validator := NewValidator(testValidatorOptions())
+			validator := NewValidator(testValidatorOptions().SetFilterInvalidTagNames([]string{"timertype"}))
 			assert.Error(t, validator.ValidateSnapshot(ruleView))
 
 			if test == "rollup" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**: Make rule validator more robust for a common gotcha.
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**: `timertype` is added at the aggregation tier, not at the client layer.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
