### PR TITLE
[ci] add script for running builds on external PRs

### DIFF
--- a/.buildkite/scripts/pr_build.sh
+++ b/.buildkite/scripts/pr_build.sh
@@ -26,6 +26,11 @@ if [[ -z "$BUILDKITE_CLI_TOKEN" ]]; then
   exit 1
 fi
 
+if ! command -v jq; then
+  echo "cannot find jq in PATH"
+  exit 1
+fi
+
 RESP=$(mktemp)
 
 function cleanup() {

--- a/.buildkite/scripts/pr_build.sh
+++ b/.buildkite/scripts/pr_build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -exo pipefail
+
+# Script to run adhoc buildkite builds for the given branch. Useful for running
+# CI tests against branches that may not yet be ready for a PR. See
+# https://buildkite.com/docs/apis/rest-api#authentication for more info on
+# buildkite tokens. To take full advantage of this script your token will need
+# `read_builds` and `write_builds` scopes. The script expects a working
+# installation of jq.
+#
+# You'll also need a Github token with `public_repo` permissions.
+
+function usage() {
+  echo "build.sh \$PR_NUMBER"
+  exit 1
+}
+
+if [[ -z "$GITHUB_PR_TOKEN" ]]; then
+  echo "must set GITHUB_PR_TOKEN"
+  exit 1
+fi
+
+if [[ -z "$BUILDKITE_CLI_TOKEN" ]]; then
+  echo "must set BUILDKITE_CLI_TOKEN"
+  exit 1
+fi
+
+RESP=$(mktemp)
+
+function cleanup() {
+  rm -f "$RESP"
+}
+
+trap cleanup EXIT
+
+curl -H "Authorization: token $GITHUB_PR_TOKEN" -sSf -o "$RESP" "https://api.github.com/repos/m3db/m3/pulls/$1"
+
+function jq_field() {
+  <"$RESP" jq -r "$1"
+}
+
+function build() {
+  local pr=$1
+  local url="https://api.buildkite.com/v2/organizations/uberopensource/pipelines/m3-monorepo-ci"
+  local auth="Authorization: Bearer $BUILDKITE_CLI_TOKEN"
+  local repo; repo=$(jq_field '.head.repo.clone_url')
+  local sha; sha=$(jq_field '.head.sha')
+  local branch; branch=$(jq_field '.head.ref')
+  local message; message=$(jq_field '.title')
+
+  local data
+  data=$(cat <<EOF
+    {
+      "branch": "$branch",
+      "message": "$message",
+      "commit": "$sha",
+      "ignore_pipeline_branch_filters": true,
+      "clean_checkout": true,
+      "pull_request_base_branch": "master",
+      "pull_request_id": $pr,
+      "pull_request_repository": "$repo"
+    }
+EOF
+  )
+
+  curl -sSf -X POST -H "$auth" "${url}/builds" -d "$data" | jq -r .web_url
+}
+
+build "$*"


### PR DESCRIPTION
Until we have a more complex label system for running PRs from external
contributors, this can hold us over.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
