### PR TITLE
Implement UpdateOpenLease() in SeekerManager

### DIFF
--- a/src/cmd/tools/dtest/util/seed/generator_test.go
+++ b/src/cmd/tools/dtest/util/seed/generator_test.go
@@ -128,18 +128,12 @@ func (t *fileInfoExtractor) visit(fPath string, f os.FileInfo, err error) error 
 	t.shards[uint32(shardNum)] = struct{}{}
 
 	name := f.Name()
-	first := strings.Index(name, "-")
-	if first == -1 {
-		return fmt.Errorf("unable to find '-' in %v", name)
+	nameSplit := strings.Split(name, "-")
+	if len(nameSplit) < 2 {
+		return fmt.Errorf("unable to parse time from %v", name)
 	}
-	last := strings.LastIndex(name, "-")
-	if last == -1 {
-		return fmt.Errorf("unable to find '-' in %v", name)
-	}
-	if first == last {
-		return fmt.Errorf("found only single '-' in %v", name)
-	}
-	num, parseErr := strconv.ParseInt(name[first+1:last], 10, 64)
+
+	num, parseErr := strconv.ParseInt(nameSplit[1], 10, 64)
 	if parseErr != nil {
 		return err
 	}

--- a/src/dbnode/integration/disk_cleanup_helpers.go
+++ b/src/dbnode/integration/disk_cleanup_helpers.go
@@ -27,11 +27,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/x/ident"
 
 	"github.com/stretchr/testify/require"
@@ -114,7 +114,7 @@ type cleanupTimesFileSet struct {
 
 func (fset *cleanupTimesFileSet) anyExist() bool {
 	for _, t := range fset.times {
-		exists, err := fs.DataFileSetExistsAt(fset.filePathPrefix, fset.namespace, fset.shard, t)
+		exists, err := fs.DataFileSetExists(fset.filePathPrefix, fset.namespace, fset.shard, t, 0)
 		if err != nil {
 			panic(err)
 		}

--- a/src/dbnode/integration/disk_cleanup_index_test.go
+++ b/src/dbnode/integration/disk_cleanup_index_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/retention"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	xclock "github.com/m3db/m3/src/x/clock"
 
 	"github.com/stretchr/testify/require"

--- a/src/dbnode/integration/disk_flush_helpers.go
+++ b/src/dbnode/integration/disk_flush_helpers.go
@@ -30,11 +30,11 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/integration/generate"
+	ns "github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage"
-	ns "github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/ident/testutil"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -122,8 +122,8 @@ func waitUntilDataFilesFlushed(
 		for timestamp, seriesList := range testData {
 			for _, series := range seriesList {
 				shard := shardSet.Lookup(series.ID)
-				exists, err := fs.DataFileSetExistsAt(
-					filePathPrefix, namespace, shard, timestamp.ToTime())
+				exists, err := fs.DataFileSetExists(
+					filePathPrefix, namespace, shard, timestamp.ToTime(), 0)
 				if err != nil {
 					panic(err)
 				}

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -418,8 +418,8 @@ func (a fileSetFilesByTimeAndVolumeIndexAscending) Less(i, j int) bool {
 // Returns the positions of filename delimiters ('-' and '.') and the number of
 // delimeters found, to be used in conjunction with the intComponentFromFilename
 // function to extract filename components. This function is deliberately
-// optimized for speed and lack of allocationsm, since filename parsing is known
-// to account for a significant proportion of sytstem resources.
+// optimized for speed and lack of allocations, since filename parsing is known
+// to account for a significant proportion of system resources.
 func delimiterPositions(baseFilename string) ([maxDelimNum]int, int) {
 	var (
 		delimPos    [maxDelimNum]int
@@ -441,9 +441,10 @@ func delimiterPositions(baseFilename string) ([maxDelimNum]int, int) {
 	return delimPos, delimsFound
 }
 
-// Returns the the specified component of a filename given delimeter positions.
-// Our only use cases involve extracting numeric components, so this function
-// assumes this and returns the component as an int64.
+// Returns the the specified component of a filename, given the positions of
+// delimeters. Our only use cases for this involve extracting numeric
+// components, so this function assumes this and returns the component as an
+// int64.
 func intComponentFromFilename(
 	baseFilename string,
 	componentPos int,

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -980,8 +980,8 @@ func DeleteFileSetAt(filePathPrefix string, namespace ident.ID, shard uint32, bl
 	return DeleteFiles(fileset.AbsoluteFilepaths)
 }
 
-// DataFilePathsBefore returns all the flush data fileset paths whose timestamps are earlier than a given time.
-func DataFilePathsBefore(filePathPrefix string, namespace ident.ID, shard uint32, t time.Time) ([]string, error) {
+// DataFileSetsBefore returns all the flush data fileset paths whose timestamps are earlier than a given time.
+func DataFileSetsBefore(filePathPrefix string, namespace ident.ID, shard uint32, t time.Time) ([]string, error) {
 	matched, err := filesetFiles(filesetFilesSelector{
 		fileSetType:    persist.FileSetFlushType,
 		contentType:    persist.FileSetDataContentType,
@@ -996,8 +996,8 @@ func DataFilePathsBefore(filePathPrefix string, namespace ident.ID, shard uint32
 	return FilesBefore(matched.Filepaths(), t)
 }
 
-// IndexFilePathsBefore returns all the flush index fileset paths whose timestamps are earlier than a given time.
-func IndexFilePathsBefore(filePathPrefix string, namespace ident.ID, t time.Time) ([]string, error) {
+// IndexFileSetsBefore returns all the flush index fileset paths whose timestamps are earlier than a given time.
+func IndexFileSetsBefore(filePathPrefix string, namespace ident.ID, t time.Time) ([]string, error) {
 	matched, err := filesetFiles(filesetFilesSelector{
 		fileSetType:    persist.FileSetFlushType,
 		contentType:    persist.FileSetIndexContentType,

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -633,13 +633,6 @@ func forEachInfoFile(
 		t := matched[i].ID.BlockStart
 		volume := matched[i].ID.VolumeIndex
 
-		isLegacy := false
-		if volume == 0 {
-			isLegacy, err = isFirstVolumeLegacy(dir, t, checkpointFileSuffix)
-			if err != nil {
-				continue
-			}
-		}
 		var (
 			checkpointFilePath string
 			digestsFilePath    string
@@ -649,6 +642,13 @@ func forEachInfoFile(
 		case persist.FileSetFlushType:
 			switch args.contentType {
 			case persist.FileSetDataContentType:
+				isLegacy := false
+				if volume == 0 {
+					isLegacy, err = isFirstVolumeLegacy(dir, t, checkpointFileSuffix)
+					if err != nil {
+						continue
+					}
+				}
 				checkpointFilePath = dataFilesetPathFromTimeAndIndex(dir, t, volume, checkpointFileSuffix, isLegacy)
 				digestsFilePath = dataFilesetPathFromTimeAndIndex(dir, t, volume, digestFileSuffix, isLegacy)
 				infoFilePath = dataFilesetPathFromTimeAndIndex(dir, t, volume, infoFileSuffix, isLegacy)

--- a/src/dbnode/persist/fs/files_test.go
+++ b/src/dbnode/persist/fs/files_test.go
@@ -208,7 +208,7 @@ func TestForEachInfoFile(t *testing.T) {
 			res = append(res, data...)
 		})
 
-	require.Equal(t, []string{filesetPathFromTime(shardDir, blockStart, infoFileSuffix)}, fnames)
+	require.Equal(t, []string{filesetPathFromTimeLegacy(shardDir, blockStart, infoFileSuffix)}, fnames)
 	require.Equal(t, infoData, res)
 }
 
@@ -391,16 +391,16 @@ func TestFileExists(t *testing.T) {
 	defer os.RemoveAll(dir)
 	require.NoError(t, err)
 
-	infoFilePath := filesetPathFromTime(shardDir, start, infoFileSuffix)
+	infoFilePath := filesetPathFromTimeLegacy(shardDir, start, infoFileSuffix)
 	createDataFile(t, shardDir, start, infoFileSuffix, checkpointFileBuf)
 	require.True(t, mustFileExists(t, infoFilePath))
-	exists, err := DataFileSetExistsAt(dir, testNs1ID, uint32(shard), start)
+	exists, err := DataFileSetExists(dir, testNs1ID, uint32(shard), start, 0)
 	require.NoError(t, err)
 	require.False(t, exists)
 
-	checkpointFilePath := filesetPathFromTime(shardDir, start, checkpointFileSuffix)
+	checkpointFilePath := filesetPathFromTimeLegacy(shardDir, start, checkpointFileSuffix)
 	createDataFile(t, shardDir, start, checkpointFileSuffix, checkpointFileBuf)
-	exists, err = DataFileSetExistsAt(dir, testNs1ID, uint32(shard), start)
+	exists, err = DataFileSetExists(dir, testNs1ID, uint32(shard), start, 0)
 	require.NoError(t, err)
 	require.True(t, exists)
 
@@ -421,7 +421,7 @@ func TestCompleteCheckpointFileExists(t *testing.T) {
 		shard              = uint32(10)
 		start              = time.Now()
 		shardDir           = ShardDataDirPath(dir, testNs1ID, shard)
-		checkpointFilePath = filesetPathFromTime(shardDir, start, checkpointFileSuffix)
+		checkpointFilePath = filesetPathFromTimeLegacy(shardDir, start, checkpointFileSuffix)
 		err                = os.MkdirAll(shardDir, defaultNewDirectoryMode)
 
 		validCheckpointFileBuf   = make([]byte, CheckpointFileSizeBytes)
@@ -464,7 +464,7 @@ func TestFilePathFromTime(t *testing.T) {
 		{"foo/bar/", infoFileSuffix, "foo/bar/fileset-1465501321123456789-info.db"},
 	}
 	for _, input := range inputs {
-		require.Equal(t, input.expected, filesetPathFromTime(input.prefix, start, input.suffix))
+		require.Equal(t, input.expected, filesetPathFromTimeLegacy(input.prefix, start, input.suffix))
 	}
 }
 
@@ -482,7 +482,7 @@ func TestFileSetFilesBefore(t *testing.T) {
 	shardDir := path.Join(dir, dataDirName, testNs1ID.String(), strconv.Itoa(int(shard)))
 	for i := 0; i < len(res); i++ {
 		ts := time.Unix(0, int64(i))
-		require.Equal(t, filesetPathFromTime(shardDir, ts, infoFileSuffix), res[i])
+		require.Equal(t, filesetPathFromTimeLegacy(shardDir, ts, infoFileSuffix), res[i])
 	}
 }
 
@@ -1173,7 +1173,7 @@ func createDataFiles(t *testing.T,
 		if isSnapshot {
 			infoFilePath = filesetPathFromTimeAndIndex(shardDir, ts, 0, fileSuffix)
 		} else {
-			infoFilePath = filesetPathFromTime(shardDir, ts, fileSuffix)
+			infoFilePath = filesetPathFromTimeLegacy(shardDir, ts, fileSuffix)
 		}
 		var contents []byte
 		if fileSuffix == checkpointFileSuffix {
@@ -1230,7 +1230,7 @@ func (filesets fileSetFileIdentifiers) create(t *testing.T, prefixDir string, fi
 				var path string
 				switch fileSetType {
 				case persist.FileSetFlushType:
-					path = filesetPathFromTime(shardDir, blockStart, suffix)
+					path = filesetPathFromTimeLegacy(shardDir, blockStart, suffix)
 					writeFile(t, path, nil)
 				case persist.FileSetSnapshotType:
 					path = filesetPathFromTimeAndIndex(shardDir, blockStart, 0, fileSuffix)
@@ -1262,7 +1262,7 @@ func (filesets fileSetFileIdentifiers) create(t *testing.T, prefixDir string, fi
 }
 
 func createDataFile(t *testing.T, shardDir string, blockStart time.Time, suffix string, b []byte) {
-	filePath := filesetPathFromTime(shardDir, blockStart, suffix)
+	filePath := filesetPathFromTimeLegacy(shardDir, blockStart, suffix)
 	createFile(t, filePath, b)
 }
 

--- a/src/dbnode/persist/fs/files_test.go
+++ b/src/dbnode/persist/fs/files_test.go
@@ -215,7 +215,7 @@ func TestForEachInfoFile(t *testing.T) {
 func TestTimeFromFileName(t *testing.T) {
 	_, err := TimeFromFileName("foo/bar")
 	require.Error(t, err)
-	require.Equal(t, "unexpected file name foo/bar", err.Error())
+	require.Equal(t, "unexpected filename: foo/bar", err.Error())
 
 	_, err = TimeFromFileName("foo/bar-baz")
 	require.Error(t, err)
@@ -239,7 +239,7 @@ func TestTimeFromFileName(t *testing.T) {
 func TestTimeAndIndexFromCommitlogFileName(t *testing.T) {
 	_, _, err := TimeAndIndexFromCommitlogFilename("foo/bar")
 	require.Error(t, err)
-	require.Equal(t, "unexpected file name foo/bar", err.Error())
+	require.Equal(t, "unexpected filename: foo/bar", err.Error())
 
 	_, _, err = TimeAndIndexFromCommitlogFilename("foo/bar-baz")
 	require.Error(t, err)
@@ -264,7 +264,7 @@ func TestTimeAndIndexFromCommitlogFileName(t *testing.T) {
 func TestTimeAndVolumeIndexFromFileSetFilename(t *testing.T) {
 	_, _, err := TimeAndVolumeIndexFromFileSetFilename("foo/bar")
 	require.Error(t, err)
-	require.Equal(t, "unexpected file name foo/bar", err.Error())
+	require.Equal(t, "unexpected filename: foo/bar", err.Error())
 
 	_, _, err = TimeAndVolumeIndexFromFileSetFilename("foo/bar-baz")
 	require.Error(t, err)
@@ -291,7 +291,7 @@ func TestTimeAndVolumeIndexFromFileSetFilename(t *testing.T) {
 func TestTimeAndVolumeIndexFromDataFileSetFilename(t *testing.T) {
 	_, _, err := TimeAndVolumeIndexFromDataFileSetFilename("foo/bar")
 	require.Error(t, err)
-	require.Equal(t, "unexpected file name foo/bar", err.Error())
+	require.Equal(t, "unexpected filename: foo/bar", err.Error())
 
 	_, _, err = TimeAndVolumeIndexFromDataFileSetFilename("foo/bar-baz")
 	require.Error(t, err)

--- a/src/dbnode/persist/fs/files_test.go
+++ b/src/dbnode/persist/fs/files_test.go
@@ -475,7 +475,7 @@ func TestFileSetFilesBefore(t *testing.T) {
 
 	cutoffIter := 8
 	cutoff := time.Unix(0, int64(cutoffIter))
-	res, err := DataFilePathsBefore(dir, testNs1ID, shard, cutoff)
+	res, err := DataFileSetsBefore(dir, testNs1ID, shard, cutoff)
 	require.NoError(t, err)
 	require.Equal(t, cutoffIter, len(res))
 
@@ -1073,7 +1073,7 @@ func TestIndexFileSetsBefore(t *testing.T) {
 	}
 	files.create(t, dir)
 
-	results, err := IndexFilePathsBefore(dir, ns1, timeFor(3))
+	results, err := IndexFileSetsBefore(dir, ns1, timeFor(3))
 	require.NoError(t, err)
 	require.Len(t, results, 3)
 	for _, res := range results {

--- a/src/dbnode/persist/fs/fs.go
+++ b/src/dbnode/persist/fs/fs.go
@@ -34,13 +34,16 @@ const (
 	filesetFilePrefix        = "fileset"
 	commitLogFilePrefix      = "commitlog"
 	segmentFileSetFilePrefix = "segment"
-	fileSuffix               = ".db"
+
+	fileSuffix              = ".db"
+	fileSuffixDelimeterRune = '.'
 
 	anyLowerCaseCharsPattern        = "[a-z]*"
 	anyNumbersPattern               = "[0-9]*"
 	anyLowerCaseCharsNumbersPattern = "[a-z0-9]*"
 
-	separator = "-"
+	separator     = "-"
+	separatorRune = '-'
 
 	infoFilePattern      = filesetFilePrefix + separator + anyNumbersPattern + separator + infoFileSuffix + fileSuffix
 	filesetFilePattern   = filesetFilePrefix + separator + anyNumbersPattern + separator + anyLowerCaseCharsPattern + fileSuffix

--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -400,17 +400,17 @@ func (mr *MockDataFileSetSeekerMockRecorder) ConcurrentIDBloomFilter() *gomock.C
 }
 
 // Open mocks base method
-func (m *MockDataFileSetSeeker) Open(arg0 ident.ID, arg1 uint32, arg2 time.Time, arg3 ReusableSeekerResources) error {
+func (m *MockDataFileSetSeeker) Open(arg0 ident.ID, arg1 uint32, arg2 time.Time, arg3 int, arg4 ReusableSeekerResources) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Open", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Open", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Open indicates an expected call of Open
-func (mr *MockDataFileSetSeekerMockRecorder) Open(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDataFileSetSeekerMockRecorder) Open(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockDataFileSetSeeker)(nil).Open), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockDataFileSetSeeker)(nil).Open), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Range mocks base method

--- a/src/dbnode/persist/fs/index_lookup_prop_test.go
+++ b/src/dbnode/persist/fs/index_lookup_prop_test.go
@@ -107,7 +107,7 @@ func TestIndexLookupWriteRead(t *testing.T) {
 		}
 
 		// Read the summaries file into memory
-		summariesFilePath := filesetPathFromTime(
+		summariesFilePath := filesetPathFromTimeLegacy(
 			shardDirPath, testWriterStart, summariesFileSuffix)
 		summariesFile, err := os.Open(summariesFilePath)
 		if err != nil {
@@ -254,7 +254,7 @@ func genTagIdent() gopter.Gen {
 }
 
 func readIndexFileOffsets(shardDirPath string, numEntries int, start time.Time) (map[string]int64, error) {
-	indexFilePath := filesetPathFromTime(shardDirPath, start, indexFileSuffix)
+	indexFilePath := filesetPathFromTimeLegacy(shardDirPath, start, indexFileSuffix)
 	buf, err := ioutil.ReadFile(indexFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("err reading index file: %v, ", err)

--- a/src/dbnode/persist/fs/index_lookup_prop_test.go
+++ b/src/dbnode/persist/fs/index_lookup_prop_test.go
@@ -107,8 +107,8 @@ func TestIndexLookupWriteRead(t *testing.T) {
 		}
 
 		// Read the summaries file into memory
-		summariesFilePath := filesetPathFromTimeLegacy(
-			shardDirPath, testWriterStart, summariesFileSuffix)
+		summariesFilePath := dataFilesetPathFromTimeAndIndex(
+			shardDirPath, testWriterStart, 0, summariesFileSuffix, false)
 		summariesFile, err := os.Open(summariesFilePath)
 		if err != nil {
 			return false, fmt.Errorf("err opening summaries file: %v, ", err)
@@ -254,7 +254,7 @@ func genTagIdent() gopter.Gen {
 }
 
 func readIndexFileOffsets(shardDirPath string, numEntries int, start time.Time) (map[string]int64, error) {
-	indexFilePath := filesetPathFromTimeLegacy(shardDirPath, start, indexFileSuffix)
+	indexFilePath := dataFilesetPathFromTimeAndIndex(shardDirPath, start, 0, indexFileSuffix, false)
 	buf, err := ioutil.ReadFile(indexFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("err reading index file: %v, ", err)

--- a/src/dbnode/persist/fs/merger.go
+++ b/src/dbnode/persist/fs/merger.go
@@ -192,10 +192,10 @@ func (m *merger) Merge(
 
 	// First stage: loop through series on disk.
 	for id, tagsIter, data, _, err := reader.Read(); err != io.EOF; id, tagsIter, data, _, err = reader.Read() {
-		idsToFinalize = append(idsToFinalize, id)
 		if err != nil {
 			return err
 		}
+		idsToFinalize = append(idsToFinalize, id)
 
 		// Reset BlockReaders.
 		brs = brs[:0]
@@ -220,10 +220,10 @@ func (m *merger) Merge(
 		// are valid, and the IDs are valid for the duration of the file writing.
 		tags, err := convert.TagsFromTagsIter(id, tagsIter, identPool)
 		tagsIter.Close()
-		tagsToFinalize = append(tagsToFinalize, tags)
 		if err != nil {
 			return err
 		}
+		tagsToFinalize = append(tagsToFinalize, tags)
 		if err := persistIter(prepared.Persist, multiIter, startTime,
 			id, tags, blockAllocSize, nsCtx.Schema, encoderPool); err != nil {
 			return err

--- a/src/dbnode/persist/fs/merger.go
+++ b/src/dbnode/persist/fs/merger.go
@@ -97,13 +97,15 @@ func (m *merger) Merge(
 		nsID       = fileID.Namespace
 		shard      = fileID.Shard
 		startTime  = fileID.BlockStart
+		volume     = fileID.VolumeIndex
 		blockSize  = nsOpts.RetentionOptions().BlockSize()
 		blockStart = xtime.ToUnixNano(startTime)
 		openOpts   = DataReaderOpenOptions{
 			Identifier: FileSetFileIdentifier{
-				Namespace:  nsID,
-				Shard:      shard,
-				BlockStart: startTime,
+				Namespace:   nsID,
+				Shard:       shard,
+				BlockStart:  startTime,
+				VolumeIndex: volume,
 			},
 			FileSetType: persist.FileSetFlushType,
 		}

--- a/src/dbnode/persist/fs/merger.go
+++ b/src/dbnode/persist/fs/merger.go
@@ -128,6 +128,8 @@ func (m *merger) Merge(
 		NamespaceMetadata: nsMd,
 		Shard:             shard,
 		BlockStart:        startTime,
+		VolumeIndex:       fileID.VolumeIndex + 1,
+		FileSetType:       persist.FileSetFlushType,
 		DeleteIfExists:    false,
 	}
 	prepared, err := flushPreparer.PrepareData(prepareOpts)

--- a/src/dbnode/persist/fs/persist_manager.go
+++ b/src/dbnode/persist/fs/persist_manager.go
@@ -424,8 +424,8 @@ func (pm *persistManager) PrepareData(opts persist.DataPrepareOptions) (persist.
 	var volumeIndex int
 	switch opts.FileSetType {
 	case persist.FileSetFlushType:
-		// Use the volume index passed in. This ensures that this index is the
-		// same as the flush index.
+		// Use the volume index passed in. This ensures that the volume index is
+		// the same as the cold flush version.
 		volumeIndex = opts.VolumeIndex
 	case persist.FileSetSnapshotType:
 		// Need to work out the volume index for the next snapshot.

--- a/src/dbnode/persist/fs/persist_manager.go
+++ b/src/dbnode/persist/fs/persist_manager.go
@@ -416,7 +416,7 @@ func (pm *persistManager) PrepareData(opts persist.DataPrepareOptions) (persist.
 		return prepared, errPersistManagerCannotPrepareDataNotPersisting
 	}
 
-	exists, err := pm.dataFilesetExistsAt(opts)
+	exists, err := pm.dataFilesetExists(opts)
 	if err != nil {
 		return prepared, err
 	}
@@ -424,12 +424,9 @@ func (pm *persistManager) PrepareData(opts persist.DataPrepareOptions) (persist.
 	var volumeIndex int
 	switch opts.FileSetType {
 	case persist.FileSetFlushType:
-		// Need to work out the volume index for the next data file.
-		volumeIndex, err = NextDataFileSetVolumeIndex(pm.opts.FilePathPrefix(),
-			nsMetadata.ID(), shard, blockStart)
-		if err != nil {
-			return prepared, err
-		}
+		// Use the volume index passed in. This ensures that this index is the
+		// same as the flush index.
+		volumeIndex = opts.VolumeIndex
 	case persist.FileSetSnapshotType:
 		// Need to work out the volume index for the next snapshot.
 		volumeIndex, err = NextSnapshotFileSetVolumeIndex(pm.opts.FilePathPrefix(),
@@ -606,20 +603,25 @@ func (pm *persistManager) doneShared() error {
 	return nil
 }
 
-func (pm *persistManager) dataFilesetExistsAt(prepareOpts persist.DataPrepareOptions) (bool, error) {
+func (pm *persistManager) dataFilesetExists(prepareOpts persist.DataPrepareOptions) (bool, error) {
 	var (
-		blockStart = prepareOpts.BlockStart
-		shard      = prepareOpts.Shard
 		nsID       = prepareOpts.NamespaceMetadata.ID()
+		shard      = prepareOpts.Shard
+		blockStart = prepareOpts.BlockStart
+		volume     = prepareOpts.VolumeIndex
 	)
 
 	switch prepareOpts.FileSetType {
 	case persist.FileSetSnapshotType:
-		// Snapshot files are indexed (multiple per block-start), so checking if the file
-		// already exist doesn't make much sense
+		// Checking if a snapshot file exists for a block start doesn't make
+		// sense in this context because the logic for creating new snapshot
+		// files does not use the volume index provided in the prepareOpts.
+		// Instead, the new volume index is determined by looking at what files
+		// exist on disk. This means that there can never be a conflict when
+		// trying to write new snapshot files.
 		return false, nil
 	case persist.FileSetFlushType:
-		return DataFileSetExistsAt(pm.filePathPrefix, nsID, shard, blockStart)
+		return DataFileSetExists(pm.filePathPrefix, nsID, shard, blockStart, volume)
 	default:
 		return false, fmt.Errorf(
 			"unable to determine if fileset exists in persist manager for fileset type: %s",

--- a/src/dbnode/persist/fs/persist_manager_test.go
+++ b/src/dbnode/persist/fs/persist_manager_test.go
@@ -55,7 +55,7 @@ func TestPersistenceManagerPrepareDataFileExistsNoDelete(t *testing.T) {
 		shard              = uint32(0)
 		blockStart         = time.Unix(1000, 0)
 		shardDir           = createDataShardDir(t, pm.filePathPrefix, testNs1ID, shard)
-		checkpointFilePath = filesetPathFromTime(shardDir, blockStart, checkpointFileSuffix)
+		checkpointFilePath = filesetPathFromTimeLegacy(shardDir, blockStart, checkpointFileSuffix)
 		checkpointFileBuf  = make([]byte, CheckpointFileSizeBytes)
 	)
 	createFile(t, checkpointFilePath, checkpointFileBuf)
@@ -102,7 +102,7 @@ func TestPersistenceManagerPrepareDataFileExistsWithDelete(t *testing.T) {
 
 	var (
 		shardDir           = createDataShardDir(t, pm.filePathPrefix, testNs1ID, shard)
-		checkpointFilePath = filesetPathFromTime(shardDir, blockStart, checkpointFileSuffix)
+		checkpointFilePath = filesetPathFromTimeLegacy(shardDir, blockStart, checkpointFileSuffix)
 		checkpointFileBuf  = make([]byte, CheckpointFileSizeBytes)
 	)
 	createFile(t, checkpointFilePath, checkpointFileBuf)

--- a/src/dbnode/persist/fs/read.go
+++ b/src/dbnode/persist/fs/read.go
@@ -146,9 +146,12 @@ func (r *reader) Open(opts DataReaderOpenOptions) error {
 		dataFilepath        string
 	)
 
-	isLegacy, err := isFirstVolumeLegacy(shardDir, blockStart, checkpointFileSuffix)
-	if err != nil {
-		return err
+	isLegacy := false
+	if volumeIndex == 0 {
+		isLegacy, err = isFirstVolumeLegacy(shardDir, blockStart, checkpointFileSuffix)
+		if err != nil {
+			return err
+		}
 	}
 	switch opts.FileSetType {
 	case persist.FileSetSnapshotType:

--- a/src/dbnode/persist/fs/read.go
+++ b/src/dbnode/persist/fs/read.go
@@ -146,13 +146,6 @@ func (r *reader) Open(opts DataReaderOpenOptions) error {
 		dataFilepath        string
 	)
 
-	isLegacy := false
-	if volumeIndex == 0 {
-		isLegacy, err = isFirstVolumeLegacy(shardDir, blockStart, checkpointFileSuffix)
-		if err != nil {
-			return err
-		}
-	}
 	switch opts.FileSetType {
 	case persist.FileSetSnapshotType:
 		shardDir = ShardSnapshotsDirPath(r.filePathPrefix, namespace, shard)
@@ -164,6 +157,15 @@ func (r *reader) Open(opts DataReaderOpenOptions) error {
 		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, dataFileSuffix)
 	case persist.FileSetFlushType:
 		shardDir = ShardDataDirPath(r.filePathPrefix, namespace, shard)
+
+		isLegacy := false
+		if volumeIndex == 0 {
+			isLegacy, err = isFirstVolumeLegacy(shardDir, blockStart, checkpointFileSuffix)
+			if err != nil {
+				return err
+			}
+		}
+
 		checkpointFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, checkpointFileSuffix, isLegacy)
 		infoFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, infoFileSuffix, isLegacy)
 		digestFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, digestFileSuffix, isLegacy)

--- a/src/dbnode/persist/fs/read.go
+++ b/src/dbnode/persist/fs/read.go
@@ -92,6 +92,7 @@ type reader struct {
 	expectedDigestOfDigest    uint32
 	expectedBloomFilterDigest uint32
 	shard                     uint32
+	volume                    int
 	open                      bool
 }
 
@@ -128,11 +129,11 @@ func NewReader(
 
 func (r *reader) Open(opts DataReaderOpenOptions) error {
 	var (
-		namespace     = opts.Identifier.Namespace
-		shard         = opts.Identifier.Shard
-		blockStart    = opts.Identifier.BlockStart
-		snapshotIndex = opts.Identifier.VolumeIndex
-		err           error
+		namespace   = opts.Identifier.Namespace
+		shard       = opts.Identifier.Shard
+		blockStart  = opts.Identifier.BlockStart
+		volumeIndex = opts.Identifier.VolumeIndex
+		err         error
 	)
 
 	var (
@@ -147,20 +148,20 @@ func (r *reader) Open(opts DataReaderOpenOptions) error {
 	switch opts.FileSetType {
 	case persist.FileSetSnapshotType:
 		shardDir = ShardSnapshotsDirPath(r.filePathPrefix, namespace, shard)
-		checkpointFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, snapshotIndex, checkpointFileSuffix)
-		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, snapshotIndex, infoFileSuffix)
-		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, snapshotIndex, digestFileSuffix)
-		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, snapshotIndex, bloomFilterFileSuffix)
-		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, snapshotIndex, indexFileSuffix)
-		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, snapshotIndex, dataFileSuffix)
+		checkpointFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, checkpointFileSuffix)
+		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, infoFileSuffix)
+		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, digestFileSuffix)
+		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, bloomFilterFileSuffix)
+		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, indexFileSuffix)
+		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, dataFileSuffix)
 	case persist.FileSetFlushType:
 		shardDir = ShardDataDirPath(r.filePathPrefix, namespace, shard)
-		checkpointFilepath = filesetPathFromTime(shardDir, blockStart, checkpointFileSuffix)
-		infoFilepath = filesetPathFromTime(shardDir, blockStart, infoFileSuffix)
-		digestFilepath = filesetPathFromTime(shardDir, blockStart, digestFileSuffix)
-		bloomFilterFilepath = filesetPathFromTime(shardDir, blockStart, bloomFilterFileSuffix)
-		indexFilepath = filesetPathFromTime(shardDir, blockStart, indexFileSuffix)
-		dataFilepath = filesetPathFromTime(shardDir, blockStart, dataFileSuffix)
+		checkpointFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, checkpointFileSuffix)
+		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, infoFileSuffix)
+		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, digestFileSuffix)
+		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, bloomFilterFileSuffix)
+		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, indexFileSuffix)
+		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, dataFileSuffix)
 	default:
 		return fmt.Errorf("unable to open reader with fileset type: %s", opts.FileSetType)
 	}
@@ -237,6 +238,7 @@ func (r *reader) Open(opts DataReaderOpenOptions) error {
 	r.open = true
 	r.namespace = namespace
 	r.shard = shard
+	r.volume = volumeIndex
 
 	return nil
 }
@@ -246,6 +248,7 @@ func (r *reader) Status() DataFileSetReaderStatus {
 		Open:       r.open,
 		Namespace:  r.namespace,
 		Shard:      r.shard,
+		Volume:     r.volume,
 		BlockStart: r.start,
 	}
 }

--- a/src/dbnode/persist/fs/read_test.go
+++ b/src/dbnode/persist/fs/read_test.go
@@ -271,7 +271,7 @@ func TestReadNoCheckpointFile(t *testing.T) {
 
 	var (
 		shardDir       = ShardDataDirPath(filePathPrefix, testNs1ID, shard)
-		checkpointFile = filesetPathFromTime(shardDir, testWriterStart, checkpointFileSuffix)
+		checkpointFile = filesetPathFromTimeLegacy(shardDir, testWriterStart, checkpointFileSuffix)
 	)
 	exists, err := CompleteCheckpointFileExists(checkpointFile)
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func testReadOpen(t *testing.T, fileData map[string][]byte) {
 	assert.NoError(t, w.Close())
 
 	for suffix, data := range fileData {
-		digestFile := filesetPathFromTime(shardDir, start, suffix)
+		digestFile := filesetPathFromTimeLegacy(shardDir, start, suffix)
 		fd, err := os.OpenFile(digestFile, os.O_WRONLY|os.O_TRUNC, os.FileMode(0666))
 		require.NoError(t, err)
 		_, err = fd.Write(data)

--- a/src/dbnode/persist/fs/read_test.go
+++ b/src/dbnode/persist/fs/read_test.go
@@ -271,7 +271,7 @@ func TestReadNoCheckpointFile(t *testing.T) {
 
 	var (
 		shardDir       = ShardDataDirPath(filePathPrefix, testNs1ID, shard)
-		checkpointFile = filesetPathFromTimeLegacy(shardDir, testWriterStart, checkpointFileSuffix)
+		checkpointFile = dataFilesetPathFromTimeAndIndex(shardDir, testWriterStart, 0, checkpointFileSuffix, false)
 	)
 	exists, err := CompleteCheckpointFileExists(checkpointFile)
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func testReadOpen(t *testing.T, fileData map[string][]byte) {
 	assert.NoError(t, w.Close())
 
 	for suffix, data := range fileData {
-		digestFile := filesetPathFromTimeLegacy(shardDir, start, suffix)
+		digestFile := dataFilesetPathFromTimeAndIndex(shardDir, start, 0, suffix, false)
 		fd, err := os.OpenFile(digestFile, os.O_WRONLY|os.O_TRUNC, os.FileMode(0666))
 		require.NoError(t, err)
 		_, err = fd.Write(data)

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -271,7 +271,9 @@ func (r *blockRetriever) fetchBatch(
 	seekerResources ReusableSeekerResources,
 ) {
 	// Resolve the seeker from the seeker mgr
-	seeker, err := seekerMgr.Borrow(shard, blockStart)
+	// TODO(juchan): actually get the correct volume.
+	vol := 0
+	seeker, err := seekerMgr.Borrow(shard, blockStart, vol)
 	if err != nil {
 		for _, req := range reqs {
 			req.onError(err)
@@ -366,7 +368,8 @@ func (r *blockRetriever) fetchBatch(
 		}(req)
 	}
 
-	err = seekerMgr.Return(shard, blockStart, seeker)
+	// TODO(juchan): actually get the correct volume.
+	err = seekerMgr.Return(shard, blockStart, vol, seeker)
 	if err != nil {
 		r.logger.Error("err returning seeker for shard",
 			zap.Uint32("shard", shard),
@@ -408,7 +411,9 @@ func (r *blockRetriever) Stream(
 	}
 	r.RUnlock()
 
-	bloomFilter, err := r.seekerMgr.ConcurrentIDBloomFilter(shard, startTime)
+	// TODO(juchan): actually get the correct volume.
+	vol := 0
+	bloomFilter, err := r.seekerMgr.ConcurrentIDBloomFilter(shard, startTime, vol)
 	if err != nil {
 		return xio.EmptyBlockReader, err
 	}

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -64,7 +64,6 @@ const (
 type blockRetrieverStatus int
 
 type newSeekerMgrFn func(
-	ns namespace.Metadata,
 	bytesPool pool.CheckedBytesPool,
 	opts Options,
 	blockRetrieverOpts BlockRetrieverOptions,
@@ -138,7 +137,7 @@ func (r *blockRetriever) Open(ns namespace.Metadata) error {
 		return errBlockRetrieverAlreadyOpenOrClosed
 	}
 
-	seekerMgr := r.newSeekerMgrFn(ns, r.bytesPool, r.fsOpts, r.opts)
+	seekerMgr := r.newSeekerMgrFn(r.bytesPool, r.fsOpts, r.opts)
 	if err := seekerMgr.Open(ns); err != nil {
 		return err
 	}

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -64,6 +64,7 @@ const (
 type blockRetrieverStatus int
 
 type newSeekerMgrFn func(
+	ns namespace.Metadata,
 	bytesPool pool.CheckedBytesPool,
 	opts Options,
 	blockRetrieverOpts BlockRetrieverOptions,
@@ -137,7 +138,7 @@ func (r *blockRetriever) Open(ns namespace.Metadata) error {
 		return errBlockRetrieverAlreadyOpenOrClosed
 	}
 
-	seekerMgr := r.newSeekerMgrFn(r.bytesPool, r.fsOpts, r.opts)
+	seekerMgr := r.newSeekerMgrFn(ns, r.bytesPool, r.fsOpts, r.opts)
 	if err := seekerMgr.Open(ns); err != nil {
 		return err
 	}

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -271,9 +271,7 @@ func (r *blockRetriever) fetchBatch(
 	seekerResources ReusableSeekerResources,
 ) {
 	// Resolve the seeker from the seeker mgr
-	// TODO(juchan): actually get the correct volume.
-	vol := 0
-	seeker, err := seekerMgr.Borrow(shard, blockStart, vol)
+	seeker, err := seekerMgr.Borrow(shard, blockStart)
 	if err != nil {
 		for _, req := range reqs {
 			req.onError(err)
@@ -368,8 +366,7 @@ func (r *blockRetriever) fetchBatch(
 		}(req)
 	}
 
-	// TODO(juchan): actually get the correct volume.
-	err = seekerMgr.Return(shard, blockStart, vol, seeker)
+	err = seekerMgr.Return(shard, blockStart, seeker)
 	if err != nil {
 		r.logger.Error("err returning seeker for shard",
 			zap.Uint32("shard", shard),
@@ -411,9 +408,7 @@ func (r *blockRetriever) Stream(
 	}
 	r.RUnlock()
 
-	// TODO(juchan): actually get the correct volume.
-	vol := 0
-	bloomFilter, err := r.seekerMgr.ConcurrentIDBloomFilter(shard, startTime, vol)
+	bloomFilter, err := r.seekerMgr.ConcurrentIDBloomFilter(shard, startTime)
 	if err != nil {
 		return xio.EmptyBlockReader, err
 	}

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -1,3 +1,4 @@
+// +build big
 //
 // Copyright (c) 2016 Uber Technologies, Inc.
 //
@@ -589,11 +590,11 @@ func testBlockRetrieverHandlesSeekErrors(t *testing.T, ctrl *gomock.Controller, 
 	mockSeekerManager.EXPECT().Close().Return(nil)
 
 	newSeekerMgr := func(
-		nsMeta namespace.Metadata,
 		bytesPool pool.CheckedBytesPool,
 		opts Options,
 		blockRetrieverOpts BlockRetrieverOptions,
 	) DataFileSetSeekerManager {
+
 		return mockSeekerManager
 	}
 

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -171,7 +171,7 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 		dataBytesPerID = 32
 		shardData      = make(map[uint32]map[string]map[xtime.UnixNano]checked.Bytes)
 		blockStarts    []time.Time
-		volumes        = []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+		// volumes        = []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	)
 	for st := min; !st.After(max); st = st.Add(ropts.BlockSize()) {
 		blockStarts = append(blockStarts, st)

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -1,4 +1,3 @@
-// +build big
 //
 // Copyright (c) 2016 Uber Technologies, Inc.
 //
@@ -391,6 +390,7 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 		}
 	}
 
+	// panic("yolo")
 }
 
 // TestBlockRetrieverIDDoesNotExist verifies the behavior of the Stream() method

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -146,7 +146,7 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 
 		fetchConcurrency           = 4
 		seekConcurrency            = 4 * fetchConcurrency
-		updateOpenLeaseConcurrency = 16
+		updateOpenLeaseConcurrency = 4
 		opts                       = testBlockRetrieverOptions{
 			retrieverOpts: defaultTestBlockRetrieverOptions.
 				SetFetchConcurrency(fetchConcurrency).
@@ -168,9 +168,9 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 		// to wait for the others to complete.
 		// time.Sleep(5 * time.Millisecond)
 		// 10% chance for this to fail to exercise error paths as well.
-		// if val := rand.Intn(100); val >= 90 {
-		// 	return nil, errors.New("some-error")
-		// }
+		if val := rand.Intn(100); val >= 90 {
+			return nil, errors.New("some-error")
+		}
 		return existingFn(shard, blockStart, volume)
 	}
 	seekerMgr.newOpenSeekerFn = newFn

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -1,4 +1,3 @@
-// +build big
 //
 // Copyright (c) 2016 Uber Technologies, Inc.
 //
@@ -590,11 +589,11 @@ func testBlockRetrieverHandlesSeekErrors(t *testing.T, ctrl *gomock.Controller, 
 	mockSeekerManager.EXPECT().Close().Return(nil)
 
 	newSeekerMgr := func(
+		nsMeta namespace.Metadata,
 		bytesPool pool.CheckedBytesPool,
 		opts Options,
 		blockRetrieverOpts BlockRetrieverOptions,
 	) DataFileSetSeekerManager {
-
 		return mockSeekerManager
 	}
 

--- a/src/dbnode/persist/fs/seek.go
+++ b/src/dbnode/persist/fs/seek.go
@@ -145,7 +145,6 @@ func (s *seeker) Open(
 	namespace ident.ID,
 	shard uint32,
 	blockStart time.Time,
-	volume int,
 	resources ReusableSeekerResources,
 ) error {
 	if s.isClone {
@@ -157,12 +156,12 @@ func (s *seeker) Open(
 
 	// Open necessary files
 	if err := openFiles(os.Open, map[string]**os.File{
-		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, infoFileSuffix):        &infoFd,
-		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, indexFileSuffix):       &s.indexFd,
-		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, dataFileSuffix):        &s.dataFd,
-		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, digestFileSuffix):      &digestFd,
-		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, bloomFilterFileSuffix): &bloomFilterFd,
-		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, summariesFileSuffix):   &summariesFd,
+		filesetPathFromTime(shardDir, blockStart, infoFileSuffix):        &infoFd,
+		filesetPathFromTime(shardDir, blockStart, indexFileSuffix):       &s.indexFd,
+		filesetPathFromTime(shardDir, blockStart, dataFileSuffix):        &s.dataFd,
+		filesetPathFromTime(shardDir, blockStart, digestFileSuffix):      &digestFd,
+		filesetPathFromTime(shardDir, blockStart, bloomFilterFileSuffix): &bloomFilterFd,
+		filesetPathFromTime(shardDir, blockStart, summariesFileSuffix):   &summariesFd,
 	}); err != nil {
 		return err
 	}

--- a/src/dbnode/persist/fs/seek.go
+++ b/src/dbnode/persist/fs/seek.go
@@ -145,6 +145,7 @@ func (s *seeker) Open(
 	namespace ident.ID,
 	shard uint32,
 	blockStart time.Time,
+	volume int,
 	resources ReusableSeekerResources,
 ) error {
 	if s.isClone {
@@ -156,12 +157,12 @@ func (s *seeker) Open(
 
 	// Open necessary files
 	if err := openFiles(os.Open, map[string]**os.File{
-		filesetPathFromTime(shardDir, blockStart, infoFileSuffix):        &infoFd,
-		filesetPathFromTime(shardDir, blockStart, indexFileSuffix):       &s.indexFd,
-		filesetPathFromTime(shardDir, blockStart, dataFileSuffix):        &s.dataFd,
-		filesetPathFromTime(shardDir, blockStart, digestFileSuffix):      &digestFd,
-		filesetPathFromTime(shardDir, blockStart, bloomFilterFileSuffix): &bloomFilterFd,
-		filesetPathFromTime(shardDir, blockStart, summariesFileSuffix):   &summariesFd,
+		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, infoFileSuffix):        &infoFd,
+		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, indexFileSuffix):       &s.indexFd,
+		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, dataFileSuffix):        &s.dataFd,
+		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, digestFileSuffix):      &digestFd,
+		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, bloomFilterFileSuffix): &bloomFilterFd,
+		filesetPathFromTimeAndIndex(shardDir, blockStart, volume, summariesFileSuffix):   &summariesFd,
 	}); err != nil {
 		return err
 	}

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -788,7 +788,7 @@ func (m *seekerManager) openCloseLoop() {
 					}
 				}
 
-				// Ensure no ianctive seekers are still borrowed
+				// Ensure no ianctive seekers are still borrowed.
 				for _, seeker := range seekers.inactive.seekers {
 					if seeker.isBorrowed {
 						allSeekersAreReturned = false

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -72,7 +72,6 @@ const (
 type seekerManager struct {
 	sync.RWMutex
 
-	nsMeta             namespace.Metadata
 	opts               Options
 	blockRetrieverOpts BlockRetrieverOptions
 	fetchConcurrency   int
@@ -134,7 +133,6 @@ type seekerManagerPendingClose struct {
 
 // NewSeekerManager returns a new TSDB file set seeker manager.
 func NewSeekerManager(
-	nsMeta namespace.Metadata,
 	bytesPool pool.CheckedBytesPool,
 	opts Options,
 	blockRetrieverOpts BlockRetrieverOptions,
@@ -149,7 +147,6 @@ func NewSeekerManager(
 	})
 
 	m := &seekerManager{
-		nsMeta:                      nsMeta,
 		bytesPool:                   bytesPool,
 		filePathPrefix:              opts.FilePathPrefix(),
 		opts:                        opts,

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -72,6 +72,7 @@ const (
 type seekerManager struct {
 	sync.RWMutex
 
+	nsMeta             namespace.Metadata
 	opts               Options
 	blockRetrieverOpts BlockRetrieverOptions
 	fetchConcurrency   int
@@ -132,6 +133,7 @@ type seekerManagerPendingClose struct {
 
 // NewSeekerManager returns a new TSDB file set seeker manager.
 func NewSeekerManager(
+	nsMeta namespace.Metadata,
 	bytesPool pool.CheckedBytesPool,
 	opts Options,
 	blockRetrieverOpts BlockRetrieverOptions,
@@ -146,6 +148,7 @@ func NewSeekerManager(
 	})
 
 	m := &seekerManager{
+		nsMeta:                      nsMeta,
 		bytesPool:                   bytesPool,
 		filePathPrefix:              opts.FilePathPrefix(),
 		opts:                        opts,

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -397,9 +397,17 @@ func (m *seekerManager) newOpenSeeker(
 	shard uint32,
 	blockStart time.Time,
 ) (DataFileSetSeeker, error) {
-	// TODO(juchan): get the actual volume here.
-	vol := 0
-	exists, err := DataFileSetExists(m.filePathPrefix, m.namespace, shard, blockStart, vol)
+	blm := m.blockRetrieverOpts.BlockLeaseManager()
+	state, err := blm.OpenLatestLease(m, block.LeaseDescriptor{
+		Namespace:  m.namespace,
+		Shard:      shard,
+		BlockStart: blockStart,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("err opening latest lease: %v", err)
+	}
+
+	exists, err := DataFileSetExists(m.filePathPrefix, m.namespace, shard, blockStart, state.Volume)
 	if err != nil {
 		return nil, err
 	}
@@ -426,20 +434,8 @@ func (m *seekerManager) newOpenSeeker(
 	// Set the unread buffer to reuse it amongst all seekers.
 	seeker.setUnreadBuffer(m.unreadBuf.value)
 
-	var (
-		resources = m.getSeekerResources()
-		blm       = m.blockRetrieverOpts.BlockLeaseManager()
-	)
-	_, err = blm.OpenLatestLease(m, block.LeaseDescriptor{
-		Namespace:  m.namespace,
-		Shard:      shard,
-		BlockStart: blockStart,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("err opening latest lease: %v", err)
-	}
-
-	err = seeker.Open(m.namespace, shard, blockStart, volume, resources)
+	resources := m.getSeekerResources()
+	err = seeker.Open(m.namespace, shard, blockStart, state.Volume, resources)
 	m.putSeekerResources(resources)
 	if err != nil {
 		return nil, err

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -292,7 +292,7 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 		return nil
 	}
 
-	// If no match was found in the active seekers, its possible that an inactive seeker is being returned.
+	// If no match was found in the active seekers, it's possible that an inactive seeker is being returned.
 	for i, compareSeeker := range seekers.inactive.seekers {
 		if seeker == compareSeeker.seeker {
 			found = true
@@ -314,7 +314,7 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 				break
 			}
 
-			// All the inactive seekers have been returned so its safe to signal and clear them out.
+			// All the inactive seekers have been returned so it's safe to signal and clear them out.
 			var multiErr = xerrors.NewMultiError()
 			for _, inactiveSeeker := range seekers.inactive.seekers {
 				multiErr = multiErr.Add(inactiveSeeker.seeker.Close())
@@ -364,7 +364,7 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 //      be used to "wait" for all of the existing seekers that are currently borrowed to be returned.
 //   3. Release the lock so that reads can continue uninterrupted and call waitgroup.Wait() to wait for all
 //      the currently borrowed "inactive" seekers (if any) to be returned.
-//   4. Every call to Return() for an "inactive" seeker will check if its the last borrowed inactive seeker,
+//   4. Every call to Return() for an "inactive" seeker will check if it's the last borrowed inactive seeker,
 //      and if so, will close all the inactive seekers and call wg.Done() which will notify the goroutine
 //      running the UpdateOpenlease() function that all inactive seekers have been returned and closed at
 //      which point the function will return sucessfully.
@@ -379,9 +379,10 @@ func (m *seekerManager) UpdateOpenLease(
 	}
 
 	if m.isUpdatingLease {
-		// This guard is a little overly aggressive. In practice, the algorithm permits concurrent UpdateOpenLease()
-		// calls as long as they are for different shard/blockStart combinations. However, the calling code currently
-		// has no need to call this method concurrently at all so use the simpler check for now.
+		// This guard is a little overly aggressive. In practice, the algorithm remains correct even in the presence
+		// of concurrent UpdateOpenLease() calls as long as they are for different shard/blockStart combinations.
+		// However, the calling code currently has no need to call this method concurrently at all so use the
+		// simpler check for now.
 		m.Unlock()
 		return 0, errConcurrentUpdateOpenLeaseNotAllowed
 	}

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -376,8 +376,9 @@ func (m *seekerManager) UpdateOpenLease(
 		return 0, errUpdateOpenLeaseSeekerManagerNotOpen
 	}
 
-	if !m.nsMeta.ID().Equal(descriptor.Namespace) {
+	if !m.namespace.Equal(descriptor.Namespace) {
 		m.Unlock()
+		// TODO(rartoul): Maybe this should be a separate outcome.
 		return block.NoOpenLease, nil
 	}
 	m.Unlock()

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -115,7 +115,12 @@ type seekersByTime struct {
 	sync.RWMutex
 	shard    uint32
 	accessed bool
-	seekers  map[xtime.UnixNano]seekersAndBloom
+	seekers  map[xtime.UnixNano]seekers
+}
+
+type seekers struct {
+	active   seekersAndBloom
+	inactive seekersAndBloom
 }
 
 type seekerManagerPendingClose struct {
@@ -204,11 +209,12 @@ func (m *seekerManager) ConcurrentIDBloomFilter(shard uint32, start time.Time) (
 	// Try fast RLock() first
 	byTime.RLock()
 	startNano := xtime.ToUnixNano(start)
-	seekersAndBloom, ok := byTime.seekers[startNano]
+	seekers, ok := byTime.seekers[startNano]
 	byTime.RUnlock()
 
-	if ok && seekersAndBloom.wg == nil {
-		return seekersAndBloom.bloomFilter, nil
+	// TODO(rartoul): Is this nil check safe?
+	if ok && seekers.active.wg == nil {
+		return seekers.active.bloomFilter, nil
 	}
 
 	byTime.Lock()
@@ -259,7 +265,7 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 	defer byTime.Unlock()
 
 	startNano := xtime.ToUnixNano(start)
-	seekersAndBloom, ok := byTime.seekers[startNano]
+	seekers, ok := byTime.seekers[startNano]
 	// Should never happen - This either means that the caller (DataBlockRetriever) is trying to return seekers
 	// that it never requested, OR its trying to return seekers after the openCloseLoop has already
 	// determined that they were all no longer in use and safe to close. Either way it indicates there is
@@ -268,12 +274,13 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 		return errSeekersDontExist
 	}
 
+	// TODO(rartoul): Handle the case where an inactive seeker is being returned.
 	found := false
-	for i, compareSeeker := range seekersAndBloom.seekers {
+	for i, compareSeeker := range seekers.active.seekers {
 		if seeker == compareSeeker.seeker {
 			found = true
 			compareSeeker.isBorrowed = false
-			seekersAndBloom.seekers[i] = compareSeeker
+			seekers.active.seekers[i] = compareSeeker
 			break
 		}
 	}
@@ -308,15 +315,15 @@ func (m *seekerManager) UpdateOpenLease(
 // and then notify the waiting goroutines that we've finished.
 func (m *seekerManager) getOrOpenSeekersWithLock(start xtime.UnixNano, byTime *seekersByTime) (seekersAndBloom, error) {
 	seekers, ok := byTime.seekers[start]
-	if ok && seekers.wg == nil {
+	if ok && seekers.active.wg == nil {
 		// Seekers are already open
-		return seekers, nil
+		return seekers.active, nil
 	}
 
-	if seekers.wg != nil {
+	if seekers.active.wg != nil {
 		// Seekers are being initialized / opened, wait for the that to complete
 		byTime.Unlock()
-		seekers.wg.Wait()
+		seekers.active.wg.Wait()
 		byTime.Lock()
 		// Need to do the lookup again recursively to see the new state
 		return m.getOrOpenSeekersWithLock(start, byTime)
@@ -328,8 +335,8 @@ func (m *seekerManager) getOrOpenSeekersWithLock(start xtime.UnixNano, byTime *s
 	// that other routines which would have otherwise attempted to also open this
 	// same seeker can use instead to wait for us to finish.
 	wg := &sync.WaitGroup{}
-	seekers.wg = wg
-	seekers.wg.Add(1)
+	seekers.active.wg = wg
+	seekers.active.wg.Add(1)
 	byTime.seekers[start] = seekers
 	byTime.Unlock()
 	// Open first one - Do this outside the context of the lock because opening
@@ -366,13 +373,13 @@ func (m *seekerManager) getOrOpenSeekersWithLock(start xtime.UnixNano, byTime *s
 		borrowableSeekers = append(borrowableSeekers, borrowableSeeker{seeker: clone})
 	}
 
-	seekers.wg = nil
-	seekers.seekers = borrowableSeekers
+	seekers.active.wg = nil
+	seekers.active.seekers = borrowableSeekers
 	// Doesn't matter which seeker we pick to grab the bloom filter from, they all share the same underlying one.
 	// Use index 0 because its guaranteed to be there.
-	seekers.bloomFilter = borrowableSeekers[0].seeker.ConcurrentIDBloomFilter()
+	seekers.active.bloomFilter = borrowableSeekers[0].seeker.ConcurrentIDBloomFilter()
 	byTime.seekers[start] = seekers
-	return seekers, nil
+	return seekers.active, nil
 }
 
 func (m *seekerManager) openAnyUnopenSeekers(byTime *seekersByTime) error {
@@ -476,7 +483,7 @@ func (m *seekerManager) seekersByTime(shard uint32) *seekersByTime {
 		}
 		seekersByShardIdx[i] = &seekersByTime{
 			shard:   uint32(i),
-			seekers: make(map[xtime.UnixNano]seekersAndBloom),
+			seekers: make(map[xtime.UnixNano]seekers),
 		}
 	}
 
@@ -498,8 +505,18 @@ func (m *seekerManager) Close() error {
 	// Actual cleanup of the seekers themselves will be handled by the openCloseLoop.
 	for _, byTime := range m.seekersByShardIdx {
 		byTime.Lock()
-		for _, seekersByTime := range byTime.seekers {
-			for _, seeker := range seekersByTime.seekers {
+		for _, seekersForBlock := range byTime.seekers {
+			// Ensure active seekers are all returned.
+			for _, seeker := range seekersForBlock.active.seekers {
+				if seeker.isBorrowed {
+					byTime.Unlock()
+					m.Unlock()
+					return errCantCloseSeekerManagerWhileSeekersAreBorrowed
+				}
+			}
+
+			// Ensure inactive seekers are all returned.
+			for _, seeker := range seekersForBlock.inactive.seekers {
 				if seeker.isBorrowed {
 					byTime.Unlock()
 					m.Unlock()
@@ -609,9 +626,19 @@ func (m *seekerManager) openCloseLoop() {
 				byTime := m.seekersByShardIdx[elem.shard]
 				blockStartNano := xtime.ToUnixNano(elem.blockStart)
 				byTime.Lock()
-				seekersAndBloom := byTime.seekers[blockStartNano]
+				seekers := byTime.seekers[blockStartNano]
 				allSeekersAreReturned := true
-				for _, seeker := range seekersAndBloom.seekers {
+
+				// Ensure no active seekers are still borrowed.
+				for _, seeker := range seekers.active.seekers {
+					if seeker.isBorrowed {
+						allSeekersAreReturned = false
+						break
+					}
+				}
+
+				// Ensure no ianctive seekers are still borrowed
+				for _, seeker := range seekers.inactive.seekers {
 					if seeker.isBorrowed {
 						allSeekersAreReturned = false
 						break
@@ -621,7 +648,8 @@ func (m *seekerManager) openCloseLoop() {
 				// some of them are clones of the original and can't be used once
 				// the parent is closed (because they share underlying resources)
 				if allSeekersAreReturned {
-					closing = append(closing, seekersAndBloom.seekers...)
+					closing = append(closing, seekers.active.seekers...)
+					closing = append(closing, seekers.inactive.seekers...)
 					delete(byTime.seekers, blockStartNano)
 				}
 				byTime.Unlock()
@@ -646,8 +674,19 @@ func (m *seekerManager) openCloseLoop() {
 	m.Lock()
 	for _, byTime := range m.seekersByShardIdx {
 		byTime.Lock()
-		for _, seekersByTime := range byTime.seekers {
-			for _, seeker := range seekersByTime.seekers {
+		for _, seekersForBlock := range byTime.seekers {
+			// Close the active seekers.
+			for _, seeker := range seekersForBlock.active.seekers {
+				// We don't need to check if the seeker is borrowed here because we don't allow the
+				// SeekerManager to be closed if any seekers are still outstanding.
+				err := seeker.seeker.Close()
+				if err != nil {
+					m.logger.Error("err closing seeker in SeekerManager at end of openCloseLoop", zap.Error(err))
+				}
+			}
+
+			// Close the inactive seekers.
+			for _, seeker := range seekersForBlock.inactive.seekers {
 				// We don't need to check if the seeker is borrowed here because we don't allow the
 				// SeekerManager to be closed if any seekers are still outstanding.
 				err := seeker.seeker.Close()

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -397,7 +397,9 @@ func (m *seekerManager) newOpenSeeker(
 	shard uint32,
 	blockStart time.Time,
 ) (DataFileSetSeeker, error) {
-	exists, err := DataFileSetExistsAt(m.filePathPrefix, m.namespace, shard, blockStart)
+	// TODO(juchan): get the actual volume here.
+	vol := 0
+	exists, err := DataFileSetExists(m.filePathPrefix, m.namespace, shard, blockStart, vol)
 	if err != nil {
 		return nil, err
 	}

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -50,6 +50,7 @@ var (
 	errSeekersDontExist                              = errors.New("seekers don't exist")
 	errCantCloseSeekerManagerWhileSeekersAreBorrowed = errors.New("cant close seeker manager while seekers are borrowed")
 	errReturnedUnmanagedSeeker                       = errors.New("cant return a seeker not managed by the seeker manager")
+	errUpdateOpenLeaseSeekerManagerNotOpen           = errors.New("cant update open lease because seeker manager is not open")
 )
 
 type openAnyUnopenSeekersFn func(*seekersByTime) error
@@ -115,10 +116,10 @@ type seekersByTime struct {
 	sync.RWMutex
 	shard    uint32
 	accessed bool
-	seekers  map[xtime.UnixNano]seekers
+	seekers  map[xtime.UnixNano]rotatableSeekers
 }
 
-type seekers struct {
+type rotatableSeekers struct {
 	active   seekersAndBloom
 	inactive seekersAndBloom
 }
@@ -260,7 +261,6 @@ func (m *seekerManager) Borrow(shard uint32, start time.Time) (ConcurrentDataFil
 
 func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentDataFileSetSeeker) error {
 	byTime := m.seekersByTime(shard)
-
 	byTime.Lock()
 	defer byTime.Unlock()
 
@@ -294,13 +294,55 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 }
 
 // Implements block.Leaser.
+// TODO(rartoul): Guard against concurrent calls without holding lock forever.
 func (m *seekerManager) UpdateOpenLease(
 	descriptor block.LeaseDescriptor,
 	state block.LeaseState,
 ) (block.UpdateOpenLeaseResult, error) {
-	// TODO(rartoul): This is a no-op for now until the logic for swapping out seekers is written.
-	// Also make sure that this function is a proper no-op if the SeekerManager state has been
-	// been switched to closed.
+	m.Lock()
+	if m.status != seekerManagerOpen {
+		m.Unlock()
+		return 0, errUpdateOpenLeaseSeekerManagerNotOpen
+	}
+	m.Unlock()
+
+	// First open a new seeker outside the context of any locks.
+	seeker, err := m.newOpenSeekerFn(descriptor.Shard, descriptor.BlockStart)
+	if err != nil {
+		return 0, err
+	}
+
+	newActiveSeekers, err := m.seekersAndBloomFromSeeker(seeker)
+	if err != nil {
+		// Don't need to worry about closing / leaking seeker here because
+		// seekersAndBloomFromSeeker will have closed it already if there
+		// were any errors.
+		return 0, err
+	}
+
+	byTime := m.seekersByTime(descriptor.Shard)
+	blockStartNano := xtime.ToUnixNano(descriptor.BlockStart)
+	byTime.Lock()
+	seekers, ok := byTime.seekers[blockStartNano]
+	if !ok {
+		seekers.active = newActiveSeekers
+	} else {
+		if seekers.active.wg != nil {
+			// If another goroutine is currently trying to open seekers for this block start
+			// then wait for that operation to complete.
+			// TODO(rartoul): This needs to be recursive / in a for loop or something.
+			wg := seekers.active.wg
+			byTime.Unlock()
+			wg.Wait()
+			byTime.Lock()
+		}
+
+		seekers.inactive = seekers.active
+		seekers.active = newActiveSeekers
+	}
+	byTime.seekers[blockStartNano] = seekers
+	byTime.Unlock()
+
 	return block.NoOpenLease, nil
 }
 
@@ -329,8 +371,7 @@ func (m *seekerManager) getOrOpenSeekersWithLock(start xtime.UnixNano, byTime *s
 		return m.getOrOpenSeekersWithLock(start, byTime)
 	}
 
-	// Seekers need to be opened
-	borrowableSeekers := make([]borrowableSeeker, 0, m.fetchConcurrency)
+	// Seekers need to be opened.
 	// We're going to release the lock temporarily, so we initialize a WaitGroup
 	// that other routines which would have otherwise attempted to also open this
 	// same seeker can use instead to wait for us to finish.
@@ -355,6 +396,23 @@ func (m *seekerManager) getOrOpenSeekersWithLock(start xtime.UnixNano, byTime *s
 		return seekersAndBloom{}, err
 	}
 
+	activeSeekers, err := m.seekersAndBloomFromSeeker(seeker)
+	if err != nil {
+		// Delete the seekersByTime struct so that the process can be restarted if necessary
+		delete(byTime.seekers, start)
+		// Don't need to worry about closing / leaking seeker here because
+		// seekersAndBloomFromSeeker will have closed it already if there
+		// were any errors.
+		return seekersAndBloom{}, err
+	}
+
+	seekers.active = activeSeekers
+	byTime.seekers[start] = seekers
+	return activeSeekers, nil
+}
+
+func (m *seekerManager) seekersAndBloomFromSeeker(seeker DataFileSetSeeker) (seekersAndBloom, error) {
+	borrowableSeekers := make([]borrowableSeeker, 0, m.fetchConcurrency)
 	borrowableSeekers = append(borrowableSeekers, borrowableSeeker{seeker: seeker})
 	// Clone remaining seekers from the original - No need to release the lock, cloning is cheap.
 	for i := 0; i < m.fetchConcurrency-1; i++ {
@@ -366,20 +424,15 @@ func (m *seekerManager) getOrOpenSeekersWithLock(start xtime.UnixNano, byTime *s
 				// Don't leak successfully opened seekers
 				multiErr = multiErr.Add(seeker.seeker.Close())
 			}
-			// Delete the seekersByTime struct so that the process can be restarted if necessary
-			delete(byTime.seekers, start)
 			return seekersAndBloom{}, multiErr.FinalError()
 		}
 		borrowableSeekers = append(borrowableSeekers, borrowableSeeker{seeker: clone})
 	}
 
-	seekers.active.wg = nil
-	seekers.active.seekers = borrowableSeekers
-	// Doesn't matter which seeker we pick to grab the bloom filter from, they all share the same underlying one.
-	// Use index 0 because its guaranteed to be there.
-	seekers.active.bloomFilter = borrowableSeekers[0].seeker.ConcurrentIDBloomFilter()
-	byTime.seekers[start] = seekers
-	return seekers.active, nil
+	return seekersAndBloom{
+		seekers:     borrowableSeekers,
+		bloomFilter: borrowableSeekers[0].seeker.ConcurrentIDBloomFilter(),
+	}, nil
 }
 
 func (m *seekerManager) openAnyUnopenSeekers(byTime *seekersByTime) error {
@@ -483,7 +536,7 @@ func (m *seekerManager) seekersByTime(shard uint32) *seekersByTime {
 		}
 		seekersByShardIdx[i] = &seekersByTime{
 			shard:   uint32(i),
-			seekers: make(map[xtime.UnixNano]seekers),
+			seekers: make(map[xtime.UnixNano]rotatableSeekers),
 		}
 	}
 

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -307,6 +307,7 @@ func (m *seekerManager) UpdateOpenLease(
 	m.Unlock()
 
 	// First open a new seeker outside the context of any locks.
+	// TODO(rartoul): Use the volume number from the LeaseState.
 	seeker, err := m.newOpenSeekerFn(descriptor.Shard, descriptor.BlockStart)
 	if err != nil {
 		return 0, err

--- a/src/dbnode/persist/fs/seek_manager_test.go
+++ b/src/dbnode/persist/fs/seek_manager_test.go
@@ -162,7 +162,7 @@ func TestSeekerManagerOpenCloseLoop(t *testing.T) {
 		mock.EXPECT().Close().Return(nil)
 		mocks := []borrowableSeeker{}
 		mocks = append(mocks, borrowableSeeker{seeker: mock})
-		byTime.seekers[startNano] = seekers{
+		byTime.seekers[startNano] = rotatableSeekers{
 			active: seekersAndBloom{
 				seekers:     mocks,
 				bloomFilter: nil,

--- a/src/dbnode/persist/fs/seek_manager_test.go
+++ b/src/dbnode/persist/fs/seek_manager_test.go
@@ -87,7 +87,7 @@ func TestSeekerManagerBorrowOpenSeekersLazy(t *testing.T) {
 		blockStart time.Time,
 	) (DataFileSetSeeker, error) {
 		mock := NewMockDataFileSetSeeker(ctrl)
-		mock.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mock.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mock.EXPECT().ConcurrentClone().Return(mock, nil)
 		for i := 0; i < defaultFetchConcurrency; i++ {
 			mock.EXPECT().Close().Return(nil)

--- a/src/dbnode/persist/fs/seek_manager_test.go
+++ b/src/dbnode/persist/fs/seek_manager_test.go
@@ -79,7 +79,7 @@ func TestSeekerManagerIgnoreUpdateOpenLeaseWrongNamespace(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	shards := []uint32{2, 5, 9, 478, 1023}
-	m := NewSeekerManager(nil, nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
 	m.newOpenSeekerFn = func(
 		shard uint32,
 		blockStart time.Time,

--- a/src/dbnode/persist/fs/seek_manager_test.go
+++ b/src/dbnode/persist/fs/seek_manager_test.go
@@ -85,6 +85,7 @@ func TestSeekerManagerBorrowOpenSeekersLazy(t *testing.T) {
 	m.newOpenSeekerFn = func(
 		shard uint32,
 		blockStart time.Time,
+		volume int,
 	) (DataFileSetSeeker, error) {
 		mock := NewMockDataFileSetSeeker(ctrl)
 		mock.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)

--- a/src/dbnode/persist/fs/seek_manager_test.go
+++ b/src/dbnode/persist/fs/seek_manager_test.go
@@ -152,6 +152,16 @@ func TestSeekerManagerUpdateOpenLease(t *testing.T) {
 		byTime.RUnlock()
 	}
 
+	// Ensure that UpdateOpenLease() returns a lease for out-of-order updates.
+	for _, shard := range shards {
+		_, err := m.UpdateOpenLease(block.LeaseDescriptor{
+			Namespace:  metadata.ID(),
+			Shard:      shard,
+			BlockStart: time.Time{},
+		}, block.LeaseState{Volume: 0})
+		require.Equal(t, errOutOfOrderUpdateOpenLease, err)
+	}
+
 	require.NoError(t, m.Close())
 }
 

--- a/src/dbnode/persist/fs/seek_manager_test.go
+++ b/src/dbnode/persist/fs/seek_manager_test.go
@@ -42,7 +42,7 @@ func TestSeekerManagerCacheShardIndices(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 1*time.Minute)()
 
 	shards := []uint32{2, 5, 9, 478, 1023}
-	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	m := NewSeekerManager(nil, nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
 	var byTimes []*seekersByTime
 	m.openAnyUnopenSeekersFn = func(byTime *seekersByTime) error {
 		byTimes = append(byTimes, byTime)
@@ -81,7 +81,7 @@ func TestSeekerManagerBorrowOpenSeekersLazy(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	shards := []uint32{2, 5, 9, 478, 1023}
-	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	m := NewSeekerManager(nil, nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
 	m.newOpenSeekerFn = func(
 		shard uint32,
 		blockStart time.Time,
@@ -125,7 +125,7 @@ func TestSeekerManagerOpenCloseLoop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	shards := []uint32{2, 5, 9, 478, 1023}
-	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	m := NewSeekerManager(nil, nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
 	clockOpts := m.opts.ClockOptions()
 	now := clockOpts.NowFn()()
 	startNano := xtime.ToUnixNano(now)

--- a/src/dbnode/persist/fs/seek_manager_test.go
+++ b/src/dbnode/persist/fs/seek_manager_test.go
@@ -42,7 +42,7 @@ func TestSeekerManagerCacheShardIndices(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 1*time.Minute)()
 
 	shards := []uint32{2, 5, 9, 478, 1023}
-	m := NewSeekerManager(nil, nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
 	var byTimes []*seekersByTime
 	m.openAnyUnopenSeekersFn = func(byTime *seekersByTime) error {
 		byTimes = append(byTimes, byTime)
@@ -122,7 +122,7 @@ func TestSeekerManagerBorrowOpenSeekersLazy(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	shards := []uint32{2, 5, 9, 478, 1023}
-	m := NewSeekerManager(nil, nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
 	m.newOpenSeekerFn = func(
 		shard uint32,
 		blockStart time.Time,
@@ -166,7 +166,7 @@ func TestSeekerManagerOpenCloseLoop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	shards := []uint32{2, 5, 9, 478, 1023}
-	m := NewSeekerManager(nil, nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
 	clockOpts := m.opts.ClockOptions()
 	now := clockOpts.NowFn()()
 	startNano := xtime.ToUnixNano(now)

--- a/src/dbnode/persist/fs/seek_test.go
+++ b/src/dbnode/persist/fs/seek_test.go
@@ -64,7 +64,7 @@ func TestSeekEmptyIndex(t *testing.T) {
 
 	resources := newTestReusableSeekerResources()
 	s := newTestSeeker(filePathPrefix)
-	err = s.Open(testNs1ID, 0, testWriterStart, resources)
+	err = s.Open(testNs1ID, 0, testWriterStart, 0, resources)
 	assert.NoError(t, err)
 	_, err = s.SeekByID(ident.StringID("foo"), resources)
 	assert.Error(t, err)
@@ -104,7 +104,7 @@ func TestSeekDataUnexpectedSize(t *testing.T) {
 
 	resources := newTestReusableSeekerResources()
 	s := newTestSeeker(filePathPrefix)
-	err = s.Open(testNs1ID, 0, testWriterStart, resources)
+	err = s.Open(testNs1ID, 0, testWriterStart, 0, resources)
 	assert.NoError(t, err)
 
 	_, err = s.SeekByID(ident.StringID("foo"), resources)
@@ -143,7 +143,7 @@ func TestSeekBadChecksum(t *testing.T) {
 
 	resources := newTestReusableSeekerResources()
 	s := newTestSeeker(filePathPrefix)
-	err = s.Open(testNs1ID, 0, testWriterStart, resources)
+	err = s.Open(testNs1ID, 0, testWriterStart, 0, resources)
 	assert.NoError(t, err)
 
 	_, err = s.SeekByID(ident.StringID("foo"), resources)
@@ -193,7 +193,7 @@ func TestSeek(t *testing.T) {
 
 	resources := newTestReusableSeekerResources()
 	s := newTestSeeker(filePathPrefix)
-	err = s.Open(testNs1ID, 0, testWriterStart, resources)
+	err = s.Open(testNs1ID, 0, testWriterStart, 0, resources)
 	assert.NoError(t, err)
 
 	data, err := s.SeekByID(ident.StringID("foo3"), resources)
@@ -261,7 +261,7 @@ func TestSeekIDNotExists(t *testing.T) {
 
 	resources := newTestReusableSeekerResources()
 	s := newTestSeeker(filePathPrefix)
-	err = s.Open(testNs1ID, 0, testWriterStart, resources)
+	err = s.Open(testNs1ID, 0, testWriterStart, 0, resources)
 	assert.NoError(t, err)
 
 	// Test errSeekIDNotFound when we scan far enough into the index file that
@@ -323,7 +323,7 @@ func TestReuseSeeker(t *testing.T) {
 
 	resources := newTestReusableSeekerResources()
 	s := newTestSeeker(filePathPrefix)
-	err = s.Open(testNs1ID, 0, testWriterStart.Add(-time.Hour), resources)
+	err = s.Open(testNs1ID, 0, testWriterStart.Add(-time.Hour), 0, resources)
 	assert.NoError(t, err)
 
 	data, err := s.SeekByID(ident.StringID("foo"), resources)
@@ -333,7 +333,7 @@ func TestReuseSeeker(t *testing.T) {
 	defer data.DecRef()
 	assert.Equal(t, []byte{1, 2, 1}, data.Bytes())
 
-	err = s.Open(testNs1ID, 0, testWriterStart, resources)
+	err = s.Open(testNs1ID, 0, testWriterStart, 0, resources)
 	assert.NoError(t, err)
 
 	data, err = s.SeekByID(ident.StringID("foo"), resources)
@@ -388,7 +388,7 @@ func TestCloneSeeker(t *testing.T) {
 
 	resources := newTestReusableSeekerResources()
 	s := newTestSeeker(filePathPrefix)
-	err = s.Open(testNs1ID, 0, testWriterStart.Add(-time.Hour), resources)
+	err = s.Open(testNs1ID, 0, testWriterStart.Add(-time.Hour), 0, resources)
 	assert.NoError(t, err)
 
 	clone, err := s.ConcurrentClone()

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -51,7 +51,7 @@ type FileSetFileIdentifier struct {
 	BlockStart         time.Time
 	// Only required for data content files
 	Shard uint32
-	// Required for snapshot files (index yes, data yes) and flush files (index yes, data no)
+	// Required for snapshot files (index yes, data yes) and flush files (index yes, data yes)
 	VolumeIndex int
 }
 
@@ -105,9 +105,9 @@ type SnapshotMetadataFileReader interface {
 type DataFileSetReaderStatus struct {
 	Namespace  ident.ID
 	BlockStart time.Time
-
-	Shard uint32
-	Open  bool
+	Shard      uint32
+	Volume     int
+	Open       bool
 }
 
 // DataReaderOpenOptions is options struct for the reader open method.
@@ -173,6 +173,7 @@ type DataFileSetSeeker interface {
 		namespace ident.ID,
 		shard uint32,
 		start time.Time,
+		volume int,
 		resources ReusableSeekerResources,
 	) error
 
@@ -237,15 +238,15 @@ type DataFileSetSeekerManager interface {
 	// to improve times when seeking to a block.
 	CacheShardIndices(shards []uint32) error
 
-	// Borrow returns an open seeker for a given shard and block start time.
-	Borrow(shard uint32, start time.Time) (ConcurrentDataFileSetSeeker, error)
+	// Borrow returns an open seeker for a given shard, block start time, and volume.
+	Borrow(shard uint32, start time.Time, volume int) (ConcurrentDataFileSetSeeker, error)
 
-	// Return returns an open seeker for a given shard and block start time.
-	Return(shard uint32, start time.Time, seeker ConcurrentDataFileSetSeeker) error
+	// Return returns an open seeker for a given shard, block start time, and volume.
+	Return(shard uint32, start time.Time, volume int, seeker ConcurrentDataFileSetSeeker) error
 
 	// ConcurrentIDBloomFilter returns a concurrent ID bloom filter for a given
-	// shard and block start time
-	ConcurrentIDBloomFilter(shard uint32, start time.Time) (*ManagedConcurrentBloomFilter, error)
+	// shard, block start time, and volume.
+	ConcurrentIDBloomFilter(shard uint32, start time.Time, volume int) (*ManagedConcurrentBloomFilter, error)
 }
 
 // DataBlockRetriever provides a block retriever for TSDB file sets

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -173,7 +173,6 @@ type DataFileSetSeeker interface {
 		namespace ident.ID,
 		shard uint32,
 		start time.Time,
-		volume int,
 		resources ReusableSeekerResources,
 	) error
 
@@ -239,14 +238,14 @@ type DataFileSetSeekerManager interface {
 	CacheShardIndices(shards []uint32) error
 
 	// Borrow returns an open seeker for a given shard, block start time, and volume.
-	Borrow(shard uint32, start time.Time, volume int) (ConcurrentDataFileSetSeeker, error)
+	Borrow(shard uint32, start time.Time) (ConcurrentDataFileSetSeeker, error)
 
 	// Return returns an open seeker for a given shard, block start time, and volume.
-	Return(shard uint32, start time.Time, volume int, seeker ConcurrentDataFileSetSeeker) error
+	Return(shard uint32, start time.Time, seeker ConcurrentDataFileSetSeeker) error
 
 	// ConcurrentIDBloomFilter returns a concurrent ID bloom filter for a given
 	// shard, block start time, and volume.
-	ConcurrentIDBloomFilter(shard uint32, start time.Time, volume int) (*ManagedConcurrentBloomFilter, error)
+	ConcurrentIDBloomFilter(shard uint32, start time.Time) (*ManagedConcurrentBloomFilter, error)
 }
 
 // DataBlockRetriever provides a block retriever for TSDB file sets

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -173,6 +173,7 @@ type DataFileSetSeeker interface {
 		namespace ident.ID,
 		shard uint32,
 		start time.Time,
+		volume int,
 		resources ReusableSeekerResources,
 	) error
 

--- a/src/dbnode/persist/fs/write.go
+++ b/src/dbnode/persist/fs/write.go
@@ -145,11 +145,11 @@ func NewWriter(opts Options) (DataFileSetWriter, error) {
 // opening / truncating files associated with that shard for writing.
 func (w *writer) Open(opts DataWriterOpenOptions) error {
 	var (
-		nextSnapshotIndex int
-		err               error
-		namespace         = opts.Identifier.Namespace
-		shard             = opts.Identifier.Shard
-		blockStart        = opts.Identifier.BlockStart
+		err             error
+		namespace       = opts.Identifier.Namespace
+		shard           = opts.Identifier.Shard
+		blockStart      = opts.Identifier.BlockStart
+		nextVolumeIndex = opts.Identifier.VolumeIndex
 	)
 
 	w.blockSize = opts.BlockSize
@@ -178,27 +178,26 @@ func (w *writer) Open(opts DataWriterOpenOptions) error {
 			return err
 		}
 
-		nextSnapshotIndex = opts.Identifier.VolumeIndex
-		w.checkpointFilePath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextSnapshotIndex, checkpointFileSuffix)
-		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextSnapshotIndex, infoFileSuffix)
-		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextSnapshotIndex, indexFileSuffix)
-		summariesFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextSnapshotIndex, summariesFileSuffix)
-		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextSnapshotIndex, bloomFilterFileSuffix)
-		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextSnapshotIndex, dataFileSuffix)
-		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextSnapshotIndex, digestFileSuffix)
+		w.checkpointFilePath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, checkpointFileSuffix)
+		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, infoFileSuffix)
+		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, indexFileSuffix)
+		summariesFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, summariesFileSuffix)
+		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, bloomFilterFileSuffix)
+		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, dataFileSuffix)
+		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, digestFileSuffix)
 	case persist.FileSetFlushType:
 		shardDir = ShardDataDirPath(w.filePathPrefix, namespace, shard)
 		if err := os.MkdirAll(shardDir, w.newDirectoryMode); err != nil {
 			return err
 		}
 
-		w.checkpointFilePath = filesetPathFromTime(shardDir, blockStart, checkpointFileSuffix)
-		infoFilepath = filesetPathFromTime(shardDir, blockStart, infoFileSuffix)
-		indexFilepath = filesetPathFromTime(shardDir, blockStart, indexFileSuffix)
-		summariesFilepath = filesetPathFromTime(shardDir, blockStart, summariesFileSuffix)
-		bloomFilterFilepath = filesetPathFromTime(shardDir, blockStart, bloomFilterFileSuffix)
-		dataFilepath = filesetPathFromTime(shardDir, blockStart, dataFileSuffix)
-		digestFilepath = filesetPathFromTime(shardDir, blockStart, digestFileSuffix)
+		w.checkpointFilePath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, checkpointFileSuffix)
+		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, infoFileSuffix)
+		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, indexFileSuffix)
+		summariesFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, summariesFileSuffix)
+		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, bloomFilterFileSuffix)
+		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, dataFileSuffix)
+		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, digestFileSuffix)
 	default:
 		return fmt.Errorf("unable to open reader with fileset type: %s", opts.FileSetType)
 	}

--- a/src/dbnode/persist/fs/write.go
+++ b/src/dbnode/persist/fs/write.go
@@ -191,13 +191,13 @@ func (w *writer) Open(opts DataWriterOpenOptions) error {
 			return err
 		}
 
-		w.checkpointFilePath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, checkpointFileSuffix)
-		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, infoFileSuffix)
-		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, indexFileSuffix)
-		summariesFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, summariesFileSuffix)
-		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, bloomFilterFileSuffix)
-		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, dataFileSuffix)
-		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, digestFileSuffix)
+		w.checkpointFilePath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, checkpointFileSuffix, false)
+		infoFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, infoFileSuffix, false)
+		indexFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, indexFileSuffix, false)
+		summariesFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, summariesFileSuffix, false)
+		bloomFilterFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, bloomFilterFileSuffix, false)
+		dataFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, dataFileSuffix, false)
+		digestFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, digestFileSuffix, false)
 	default:
 		return fmt.Errorf("unable to open reader with fileset type: %s", opts.FileSetType)
 	}

--- a/src/dbnode/persist/types.go
+++ b/src/dbnode/persist/types.go
@@ -136,17 +136,14 @@ type DataPrepareOptions struct {
 	NamespaceMetadata namespace.Metadata
 	BlockStart        time.Time
 	Shard             uint32
-	FileSetType       FileSetType
-	DeleteIfExists    bool
+	// This volume index is only used when preparing for a flush fileset type.
+	// When opening a snapshot, the new volume index is determined by looking
+	// at what files exist on disk.
+	VolumeIndex    int
+	FileSetType    FileSetType
+	DeleteIfExists bool
 	// Snapshot options are applicable to snapshots (index yes, data yes)
 	Snapshot DataPrepareSnapshotOptions
-}
-
-// DataPrepareVolumeOptions is the options struct for the prepare method that contains
-// information specific to read/writing filesets that have multiple volumes (such as
-// snapshots and index file sets).
-type DataPrepareVolumeOptions struct {
-	VolumeIndex int
 }
 
 // IndexPrepareOptions is the options struct for the IndexFlush's Prepare method.

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -439,8 +439,11 @@ type UpdateOpenLeaseResult uint
 const (
 	// UpdateOpenLease is used to communicate a lease updated successfully.
 	UpdateOpenLease UpdateOpenLeaseResult = iota
-	// NoOpenLease is used to communitcate there is no related open lease.
+	// NoOpenLease is used to communicate there is no related open lease.
 	NoOpenLease
+	// OutOfOrderOpenLease is used to communicate that the leaser received an
+	// out of order lease (i.e it received volume 7 and then volume 6).
+	OutOfOrderOpenLease
 )
 
 // Leaser is a block leaser.

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -441,9 +441,6 @@ const (
 	UpdateOpenLease UpdateOpenLeaseResult = iota
 	// NoOpenLease is used to communicate there is no related open lease.
 	NoOpenLease
-	// OutOfOrderOpenLease is used to communicate that the leaser received an
-	// out of order lease (i.e it received volume 7 and then volume 6).
-	OutOfOrderOpenLease
 )
 
 // Leaser is a block leaser.

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
@@ -107,19 +107,19 @@ func createTempDir(t *testing.T) string {
 
 func writeInfoFile(t *testing.T, prefix string, namespace ident.ID, shard uint32, start time.Time, data []byte) {
 	shardDir := fs.ShardDataDirPath(prefix, namespace, shard)
-	filePath := path.Join(shardDir, fmt.Sprintf("fileset-%d-info.db", xtime.ToNanoseconds(start)))
+	filePath := path.Join(shardDir, fmt.Sprintf("fileset-%d-0-info.db", xtime.ToNanoseconds(start)))
 	writeFile(t, filePath, data)
 }
 
 func writeDataFile(t *testing.T, prefix string, namespace ident.ID, shard uint32, start time.Time, data []byte) {
 	shardDir := fs.ShardDataDirPath(prefix, namespace, shard)
-	filePath := path.Join(shardDir, fmt.Sprintf("fileset-%d-data.db", xtime.ToNanoseconds(start)))
+	filePath := path.Join(shardDir, fmt.Sprintf("fileset-%d-0-data.db", xtime.ToNanoseconds(start)))
 	writeFile(t, filePath, data)
 }
 
 func writeDigestFile(t *testing.T, prefix string, namespace ident.ID, shard uint32, start time.Time, data []byte) {
 	shardDir := fs.ShardDataDirPath(prefix, namespace, shard)
-	filePath := path.Join(shardDir, fmt.Sprintf("fileset-%d-digest.db", xtime.ToNanoseconds(start)))
+	filePath := path.Join(shardDir, fmt.Sprintf("fileset-%d-0-digest.db", xtime.ToNanoseconds(start)))
 	writeFile(t, filePath, data)
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -386,6 +386,14 @@ func (s *peersSource) flush(
 			FileSetType:       persistConfig.FileSetType,
 			Shard:             shard,
 			BlockStart:        start,
+			// When bootstrapping, the volume index will always be 0. However,
+			// if we want to be able to snapshot and flush while bootstrapping,
+			// this may not be the case, e.g. if a flush occurs before a
+			// bootstrap, then the bootstrap volume index will be >0. In order
+			// to support this, bootstrapping code will need to incorporate
+			// merging logic and flush version/volume index will need to be
+			// synchronized between processes.
+			VolumeIndex: 0,
 			// If we've peer bootstrapped this shard/block combination AND the fileset
 			// already exists on disk, then that means either:
 			// 1) The Filesystem bootstrapper was unable to bootstrap the fileset

--- a/src/dbnode/storage/cleanup_test.go
+++ b/src/dbnode/storage/cleanup_test.go
@@ -286,6 +286,8 @@ func TestCleanupManagerCleanupCommitlogsAndSnapshots(t *testing.T) {
 				shard := NewMockdatabaseShard(ctrl)
 				shard.EXPECT().ID().Return(uint32(i)).AnyTimes()
 				shard.EXPECT().CleanupExpiredFileSets(gomock.Any()).Return(nil).AnyTimes()
+				shard.EXPECT().CleanupCompactedFileSets().Return(nil).AnyTimes()
+
 				shards = append(shards, shard)
 			}
 
@@ -405,6 +407,7 @@ func TestCleanupDataAndSnapshotFileSetFiles(t *testing.T) {
 	shard := NewMockdatabaseShard(ctrl)
 	expectedEarliestToRetain := retention.FlushTimeStart(ns.Options().RetentionOptions(), ts)
 	shard.EXPECT().CleanupExpiredFileSets(expectedEarliestToRetain).Return(nil)
+	shard.EXPECT().CleanupCompactedFileSets().Return(nil)
 	shard.EXPECT().ID().Return(uint32(0)).AnyTimes()
 	ns.EXPECT().GetOwnedShards().Return([]databaseShard{shard}).AnyTimes()
 	ns.EXPECT().ID().Return(ident.StringID("nsID")).AnyTimes()

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -277,7 +277,7 @@ func newNamespaceIndexWithOptions(
 		bufferFuture:          nsMD.Options().RetentionOptions().BufferFuture(),
 		coldWritesEnabled:     nsMD.Options().ColdWritesEnabled(),
 
-		indexFilesetsBeforeFn: fs.IndexFileSetsBefore,
+		indexFilesetsBeforeFn: fs.IndexFilePathsBefore,
 		deleteFilesFn:         fs.DeleteFiles,
 
 		newBlockFn: newBlockFn,

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -277,7 +277,7 @@ func newNamespaceIndexWithOptions(
 		bufferFuture:          nsMD.Options().RetentionOptions().BufferFuture(),
 		coldWritesEnabled:     nsMD.Options().ColdWritesEnabled(),
 
-		indexFilesetsBeforeFn: fs.IndexFilePathsBefore,
+		indexFilesetsBeforeFn: fs.IndexFileSetsBefore,
 		deleteFilesFn:         fs.DeleteFiles,
 
 		newBlockFn: newBlockFn,

--- a/src/dbnode/storage/namespace_readers.go
+++ b/src/dbnode/storage/namespace_readers.go
@@ -21,7 +21,6 @@
 package storage
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -256,15 +255,17 @@ func (m *namespaceReaderManager) get(
 	// We have a closed reader from the cache (either a cached closed
 	// reader or newly allocated, either way need to prepare it)
 	reader := lookup.closedReader
+	// TODO(juchan): get the actual volume here.
+	vol := 0
 	openOpts := fs.DataReaderOpenOptions{
 		Identifier: fs.FileSetFileIdentifier{
-			Namespace:  m.namespace.ID(),
-			Shard:      shard,
-			BlockStart: blockStart,
+			Namespace:   m.namespace.ID(),
+			Shard:       shard,
+			BlockStart:  blockStart,
+			VolumeIndex: vol,
 		},
 	}
 	if err := reader.Open(openOpts); err != nil {
-		fmt.Printf("j>> %+v\n", 2)
 		return nil, err
 	}
 

--- a/src/dbnode/storage/namespace_readers.go
+++ b/src/dbnode/storage/namespace_readers.go
@@ -21,6 +21,7 @@
 package storage
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -66,7 +67,6 @@ type databaseNamespaceReaderManager interface {
 	get(
 		shard uint32,
 		blockStart time.Time,
-		volume int,
 		position readerPosition,
 	) (fs.DataFileSetReader, error)
 
@@ -234,14 +234,12 @@ func (m *namespaceReaderManager) cachedReaderForKey(
 func (m *namespaceReaderManager) get(
 	shard uint32,
 	blockStart time.Time,
-	volume int,
 	position readerPosition,
 ) (fs.DataFileSetReader, error) {
 	key := cachedOpenReaderKey{
 		shard:      shard,
 		blockStart: xtime.ToUnixNano(blockStart),
 		position:   position,
-		volume:     volume,
 	}
 
 	lookup, err := m.cachedReaderForKey(key)
@@ -257,13 +255,13 @@ func (m *namespaceReaderManager) get(
 	reader := lookup.closedReader
 	openOpts := fs.DataReaderOpenOptions{
 		Identifier: fs.FileSetFileIdentifier{
-			Namespace:   m.namespace.ID(),
-			Shard:       shard,
-			BlockStart:  blockStart,
-			VolumeIndex: volume,
+			Namespace:  m.namespace.ID(),
+			Shard:      shard,
+			BlockStart: blockStart,
 		},
 	}
 	if err := reader.Open(openOpts); err != nil {
+		fmt.Printf("j>> %+v\n", 2)
 		return nil, err
 	}
 

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -269,7 +269,7 @@ func newDatabaseShard(
 		newMergerFn:          fs.NewMerger,
 		newFSMergeWithMemFn:  newFSMergeWithMem,
 		filesetsFn:           fs.DataFiles,
-		filesetPathsBeforeFn: fs.DataFilePathsBefore,
+		filesetPathsBeforeFn: fs.DataFileSetsBefore,
 		deleteFilesFn:        fs.DeleteFiles,
 		snapshotFilesFn:      fs.SnapshotFiles,
 		sleepFn:              time.Sleep,

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1687,8 +1687,10 @@ func (s *dbShard) FetchBlocksMetadataV2(
 			pos.metadataIdx = int(flushedPhase.CurrBlockEntryIdx)
 		}
 
+		// TODO(juchan): actually get the volume
+		vol := 0
 		// Open a reader at this position, potentially from cache
-		reader, err := s.namespaceReaderMgr.get(s.shard, blockStart, pos)
+		reader, err := s.namespaceReaderMgr.get(s.shard, blockStart, vol, pos)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1902,9 +1902,9 @@ func (s *dbShard) WarmFlush(
 		// happen first before cold flushes happen.
 		VolumeIndex: 0,
 		// We explicitly set delete if exists to false here as we track which
-		// filesets exists at bootstrap time so we should never encounter a time
-		// when we attempt to flush and a fileset already exists unless there is
-		// racing competing processes.
+		// filesets exist at bootstrap time so we should never encounter a time
+		// when we attempt to flush and a fileset that already exists unless
+		// there are racing competing processes.
 		DeleteIfExists: false,
 	}
 	prepared, err := flushPreparer.PrepareData(prepareOpts)

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -1136,7 +1136,7 @@ func TestShardCleanupExpiredFileSets(t *testing.T) {
 	opts := DefaultTestOptions()
 	shard := testDatabaseShard(t, opts)
 	defer shard.Close()
-	shard.filesetBeforeFn = func(_ string, namespace ident.ID, shardID uint32, t time.Time) ([]string, error) {
+	shard.filesetPathsBeforeFn = func(_ string, namespace ident.ID, shardID uint32, t time.Time) ([]string, error) {
 		return []string{namespace.String(), strconv.Itoa(int(shardID))}, nil
 	}
 	var deletedFiles []string

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -1789,6 +1789,20 @@ func (mr *MockdatabaseShardMockRecorder) CleanupExpiredFileSets(earliestToRetain
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupExpiredFileSets", reflect.TypeOf((*MockdatabaseShard)(nil).CleanupExpiredFileSets), earliestToRetain)
 }
 
+// CleanupCompactedFileSets mocks base method
+func (m *MockdatabaseShard) CleanupCompactedFileSets() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupCompactedFileSets")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupCompactedFileSets indicates an expected call of CleanupCompactedFileSets
+func (mr *MockdatabaseShardMockRecorder) CleanupCompactedFileSets() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupCompactedFileSets", reflect.TypeOf((*MockdatabaseShard)(nil).CleanupCompactedFileSets))
+}
+
 // Repair mocks base method
 func (m *MockdatabaseShard) Repair(ctx context.Context, nsCtx namespace.Context, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
 	m.ctrl.T.Helper()

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -494,6 +494,11 @@ type databaseShard interface {
 	// CleanupExpiredFileSets removes expired fileset files.
 	CleanupExpiredFileSets(earliestToRetain time.Time) error
 
+	// CleanupCompactedFileSets removes fileset files that have been compacted,
+	// meaning that there exists a more recent, superset, fully persisted
+	// fileset for that block.
+	CleanupCompactedFileSets() error
+
 	// Repair repairs the shard data for a given time.
 	Repair(
 		ctx context.Context,


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R is required for the out of order writes feature. After a new volume for a given namespace/shard/blockstart is written out, the SeekerManager will be notified via a call to UpdateOpenLease(). This function imlpements UpdateOpenLease such that the SeekerManager "hot swaps" its old seekers for the old volume with new seekers for the new volume.