### PR TITLE
Implement UpdateOpenLease in `SeekManager`

### DIFF
--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -1,3 +1,4 @@
+// +build big
 //
 // Copyright (c) 2016 Uber Technologies, Inc.
 //

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -462,8 +462,6 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 			require.Equal(t, expectedVolumeTag, volumeTag)
 		}
 	}
-
-	// panic("yolo")
 }
 
 // TestBlockRetrieverIDDoesNotExist verifies the behavior of the Stream() method

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -175,7 +175,7 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 		if val := rand.Intn(100); val >= 90 {
 			return nil, errors.New("some-error")
 		}
-		return existingNewSeekerFn(shard, blockStart, volume)
+		return existingNewOpenSeekerFn(shard, blockStart, volume)
 	}
 	seekerMgr.newOpenSeekerFn = newNewOpenSeekerFn
 

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -29,6 +29,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -80,7 +81,7 @@ func newOpenTestBlockRetriever(
 	require.NoError(t, retriever.Open(testNs1Metadata(t)))
 
 	return retriever, func() {
-		assert.NoError(t, retriever.Close())
+		require.NoError(t, retriever.Close())
 	}
 }
 
@@ -89,19 +90,21 @@ func newOpenTestWriter(
 	fsOpts Options,
 	shard uint32,
 	start time.Time,
+	volume int,
 ) (DataFileSetWriter, testCleanupFn) {
 	w := newTestWriter(t, fsOpts.FilePathPrefix())
 	writerOpts := DataWriterOpenOptions{
 		BlockSize: testBlockSize,
 		Identifier: FileSetFileIdentifier{
-			Namespace:  testNs1ID,
-			Shard:      shard,
-			BlockStart: start,
+			Namespace:   testNs1ID,
+			Shard:       shard,
+			BlockStart:  start,
+			VolumeIndex: volume,
 		},
 	}
 	require.NoError(t, w.Open(writerOpts))
 	return w, func() {
-		assert.NoError(t, w.Close())
+		require.NoError(t, w.Close())
 	}
 }
 
@@ -131,74 +134,124 @@ func TestBlockRetrieverHighConcurrentSeeksCacheShardIndices(t *testing.T) {
 }
 
 func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices bool) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	defer leaktest.CheckTimeout(t, 2*time.Minute)()
 
 	dir, err := ioutil.TempDir("", "testdb")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
-	filePathPrefix := filepath.Join(dir, "")
-	fsOpts := testDefaultOpts.SetFilePathPrefix(filePathPrefix)
 
-	fetchConcurrency := 4
-	seekConcurrency := 4 * fetchConcurrency
-	opts := testBlockRetrieverOptions{
-		retrieverOpts: defaultTestBlockRetrieverOptions.
-			SetFetchConcurrency(fetchConcurrency).
-			SetRequestPoolOptions(pool.NewObjectPoolOptions().
-				// NB(r): Try to make sure same req structs are reused frequently
-				// to surface any race issues that might occur with pooling.
-				SetSize(fetchConcurrency / 2)),
-		fsOpts: fsOpts,
-	}
+	// Setup retriever.
+	var (
+		filePathPrefix = filepath.Join(dir, "")
+		fsOpts         = testDefaultOpts.SetFilePathPrefix(filePathPrefix)
+
+		fetchConcurrency           = 4
+		seekConcurrency            = 4 * fetchConcurrency
+		updateOpenLeaseConcurrency = 4
+		opts                       = testBlockRetrieverOptions{
+			retrieverOpts: defaultTestBlockRetrieverOptions.
+				SetFetchConcurrency(fetchConcurrency).
+				SetRequestPoolOptions(pool.NewObjectPoolOptions().
+					// NB(r): Try to make sure same req structs are reused frequently
+					// to surface any race issues that might occur with pooling.
+					SetSize(fetchConcurrency / 2)),
+			fsOpts: fsOpts,
+		}
+	)
 	retriever, cleanup := newOpenTestBlockRetriever(t, opts)
 	defer cleanup()
 
-	nsMeta := testNs1Metadata(t)
-	ropts := nsMeta.Options().RetentionOptions()
-	nsCtx := namespace.NewContextFrom(nsMeta)
+	// Setup the open seeker function to fail sometimes to exercise that code path.
+	seekerMgr := retriever.seekerMgr.(*seekerManager)
+	existingNewSeekerFn := seekerMgr.newOpenSeekerFn
+	newNewSeekerFn := func(shard uint32, blockStart time.Time, volume int) (DataFileSetSeeker, error) {
+		// Artificially slow down how long it takes to open a seeker to exercise the logic where
+		// multiple goroutines are trying to open seekers for the same shard/blockStart and need
+		// to wait for the others to complete.
+		time.Sleep(5 * time.Millisecond)
+		// 10% chance for this to fail so that error paths get exercised as well.
+		if val := rand.Intn(100); val >= 90 {
+			return nil, errors.New("some-error")
+		}
+		return existingNewSeekerFn(shard, blockStart, volume)
+	}
+	seekerMgr.newOpenSeekerFn = newNewSeekerFn
 
-	now := time.Now().Truncate(ropts.BlockSize())
-	min, max := now.Add(-6*ropts.BlockSize()), now.Add(-ropts.BlockSize())
+	// Setup the block lease manager to return errors sometimes to exercise that code path.
+	mockBlockLeaseManager := block.NewMockLeaseManager(ctrl)
+	mockBlockLeaseManager.EXPECT().RegisterLeaser(gomock.Any()).AnyTimes()
+	mockBlockLeaseManager.EXPECT().UnregisterLeaser(gomock.Any()).AnyTimes()
+	mockBlockLeaseManager.EXPECT().OpenLatestLease(gomock.Any(), gomock.Any()).DoAndReturn(func(_ block.Leaser, _ block.LeaseDescriptor) (block.LeaseState, error) {
+		// 10% chance for this to fail so that error paths get exercised as well.
+		if val := rand.Intn(100); val >= 90 {
+			return block.LeaseState{}, errors.New("some-error")
+		}
 
+		return block.LeaseState{Volume: 0}, nil
+	}).AnyTimes()
+	seekerMgr.blockRetrieverOpts = seekerMgr.blockRetrieverOpts.SetBlockLeaseManager(mockBlockLeaseManager)
+
+	// Setup data generation.
 	var (
+		nsMeta   = testNs1Metadata(t)
+		ropts    = nsMeta.Options().RetentionOptions()
+		nsCtx    = namespace.NewContextFrom(nsMeta)
+		now      = time.Now().Truncate(ropts.BlockSize())
+		min, max = now.Add(-6 * ropts.BlockSize()), now.Add(-ropts.BlockSize())
+
 		shards         = []uint32{0, 1, 2}
 		idsPerShard    = 16
 		shardIDs       = make(map[uint32][]ident.ID)
 		shardIDStrings = make(map[uint32][]string)
 		dataBytesPerID = 32
-		shardData      = make(map[uint32]map[string]map[xtime.UnixNano]checked.Bytes)
-		blockStarts    []time.Time
+		// Shard -> ID -> Blockstart -> Data
+		shardData   = make(map[uint32]map[string]map[xtime.UnixNano]checked.Bytes)
+		blockStarts []time.Time
+		volumes     = []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 	)
 	for st := min; !st.After(max); st = st.Add(ropts.BlockSize()) {
 		blockStarts = append(blockStarts, st)
 	}
+
+	// Generate data.
 	for _, shard := range shards {
 		shardIDs[shard] = make([]ident.ID, 0, idsPerShard)
 		shardData[shard] = make(map[string]map[xtime.UnixNano]checked.Bytes, idsPerShard)
 		for _, blockStart := range blockStarts {
-			w, closer := newOpenTestWriter(t, fsOpts, shard, blockStart)
-			for i := 0; i < idsPerShard; i++ {
-				idString := fmt.Sprintf("foo.%d", i)
-				shardIDStrings[shard] = append(shardIDStrings[shard], idString)
+			for _, volume := range volumes {
+				w, closer := newOpenTestWriter(t, fsOpts, shard, blockStart, volume)
+				for i := 0; i < idsPerShard; i++ {
+					idString := fmt.Sprintf("foo.%d", i)
+					shardIDStrings[shard] = append(shardIDStrings[shard], idString)
 
-				id := ident.StringID(idString)
-				shardIDs[shard] = append(shardIDs[shard], id)
-				if _, ok := shardData[shard][idString]; !ok {
-					shardData[shard][idString] = make(map[xtime.UnixNano]checked.Bytes, len(blockStarts))
+					id := ident.StringID(idString)
+					shardIDs[shard] = append(shardIDs[shard], id)
+					if _, ok := shardData[shard][idString]; !ok {
+						shardData[shard][idString] = make(map[xtime.UnixNano]checked.Bytes, len(blockStarts))
+					}
+
+					// Always write the same data for each series regardless of volume to make asserting on
+					// Stream() responses simpler. Each volume gets a unique tag so we can verify that leases
+					// are being upgraded by checking the tags.
+					blockStartNanos := xtime.ToUnixNano(blockStart)
+					data, ok := shardData[shard][idString][blockStartNanos]
+					if !ok {
+						data = checked.NewBytes(nil, nil)
+						data.IncRef()
+						for j := 0; j < dataBytesPerID; j++ {
+							data.Append(byte(rand.Int63n(256)))
+						}
+						shardData[shard][idString][blockStartNanos] = data
+					}
+
+					tags := testTagsFromIDAndVolume(id.String(), volume)
+					err := w.Write(id, tags, data, digest.Checksum(data.Bytes()))
+					require.NoError(t, err)
 				}
-
-				data := checked.NewBytes(nil, nil)
-				data.IncRef()
-				for j := 0; j < dataBytesPerID; j++ {
-					data.Append(byte(rand.Int63n(256)))
-				}
-				shardData[shard][idString][xtime.ToUnixNano(blockStart)] = data
-
-				tags := testTagsFromTestID(id.String())
-				err := w.Write(id, ident.NewTags(tags...), data, digest.Checksum(data.Bytes()))
-				require.NoError(t, err)
+				closer()
 			}
-			closer()
 		}
 	}
 
@@ -234,6 +287,7 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 		retrievedIDsMutex.Unlock()
 	})
 
+	// Setup concurrent seeks.
 	var enqueueWg sync.WaitGroup
 	startWg.Add(1)
 	for i := 0; i < seekConcurrency; i++ {
@@ -257,8 +311,20 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 
 				for k := 0; k < len(blockStarts); k++ {
 					ctx := context.NewContext()
-					stream, err := retriever.Stream(ctx, shard, id, blockStarts[k], onRetrieve, nsCtx)
-					require.NoError(t, err)
+
+					var (
+						stream xio.BlockReader
+						err    error
+					)
+					for {
+						// Run in a loop since the open seeker function is configured to randomly fail
+						// sometimes.
+						stream, err = retriever.Stream(ctx, shard, id, blockStarts[k], onRetrieve, nsCtx)
+						if err == nil {
+							break
+						}
+					}
+
 					results = append(results, streamResult{
 						ctx:        ctx,
 						shard:      shard,
@@ -279,7 +345,13 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 
 					require.NoError(t, err)
 					compare.Head = shardData[r.shard][r.id][xtime.ToUnixNano(r.blockStart)]
-					assert.True(t, seg.Equal(&compare))
+					require.True(
+						t,
+						seg.Equal(&compare),
+						"data mismatch for series %s, returned data: %v",
+						r.id,
+						string(seg.Head.Bytes()),
+						string(compare.Head.Bytes()))
 
 					r.ctx.Close()
 				}
@@ -288,9 +360,47 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 		}()
 	}
 
-	// Wait for all routines to be ready then start.
+	// Wait for all routines to be ready.
 	readyWg.Wait()
+	// Allow all the goroutines to begin.
 	startWg.Done()
+
+	// Setup concurrent block lease updates.
+	sem := make(chan struct{}, updateOpenLeaseConcurrency)
+	// Volume -> shard -> blockStart to stripe as many shard/blockStart as quickly as possible to
+	// improve the chance of triggering the code path where UpdateOpenLease is the first time a set
+	// of seekers are opened for a shard/blocksStart combination.
+	for _, volume := range volumes {
+		for _, shard := range shards {
+			for _, blockStart := range blockStarts {
+				enqueueWg.Add(1)
+				sem <- struct{}{}
+				go func(shard uint32, blockStart time.Time, volume int) {
+					defer enqueueWg.Done()
+					leaser := retriever.seekerMgr.(block.Leaser)
+
+					for {
+						// Run in a loop since the open seeker function is configured to randomly fail
+						// sometimes.
+						_, err := leaser.UpdateOpenLease(block.LeaseDescriptor{
+							Namespace:  nsMeta.ID(),
+							Shard:      shard,
+							BlockStart: blockStart,
+						}, block.LeaseState{Volume: volume})
+						// Ignore errOutOfOrderUpdateOpenLease because the goroutines in this test are not coordinated
+						// and thus may try to call UpdateOpenLease() with out of order volumes. Thats fine for the
+						// purposes of this test since the goal here is to make sure there are no race conditions and
+						// ensure that the SeekerManager ends up in the correct state when the test is complete.
+						if err == nil || err == errOutOfOrderUpdateOpenLease {
+							break
+						}
+					}
+
+					<-sem
+				}(shard, blockStart, volume)
+			}
+		}
+	}
 
 	// Wait until done.
 	enqueueWg.Wait()
@@ -303,13 +413,57 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 			retrievedIDsMutex.Unlock()
 			require.True(t, ok, fmt.Sprintf("expected %s to be retrieved, but it was not", id))
 
-			expectedTags := ident.NewTags(testTagsFromTestID(id)...)
+			// Strip the volume tag because these reads were performed while concurrent block lease updates
+			// were happening so its not deterministic which volume tag they'll have at this point.
+			tags = stripVolumeTag(tags)
+			expectedTags := stripVolumeTag(testTagsFromIDAndVolume(id, 0))
 			require.True(
 				t,
 				tags.Equal(expectedTags),
 				fmt.Sprintf("expectedNumTags=%d, actualNumTags=%d", len(expectedTags.Values()), len(tags.Values())))
 		}
 	}
+
+	// Now that all the block lease updates have completed, all reads from this point should return tags with the
+	// highest volume number.
+	for _, shard := range shards {
+		for _, blockStart := range blockStarts {
+			for _, idString := range shardIDStrings[shard] {
+				var (
+					ctx = context.NewContext()
+					id  = ident.StringID(idString)
+				)
+
+				for {
+					// Run in a loop since the open seeker function is configured to randomly fail
+					// sometimes.
+					_, err := retriever.Stream(ctx, shard, id, blockStart, onRetrieve, nsCtx)
+					if err == nil {
+						break
+					}
+				}
+
+			}
+		}
+	}
+
+	for _, shard := range shardIDStrings {
+		for _, id := range shard {
+			retrievedIDsMutex.Lock()
+			tags, ok := retrievedIDs[id]
+			retrievedIDsMutex.Unlock()
+			require.True(t, ok, fmt.Sprintf("expected %s to be retrieved, but it was not", id))
+			tagsSlice := tags.Values()
+
+			// Highest volume is expected.
+			expectedVolumeTag := strconv.Itoa(volumes[len(volumes)-1])
+			// Volume tag is last.
+			volumeTag := tagsSlice[len(tagsSlice)-1].Value.String()
+			require.Equal(t, expectedVolumeTag, volumeTag)
+		}
+	}
+
+	// panic("yolo")
 }
 
 // TestBlockRetrieverIDDoesNotExist verifies the behavior of the Stream() method
@@ -339,7 +493,7 @@ func TestBlockRetrieverIDDoesNotExist(t *testing.T) {
 	defer cleanup()
 
 	// Write out a test file
-	w, closer := newOpenTestWriter(t, fsOpts, shard, blockStart)
+	w, closer := newOpenTestWriter(t, fsOpts, shard, blockStart, 0)
 	data := checked.NewBytes([]byte("Hello world!"), nil)
 	data.IncRef()
 	defer data.DecRef()
@@ -386,7 +540,7 @@ func TestBlockRetrieverOnlyCreatesTagItersIfTagsExists(t *testing.T) {
 
 	// Write out a test file.
 	var (
-		w, closer = newOpenTestWriter(t, fsOpts, shard, blockStart)
+		w, closer = newOpenTestWriter(t, fsOpts, shard, blockStart, 0)
 		tag       = ident.Tag{
 			Name:  ident.StringID("name"),
 			Value: ident.StringID("value"),
@@ -539,13 +693,20 @@ func testBlockRetrieverHandlesSeekErrors(t *testing.T, ctrl *gomock.Controller, 
 	assert.Equal(t, nil, segment.Tail)
 }
 
-func testTagsFromTestID(seriesID string) []ident.Tag {
+func testTagsFromIDAndVolume(seriesID string, volume int) ident.Tags {
 	tags := []ident.Tag{}
 	for j := 0; j < 5; j++ {
-		tags = append(tags, ident.Tag{
-			Name:  ident.StringID(fmt.Sprintf("%s.tag.%d.name", seriesID, j)),
-			Value: ident.StringID(fmt.Sprintf("%s.tag.%d.value", seriesID, j)),
-		})
+		tags = append(tags, ident.StringTag(
+			fmt.Sprintf("%s.tag.%d.name", seriesID, j),
+			fmt.Sprintf("%s.tag.%d.value", seriesID, j),
+		))
 	}
-	return tags
+	tags = append(tags, ident.StringTag("volume", strconv.Itoa(volume)))
+	return ident.NewTags(tags...)
+}
+
+func stripVolumeTag(tags ident.Tags) ident.Tags {
+	tagsSlice := tags.Values()
+	tagsSlice = tagsSlice[:len(tagsSlice)-1]
+	return ident.NewTags(tagsSlice...)
 }

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -367,6 +367,7 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 
 	// Setup concurrent block lease updates.
 	workers := xsync.NewWorkerPool(updateOpenLeaseConcurrency)
+	workers.Init()
 	// Volume -> shard -> blockStart to stripe as many shard/blockStart as quickly as possible to
 	// improve the chance of triggering the code path where UpdateOpenLease is the first time a set
 	// of seekers are opened for a shard/blocksStart combination.

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -315,7 +315,7 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 			}
 
 			// All the inactive seekers have been returned so it's safe to signal and clear them out.
-			var multiErr = xerrors.NewMultiError()
+			multiErr := xerrors.NewMultiError()
 			for _, inactiveSeeker := range seekers.inactive.seekers {
 				multiErr = multiErr.Add(inactiveSeeker.seeker.Close())
 			}
@@ -328,8 +328,8 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 				allInactiveSeekersClosedWg.Done()
 			}
 
-			if multiErr.FinalError() != nil {
-				return multiErr.FinalError()
+			if err := multiErr.FinalError(); err != nil {
+				return err
 			}
 			break
 		}

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -344,7 +344,7 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 }
 
 // UpdateOpenLease() implements block.Leaser. The contract of this API is that once the function
-// returns successfully any resources associated with the previous release should have been
+// returns successfully any resources associated with the previous lease should have been
 // released (in this case the Seeker / files for the previous volume) and the resources associated
 // with the new lease should have been acquired (the seeker for the provided volume).
 //

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -514,6 +514,8 @@ func (m *seekerManager) startUpdateOpenLease(descriptor block.LeaseDescriptor) (
 	}
 
 	m.isUpdatingLease = true
+
+	return false, nil
 }
 
 // closeSeekersAndLogError is a helper function that closes all the seekers in a slice of borrowableSeeker

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -386,18 +386,8 @@ func (m *seekerManager) UpdateOpenLease(
 		m.Unlock()
 	}()
 
-	// First open a new seeker outside the context of any locks.
-	seeker, err := m.newOpenSeekerFn(
-		descriptor.Shard, descriptor.BlockStart, state.Volume)
+	newActiveSeekers, err := m.newSeekersAndBloom(descriptor.Shard, descriptor.BlockStart, state.Volume)
 	if err != nil {
-		return 0, err
-	}
-
-	newActiveSeekers, err := m.seekersAndBloomFromSeeker(seeker, state.Volume)
-	if err != nil {
-		// Don't need to worry about closing / leaking seeker here because
-		// seekersAndBloomFromSeeker will have closed it already if there
-		// were any errors.
 		return 0, err
 	}
 

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -445,12 +445,6 @@ func (m *seekerManager) updateOpenLeaseHotSwapSeekers(
 	if !ok {
 		// No existing seekers, so just set the newly created ones and be done.
 		seekers.active = newActiveSeekers
-		if seekers.active.volume > state.Volume {
-			// Ignore any close errors because its not relevant from the callers perspective.
-			m.closeSeekersAndLogError(descriptor, newActiveSeekers.seekers)
-			return nil, 0, errOutOfOrderUpdateOpenLease
-		}
-
 		byTime.seekers[blockStartNano] = seekers
 		return nil, updateOpenLeaseResult, nil
 	}

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -50,6 +50,9 @@ var (
 	errSeekersDontExist                              = errors.New("seekers don't exist")
 	errCantCloseSeekerManagerWhileSeekersAreBorrowed = errors.New("cant close seeker manager while seekers are borrowed")
 	errReturnedUnmanagedSeeker                       = errors.New("cant return a seeker not managed by the seeker manager")
+	errUpdateOpenLeaseSeekerManagerNotOpen           = errors.New("cant update open lease because seeker manager is not open")
+	errConcurrentUpdateOpenLeaseNotAllowed           = errors.New("concurrent open lease updates are not allowed")
+	errOutOfOrderUpdateOpenLease                     = errors.New("received update open lease volumes out of order")
 )
 
 type openAnyUnopenSeekersFn func(*seekersByTime) error
@@ -57,6 +60,7 @@ type openAnyUnopenSeekersFn func(*seekersByTime) error
 type newOpenSeekerFn func(
 	shard uint32,
 	blockStart time.Time,
+	volume int,
 ) (DataFileSetSeeker, error)
 
 type seekerManagerStatus int
@@ -79,6 +83,7 @@ type seekerManager struct {
 	filePathPrefix string
 
 	status                 seekerManagerStatus
+	isUpdatingLease        bool
 	seekersByShardIdx      []*seekersByTime
 	namespace              ident.ID
 	namespaceMetadata      namespace.Metadata
@@ -103,6 +108,7 @@ type seekersAndBloom struct {
 	wg          *sync.WaitGroup
 	seekers     []borrowableSeeker
 	bloomFilter *ManagedConcurrentBloomFilter
+	volume      int
 }
 
 // borrowableSeeker is just a seeker with an additional field for keeping track of whether or not it has been borrowed.
@@ -115,7 +121,12 @@ type seekersByTime struct {
 	sync.RWMutex
 	shard    uint32
 	accessed bool
-	seekers  map[xtime.UnixNano]seekersAndBloom
+	seekers  map[xtime.UnixNano]rotatableSeekers
+}
+
+type rotatableSeekers struct {
+	active   seekersAndBloom
+	inactive seekersAndBloom
 }
 
 type seekerManagerPendingClose struct {
@@ -201,14 +212,14 @@ func (m *seekerManager) CacheShardIndices(shards []uint32) error {
 func (m *seekerManager) ConcurrentIDBloomFilter(shard uint32, start time.Time) (*ManagedConcurrentBloomFilter, error) {
 	byTime := m.seekersByTime(shard)
 
-	// Try fast RLock() first
+	// Try fast RLock() first.
 	byTime.RLock()
 	startNano := xtime.ToUnixNano(start)
-	seekersAndBloom, ok := byTime.seekers[startNano]
+	seekers, ok := byTime.seekers[startNano]
 	byTime.RUnlock()
 
-	if ok && seekersAndBloom.wg == nil {
-		return seekersAndBloom.bloomFilter, nil
+	if ok && seekers.active.wg == nil {
+		return seekers.active.bloomFilter, nil
 	}
 
 	byTime.Lock()
@@ -254,12 +265,11 @@ func (m *seekerManager) Borrow(shard uint32, start time.Time) (ConcurrentDataFil
 
 func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentDataFileSetSeeker) error {
 	byTime := m.seekersByTime(shard)
-
 	byTime.Lock()
 	defer byTime.Unlock()
 
 	startNano := xtime.ToUnixNano(start)
-	seekersAndBloom, ok := byTime.seekers[startNano]
+	seekers, ok := byTime.seekers[startNano]
 	// Should never happen - This either means that the caller (DataBlockRetriever) is trying to return seekers
 	// that it never requested, OR its trying to return seekers after the openCloseLoop has already
 	// determined that they were all no longer in use and safe to close. Either way it indicates there is
@@ -269,11 +279,58 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 	}
 
 	found := false
-	for i, compareSeeker := range seekersAndBloom.seekers {
+	for i, compareSeeker := range seekers.active.seekers {
 		if seeker == compareSeeker.seeker {
 			found = true
 			compareSeeker.isBorrowed = false
-			seekersAndBloom.seekers[i] = compareSeeker
+			seekers.active.seekers[i] = compareSeeker
+			break
+		}
+	}
+
+	if found {
+		return nil
+	}
+
+	// If no match was found in the active seekers, it's possible that an inactive seeker is being returned.
+	for i, compareSeeker := range seekers.inactive.seekers {
+		if seeker == compareSeeker.seeker {
+			found = true
+			compareSeeker.isBorrowed = false
+			seekers.inactive.seekers[i] = compareSeeker
+
+			// The goroutine that returns the last outstanding inactive seeker is responsible for notifying any
+			// goroutines waiting for all inactive seekers to be returned and clearing out the inactive seekers
+			// state entirely.
+			allAreReturned := true
+			for _, inactiveSeeker := range seekers.inactive.seekers {
+				if inactiveSeeker.isBorrowed {
+					allAreReturned = false
+					break
+				}
+			}
+
+			if !allAreReturned {
+				break
+			}
+
+			// All the inactive seekers have been returned so it's safe to signal and clear them out.
+			var multiErr = xerrors.NewMultiError()
+			for _, inactiveSeeker := range seekers.inactive.seekers {
+				multiErr = multiErr.Add(inactiveSeeker.seeker.Close())
+			}
+
+			// Clear out inactive state.
+			allInactiveSeekersClosedWg := seekers.inactive.wg
+			seekers.inactive = seekersAndBloom{}
+			if allInactiveSeekersClosedWg != nil {
+				// Signal completion regardless of any errors encountered while closing.
+				allInactiveSeekersClosedWg.Done()
+			}
+
+			if multiErr.FinalError() != nil {
+				return multiErr.FinalError()
+			}
 			break
 		}
 	}
@@ -286,15 +343,188 @@ func (m *seekerManager) Return(shard uint32, start time.Time, seeker ConcurrentD
 	return nil
 }
 
-// Implements block.Leaser.
+// UpdateOpenLease() implements block.Leaser. The contract of this API is that once the function
+// returns successfully any resources associated with the previous release should have been
+// released (in this case the Seeker / files for the previous volume) and the resources associated
+// with the new lease should have been acquired (the seeker for the provided volume).
+//
+// Practically speaking, the goal of this function is to open a new seeker for the latest volume and
+// then "hot-swap" it so that by the time this function returns there are no more outstanding reads
+// using the old seekers, all the old seekers have been closed, and all subsequent reads will use the
+// seekers associated with the latest volume.
+//
+// The bulk of the complexity of this function is caused by the desire to avoid the hot-swap from
+// causing any latency spikes. To accomplish this, the following is performed:
+//
+//   1. Open the new seeker outside the context of any locks.
+//   2. Acquire a lock on the seekers that need to be swapped and rotate the existing "active" seekers
+//      to be "inactive" and set the newly opened seekers as "active". This operation is extremely cheap
+//      and ensures that all subsequent reads will use the seekers for the latest volume instead of the
+//      previous. In addition, this phase also creates a waitgroup for the inactive seekers that will be
+//      be used to "wait" for all of the existing seekers that are currently borrowed to be returned.
+//   3. Release the lock so that reads can continue uninterrupted and call waitgroup.Wait() to wait for all
+//      the currently borrowed "inactive" seekers (if any) to be returned.
+//   4. Every call to Return() for an "inactive" seeker will check if it's the last borrowed inactive seeker,
+//      and if so, will close all the inactive seekers and call wg.Done() which will notify the goroutine
+//      running the UpdateOpenlease() function that all inactive seekers have been returned and closed at
+//      which point the function will return sucessfully.
 func (m *seekerManager) UpdateOpenLease(
 	descriptor block.LeaseDescriptor,
 	state block.LeaseState,
 ) (block.UpdateOpenLeaseResult, error) {
-	// TODO(rartoul): This is a no-op for now until the logic for swapping out seekers is written.
-	// Also make sure that this function is a proper no-op if the SeekerManager state has been
-	// been switched to closed.
-	return block.NoOpenLease, nil
+	m.Lock()
+	if m.status != seekerManagerOpen {
+		m.Unlock()
+		return 0, errUpdateOpenLeaseSeekerManagerNotOpen
+	}
+
+	if m.isUpdatingLease {
+		// This guard is a little overly aggressive. In practice, the algorithm remains correct even in the presence
+		// of concurrent UpdateOpenLease() calls as long as they are for different shard/blockStart combinations.
+		// However, the calling code currently has no need to call this method concurrently at all so use the
+		// simpler check for now.
+		m.Unlock()
+		return 0, errConcurrentUpdateOpenLeaseNotAllowed
+	}
+
+	if !m.namespace.Equal(descriptor.Namespace) {
+		m.Unlock()
+		return block.NoOpenLease, nil
+	}
+	m.isUpdatingLease = true
+	m.Unlock()
+	defer func() {
+		m.Lock()
+		m.isUpdatingLease = false
+		m.Unlock()
+	}()
+
+	// First open a new seeker outside the context of any locks.
+	seeker, err := m.newOpenSeekerFn(
+		descriptor.Shard, descriptor.BlockStart, state.Volume)
+	if err != nil {
+		return 0, err
+	}
+
+	newActiveSeekers, err := m.seekersAndBloomFromSeeker(seeker, state.Volume)
+	if err != nil {
+		// Don't need to worry about closing / leaking seeker here because
+		// seekersAndBloomFromSeeker will have closed it already if there
+		// were any errors.
+		return 0, err
+	}
+
+	var (
+		byTime                = m.seekersByTime(descriptor.Shard)
+		blockStartNano        = xtime.ToUnixNano(descriptor.BlockStart)
+		updateOpenLeaseResult = block.NoOpenLease
+
+		seekers rotatableSeekers
+		ok      bool
+	)
+	// It's possible that another goroutine is currently trying to open seekers for this blockStart. If so, this
+	// goroutine will need to wait for the other goroutine to finish before proceeding. The check is performed in
+	// a loop because each iteration relinquishes the lock temporarily. Once the lock is reacquired the same
+	// conditions need to be checked again until this Goroutine finds that either:
+	//
+	//   a) Seekers are already present for this blockStart in which case it can proceed to hot swap them.
+	// or
+	//   b) Seeks are not present for this blockStart and no other goroutines are currently trying to open them,
+	//      in which case this goroutine can just set the new seekers and be done.
+	for {
+		byTime.Lock()
+		seekers, ok = byTime.seekers[blockStartNano]
+
+		if !ok || seekers.active.wg == nil {
+			// Exit the loop still holding the lock.
+			break
+		}
+
+		// If another goroutine is currently trying to open seekers for this block start
+		// then wait for that operation to complete.
+		wg := seekers.active.wg
+		byTime.Unlock()
+		wg.Wait()
+	}
+
+	if !ok {
+		// No existing seekers, so just set the newly created ones and be done.
+		seekers.active = newActiveSeekers
+		if seekers.active.volume > state.Volume {
+			// Ignore any close errors because its not relevant from the callers perspective.
+			m.closeSeekersAndLogError(descriptor, newActiveSeekers.seekers)
+			byTime.Unlock()
+			return 0, errOutOfOrderUpdateOpenLease
+		}
+
+		byTime.seekers[blockStartNano] = seekers
+		byTime.Unlock()
+		return updateOpenLeaseResult, nil
+	}
+
+	// Existing seekers exist.
+	updateOpenLeaseResult = block.UpdateOpenLease
+
+	if seekers.active.volume > state.Volume {
+		// Ignore any close errors because its not relevant from the callers perspective.
+		m.closeSeekersAndLogError(descriptor, newActiveSeekers.seekers)
+		byTime.Unlock()
+		// TODO(rartoul): Should this just be an error?
+		return 0, errOutOfOrderUpdateOpenLease
+	}
+
+	seekers.inactive = seekers.active
+	seekers.active = newActiveSeekers
+
+	// If any of the previous seekers are still borrowed this function will need to wait for
+	// them to be returned.
+	anySeekersAreBorrowed := false
+	for _, seeker := range seekers.inactive.seekers {
+		if seeker.isBorrowed {
+			anySeekersAreBorrowed = true
+			break
+		}
+	}
+
+	var wg *sync.WaitGroup
+	if anySeekersAreBorrowed {
+		// If any of the seekers are borrowed setup a waitgroup which will be used to
+		// signal when they've all been returned (the last seeker that is returned via
+		// the Return() API will call wg.Done()).
+		wg = &sync.WaitGroup{}
+		wg.Add(1)
+		seekers.inactive.wg = wg
+	}
+	byTime.seekers[blockStartNano] = seekers
+	byTime.Unlock()
+
+	if wg != nil {
+		// Wait for all the inactive seekers to be returned and closed because the contract
+		// of this API is that the Leaser (SeekerManager) should have relinquished any resources
+		// associated with the old lease by the time this function returns.
+		wg.Wait()
+	}
+
+	return updateOpenLeaseResult, nil
+}
+
+// closeSeekersAndLogError is a helper function that closes all the seekers in a slice of borrowableSeeker
+// and emits a log if any errors occurred.
+func (m *seekerManager) closeSeekersAndLogError(descriptor block.LeaseDescriptor, seekers []borrowableSeeker) {
+	var multiErr = xerrors.NewMultiError()
+	for _, seeker := range seekers {
+		multiErr = multiErr.Add(seeker.seeker.Close())
+	}
+	if multiErr.FinalError() != nil {
+		// Log the error but don't return it since its not relevant from
+		// the callers perspective.
+		m.logger.Error(
+			"error closing seeker in update open lease",
+			zap.Error(multiErr.FinalError()),
+			zap.String("namespace", descriptor.Namespace.String()),
+			zap.Int("shard", int(descriptor.Shard)),
+			zap.Time("blockStart", descriptor.BlockStart))
+	}
 }
 
 // getOrOpenSeekersWithLock checks if the seekers are already open / initialized. If they are, then it
@@ -308,46 +538,79 @@ func (m *seekerManager) UpdateOpenLease(
 // and then notify the waiting goroutines that we've finished.
 func (m *seekerManager) getOrOpenSeekersWithLock(start xtime.UnixNano, byTime *seekersByTime) (seekersAndBloom, error) {
 	seekers, ok := byTime.seekers[start]
-	if ok && seekers.wg == nil {
+	if ok && seekers.active.wg == nil {
 		// Seekers are already open
-		return seekers, nil
+		return seekers.active, nil
 	}
 
-	if seekers.wg != nil {
+	if seekers.active.wg != nil {
 		// Seekers are being initialized / opened, wait for the that to complete
 		byTime.Unlock()
-		seekers.wg.Wait()
+		seekers.active.wg.Wait()
 		byTime.Lock()
 		// Need to do the lookup again recursively to see the new state
 		return m.getOrOpenSeekersWithLock(start, byTime)
 	}
 
-	// Seekers need to be opened
-	borrowableSeekers := make([]borrowableSeeker, 0, m.fetchConcurrency)
+	// Seekers need to be opened.
 	// We're going to release the lock temporarily, so we initialize a WaitGroup
 	// that other routines which would have otherwise attempted to also open this
 	// same seeker can use instead to wait for us to finish.
 	wg := &sync.WaitGroup{}
-	seekers.wg = wg
-	seekers.wg.Add(1)
+	seekers.active.wg = wg
+	seekers.active.wg.Add(1)
 	byTime.seekers[start] = seekers
 	byTime.Unlock()
+
+	onDoneOpeningNewSeeker := func() {
+		// Lock must be held when function returns.
+		byTime.Lock()
+		// Signal to other waiting goroutines that this goroutine is done attempting to open
+		// the seekers. This is done *after* acquiring the lock so that other goroutines that
+		// were waiting won't acquire the lock before this goroutine does.
+		wg.Done()
+	}
+	onErr := func() {
+		onDoneOpeningNewSeeker()
+		// Delete the seekersByTime struct so that the process can be restarted by the next
+		// goroutine (since this one errored out).
+		delete(byTime.seekers, start)
+	}
+
 	// Open first one - Do this outside the context of the lock because opening
-	// a seeker can be an expensive operation (validating index files)
-	seeker, err := m.newOpenSeekerFn(byTime.shard, start.ToTime())
-	// Immediately re-lock once the seeker is open regardless of errors because
-	// thats the contract of this function
-	byTime.Lock()
-	// Call done after we re-acquire the lock so that callers who were waiting
-	// won't get the lock before us.
-	wg.Done()
+	// a seeker can be an expensive operation (validating index files).
+	blm := m.blockRetrieverOpts.BlockLeaseManager()
+	state, err := blm.OpenLatestLease(m, block.LeaseDescriptor{
+		Namespace:  m.namespace,
+		Shard:      byTime.shard,
+		BlockStart: start.ToTime(),
+	})
 
 	if err != nil {
-		// Delete the seekersByTime struct so that the process can be restarted if necessary
-		delete(byTime.seekers, start)
+		onErr()
+		return seekersAndBloom{}, fmt.Errorf("err opening latest lease: %v", err)
+	}
+
+	seeker, err := m.newOpenSeekerFn(byTime.shard, start.ToTime(), state.Volume)
+	if err != nil {
+		onErr()
 		return seekersAndBloom{}, err
 	}
 
+	activeSeekers, err := m.seekersAndBloomFromSeeker(seeker, state.Volume)
+	if err != nil {
+		onErr()
+		return seekersAndBloom{}, err
+	}
+
+	onDoneOpeningNewSeeker()
+	seekers.active = activeSeekers
+	byTime.seekers[start] = seekers
+	return activeSeekers, nil
+}
+
+func (m *seekerManager) seekersAndBloomFromSeeker(seeker DataFileSetSeeker, volume int) (seekersAndBloom, error) {
+	borrowableSeekers := make([]borrowableSeeker, 0, m.fetchConcurrency)
 	borrowableSeekers = append(borrowableSeekers, borrowableSeeker{seeker: seeker})
 	// Clone remaining seekers from the original - No need to release the lock, cloning is cheap.
 	for i := 0; i < m.fetchConcurrency-1; i++ {
@@ -359,20 +622,16 @@ func (m *seekerManager) getOrOpenSeekersWithLock(start xtime.UnixNano, byTime *s
 				// Don't leak successfully opened seekers
 				multiErr = multiErr.Add(seeker.seeker.Close())
 			}
-			// Delete the seekersByTime struct so that the process can be restarted if necessary
-			delete(byTime.seekers, start)
 			return seekersAndBloom{}, multiErr.FinalError()
 		}
 		borrowableSeekers = append(borrowableSeekers, borrowableSeeker{seeker: clone})
 	}
 
-	seekers.wg = nil
-	seekers.seekers = borrowableSeekers
-	// Doesn't matter which seeker we pick to grab the bloom filter from, they all share the same underlying one.
-	// Use index 0 because its guaranteed to be there.
-	seekers.bloomFilter = borrowableSeekers[0].seeker.ConcurrentIDBloomFilter()
-	byTime.seekers[start] = seekers
-	return seekers, nil
+	return seekersAndBloom{
+		seekers:     borrowableSeekers,
+		bloomFilter: borrowableSeekers[0].seeker.ConcurrentIDBloomFilter(),
+		volume:      volume,
+	}, nil
 }
 
 func (m *seekerManager) openAnyUnopenSeekers(byTime *seekersByTime) error {
@@ -396,18 +655,10 @@ func (m *seekerManager) openAnyUnopenSeekers(byTime *seekersByTime) error {
 func (m *seekerManager) newOpenSeeker(
 	shard uint32,
 	blockStart time.Time,
+	volume int,
 ) (DataFileSetSeeker, error) {
-	blm := m.blockRetrieverOpts.BlockLeaseManager()
-	state, err := blm.OpenLatestLease(m, block.LeaseDescriptor{
-		Namespace:  m.namespace,
-		Shard:      shard,
-		BlockStart: blockStart,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("err opening latest lease: %v", err)
-	}
-
-	exists, err := DataFileSetExists(m.filePathPrefix, m.namespace, shard, blockStart, state.Volume)
+	exists, err := DataFileSetExists(
+		m.filePathPrefix, m.namespace, shard, blockStart, volume)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +686,7 @@ func (m *seekerManager) newOpenSeeker(
 	seeker.setUnreadBuffer(m.unreadBuf.value)
 
 	resources := m.getSeekerResources()
-	err = seeker.Open(m.namespace, shard, blockStart, state.Volume, resources)
+	err = seeker.Open(m.namespace, shard, blockStart, volume, resources)
 	m.putSeekerResources(resources)
 	if err != nil {
 		return nil, err
@@ -476,7 +727,7 @@ func (m *seekerManager) seekersByTime(shard uint32) *seekersByTime {
 		}
 		seekersByShardIdx[i] = &seekersByTime{
 			shard:   uint32(i),
-			seekers: make(map[xtime.UnixNano]seekersAndBloom),
+			seekers: make(map[xtime.UnixNano]rotatableSeekers),
 		}
 	}
 
@@ -498,8 +749,18 @@ func (m *seekerManager) Close() error {
 	// Actual cleanup of the seekers themselves will be handled by the openCloseLoop.
 	for _, byTime := range m.seekersByShardIdx {
 		byTime.Lock()
-		for _, seekersByTime := range byTime.seekers {
-			for _, seeker := range seekersByTime.seekers {
+		for _, seekersForBlock := range byTime.seekers {
+			// Ensure active seekers are all returned.
+			for _, seeker := range seekersForBlock.active.seekers {
+				if seeker.isBorrowed {
+					byTime.Unlock()
+					m.Unlock()
+					return errCantCloseSeekerManagerWhileSeekersAreBorrowed
+				}
+			}
+
+			// Ensure inactive seekers are all returned.
+			for _, seeker := range seekersForBlock.inactive.seekers {
 				if seeker.isBorrowed {
 					byTime.Unlock()
 					m.Unlock()
@@ -609,9 +870,19 @@ func (m *seekerManager) openCloseLoop() {
 				byTime := m.seekersByShardIdx[elem.shard]
 				blockStartNano := xtime.ToUnixNano(elem.blockStart)
 				byTime.Lock()
-				seekersAndBloom := byTime.seekers[blockStartNano]
+				seekers := byTime.seekers[blockStartNano]
 				allSeekersAreReturned := true
-				for _, seeker := range seekersAndBloom.seekers {
+
+				// Ensure no active seekers are still borrowed.
+				for _, seeker := range seekers.active.seekers {
+					if seeker.isBorrowed {
+						allSeekersAreReturned = false
+						break
+					}
+				}
+
+				// Ensure no ianctive seekers are still borrowed.
+				for _, seeker := range seekers.inactive.seekers {
 					if seeker.isBorrowed {
 						allSeekersAreReturned = false
 						break
@@ -621,7 +892,8 @@ func (m *seekerManager) openCloseLoop() {
 				// some of them are clones of the original and can't be used once
 				// the parent is closed (because they share underlying resources)
 				if allSeekersAreReturned {
-					closing = append(closing, seekersAndBloom.seekers...)
+					closing = append(closing, seekers.active.seekers...)
+					closing = append(closing, seekers.inactive.seekers...)
 					delete(byTime.seekers, blockStartNano)
 				}
 				byTime.Unlock()
@@ -646,8 +918,19 @@ func (m *seekerManager) openCloseLoop() {
 	m.Lock()
 	for _, byTime := range m.seekersByShardIdx {
 		byTime.Lock()
-		for _, seekersByTime := range byTime.seekers {
-			for _, seeker := range seekersByTime.seekers {
+		for _, seekersForBlock := range byTime.seekers {
+			// Close the active seekers.
+			for _, seeker := range seekersForBlock.active.seekers {
+				// We don't need to check if the seeker is borrowed here because we don't allow the
+				// SeekerManager to be closed if any seekers are still outstanding.
+				err := seeker.seeker.Close()
+				if err != nil {
+					m.logger.Error("err closing seeker in SeekerManager at end of openCloseLoop", zap.Error(err))
+				}
+			}
+
+			// Close the inactive seekers.
+			for _, seeker := range seekersForBlock.inactive.seekers {
 				// We don't need to check if the seeker is borrowed here because we don't allow the
 				// SeekerManager to be closed if any seekers are still outstanding.
 				err := seeker.seeker.Close()

--- a/src/dbnode/persist/fs/seek_manager_test.go
+++ b/src/dbnode/persist/fs/seek_manager_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/storage/block"
+	"github.com/m3db/m3/src/x/ident"
 	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/fortytw2/leaktest"
@@ -73,18 +74,19 @@ func TestSeekerManagerCacheShardIndices(t *testing.T) {
 	}
 }
 
-// TestSeekerManagerBorrowOpenSeekersLazy tests that the Borrow() method will
-// open seekers lazily if they're not already open.
-func TestSeekerManagerBorrowOpenSeekersLazy(t *testing.T) {
+func TestSeekerManagerUpdateOpenLease(t *testing.T) {
 	defer leaktest.CheckTimeout(t, 1*time.Minute)()
 
-	ctrl := gomock.NewController(t)
+	var (
+		ctrl   = gomock.NewController(t)
+		shards = []uint32{2, 5, 9, 478, 1023}
+		m      = NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	)
 
-	shards := []uint32{2, 5, 9, 478, 1023}
-	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
 	m.newOpenSeekerFn = func(
 		shard uint32,
 		blockStart time.Time,
+		volume int,
 	) (DataFileSetSeeker, error) {
 		mock := NewMockDataFileSetSeeker(ctrl)
 		mock.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -107,7 +109,98 @@ func TestSeekerManagerBorrowOpenSeekersLazy(t *testing.T) {
 		byTime := m.seekersByTime(shard)
 		byTime.RLock()
 		seekers := byTime.seekers[xtime.ToUnixNano(time.Time{})]
-		require.Equal(t, defaultFetchConcurrency, len(seekers.seekers))
+		require.Equal(t, defaultFetchConcurrency, len(seekers.active.seekers))
+		require.Equal(t, 0, seekers.active.volume)
+		byTime.RUnlock()
+		require.NoError(t, m.Return(shard, time.Time{}, seeker))
+	}
+
+	// Ensure that UpdateOpenLease() updates the volumes.
+	for _, shard := range shards {
+		updateResult, err := m.UpdateOpenLease(block.LeaseDescriptor{
+			Namespace:  metadata.ID(),
+			Shard:      shard,
+			BlockStart: time.Time{},
+		}, block.LeaseState{Volume: 1})
+		require.NoError(t, err)
+		require.Equal(t, block.UpdateOpenLease, updateResult)
+
+		byTime := m.seekersByTime(shard)
+		byTime.RLock()
+		seekers := byTime.seekers[xtime.ToUnixNano(time.Time{})]
+		require.Equal(t, defaultFetchConcurrency, len(seekers.active.seekers))
+		require.Equal(t, 1, seekers.active.volume)
+		byTime.RUnlock()
+	}
+
+	// Ensure that UpdateOpenLease() ignores updates for the wrong namespace.
+	for _, shard := range shards {
+		updateResult, err := m.UpdateOpenLease(block.LeaseDescriptor{
+			Namespace:  ident.StringID("some-other-ns"),
+			Shard:      shard,
+			BlockStart: time.Time{},
+		}, block.LeaseState{Volume: 2})
+		require.NoError(t, err)
+		require.Equal(t, block.NoOpenLease, updateResult)
+
+		byTime := m.seekersByTime(shard)
+		byTime.RLock()
+		seekers := byTime.seekers[xtime.ToUnixNano(time.Time{})]
+		require.Equal(t, defaultFetchConcurrency, len(seekers.active.seekers))
+		// Should not have increased to 2.
+		require.Equal(t, 1, seekers.active.volume)
+		byTime.RUnlock()
+	}
+
+	// Ensure that UpdateOpenLease() returns a lease for out-of-order updates.
+	for _, shard := range shards {
+		_, err := m.UpdateOpenLease(block.LeaseDescriptor{
+			Namespace:  metadata.ID(),
+			Shard:      shard,
+			BlockStart: time.Time{},
+		}, block.LeaseState{Volume: 0})
+		require.Equal(t, errOutOfOrderUpdateOpenLease, err)
+	}
+
+	require.NoError(t, m.Close())
+}
+
+// TestSeekerManagerBorrowOpenSeekersLazy tests that the Borrow() method will
+// open seekers lazily if they're not already open.
+func TestSeekerManagerBorrowOpenSeekersLazy(t *testing.T) {
+	defer leaktest.CheckTimeout(t, 1*time.Minute)()
+
+	ctrl := gomock.NewController(t)
+
+	shards := []uint32{2, 5, 9, 478, 1023}
+	m := NewSeekerManager(nil, testDefaultOpts, defaultTestBlockRetrieverOptions).(*seekerManager)
+	m.newOpenSeekerFn = func(
+		shard uint32,
+		blockStart time.Time,
+		volume int,
+	) (DataFileSetSeeker, error) {
+		mock := NewMockDataFileSetSeeker(ctrl)
+		mock.EXPECT().Open(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mock.EXPECT().ConcurrentClone().Return(mock, nil)
+		for i := 0; i < defaultFetchConcurrency; i++ {
+			mock.EXPECT().Close().Return(nil)
+			mock.EXPECT().ConcurrentIDBloomFilter().Return(nil)
+		}
+		return mock, nil
+	}
+	m.sleepFn = func(_ time.Duration) {
+		time.Sleep(time.Millisecond)
+	}
+
+	metadata := testNs1Metadata(t)
+	require.NoError(t, m.Open(metadata))
+	for _, shard := range shards {
+		seeker, err := m.Borrow(shard, time.Time{})
+		require.NoError(t, err)
+		byTime := m.seekersByTime(shard)
+		byTime.RLock()
+		seekers := byTime.seekers[xtime.ToUnixNano(time.Time{})]
+		require.Equal(t, defaultFetchConcurrency, len(seekers.active.seekers))
 		byTime.RUnlock()
 		require.NoError(t, m.Return(shard, time.Time{}, seeker))
 	}
@@ -162,9 +255,11 @@ func TestSeekerManagerOpenCloseLoop(t *testing.T) {
 		mock.EXPECT().Close().Return(nil)
 		mocks := []borrowableSeeker{}
 		mocks = append(mocks, borrowableSeeker{seeker: mock})
-		byTime.seekers[startNano] = seekersAndBloom{
-			seekers:     mocks,
-			bloomFilter: nil,
+		byTime.seekers[startNano] = rotatableSeekers{
+			active: seekersAndBloom{
+				seekers:     mocks,
+				bloomFilter: nil,
+			},
 		}
 		return nil
 	}
@@ -194,7 +289,7 @@ func TestSeekerManagerOpenCloseLoop(t *testing.T) {
 			step: func() {
 				m.RLock()
 				for _, shard := range shards {
-					require.Equal(t, 1, len(m.seekersByTime(shard).seekers[startNano].seekers))
+					require.Equal(t, 1, len(m.seekersByTime(shard).seekers[startNano].active.seekers))
 				}
 				m.RUnlock()
 			},
@@ -225,7 +320,7 @@ func TestSeekerManagerOpenCloseLoop(t *testing.T) {
 			step: func() {
 				m.RLock()
 				for _, shard := range shards {
-					require.Equal(t, 1, len(m.seekersByTime(shard).seekers[startNano].seekers))
+					require.Equal(t, 1, len(m.seekersByTime(shard).seekers[startNano].active.seekers))
 				}
 				m.RUnlock()
 			},

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -439,7 +439,7 @@ type UpdateOpenLeaseResult uint
 const (
 	// UpdateOpenLease is used to communicate a lease updated successfully.
 	UpdateOpenLease UpdateOpenLeaseResult = iota
-	// NoOpenLease is used to communitcate there is no related open lease.
+	// NoOpenLease is used to communicate there is no related open lease.
 	NoOpenLease
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R is required for the out of order writes feature. After a new volume for a given namespace/shard/blockstart is written out, the SeekerManager will be notified via a call to UpdateOpenLease(). This function imlpements UpdateOpenLease such that the SeekerManager "hot swaps" its old seekers for the old volume with new seekers for the new volume.

In terms of testing, this P.R adds some basic unit testing but the meat of the assurance that it works comes from extending the existing concurrency tests to use the new code paths AND simulate error cases so that those paths get tested as well (which they previously were not).