### PR TITLE
Add VolumeIndex back/forwards compatible to info files + restore flush version on shard bootstrap

### DIFF
--- a/src/dbnode/persist/fs/msgpack/decoder.go
+++ b/src/dbnode/persist/fs/msgpack/decoder.go
@@ -241,6 +241,7 @@ func (dec *Decoder) DecodeLogMetadata() (schema.LogMetadata, error) {
 func (dec *Decoder) decodeIndexInfo() schema.IndexInfo {
 	var opts checkNumFieldsOptions
 
+	// Overrides only used to test forwards compatibility.
 	switch dec.legacy.decodeLegacyIndexInfoVersion {
 	case legacyEncodingIndexVersionV1:
 		// V1 had 6 fields.

--- a/src/dbnode/persist/fs/msgpack/decoder.go
+++ b/src/dbnode/persist/fs/msgpack/decoder.go
@@ -250,13 +250,12 @@ func (dec *Decoder) decodeIndexInfo() schema.IndexInfo {
 	case legacyEncodingIndexVersionV2:
 		// V2 had 8 fields.
 		opts.override = true
-		opts.numExpectedMinFields = 8
+		opts.numExpectedMinFields = 6
 		opts.numExpectedCurrFields = 8
 	case legacyEncodingIndexVersionV3:
 		// V3 had 9 fields.
 		opts.override = true
-		// TODO(rartoul): Should this be six?
-		opts.numExpectedMinFields = 9
+		opts.numExpectedMinFields = 6
 		opts.numExpectedCurrFields = 9
 	}
 

--- a/src/dbnode/persist/fs/msgpack/encoder.go
+++ b/src/dbnode/persist/fs/msgpack/encoder.go
@@ -56,10 +56,11 @@ type Encoder struct {
 type legacyEncodingIndexInfoVersion int
 
 const (
-	legacyEncodingIndexVersionCurrent                                = legacyEncodingIndexVersionV3
+	legacyEncodingIndexVersionCurrent                                = legacyEncodingIndexVersionV4
 	legacyEncodingIndexVersionV1      legacyEncodingIndexInfoVersion = iota
 	legacyEncodingIndexVersionV2
 	legacyEncodingIndexVersionV3
+	legacyEncodingIndexVersionV4
 )
 
 type legacyEncodingOptions struct {
@@ -119,12 +120,15 @@ func (enc *Encoder) EncodeIndexInfo(info schema.IndexInfo) error {
 		return enc.err
 	}
 	enc.encodeRootObject(indexInfoVersion, indexInfoType)
-	if enc.legacy.encodeLegacyIndexInfoVersion == legacyEncodingIndexVersionV1 {
+	switch enc.legacy.encodeLegacyIndexInfoVersion {
+	case legacyEncodingIndexVersionV1:
 		enc.encodeIndexInfoV1(info)
-	} else if enc.legacy.encodeLegacyIndexInfoVersion == legacyEncodingIndexVersionV2 {
+	case legacyEncodingIndexVersionV2:
 		enc.encodeIndexInfoV2(info)
-	} else {
+	case legacyEncodingIndexVersionV3:
 		enc.encodeIndexInfoV3(info)
+	default:
+		enc.encodeIndexInfoV4(info)
 	}
 	return enc.err
 }
@@ -200,7 +204,7 @@ func (enc *Encoder) encodeIndexInfoV1(info schema.IndexInfo) {
 // backwards-compatbility.
 func (enc *Encoder) encodeIndexInfoV2(info schema.IndexInfo) {
 	// Manually encode num fields for testing purposes.
-	enc.encodeNumObjectFieldsForFn(8) // V2 had 8 fields.
+	enc.encodeArrayLenFn(8) // V2 had 8 fields.
 	enc.encodeVarintFn(info.BlockStart)
 	enc.encodeVarintFn(info.BlockSize)
 	enc.encodeVarintFn(info.Entries)
@@ -211,7 +215,23 @@ func (enc *Encoder) encodeIndexInfoV2(info schema.IndexInfo) {
 	enc.encodeVarintFn(int64(info.FileType))
 }
 
+// We only keep this method around for the sake of testing
+// backwards-compatbility.
 func (enc *Encoder) encodeIndexInfoV3(info schema.IndexInfo) {
+	// Manually encode num fields for testing purposes.
+	enc.encodeArrayLenFn(9) // V3 had 9 fields.
+	enc.encodeVarintFn(info.BlockStart)
+	enc.encodeVarintFn(info.BlockSize)
+	enc.encodeVarintFn(info.Entries)
+	enc.encodeVarintFn(info.MajorVersion)
+	enc.encodeIndexSummariesInfo(info.Summaries)
+	enc.encodeIndexBloomFilterInfo(info.BloomFilter)
+	enc.encodeVarintFn(info.SnapshotTime)
+	enc.encodeVarintFn(int64(info.FileType))
+	enc.encodeBytesFn(info.SnapshotID)
+}
+
+func (enc *Encoder) encodeIndexInfoV4(info schema.IndexInfo) {
 	enc.encodeNumObjectFieldsForFn(indexInfoType)
 	enc.encodeVarintFn(info.BlockStart)
 	enc.encodeVarintFn(info.BlockSize)
@@ -222,6 +242,7 @@ func (enc *Encoder) encodeIndexInfoV3(info schema.IndexInfo) {
 	enc.encodeVarintFn(info.SnapshotTime)
 	enc.encodeVarintFn(int64(info.FileType))
 	enc.encodeBytesFn(info.SnapshotID)
+	enc.encodeVarintFn(int64(info.VolumeIndex))
 }
 
 func (enc *Encoder) encodeIndexSummariesInfo(info schema.IndexSummariesInfo) {

--- a/src/dbnode/persist/fs/msgpack/encoder_test.go
+++ b/src/dbnode/persist/fs/msgpack/encoder_test.go
@@ -81,6 +81,7 @@ func testExpectedResultForIndexInfo(t *testing.T, indexInfo schema.IndexInfo) []
 		indexInfo.SnapshotTime,
 		int64(indexInfo.FileType),
 		indexInfo.SnapshotID,
+		int64(indexInfo.VolumeIndex),
 	}
 }
 

--- a/src/dbnode/persist/fs/msgpack/schema.go
+++ b/src/dbnode/persist/fs/msgpack/schema.go
@@ -99,7 +99,7 @@ const (
 	// correct number of fields is encoded into the files. These values need
 	// to be incremened whenever we add new fields to an object.
 	currNumRootObjectFields           = 2
-	currNumIndexInfoFields            = 9
+	currNumIndexInfoFields            = 10
 	currNumIndexSummariesInfoFields   = 1
 	currNumIndexBloomFilterInfoFields = 2
 	currNumIndexEntryFields           = 6

--- a/src/dbnode/persist/fs/read.go
+++ b/src/dbnode/persist/fs/read.go
@@ -248,7 +248,6 @@ func (r *reader) Open(opts DataReaderOpenOptions) error {
 	r.open = true
 	r.namespace = namespace
 	r.shard = shard
-	r.volume = volumeIndex
 
 	return nil
 }
@@ -296,6 +295,7 @@ func (r *reader) readInfo(size int) error {
 		return err
 	}
 	r.start = xtime.FromNanoseconds(info.BlockStart)
+	r.volume = info.VolumeIndex
 	r.blockSize = time.Duration(info.BlockSize)
 	r.entries = int(info.Entries)
 	r.entriesRead = 0

--- a/src/dbnode/persist/fs/read_write_test.go
+++ b/src/dbnode/persist/fs/read_write_test.go
@@ -366,6 +366,32 @@ func TestInfoReadWrite(t *testing.T) {
 	require.Equal(t, int64(len(entries)), infoFile.Entries)
 }
 
+func TestInfoReadWriteVolumeIndex(t *testing.T) {
+	dir := createTempDir(t)
+	filePathPrefix := filepath.Join(dir, "")
+	defer os.RemoveAll(dir)
+
+	var (
+		entries = []testEntry{}
+		w       = newTestWriter(t, filePathPrefix)
+		volume  = 1
+	)
+
+	writeTestDataWithVolume(t, w, 0, testWriterStart, volume, entries, persist.FileSetFlushType)
+
+	readInfoFileResults := ReadInfoFiles(filePathPrefix, testNs1ID, 0, 16, nil)
+	require.Equal(t, 1, len(readInfoFileResults))
+	for _, result := range readInfoFileResults {
+		require.NoError(t, result.Err.Error())
+	}
+
+	infoFile := readInfoFileResults[0].Info
+	require.True(t, testWriterStart.Equal(xtime.FromNanoseconds(infoFile.BlockStart)))
+	require.Equal(t, volume, infoFile.VolumeIndex)
+	require.Equal(t, testBlockSize, time.Duration(infoFile.BlockSize))
+	require.Equal(t, int64(len(entries)), infoFile.Entries)
+}
+
 func TestInfoReadWriteSnapshot(t *testing.T) {
 	dir := createTempDir(t)
 	filePathPrefix := filepath.Join(dir, "")

--- a/src/dbnode/persist/fs/write.go
+++ b/src/dbnode/persist/fs/write.go
@@ -71,6 +71,7 @@ type writer struct {
 	indexEntries               indexEntries
 
 	start        time.Time
+	volumeIndex  int
 	snapshotTime time.Time
 	snapshotID   uuid.UUID
 
@@ -149,11 +150,13 @@ func (w *writer) Open(opts DataWriterOpenOptions) error {
 		namespace       = opts.Identifier.Namespace
 		shard           = opts.Identifier.Shard
 		blockStart      = opts.Identifier.BlockStart
+		volumeIndex     = opts.Identifier.VolumeIndex
 		nextVolumeIndex = opts.Identifier.VolumeIndex
 	)
 
 	w.blockSize = opts.BlockSize
 	w.start = blockStart
+	w.volumeIndex = volumeIndex
 	w.snapshotTime = opts.Snapshot.SnapshotTime
 	w.snapshotID = opts.Snapshot.SnapshotID
 	w.currIdx = 0
@@ -533,6 +536,7 @@ func (w *writer) writeInfoFileContents(
 
 	info := schema.IndexInfo{
 		BlockStart:   xtime.ToNanoseconds(w.start),
+		VolumeIndex:  w.volumeIndex,
 		SnapshotTime: xtime.ToNanoseconds(w.snapshotTime),
 		SnapshotID:   snapshotBytes,
 		BlockSize:    int64(w.blockSize),

--- a/src/dbnode/persist/schema/types.go
+++ b/src/dbnode/persist/schema/types.go
@@ -40,6 +40,7 @@ type IndexInfo struct {
 	SnapshotTime int64
 	FileType     persist.FileSetType
 	SnapshotID   []byte
+	VolumeIndex  int
 }
 
 // IndexSummariesInfo stores metadata about the summaries

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1873,7 +1873,7 @@ func (s *dbShard) Bootstrap(
 
 		s.markWarmFlushStateSuccess(at)
 		// Cold version needs to get bootstrapped so that the 1:1 relationship between volume number
-		// and cold version is maintained and the volume numbers / flush versions remaining monotonically
+		// and cold version is maintained and the volume numbers / flush versions remain monotonically
 		// increasing.
 		s.setFlushStateColdVersion(at, info.VolumeIndex)
 	}

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1875,6 +1875,7 @@ func (s *dbShard) Bootstrap(
 		// Cold version needs to get bootstrapped so that the 1:1 relationship between volume number
 		// and cold version is maintained and the volume numbers / flush versions remaining monotonically
 		// increasing.
+		// TODO(rartoul): Add a test for this before merging.
 		s.setFlushStateColdVersion(at, info.VolumeIndex)
 	}
 

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1875,7 +1875,6 @@ func (s *dbShard) Bootstrap(
 		// Cold version needs to get bootstrapped so that the 1:1 relationship between volume number
 		// and cold version is maintained and the volume numbers / flush versions remaining monotonically
 		// increasing.
-		// TODO(rartoul): Add a test for this before merging.
 		s.setFlushStateColdVersion(at, info.VolumeIndex)
 	}
 

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1872,6 +1872,10 @@ func (s *dbShard) Bootstrap(
 		}
 
 		s.markWarmFlushStateSuccess(at)
+		// Cold version needs to get bootstrapped so that the 1:1 relationship between volume number
+		// and cold version is maintained and the volume numbers / flush versions remaining monotonically
+		// increasing.
+		s.setFlushStateColdVersion(at, info.VolumeIndex)
 	}
 
 	s.Lock()


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R add the `VolumeIndex` into the Info file of all the fileset files in a backwards and forwards compatible way. It also ensures that the volume index is written out by the writers and return by calls to `ReadInfoFile`.

Finally, it updates the shard bootstrap logic to restore the Cold flush version on bootstrap as well as the flush state.