### PR TITLE
Adding ETCD client option for AutoSyncInterval to support updating ET…

### DIFF
--- a/src/cluster/client/etcd/client.go
+++ b/src/cluster/client/etcd/client.go
@@ -281,8 +281,9 @@ func newClient(cluster Cluster) (*clientv3.Client, error) {
 		return nil, err
 	}
 	cfg := clientv3.Config{
-		Endpoints: cluster.Endpoints(),
-		TLS:       tls,
+		Endpoints:        cluster.Endpoints(),
+		TLS:              tls,
+		AutoSyncInterval: cluster.AutoSyncInterval(),
 	}
 
 	if opts := cluster.KeepAliveOptions(); opts.KeepAliveEnabled() {

--- a/src/cluster/client/etcd/config.go
+++ b/src/cluster/client/etcd/config.go
@@ -30,10 +30,11 @@ import (
 
 // ClusterConfig is the config for a zoned etcd cluster.
 type ClusterConfig struct {
-	Zone      string           `yaml:"zone"`
-	Endpoints []string         `yaml:"endpoints"`
-	KeepAlive *keepAliveConfig `yaml:"keepAlive"`
-	TLS       *TLSConfig       `yaml:"tls"`
+	Zone             string           `yaml:"zone"`
+	Endpoints        []string         `yaml:"endpoints"`
+	KeepAlive        *keepAliveConfig `yaml:"keepAlive"`
+	TLS              *TLSConfig       `yaml:"tls"`
+	AutoSyncInterval time.Duration    `yaml:"autoSyncInterval"`
 }
 
 // NewCluster creates a new Cluster.
@@ -46,7 +47,8 @@ func (c ClusterConfig) NewCluster() Cluster {
 		SetZone(c.Zone).
 		SetEndpoints(c.Endpoints).
 		SetKeepAliveOptions(keepAliveOpts).
-		SetTLSOptions(c.TLS.newOptions())
+		SetTLSOptions(c.TLS.newOptions()).
+		SetAutoSyncInterval(c.AutoSyncInterval)
 }
 
 // TLSConfig is the config for TLS.

--- a/src/cluster/client/etcd/config_test.go
+++ b/src/cluster/client/etcd/config_test.go
@@ -63,6 +63,7 @@ etcdClusters:
       period: 10s
       jitter: 5s
       timeout: 1s
+    autoSyncInterval: 60s
   - zone: z2
     endpoints:
       - etcd3:2379
@@ -100,6 +101,7 @@ m3sd:
 				Jitter:  5 * time.Second,
 				Timeout: time.Second,
 			},
+			AutoSyncInterval: time.Second * 60,
 		},
 		ClusterConfig{
 			Zone:      "z2",
@@ -129,6 +131,7 @@ m3sd:
 	require.Equal(t, 10*time.Second, keepAliveOpts.KeepAlivePeriod())
 	require.Equal(t, 5*time.Second, keepAliveOpts.KeepAlivePeriodMaxJitter())
 	require.Equal(t, time.Second, keepAliveOpts.KeepAliveTimeout())
+	require.Equal(t, 60*time.Second, cluster1.AutoSyncInterval())
 
 	cluster2, exists := opts.ClusterForZone("z2")
 	require.True(t, exists)

--- a/src/cluster/client/etcd/options.go
+++ b/src/cluster/client/etcd/options.go
@@ -308,10 +308,11 @@ func NewCluster() Cluster {
 }
 
 type cluster struct {
-	zone          string
-	endpoints     []string
-	keepAliveOpts KeepAliveOptions
-	tlsOpts       TLSOptions
+	zone             string
+	endpoints        []string
+	keepAliveOpts    KeepAliveOptions
+	tlsOpts          TLSOptions
+	autoSyncInterval time.Duration
 }
 
 func (c cluster) Zone() string {
@@ -347,5 +348,14 @@ func (c cluster) TLSOptions() TLSOptions {
 
 func (c cluster) SetTLSOptions(opts TLSOptions) Cluster {
 	c.tlsOpts = opts
+	return c
+}
+
+func (c cluster) AutoSyncInterval() time.Duration {
+	return c.autoSyncInterval
+}
+
+func (c cluster) SetAutoSyncInterval(autoSyncInterval time.Duration) Cluster {
+	c.autoSyncInterval = autoSyncInterval
 	return c
 }

--- a/src/cluster/client/etcd/types.go
+++ b/src/cluster/client/etcd/types.go
@@ -124,4 +124,7 @@ type Cluster interface {
 
 	TLSOptions() TLSOptions
 	SetTLSOptions(TLSOptions) Cluster
+
+	SetAutoSyncInterval(value time.Duration) Cluster
+	AutoSyncInterval() time.Duration
 }

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -601,6 +601,7 @@ func TestConfiguration(t *testing.T) {
         - 1.1.1.3:2379
         keepAlive: null
         tls: null
+        autoSyncInterval: 0s
       m3sd:
         initTimeout: null
       watchWithRevision: 0


### PR DESCRIPTION
…CD endpoints with current cluster state.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:

Currently the `cluster/client/etcd` package uses the default setting for `AutoSyncInterval` which is `0` thus auto sync of ETCD endpoints for the client is not performed. This PR enables the ability to set the `AutoSyncInterval` which will enable this functionality for ETCD clusters that have dynamic changes to the cluster membership/endpoints. 
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1769

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
No, the documentation is covered by the ETCD project already. 

<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
