### PR TITLE
[etcdclient] Set default auto sync URL

### DIFF
--- a/src/cluster/client/etcd/config.go
+++ b/src/cluster/client/etcd/config.go
@@ -34,7 +34,7 @@ type ClusterConfig struct {
 	Endpoints        []string         `yaml:"endpoints"`
 	KeepAlive        *keepAliveConfig `yaml:"keepAlive"`
 	TLS              *TLSConfig       `yaml:"tls"`
-	AutoSyncInterval time.Duration    `yaml:"autoSyncInterval"`
+	AutoSyncInterval *time.Duration   `yaml:"autoSyncInterval"`
 }
 
 // NewCluster creates a new Cluster.
@@ -43,12 +43,15 @@ func (c ClusterConfig) NewCluster() Cluster {
 	if c.KeepAlive != nil {
 		keepAliveOpts = c.KeepAlive.NewOptions()
 	}
-	return NewCluster().
+	cluster := NewCluster().
 		SetZone(c.Zone).
 		SetEndpoints(c.Endpoints).
 		SetKeepAliveOptions(keepAliveOpts).
-		SetTLSOptions(c.TLS.newOptions()).
-		SetAutoSyncInterval(c.AutoSyncInterval)
+		SetTLSOptions(c.TLS.newOptions())
+	if v := c.AutoSyncInterval; v != nil {
+		cluster = cluster.SetAutoSyncInterval(*v)
+	}
+	return cluster
 }
 
 // TLSConfig is the config for TLS.

--- a/src/cluster/client/etcd/config_test.go
+++ b/src/cluster/client/etcd/config_test.go
@@ -28,6 +28,10 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+var (
+	minute = time.Minute
+)
+
 func TestKeepAliveConfig(t *testing.T) {
 	const cfgStr = `
 enabled: true
@@ -101,7 +105,7 @@ m3sd:
 				Jitter:  5 * time.Second,
 				Timeout: time.Second,
 			},
-			AutoSyncInterval: time.Second * 60,
+			AutoSyncInterval: &minute,
 		},
 		ClusterConfig{
 			Zone:      "z2",
@@ -140,4 +144,18 @@ m3sd:
 	require.Equal(t, 5*time.Minute, keepAliveOpts.KeepAlivePeriod())
 	require.Equal(t, 5*time.Minute, keepAliveOpts.KeepAlivePeriodMaxJitter())
 	require.Equal(t, 20*time.Second, keepAliveOpts.KeepAliveTimeout())
+}
+
+func TestClusterConfigDefaultAutoSyncInterval(t *testing.T) {
+	const testConfig = `
+zone: z1
+endpoints:
+- etcd1:2379
+`
+
+	var cfg ClusterConfig
+	require.NoError(t, yaml.Unmarshal([]byte(testConfig), &cfg))
+
+	cluster := cfg.NewCluster()
+	require.Equal(t, defaultAutoSyncInterval, cluster.AutoSyncInterval())
 }

--- a/src/cluster/client/etcd/options.go
+++ b/src/cluster/client/etcd/options.go
@@ -45,6 +45,8 @@ const (
 	defaultRetryMaxRetries     = 3
 	defaultRetryMaxBackoff     = time.Duration(math.MaxInt64)
 	defaultRetryJitter         = true
+
+	defaultAutoSyncInterval = time.Minute
 )
 
 type keepAliveOptions struct {
@@ -302,8 +304,9 @@ func (o options) SetWatchWithRevision(rev int64) Options {
 // NewCluster creates a Cluster.
 func NewCluster() Cluster {
 	return cluster{
-		keepAliveOpts: NewKeepAliveOptions(),
-		tlsOpts:       NewTLSOptions(),
+		keepAliveOpts:    NewKeepAliveOptions(),
+		tlsOpts:          NewTLSOptions(),
+		autoSyncInterval: defaultAutoSyncInterval,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
There was no default specified for etcd auto sync interval, considering this is likely desirable for any deployment (discover new endpoints if membership changes) I think it would be ideal to have it default to a value.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
