### PR TITLE
[query] remove empty series from remote read endpoint

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/read.go
+++ b/src/query/api/v1/handler/prometheus/remote/read.go
@@ -55,6 +55,7 @@ type PromReadHandler struct {
 	promReadMetrics     promReadMetrics
 	timeoutOpts         *prometheus.TimeoutOpts
 	fetchOptionsBuilder handler.FetchOptionsBuilder
+	keepEmpty           bool
 }
 
 // NewPromReadHandler returns a new instance of handler.
@@ -63,12 +64,14 @@ func NewPromReadHandler(
 	fetchOptionsBuilder handler.FetchOptionsBuilder,
 	scope tally.Scope,
 	timeoutOpts *prometheus.TimeoutOpts,
+	keepEmpty bool,
 ) http.Handler {
 	return &PromReadHandler{
 		engine:              engine,
 		promReadMetrics:     newPromReadMetrics(scope),
 		timeoutOpts:         timeoutOpts,
 		fetchOptionsBuilder: fetchOptionsBuilder,
+		keepEmpty:           keepEmpty,
 	}
 }
 
@@ -203,7 +206,7 @@ func (h *PromReadHandler) read(
 			return nil, result.Err
 		}
 
-		promRes := storage.FetchResultToPromResult(result.FetchResult)
+		promRes := storage.FetchResultToPromResult(result.FetchResult, h.keepEmpty)
 		promResults = append(promResults, promRes)
 	}
 

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -172,12 +172,19 @@ func TimeToPromTimestamp(timestamp time.Time) int64 {
 // TODO(rartoul): We should pool all of these intermediary datastructures, or
 // at least the []*prompb.Sample (as thats the most heavily allocated object)
 // since we have full control over the lifecycle.
-func FetchResultToPromResult(result *FetchResult) *prompb.QueryResult {
+func FetchResultToPromResult(
+	result *FetchResult,
+	keepEmpty bool,
+) *prompb.QueryResult {
 	// Perform bulk allocation upfront then convert to pointers afterwards
 	// to reduce total number of allocations. See BenchmarkFetchResultToPromResult
 	// if modifying.
 	timeseries := make([]prompb.TimeSeries, 0, len(result.SeriesList))
 	for _, series := range result.SeriesList {
+		if !keepEmpty && series.Len() == 0 {
+			continue
+		}
+
 		promTs := SeriesToPromTS(series)
 		timeseries = append(timeseries, promTs)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Drops empty series appearing in remote read endpoint unless specified otherwise by config

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
No longer returns empty series to remote read
```
```documentation-note
No
```
