### PR TITLE
DataFileSetExists and OptimizedTimes ForEach bug fixes

### DIFF
--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -1395,6 +1395,11 @@ func DataFileSetExists(
 		return true, nil
 	}
 
+	if volume != 0 {
+		// Only check for legacy file path if volume is 0.
+		return false, nil
+	}
+
 	checkpointPath = filesetPathFromTimeLegacy(shardDir, blockStart, checkpointFileSuffix)
 	return CompleteCheckpointFileExists(checkpointPath)
 }

--- a/src/dbnode/persist/fs/files_test.go
+++ b/src/dbnode/persist/fs/files_test.go
@@ -379,7 +379,6 @@ func TestSanitizedUUIDsCanBeParsed(t *testing.T) {
 }
 
 func TestFileExists(t *testing.T) {
-
 	var (
 		dir               = createTempDir(t)
 		shard             = uint32(10)
@@ -403,6 +402,9 @@ func TestFileExists(t *testing.T) {
 	exists, err = DataFileSetExists(dir, testNs1ID, uint32(shard), start, 0)
 	require.NoError(t, err)
 	require.True(t, exists)
+	exists, err = DataFileSetExists(dir, testNs1ID, uint32(shard), start, 1)
+	require.NoError(t, err)
+	require.False(t, exists)
 
 	exists, err = CompleteCheckpointFileExists(checkpointFilePath)
 	require.NoError(t, err)

--- a/src/dbnode/persist/fs/write.go
+++ b/src/dbnode/persist/fs/write.go
@@ -146,12 +146,11 @@ func NewWriter(opts Options) (DataFileSetWriter, error) {
 // opening / truncating files associated with that shard for writing.
 func (w *writer) Open(opts DataWriterOpenOptions) error {
 	var (
-		err             error
-		namespace       = opts.Identifier.Namespace
-		shard           = opts.Identifier.Shard
-		blockStart      = opts.Identifier.BlockStart
-		volumeIndex     = opts.Identifier.VolumeIndex
-		nextVolumeIndex = opts.Identifier.VolumeIndex
+		err         error
+		namespace   = opts.Identifier.Namespace
+		shard       = opts.Identifier.Shard
+		blockStart  = opts.Identifier.BlockStart
+		volumeIndex = opts.Identifier.VolumeIndex
 	)
 
 	w.blockSize = opts.BlockSize
@@ -181,26 +180,26 @@ func (w *writer) Open(opts DataWriterOpenOptions) error {
 			return err
 		}
 
-		w.checkpointFilePath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, checkpointFileSuffix)
-		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, infoFileSuffix)
-		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, indexFileSuffix)
-		summariesFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, summariesFileSuffix)
-		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, bloomFilterFileSuffix)
-		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, dataFileSuffix)
-		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, digestFileSuffix)
+		w.checkpointFilePath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, checkpointFileSuffix)
+		infoFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, infoFileSuffix)
+		indexFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, indexFileSuffix)
+		summariesFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, summariesFileSuffix)
+		bloomFilterFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, bloomFilterFileSuffix)
+		dataFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, dataFileSuffix)
+		digestFilepath = filesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, digestFileSuffix)
 	case persist.FileSetFlushType:
 		shardDir = ShardDataDirPath(w.filePathPrefix, namespace, shard)
 		if err := os.MkdirAll(shardDir, w.newDirectoryMode); err != nil {
 			return err
 		}
 
-		w.checkpointFilePath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, checkpointFileSuffix, false)
-		infoFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, infoFileSuffix, false)
-		indexFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, indexFileSuffix, false)
-		summariesFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, summariesFileSuffix, false)
-		bloomFilterFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, bloomFilterFileSuffix, false)
-		dataFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, dataFileSuffix, false)
-		digestFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, nextVolumeIndex, digestFileSuffix, false)
+		w.checkpointFilePath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, checkpointFileSuffix, false)
+		infoFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, infoFileSuffix, false)
+		indexFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, indexFileSuffix, false)
+		summariesFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, summariesFileSuffix, false)
+		bloomFilterFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, bloomFilterFileSuffix, false)
+		dataFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, dataFileSuffix, false)
+		digestFilepath = dataFilesetPathFromTimeAndIndex(shardDir, blockStart, volumeIndex, digestFileSuffix, false)
 	default:
 		return fmt.Errorf("unable to open reader with fileset type: %s", opts.FileSetType)
 	}

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -196,7 +196,10 @@ func (t *OptimizedTimes) Contains(target xtime.UnixNano) bool {
 
 // ForEach runs the given function for each time in this OptimizedTimes.
 func (t *OptimizedTimes) ForEach(fn func(t xtime.UnixNano)) {
-	for _, tNano := range t.arr {
+	for i, tNano := range t.arr {
+		if i >= t.arrIdx {
+			break
+		}
 		fn(tNano)
 	}
 	for _, tNano := range t.slice {

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -1334,6 +1334,18 @@ func TestOptimizedTimes(t *testing.T) {
 	assert.False(t, times.Contains(xtime.UnixNano(0)))
 
 	var expectedTimes []xtime.UnixNano
+	var forEachTimes []xtime.UnixNano
+	// ForEach should only call the provided func if there are actual times in
+	// OptimizedTimes (OptimizedTimes contains an xtime.UnixNano array
+	// internally and we don't want to run the func for those zero values unless
+	// they were explicitly added).
+	times.ForEach(func(tNano xtime.UnixNano) {
+		forEachTimes = append(forEachTimes, tNano)
+	})
+	assertEqualUnixSlices(t, expectedTimes, forEachTimes)
+
+	expectedTimes = expectedTimes[:0]
+	forEachTimes = forEachTimes[:0]
 
 	// These adds should only go in the array.
 	for i := 0; i < optimizedTimesArraySize; i++ {
@@ -1359,14 +1371,17 @@ func TestOptimizedTimes(t *testing.T) {
 		assert.True(t, times.Contains(tNano))
 	}
 
-	var forEachTimes []xtime.UnixNano
 	times.ForEach(func(tNano xtime.UnixNano) {
 		forEachTimes = append(forEachTimes, tNano)
 	})
 
-	require.Equal(t, len(expectedTimes), len(forEachTimes))
-	for i := range expectedTimes {
-		assert.Equal(t, expectedTimes[i], forEachTimes[i])
+	assertEqualUnixSlices(t, expectedTimes, forEachTimes)
+}
+
+func assertEqualUnixSlices(t *testing.T, expected, actual []xtime.UnixNano) {
+	require.Equal(t, len(expected), len(actual))
+	for i := range expected {
+		assert.Equal(t, expected[i], actual[i])
 	}
 }
 

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1910,6 +1910,7 @@ func (s *dbShard) WarmFlush(
 		// where a fileset already exists when we attempt to flush unless there
 		// is a bug in the code.
 		DeleteIfExists: false,
+		FileSetType:    persist.FileSetFlushType,
 	}
 	prepared, err := flushPreparer.PrepareData(prepareOpts)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
* Fixes `DataFileSetExists` incorrectly checking the legacy fileset when the volume isn't `0`
* Fixes the `ForEach` func for `OptimizedTimes` to not loop through zero values that weren't explicitly added

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
