### PR TITLE
Check config for deprecated fields

### DIFF
--- a/src/cmd/services/m3aggregator/main/main.go
+++ b/src/cmd/services/m3aggregator/main/main.go
@@ -71,6 +71,8 @@ func main() {
 	}
 	defer logger.Sync()
 
+	xconfig.WarnOnDeprecation(cfg, logger)
+
 	scope, closer, err := cfg.Metrics.NewRootScope()
 	if err != nil {
 		logger.Fatal("error creating metrics root scope", zap.Error(err))

--- a/src/cmd/services/m3ctl/main/main.go
+++ b/src/cmd/services/m3ctl/main/main.go
@@ -71,6 +71,8 @@ func main() {
 	}
 	defer rawLogger.Sync()
 
+	xconfig.WarnOnDeprecation(cfg, rawLogger)
+
 	logger := rawLogger.Sugar()
 	envPort := os.Getenv(portEnvVar)
 	if envPort != "" {

--- a/src/cmd/services/m3em_agent/agentmain/agent.go
+++ b/src/cmd/services/m3em_agent/agentmain/agent.go
@@ -65,6 +65,8 @@ func Run() {
 		logger.Fatal("unable to read configuration file", zap.Error(err))
 	}
 
+	xconfig.WarnOnDeprecation(conf, logger)
+
 	// pprof server
 	go func() {
 		if err := http.ListenAndServe(conf.Server.DebugAddress, nil); err != nil {

--- a/src/cmd/services/m3nsch_server/main/main.go
+++ b/src/cmd/services/m3nsch_server/main/main.go
@@ -36,11 +36,12 @@ import (
 	"github.com/m3db/m3/src/m3nsch/agent"
 	"github.com/m3db/m3/src/m3nsch/datums"
 	proto "github.com/m3db/m3/src/m3nsch/generated/proto/m3nsch"
+	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/instrument"
 
-	"go.uber.org/zap"
 	"github.com/pborman/getopt"
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -64,6 +65,8 @@ func main() {
 	if err != nil {
 		logger.Fatalf("unable to read configuration file: %v", err.Error())
 	}
+
+	xconfig.WarnOnDeprecation(conf, rawLogger)
 
 	maxProcs := int(float64(runtime.NumCPU()) * conf.Server.CPUFactor)
 	logger.Infof("setting maxProcs = %d", maxProcs)

--- a/src/collector/server/server.go
+++ b/src/collector/server/server.go
@@ -76,6 +76,8 @@ func Run(runOpts RunOptions) {
 	}
 	defer logger.Sync()
 
+	xconfig.WarnOnDeprecation(cfg, logger)
+
 	logger.Info("creating metrics scope")
 	scope, closer, err := cfg.Metrics.NewRootScope()
 	if err != nil {

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -149,6 +149,8 @@ func Run(runOpts RunOptions) {
 	}
 	defer logger.Sync()
 
+	xconfig.WarnOnDeprecation(cfg, logger)
+
 	// Raise fd limits to nr_open system limit
 	result, err := xos.RaiseProcessNoFileToNROpen()
 	if err != nil {

--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -142,6 +142,8 @@ func Run(runOpts RunOptions) {
 
 	defer logger.Sync()
 
+	xconfig.WarnOnDeprecation(cfg, logger)
+
 	scope, closer, err := cfg.Metrics.NewRootScope()
 	if err != nil {
 		logger.Fatal("could not connect to metrics", zap.Error(err))

--- a/src/x/config/config_test.go
+++ b/src/x/config/config_test.go
@@ -345,13 +345,13 @@ multiple:
 		}
 		require.True(
 			t,
-			slicesCotainSameStrings(expect, actual),
+			slicesContainSameStrings(expect, actual),
 			fmt.Sprintf("expect %#v should be equal actual %#v", expect, actual),
 		)
 	})
 }
 
-func slicesCotainSameStrings(s1, s2 []string) bool {
+func slicesContainSameStrings(s1, s2 []string) bool {
 	if len(s1) != len(s2) {
 		return false
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1549

**Special notes for your reviewer**:
I tried to cover all services that require a config, let me know if I forgot any.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
