### PR TITLE
[coordinator] Add high concurrent carbon/graphite downsampling integration test

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/flush_handler.go
+++ b/src/cmd/services/m3coordinator/downsample/flush_handler.go
@@ -58,7 +58,7 @@ type downsamplerFlushHandler struct {
 	sync.RWMutex
 	storage                storage.Storage
 	metricTagsIteratorPool serialize.MetricTagsIteratorPool
-	workerPool             xsync.WorkerPool
+	workerPool             xsync.PooledWorkerPool
 	instrumentOpts         instrument.Options
 	metrics                downsamplerFlushHandlerMetrics
 	tagOptions             models.TagOptions
@@ -81,7 +81,7 @@ func newDownsamplerFlushHandlerMetrics(
 func newDownsamplerFlushHandler(
 	storage storage.Storage,
 	metricTagsIteratorPool serialize.MetricTagsIteratorPool,
-	workerPool xsync.WorkerPool,
+	workerPool xsync.PooledWorkerPool,
 	tagOptions models.TagOptions,
 	instrumentOpts instrument.Options,
 ) handler.Handler {
@@ -119,6 +119,7 @@ type downsamplerFlushHandlerWriter struct {
 func (w *downsamplerFlushHandlerWriter) Write(
 	mp aggregated.ChunkedMetricWithStoragePolicy,
 ) error {
+	// fmt.Printf("!! flushing metric\n")
 	w.wg.Add(1)
 	w.handler.workerPool.Go(func() {
 		defer w.wg.Done()

--- a/src/cmd/services/m3coordinator/downsample/test_downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/test_downsampler.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package downsample
+
+import (
+	"errors"
+
+	"github.com/m3db/m3/src/query/models"
+
+	"github.com/m3db/m3/src/aggregator/client"
+	clusterclient "github.com/m3db/m3/src/cluster/client"
+	"github.com/m3db/m3/src/cluster/kv/mem"
+	"github.com/m3db/m3/src/metrics/generated/proto/rulepb"
+	"github.com/m3db/m3/src/metrics/matcher"
+	"github.com/m3db/m3/src/metrics/rules"
+	ruleskv "github.com/m3db/m3/src/metrics/rules/store/kv"
+	"github.com/m3db/m3/src/query/storage/mock"
+	"github.com/m3db/m3/src/x/clock"
+	"github.com/m3db/m3/src/x/instrument"
+	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
+	xtest "github.com/m3db/m3/src/x/test"
+
+	"github.com/golang/mock/gomock"
+)
+
+type TestDownsampler struct {
+	Downsampler    Downsampler
+	Opts           DownsamplerOptions
+	TestOpts       TestDownsamplerOptions
+	Matcher        matcher.Matcher
+	Storage        mock.Storage
+	RulesStore     rules.Store
+	InstrumentOpts instrument.Options
+}
+
+type TestDownsamplerOptions struct {
+	ClockOpts      clock.Options
+	InstrumentOpts instrument.Options
+
+	// Options for the test
+	AutoMappingRules   []MappingRule
+	TimedSamples       bool
+	SampleAppenderOpts *SampleAppenderOptions
+	RemoteClientMock   *client.MockClient
+	BufferPastLimits   []BufferPastLimitConfiguration
+
+	// Expected values overrides
+	ExpectedAdjusted map[string]float64
+}
+
+func NewTestDownsampler(opts TestDownsamplerOptions) (TestDownsampler, error) {
+	storage := mock.NewMockStorage()
+	rulesKVStore := mem.NewStore()
+
+	clockOpts := clock.NewOptions()
+	if opts.ClockOpts != nil {
+		clockOpts = opts.ClockOpts
+	}
+
+	instrumentOpts := instrument.NewOptions()
+	if opts.InstrumentOpts != nil {
+		instrumentOpts = opts.InstrumentOpts
+	}
+
+	matcherOpts := matcher.NewOptions()
+
+	// Initialize the namespaces
+	_, err := rulesKVStore.Set(matcherOpts.NamespacesKey(), &rulepb.Namespaces{})
+	if err != nil {
+		return TestDownsampler{}, err
+	}
+
+	rulesetKeyFmt := matcherOpts.RuleSetKeyFn()([]byte("%s"))
+	rulesStoreOpts := ruleskv.NewStoreOptions(matcherOpts.NamespacesKey(),
+		rulesetKeyFmt, nil)
+	rulesStore := ruleskv.NewStore(rulesKVStore, rulesStoreOpts)
+
+	tagEncoderOptions := serialize.NewTagEncoderOptions()
+	tagDecoderOptions := serialize.NewTagDecoderOptions()
+	tagEncoderPoolOptions := pool.NewObjectPoolOptions().
+		SetInstrumentOptions(instrumentOpts.
+			SetMetricsScope(instrumentOpts.MetricsScope().
+				SubScope("tag-encoder-pool")))
+	tagDecoderPoolOptions := pool.NewObjectPoolOptions().
+		SetInstrumentOptions(instrumentOpts.
+			SetMetricsScope(instrumentOpts.MetricsScope().
+				SubScope("tag-decoder-pool")))
+
+	var cfg Configuration
+	if opts.RemoteClientMock != nil {
+		// Optionally set an override to use remote aggregation
+		// with a mock client
+		cfg.RemoteAggregator = &RemoteAggregatorConfiguration{
+			clientOverride: opts.RemoteClientMock,
+		}
+	}
+	if len(opts.BufferPastLimits) > 0 {
+		cfg.BufferPastLimits = opts.BufferPastLimits
+	}
+
+	clusterClient := clusterclient.NewMockClient(
+		gomock.NewController(xtest.PanicReporter{}))
+
+	instance, err := cfg.NewDownsampler(DownsamplerOptions{
+		Storage:               storage,
+		ClusterClient:         clusterClient,
+		RulesKVStore:          rulesKVStore,
+		AutoMappingRules:      opts.AutoMappingRules,
+		ClockOptions:          clockOpts,
+		InstrumentOptions:     instrumentOpts,
+		TagEncoderOptions:     tagEncoderOptions,
+		TagDecoderOptions:     tagDecoderOptions,
+		TagEncoderPoolOptions: tagEncoderPoolOptions,
+		TagDecoderPoolOptions: tagDecoderPoolOptions,
+		TagOptions:            models.NewTagOptions(),
+	})
+	if err != nil {
+		return TestDownsampler{}, err
+	}
+
+	downcast, ok := instance.(*downsampler)
+	if !ok {
+		return TestDownsampler{}, errors.New("cannot get access downsampler fields")
+	}
+
+	return TestDownsampler{
+		Downsampler:    instance,
+		Opts:           downcast.opts,
+		TestOpts:       opts,
+		Matcher:        downcast.agg.matcher,
+		Storage:        storage,
+		RulesStore:     rulesStore,
+		InstrumentOpts: instrumentOpts,
+	}, nil
+}

--- a/src/cmd/services/m3coordinator/ingest/carbon/ingest.go
+++ b/src/cmd/services/m3coordinator/ingest/carbon/ingest.go
@@ -113,7 +113,9 @@ func NewIngester(
 	}
 
 	poolOpts := pool.NewObjectPoolOptions().
-		SetInstrumentOptions(opts.InstrumentOptions).
+		SetInstrumentOptions(opts.InstrumentOptions.
+			SetMetricsScope(opts.InstrumentOptions.
+				MetricsScope().SubScope("carbon-line-resources"))).
 		SetRefillLowWatermark(0).
 		SetRefillHighWatermark(0).
 		SetSize(defaultResourcePoolSize)

--- a/src/x/test/reporter.go
+++ b/src/x/test/reporter.go
@@ -69,3 +69,21 @@ func (r Reporter) Errorf(format string, args ...interface{}) {
 func (r Reporter) Fatalf(format string, args ...interface{}) {
 	panic(fmt.Sprintf(format, args...))
 }
+
+// PanicReporter always panics, even on error.
+type PanicReporter struct {
+}
+
+// ensure Reporter implements gomock.TestReporter.
+var _ gomock.TestReporter = PanicReporter{}
+
+// Errorf is equivalent testing.T.Errorf.
+func (r PanicReporter) Errorf(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}
+
+// Fatalf crashes the program with a panic to allow users to diagnose
+// missing expects.
+func (r PanicReporter) Fatalf(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This adds high concurrent downsampling tests for Carbon/Graphite ingestion. This catches issues that would occur due to flush concurrency and load.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
