### PR TITLE
[query] fix bugs in binary functions, including interaction with scalars

### DIFF
--- a/src/query/block/lazy_test.go
+++ b/src/query/block/lazy_test.go
@@ -52,7 +52,7 @@ func testLazyOpts(timeOffset time.Duration, valOffset float64) LazyOptions {
 	}
 	vt := func(val float64) float64 { return val * valOffset }
 
-	return NewLazyOpts().SetTimeTransform(tt).SetMetaTransform(mt).SetValueTransform(vt)
+	return NewLazyOptions().SetTimeTransform(tt).SetMetaTransform(mt).SetValueTransform(vt)
 }
 
 func TestLazyOpts(t *testing.T) {

--- a/src/query/block/options.go
+++ b/src/query/block/options.go
@@ -36,8 +36,8 @@ type lazyOpts struct {
 	valueTransform ValueTransform
 }
 
-// NewLazyOpts creates LazyOpts with default values.
-func NewLazyOpts() LazyOptions {
+// NewLazyOptions creates LazyOpts with default values.
+func NewLazyOptions() LazyOptions {
 	return &lazyOpts{
 		timeTransform:  defaultTimeTransform,
 		metaTransform:  defaultMetaTransform,

--- a/src/query/block/scalar_test.go
+++ b/src/query/block/scalar_test.go
@@ -41,10 +41,13 @@ var (
 )
 
 func TestScalarBlock(t *testing.T) {
-	block := NewScalar(func(_ time.Time) float64 { return val }, bounds)
+	block := NewScalar(
+		func(_ time.Time) float64 { return val },
+		bounds,
+		models.NewTagOptions(),
+	)
 
 	require.IsType(t, block, &Scalar{})
-
 	stepIter, err := block.StepIter()
 	require.NoError(t, err)
 	require.NotNil(t, stepIter)

--- a/src/query/functions/aggregation/base.go
+++ b/src/query/functions/aggregation/base.go
@@ -118,8 +118,13 @@ func (n *baseNode) Process(queryCtx *models.QueryContext, ID parser.NodeID, b bl
 	return transform.ProcessSimpleBlock(n, n.controller, queryCtx, ID, b)
 }
 
-// ProcessBlock performs the aggregation on the input block, and returns the aggregated result.
-func (n *baseNode) ProcessBlock(queryCtx *models.QueryContext, ID parser.NodeID, b block.Block) (block.Block, error) {
+// ProcessBlock performs the aggregation on the input block, and returns the
+// aggregated result.
+func (n *baseNode) ProcessBlock(
+	queryCtx *models.QueryContext,
+	ID parser.NodeID,
+	b block.Block,
+) (block.Block, error) {
 	stepIter, err := b.StepIter()
 	if err != nil {
 		return nil, err
@@ -134,8 +139,8 @@ func (n *baseNode) ProcessBlock(queryCtx *models.QueryContext, ID parser.NodeID,
 		[]byte(n.op.opType),
 		seriesMetas,
 	)
-	meta.Tags, metas = utils.DedupeMetadata(metas)
 
+	meta.Tags, metas = utils.DedupeMetadata(metas, meta.Tags.Opts)
 	builder, err := n.controller.BlockBuilder(queryCtx, meta, metas)
 	if err != nil {
 		return nil, err

--- a/src/query/functions/aggregation/count_values.go
+++ b/src/query/functions/aggregation/count_values.go
@@ -215,7 +215,7 @@ func (n *countValuesNode) ProcessBlock(queryCtx *models.QueryContext, ID parser.
 	}
 
 	// Dedupe common metadatas
-	metaTags, flattenedMeta := utils.DedupeMetadata(blockMetas)
+	metaTags, flattenedMeta := utils.DedupeMetadata(blockMetas, meta.Tags.Opts)
 	meta.Tags = metaTags
 
 	builder, err := n.controller.BlockBuilder(queryCtx, meta, flattenedMeta)

--- a/src/query/functions/binary/and_test.go
+++ b/src/query/functions/binary/and_test.go
@@ -23,7 +23,9 @@ package binary
 import (
 	"math"
 	"testing"
+	"time"
 
+	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/executor/transform"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/parser"
@@ -93,4 +95,144 @@ func TestAndWithSomeValues(t *testing.T) {
 	expected[0][1] = math.NaN()
 	expected[1][0] = math.NaN()
 	test.EqualsWithNans(t, expected, sink.Values)
+}
+
+var andTests = []struct {
+	name          string
+	lhsMeta       []block.SeriesMeta
+	lhs           [][]float64
+	rhsMeta       []block.SeriesMeta
+	rhs           [][]float64
+	expectedMetas []block.SeriesMeta
+	expected      [][]float64
+	err           error
+}{
+	{
+		"valid, equal tags",
+		test.NewSeriesMeta("a", 2),
+		[][]float64{{1, 2}, {nan, nan}},
+		test.NewSeriesMeta("a", 2),
+		[][]float64{{3, nan}, {30, nan}},
+		test.NewSeriesMetaWithoutName("a", 2),
+		[][]float64{{1, nan}, {nan, nan}},
+		nil,
+	},
+	{
+		"valid, some overlap right",
+		test.NewSeriesMeta("a", 2),
+		[][]float64{{nan, 2}, {10, 20}},
+		test.NewSeriesMeta("a", 3),
+		[][]float64{{3, nan}, {30, 40}, {50, 60}},
+		test.NewSeriesMetaWithoutName("a", 2),
+		[][]float64{{nan, nan}, {10, 20}},
+		nil,
+	},
+	{
+		"valid, some overlap left",
+		test.NewSeriesMeta("a", 3),
+		[][]float64{{1, 2}, {10, 20}, {100, 200}},
+		test.NewSeriesMeta("a", 3)[1:],
+		[][]float64{{3, 4}, {nan, 40}},
+		test.NewSeriesMetaWithoutName("a", 3)[1:],
+		[][]float64{{10, 20}, {nan, 200}},
+		nil,
+	},
+	{
+		"valid, some overlap both",
+		test.NewSeriesMeta("a", 3),
+		[][]float64{{1, 2}, {10, 20}, {100, 200}},
+		test.NewSeriesMeta("a", 4)[1:],
+		[][]float64{{3, nan}, {nan, 40}, {300, 400}},
+		test.NewSeriesMetaWithoutName("a", 3)[1:],
+		[][]float64{{10, nan}, {nan, 200}},
+		nil,
+	},
+	{
+		"valid, different tags",
+		test.NewSeriesMeta("a", 2),
+		[][]float64{{1, 2}, {10, 20}},
+		test.NewSeriesMeta("b", 2),
+		[][]float64{{nan, 4}, {30, 40}},
+		[]block.SeriesMeta{},
+		[][]float64{},
+		nil,
+	},
+	{
+		"valid, different tags, longer rhs",
+		test.NewSeriesMeta("a", 2),
+		[][]float64{{1, 2}, {10, 20}},
+		test.NewSeriesMeta("b", 3),
+		[][]float64{{3, 4}, {30, 40}, {300, 400}},
+		[]block.SeriesMeta{},
+		[][]float64{},
+		nil,
+	},
+	{
+		"valid, different tags, longer lhs",
+		test.NewSeriesMeta("a", 3),
+		[][]float64{{1, 2}, {10, 20}, {100, 200}},
+		test.NewSeriesMeta("b", 2),
+		[][]float64{{3, 4}, {30, 40}},
+		[]block.SeriesMeta{},
+		[][]float64{},
+		nil,
+	},
+	{
+		"mismatched step counts",
+		test.NewSeriesMeta("a", 2),
+		[][]float64{{1, 2, 3}, {10, 20, 30}},
+		test.NewSeriesMeta("b", 2),
+		[][]float64{{3, 4}, {30, 40}},
+		[]block.SeriesMeta{},
+		[][]float64{},
+		errMismatchedStepCounts,
+	},
+}
+
+func TestAnd(t *testing.T) {
+	now := time.Now()
+	for _, tt := range andTests {
+		t.Run(tt.name, func(t *testing.T) {
+			op, err := NewOp(
+				AndType,
+				NodeParams{
+					LNode:          parser.NodeID(0),
+					RNode:          parser.NodeID(1),
+					VectorMatching: &VectorMatching{},
+				},
+			)
+			require.NoError(t, err)
+
+			c, sink := executor.NewControllerWithSink(parser.NodeID(2))
+			node := op.(baseOp).Node(c, transform.Options{})
+			bounds := models.Bounds{
+				Start:    now,
+				Duration: time.Minute * time.Duration(len(tt.lhs[0])),
+				StepSize: time.Minute,
+			}
+
+			lhs := test.NewBlockFromValuesWithSeriesMeta(bounds, tt.lhsMeta, tt.lhs)
+			err = node.Process(models.NoopQueryContext(), parser.NodeID(0), lhs)
+			require.NoError(t, err)
+			bounds = models.Bounds{
+				Start:    now,
+				Duration: time.Minute * time.Duration(len(tt.rhs[0])),
+				StepSize: time.Minute,
+			}
+
+			rhs := test.NewBlockFromValuesWithSeriesMeta(bounds, tt.rhsMeta, tt.rhs)
+			err = node.Process(models.NoopQueryContext(), parser.NodeID(1), rhs)
+			if tt.err != nil {
+				require.EqualError(t, err, tt.err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			test.EqualsWithNans(t, tt.expected, sink.Values)
+			meta := sink.Meta
+			assert.Equal(t, 0, meta.Tags.Len())
+			assert.True(t, meta.Bounds.Equals(bounds))
+			assert.Equal(t, tt.expectedMetas, sink.Metas)
+		})
+	}
 }

--- a/src/query/functions/binary/arithmetic.go
+++ b/src/query/functions/binary/arithmetic.go
@@ -29,29 +29,29 @@ import (
 )
 
 const (
-	// PlusType adds datapoints in both series
+	// PlusType adds datapoints in both series.
 	PlusType = "+"
 
-	// MinusType subtracts rhs from lhs
+	// MinusType subtracts rhs from lhs.
 	MinusType = "-"
 
-	// MultiplyType multiplies datapoints by series
+	// MultiplyType multiplies datapoints by series.
 	MultiplyType = "*"
 
-	// DivType divides datapoints by series
+	// DivType divides datapoints by series.
 	// Special cases are:
 	// 	 X / 0 = +Inf
 	// 	-X / 0 = -Inf
 	// 	 0 / 0 =  NaN
 	DivType = "/"
 
-	// ExpType raises lhs to the power of rhs
+	// ExpType raises lhs to the power of rhs.
 	// NB: to keep consistency with prometheus (and go)
 	//  0 ^ 0 = 1
 	//  NaN ^ 0 = 1
 	ExpType = "^"
 
-	// ModType takes the modulo of lhs by rhs
+	// ModType takes the modulo of lhs by rhs.
 	// Special cases are:
 	// 	 X % 0 = NaN
 	// 	 NaN % X = NaN
@@ -71,7 +71,7 @@ var (
 )
 
 // Builds an arithmetic processing function if able. If wrong opType supplied,
-// returns no function and false
+// returns no function and false.
 func buildArithmeticFunction(
 	opType string,
 	params NodeParams,
@@ -81,7 +81,7 @@ func buildArithmeticFunction(
 		return nil, false
 	}
 
-	// Build the binary processing step
+	// Build the binary processing step.
 	return func(
 		queryCtx *models.QueryContext,
 		lhs, rhs block.Block,

--- a/src/query/functions/binary/base.go
+++ b/src/query/functions/binary/base.go
@@ -37,8 +37,7 @@ type baseOp struct {
 	params       NodeParams
 }
 
-// NodeParams describes the types of nodes used
-// for binary operations
+// NodeParams describes the types of nodes used for binary operations.
 type NodeParams struct {
 	LNode, RNode         parser.NodeID
 	LIsScalar, RIsScalar bool
@@ -46,18 +45,21 @@ type NodeParams struct {
 	VectorMatching       *VectorMatching
 }
 
-// OpType for the operator
+// OpType for the operator.
 func (o baseOp) OpType() string {
 	return o.OperatorType
 }
 
-// String representation
 func (o baseOp) String() string {
-	return fmt.Sprintf("type: %s, lnode: %s, rnode: %s", o.OpType(), o.params.LNode, o.params.RNode)
+	return fmt.Sprintf("type: %s, lnode: %s, rnode: %s", o.OpType(),
+		o.params.LNode, o.params.RNode)
 }
 
-// Node creates an execution node
-func (o baseOp) Node(controller *transform.Controller, _ transform.Options) transform.OpNode {
+// Node creates an execution node.
+func (o baseOp) Node(
+	controller *transform.Controller,
+	_ transform.Options,
+) transform.OpNode {
 	return &baseNode{
 		op:         o,
 		process:    o.processFunc,
@@ -73,7 +75,7 @@ func ArithmeticFunction(opType string, returnBool bool) (Function, error) {
 	}
 
 	// For comparison functions, check if returning bool or not and return the
-	// appropriate one
+	// appropriate one.
 	if returnBool {
 		opType += returnBoolSuffix
 	}
@@ -85,7 +87,7 @@ func ArithmeticFunction(opType string, returnBool bool) (Function, error) {
 	return nil, errNoMatching
 }
 
-// NewOp creates a new binary operation
+// NewOp creates a new binary operation.
 func NewOp(
 	opType string,
 	params NodeParams,
@@ -120,10 +122,12 @@ func (n *baseNode) Params() parser.Params {
 	return n.op
 }
 
-type processFunc func(*models.QueryContext, block.Block, block.Block, *transform.Controller) (block.Block, error)
+type processFunc func(*models.QueryContext, block.Block,
+	block.Block, *transform.Controller) (block.Block, error)
 
-// Process processes a block
-func (n *baseNode) Process(queryCtx *models.QueryContext, ID parser.NodeID, b block.Block) error {
+// Process processes a block.
+func (n *baseNode) Process(queryCtx *models.QueryContext,
+	ID parser.NodeID, b block.Block) error {
 	lhs, rhs, err := n.computeOrCache(ID, b)
 	if err != nil {
 		// Clean up any blocks from cache
@@ -147,7 +151,8 @@ func (n *baseNode) Process(queryCtx *models.QueryContext, ID parser.NodeID, b bl
 	return n.controller.Process(queryCtx, nextBlock)
 }
 
-func (n *baseNode) processWithTracing(queryCtx *models.QueryContext, lhs block.Block, rhs block.Block) (block.Block, error) {
+func (n *baseNode) processWithTracing(queryCtx *models.QueryContext,
+	lhs block.Block, rhs block.Block) (block.Block, error) {
 	sp, ctx := opentracing.StartSpanFromContext(queryCtx.Ctx, n.op.OpType())
 	defer sp.Finish()
 	queryCtx = queryCtx.WithContext(ctx)
@@ -155,8 +160,12 @@ func (n *baseNode) processWithTracing(queryCtx *models.QueryContext, lhs block.B
 	return n.process(queryCtx, lhs, rhs, n.controller)
 }
 
-// computeOrCache figures out if both lhs and rhs are available, if not then it caches the incoming block
-func (n *baseNode) computeOrCache(ID parser.NodeID, b block.Block) (block.Block, block.Block, error) {
+// computeOrCache figures out if both lhs and rhs are available,
+// if not then it caches the incoming block.
+func (n *baseNode) computeOrCache(
+	ID parser.NodeID,
+	b block.Block,
+) (block.Block, block.Block, error) {
 	var lhs, rhs block.Block
 	n.mu.Lock()
 	defer n.mu.Unlock()

--- a/src/query/functions/binary/binary.go
+++ b/src/query/functions/binary/binary.go
@@ -29,11 +29,11 @@ import (
 	"github.com/m3db/m3/src/query/models"
 )
 
-// Function is a function that applies on two floats
+// Function is a function that applies on two floats.
 type Function func(x, y float64) float64
 type singleScalarFunc func(x float64) float64
 
-// processes two logical blocks, performing a logical operation on them
+// processes two logical blocks, performing a logical operation on them.
 func processBinary(
 	queryCtx *models.QueryContext,
 	lhs, rhs block.Block,
@@ -69,14 +69,14 @@ func processBinary(
 
 		// if both lhs and rhs are scalars, can create a new block
 		// by extracting values from lhs and rhs instead of doing
-		// by-value comparisons
+		// by-value comparisons.
 		scalarR, ok := rhs.(*block.Scalar)
 		if !ok {
 			return nil, errRightScalar
 		}
 
 		// NB(arnikola): this is a sanity check, as scalar comparisons
-		// should have previously errored out during the parsing step
+		// should have previously errored out during the parsing step.
 		if !params.ReturnBool && isComparison {
 			return nil, errNoModifierForComparison
 		}
@@ -86,6 +86,7 @@ func processBinary(
 				return fn(lVal, scalarR.Value(t))
 			},
 			lIter.Meta().Bounds,
+			lIter.Meta().Tags.Opts,
 		), nil
 	}
 
@@ -96,7 +97,7 @@ func processBinary(
 		}
 
 		rVal := scalarR.Value(time.Time{})
-		// lhs is a series; use lhs metadata and series meta
+		// lhs is a series; use lhs metadata and series meta.
 		return processSingleBlock(
 			queryCtx,
 			lhs,
@@ -107,7 +108,7 @@ func processBinary(
 		)
 	}
 
-	// both lhs and rhs are series
+	// both lhs and rhs are series.
 	rIter, err := rhs.StepIter()
 	if err != nil {
 		return nil, err
@@ -115,7 +116,7 @@ func processBinary(
 
 	// NB(arnikola): this is a sanity check, as functions between
 	// two series missing vector matching should have previously
-	// errored out during the parsing step
+	// errored out during the parsing step.
 	if params.VectorMatching == nil {
 		return nil, errNoMatching
 	}
@@ -182,8 +183,9 @@ func processBothSeries(
 	lSeriesMeta = utils.FlattenMetadata(lMeta, lSeriesMeta)
 	rSeriesMeta = utils.FlattenMetadata(rMeta, rSeriesMeta)
 
-	takeLeft, correspondingRight, lSeriesMeta := intersect(matching, lSeriesMeta, rSeriesMeta)
-	lMeta.Tags, lSeriesMeta = utils.DedupeMetadata(lSeriesMeta)
+	takeLeft, correspondingRight, lSeriesMeta := intersect(matching,
+		lSeriesMeta, rSeriesMeta)
+	lMeta.Tags, lSeriesMeta = utils.DedupeMetadata(lSeriesMeta, lMeta.Tags.Opts)
 
 	// Use metas from only taken left series
 	builder, err := controller.BlockBuilder(queryCtx, lMeta, lSeriesMeta)
@@ -224,7 +226,7 @@ func processBothSeries(
 }
 
 // intersect returns the slice of lhs indices that are shared with rhs,
-// the indices of the corresponding rhs values, and the metas for taken indices
+// the indices of the corresponding rhs values, and the metas for taken indices.
 func intersect(
 	matching *VectorMatching,
 	lhs, rhs []block.SeriesMeta,

--- a/src/query/functions/binary/binary_test.go
+++ b/src/query/functions/binary/binary_test.go
@@ -116,11 +116,26 @@ func TestScalars(t *testing.T) {
 			c, sink := executor.NewControllerWithSink(parser.NodeID(2))
 			node := op.(baseOp).Node(c, transform.Options{})
 
-			err = node.Process(models.NoopQueryContext(), parser.NodeID(0), block.NewScalar(func(_ time.Time) float64 { return tt.lVal }, bounds))
-			require.NoError(t, err)
+			err = node.Process(
+				models.NoopQueryContext(),
+				parser.NodeID(0),
+				block.NewScalar(
+					func(_ time.Time) float64 { return tt.lVal },
+					bounds,
+					models.NewTagOptions(),
+				),
+			)
 
-			err = node.Process(models.NoopQueryContext(), parser.NodeID(1), block.NewScalar(func(_ time.Time) float64 { return tt.rVal }, bounds))
 			require.NoError(t, err)
+			err = node.Process(
+				models.NoopQueryContext(),
+				parser.NodeID(1),
+				block.NewScalar(
+					func(_ time.Time) float64 { return tt.rVal },
+					bounds,
+					models.NewTagOptions(),
+				),
+			)
 
 			expected := [][]float64{{
 				tt.expected, tt.expected, tt.expected,
@@ -160,19 +175,35 @@ func TestScalarsReturnBoolFalse(t *testing.T) {
 			c, sink := executor.NewControllerWithSink(parser.NodeID(2))
 			node := op.(baseOp).Node(c, transform.Options{})
 
-			err = node.Process(models.NoopQueryContext(), parser.NodeID(0), block.NewScalar(func(_ time.Time) float64 { return tt.lVal }, bounds))
-			require.NoError(t, err)
+			err = node.Process(
+				models.NoopQueryContext(),
+				parser.NodeID(0),
+				block.NewScalar(
+					func(_ time.Time) float64 { return tt.lVal },
+					bounds,
+					models.NewTagOptions(),
+				),
+			)
 
-			err = node.Process(models.NoopQueryContext(), parser.NodeID(1), block.NewScalar(func(_ time.Time) float64 { return tt.rVal }, bounds))
+			require.NoError(t, err)
+			err = node.Process(
+				models.NoopQueryContext(),
+				parser.NodeID(1),
+				block.NewScalar(
+					func(_ time.Time) float64 { return tt.rVal },
+					bounds,
+					models.NewTagOptions(),
+				),
+			)
 
 			if tt.opType == EqType || tt.opType == NotEqType ||
 				tt.opType == GreaterType || tt.opType == LesserType ||
 				tt.opType == GreaterEqType || tt.opType == LesserEqType {
-				require.Error(t, err, "scalar comparisons should fail without returnBool")
+				require.Error(t, err, "scalar comparisons must fail without returnBool")
 				return
 			}
 
-			require.NoError(t, err, "scalar arithmetic should succeed without returnBool")
+			require.NoError(t, err, "scalar maths must succeed without returnBool")
 
 			expected := [][]float64{{
 				tt.expected, tt.expected, tt.expected,
@@ -241,8 +272,11 @@ var singleSeriesTests = []struct {
 	},
 	// *
 	{
-		name:         "series * scalar",
-		seriesValues: [][]float64{{-1, 0, math.NaN()}, {math.MaxFloat64 - 1, -1 * (math.MaxFloat64 - 1), 1}},
+		name: "series * scalar",
+		seriesValues: [][]float64{
+			{-1, 0, math.NaN()},
+			{math.MaxFloat64 - 1, -1 * (math.MaxFloat64 - 1), 1},
+		},
 		opType:       MultiplyType,
 		scalarVal:    10,
 		seriesLeft:   true,
@@ -402,27 +436,41 @@ var singleSeriesTests = []struct {
 		opType:     GreaterType,
 		scalarVal:  10,
 		seriesLeft: true,
-		expected: [][]float64{{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
-			{11, math.MaxFloat64, math.NaN(), math.Inf(1), math.NaN()}},
+		expected: [][]float64{
+			{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
+			{11, math.MaxFloat64, math.NaN(), math.Inf(1), math.NaN()},
+		},
 		expectedBool: [][]float64{{0, 0, 0, 0, 0}, {1, 1, 0, 1, 0}},
 	},
 	{
-		name:         "scalar > series",
-		scalarVal:    10,
-		opType:       GreaterType,
-		seriesValues: [][]float64{{-10, 0, 1, 9, 10}, {11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)}},
-		seriesLeft:   false,
-		expected:     [][]float64{{10, 10, 10, 10, math.NaN()}, {math.NaN(), math.NaN(), math.NaN(), math.NaN(), 10}},
+		name:      "scalar > series",
+		scalarVal: 10,
+		opType:    GreaterType,
+		seriesValues: [][]float64{
+			{-10, 0, 1, 9, 10},
+			{11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)},
+		},
+		seriesLeft: false,
+		expected: [][]float64{
+			{10, 10, 10, 10, math.NaN()},
+			{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 10},
+		},
 		expectedBool: [][]float64{{1, 1, 1, 1, 0}, {0, 0, 0, 0, 1}},
 	},
 	// >
 	{
-		name:         "series < scalar",
-		seriesValues: [][]float64{{-10, 0, 1, 9, 10}, {11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)}},
-		opType:       LesserType,
-		scalarVal:    10,
-		seriesLeft:   true,
-		expected:     [][]float64{{-10, 0, 1, 9, math.NaN()}, {math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.Inf(-1)}},
+		name: "series < scalar",
+		seriesValues: [][]float64{
+			{-10, 0, 1, 9, 10},
+			{11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)},
+		},
+		opType:     LesserType,
+		scalarVal:  10,
+		seriesLeft: true,
+		expected: [][]float64{
+			{-10, 0, 1, 9, math.NaN()},
+			{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.Inf(-1)},
+		},
 		expectedBool: [][]float64{{1, 1, 1, 1, 0}, {0, 0, 0, 0, 1}},
 	},
 	{
@@ -432,8 +480,10 @@ var singleSeriesTests = []struct {
 		seriesValues: [][]float64{{-10, 0, 1, 9, 10},
 			{11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)}},
 		seriesLeft: false,
-		expected: [][]float64{{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
-			{10, 10, math.NaN(), 10, math.NaN()}},
+		expected: [][]float64{
+			{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
+			{10, 10, math.NaN(), 10, math.NaN()},
+		},
 		expectedBool: [][]float64{{0, 0, 0, 0, 0}, {1, 1, 0, 1, 0}},
 	},
 	// >=
@@ -449,31 +499,49 @@ var singleSeriesTests = []struct {
 		expectedBool: [][]float64{{0, 0, 0, 0, 1}, {1, 1, 0, 1, 0}},
 	},
 	{
-		name:         "scalar >= series",
-		scalarVal:    10,
-		opType:       GreaterEqType,
-		seriesValues: [][]float64{{-10, 0, 1, 9, 10}, {11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)}},
-		seriesLeft:   false,
-		expected:     [][]float64{{10, 10, 10, 10, 10}, {math.NaN(), math.NaN(), math.NaN(), math.NaN(), 10}},
+		name:      "scalar >= series",
+		scalarVal: 10,
+		opType:    GreaterEqType,
+		seriesValues: [][]float64{
+			{-10, 0, 1, 9, 10},
+			{11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)},
+		},
+		seriesLeft: false,
+		expected: [][]float64{
+			{10, 10, 10, 10, 10},
+			{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 10},
+		},
 		expectedBool: [][]float64{{1, 1, 1, 1, 1}, {0, 0, 0, 0, 1}},
 	},
 	// <=
 	{
-		name:         "series <= scalar",
-		seriesValues: [][]float64{{-10, 0, 1, 9, 10}, {11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)}},
-		opType:       LesserEqType,
-		scalarVal:    10,
-		seriesLeft:   true,
-		expected:     [][]float64{{-10, 0, 1, 9, 10}, {math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.Inf(-1)}},
+		name: "series <= scalar",
+		seriesValues: [][]float64{
+			{-10, 0, 1, 9, 10},
+			{11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)},
+		},
+		opType:     LesserEqType,
+		scalarVal:  10,
+		seriesLeft: true,
+		expected: [][]float64{
+			{-10, 0, 1, 9, 10},
+			{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.Inf(-1)},
+		},
 		expectedBool: [][]float64{{1, 1, 1, 1, 1}, {0, 0, 0, 0, 1}},
 	},
 	{
-		name:         "scalar <= series",
-		scalarVal:    10,
-		opType:       LesserEqType,
-		seriesValues: [][]float64{{-10, 0, 1, 9, 10}, {11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)}},
-		seriesLeft:   false,
-		expected:     [][]float64{{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 10}, {10, 10, math.NaN(), 10, math.NaN()}},
+		name:      "scalar <= series",
+		scalarVal: 10,
+		opType:    LesserEqType,
+		seriesValues: [][]float64{
+			{-10, 0, 1, 9, 10},
+			{11, math.MaxFloat64, math.NaN(), math.Inf(1), math.Inf(-1)},
+		},
+		seriesLeft: false,
+		expected: [][]float64{
+			{math.NaN(), math.NaN(), math.NaN(), math.NaN(), 10},
+			{10, 10, math.NaN(), 10, math.NaN()},
+		},
 		expectedBool: [][]float64{{0, 0, 0, 0, 1}, {1, 1, 0, 1, 0}},
 	},
 }
@@ -513,12 +581,29 @@ func TestSingleSeriesReturnBool(t *testing.T) {
 				err = node.Process(models.NoopQueryContext(), parser.NodeID(0), series)
 				require.NoError(t, err)
 
-				err = node.Process(models.NoopQueryContext(), parser.NodeID(1), block.NewScalar(func(_ time.Time) float64 { return tt.scalarVal }, bounds))
+				err = node.Process(
+					models.NoopQueryContext(),
+					parser.NodeID(1),
+					block.NewScalar(
+						func(_ time.Time) float64 { return tt.scalarVal },
+						bounds,
+						models.NewTagOptions(),
+					),
+				)
+
 				require.NoError(t, err)
 			} else {
-				err = node.Process(models.NoopQueryContext(), parser.NodeID(0), block.NewScalar(func(_ time.Time) float64 { return tt.scalarVal }, bounds))
-				require.NoError(t, err)
+				err = node.Process(
+					models.NoopQueryContext(),
+					parser.NodeID(0),
+					block.NewScalar(
+						func(_ time.Time) float64 { return tt.scalarVal },
+						bounds,
+						models.NewTagOptions(),
+					),
+				)
 
+				require.NoError(t, err)
 				err = node.Process(models.NoopQueryContext(), parser.NodeID(1), series)
 				require.NoError(t, err)
 			}
@@ -549,8 +634,8 @@ func TestSingleSeriesReturnValues(t *testing.T) {
 					VectorMatching: nil,
 				},
 			)
-			require.NoError(t, err)
 
+			require.NoError(t, err)
 			c, sink := executor.NewControllerWithSink(parser.NodeID(2))
 			node := op.(baseOp).Node(c, transform.Options{})
 
@@ -568,12 +653,29 @@ func TestSingleSeriesReturnValues(t *testing.T) {
 				err = node.Process(models.NoopQueryContext(), parser.NodeID(0), series)
 				require.NoError(t, err)
 
-				err = node.Process(models.NoopQueryContext(), parser.NodeID(1), block.NewScalar(func(_ time.Time) float64 { return tt.scalarVal }, bounds))
+				err = node.Process(
+					models.NoopQueryContext(),
+					parser.NodeID(1),
+					block.NewScalar(
+						func(_ time.Time) float64 { return tt.scalarVal },
+						bounds,
+						models.NewTagOptions(),
+					),
+				)
+
 				require.NoError(t, err)
 			} else {
-				err = node.Process(models.NoopQueryContext(), parser.NodeID(0), block.NewScalar(func(_ time.Time) float64 { return tt.scalarVal }, bounds))
-				require.NoError(t, err)
+				err = node.Process(
+					models.NoopQueryContext(),
+					parser.NodeID(0),
+					block.NewScalar(
+						func(_ time.Time) float64 { return tt.scalarVal },
+						bounds,
+						models.NewTagOptions(),
+					),
+				)
 
+				require.NoError(t, err)
 				err = node.Process(models.NoopQueryContext(), parser.NodeID(1), series)
 				require.NoError(t, err)
 			}
@@ -827,10 +929,12 @@ func TestBothSeries(t *testing.T) {
 				StepSize: time.Minute,
 			}
 
-			err = node.Process(models.NoopQueryContext(), parser.NodeID(0), test.NewBlockFromValuesWithSeriesMeta(bounds, tt.lhsMeta, tt.lhs))
+			err = node.Process(models.NoopQueryContext(), parser.NodeID(0),
+				test.NewBlockFromValuesWithSeriesMeta(bounds, tt.lhsMeta, tt.lhs))
 			require.NoError(t, err)
 
-			err = node.Process(models.NoopQueryContext(), parser.NodeID(1), test.NewBlockFromValuesWithSeriesMeta(bounds, tt.rhsMeta, tt.rhs))
+			err = node.Process(models.NoopQueryContext(), parser.NodeID(1),
+				test.NewBlockFromValuesWithSeriesMeta(bounds, tt.rhsMeta, tt.rhs))
 			require.NoError(t, err)
 
 			test.EqualsWithNans(t, tt.expected, sink.Values)
@@ -838,7 +942,8 @@ func TestBothSeries(t *testing.T) {
 			// Extract duped expected metas
 			expectedMeta := block.Metadata{Bounds: bounds}
 			var expectedMetas []block.SeriesMeta
-			expectedMeta.Tags, expectedMetas = utils.DedupeMetadata(tt.expectedMetas)
+			expectedMeta.Tags, expectedMetas = utils.DedupeMetadata(
+				tt.expectedMetas, models.NewTagOptions())
 			expectedMeta, expectedMetas = removeNameTags(expectedMeta, expectedMetas)
 			assert.Equal(t, expectedMeta, sink.Meta)
 			assert.Equal(t, expectedMetas, sink.Metas)

--- a/src/query/functions/binary/common.go
+++ b/src/query/functions/binary/common.go
@@ -33,6 +33,11 @@ var (
 	errLExhausted = errors.New("left iter exhausted while right iter has values")
 )
 
+type indexMatcher struct {
+	lhsIndex int
+	rhsIndex int
+}
+
 // VectorMatchCardinality describes the cardinality relationship
 // of two Vectors in a binary operation.
 type VectorMatchCardinality int

--- a/src/query/functions/binary/common.go
+++ b/src/query/functions/binary/common.go
@@ -28,6 +28,11 @@ import (
 	"github.com/m3db/m3/src/query/models"
 )
 
+var (
+	errRExhausted = errors.New("right iter exhausted while left iter has values")
+	errLExhausted = errors.New("left iter exhausted while right iter has values")
+)
+
 // VectorMatchCardinality describes the cardinality relationship
 // of two Vectors in a binary operation.
 type VectorMatchCardinality int
@@ -60,7 +65,7 @@ type VectorMatching struct {
 }
 
 // HashFunc returns a function that calculates the signature for a metric
-// ignoring the provided labels. If on, then the given labels are only used instead.
+// ignoring the provided labels. If on, then only the given labels are used.
 func HashFunc(on bool, names ...[]byte) func(models.Tags) uint64 {
 	if on {
 		return func(tags models.Tags) uint64 {
@@ -76,12 +81,16 @@ func HashFunc(on bool, names ...[]byte) func(models.Tags) uint64 {
 const initIndexSliceLength = 10
 
 var (
-	errMismatchedBounds        = errors.New("block bounds are mismatched")
-	errMismatchedStepCounts    = errors.New("block step counts are mismatched")
-	errLeftScalar              = errors.New("expected left scalar but node type incorrect")
-	errRightScalar             = errors.New("expected right scalar but node type incorrect")
-	errNoModifierForComparison = errors.New("comparisons between scalars must use BOOL modifier")
-	errNoMatching              = errors.New("vector matching parameters must be provided for binary operations between series")
+	errMismatchedBounds     = errors.New("block bounds are mismatched")
+	errMismatchedStepCounts = errors.New("block step counts are mismatched")
+	errLeftScalar           = errors.New("expected left scalar but node type" +
+		" incorrect")
+	errRightScalar = errors.New("expected right scalar but node" +
+		" type incorrect")
+	errNoModifierForComparison = errors.New("comparisons between scalars must" +
+		" use BOOL modifier")
+	errNoMatching = errors.New("vector matching parameters must" +
+		" be provided for binary operations between series")
 )
 
 func tagMap(t models.Tags) map[string]models.Tag {
@@ -153,20 +162,6 @@ func combineMetaAndSeriesMeta(
 		seriesMeta,
 		otherSeriesMeta,
 		nil
-}
-
-func appendValuesAtIndices(idxArray []int, iter block.StepIter, builder block.Builder) error {
-	for index := 0; iter.Next(); index++ {
-		step := iter.Current()
-		values := step.Values()
-		for _, idx := range idxArray {
-			if err := builder.AppendValue(index, values[idx]); err != nil {
-				return err
-			}
-		}
-	}
-
-	return iter.Err()
 }
 
 // NB: binary functions should remove the name tag from relevant series.

--- a/src/query/functions/binary/comparison.go
+++ b/src/query/functions/binary/comparison.go
@@ -29,29 +29,29 @@ import (
 )
 
 const (
-	// EqType checks that lhs is equal to rhs
+	// EqType checks that lhs is equal to rhs.
 	EqType = "=="
 
-	// NotEqType checks that lhs is equal to rhs
+	// NotEqType checks that lhs is equal to rhs.
 	NotEqType = "!="
 
-	// GreaterType checks that lhs is equal to rhs
+	// GreaterType checks that lhs is equal to rhs.
 	GreaterType = ">"
 
-	// LesserType checks that lhs is equal to rhs
+	// LesserType checks that lhs is equal to rhs.
 	LesserType = "<"
 
-	// GreaterEqType checks that lhs is equal to rhs
+	// GreaterEqType checks that lhs is equal to rhs.
 	GreaterEqType = ">="
 
-	// LesserEqType checks that lhs is equal to rhs
+	// LesserEqType checks that lhs is equal to rhs.
 	LesserEqType = "<="
 
-	// suffix to return bool values instead of lhs values
+	// suffix to return bool values instead of lhs values.
 	returnBoolSuffix = "BOOL"
 )
 
-// convert true to 1, false to 0
+// convert true to 1, false to 0.
 func toFloat(b bool) float64 {
 	if b {
 		return 1
@@ -59,7 +59,7 @@ func toFloat(b bool) float64 {
 	return 0
 }
 
-// convert true to x, false to NaN
+// convert true to x, false to NaN.
 func toComparisonValue(b bool, x float64) float64 {
 	if b {
 		return x
@@ -86,7 +86,7 @@ var (
 )
 
 // Builds a comparison processing function if able. If wrong opType supplied,
-// returns no function and false
+// returns no function and false.
 func buildComparisonFunction(
 	opType string,
 	params NodeParams,

--- a/src/query/functions/binary/logical.go
+++ b/src/query/functions/binary/logical.go
@@ -34,7 +34,7 @@ type makeBlockFn func(
 ) (block.Block, error)
 
 // Builds a logical processing function if able. If wrong opType supplied,
-// returns no function and false
+// returns no function and false.
 func buildLogicalFunction(
 	opType string,
 	params NodeParams,
@@ -58,8 +58,10 @@ func createLogicalProcessingStep(
 	params NodeParams,
 	fn makeBlockFn,
 ) processFunc {
-	return func(queryCtx *models.QueryContext, lhs, rhs block.Block, controller *transform.Controller) (block.Block, error) {
-		return processLogical(queryCtx, lhs, rhs, controller, params.VectorMatching, fn)
+	return func(queryCtx *models.QueryContext, lhs, rhs block.Block,
+		controller *transform.Controller) (block.Block, error) {
+		return processLogical(queryCtx, lhs, rhs, controller,
+			params.VectorMatching, fn)
 	}
 }
 

--- a/src/query/functions/binary/or.go
+++ b/src/query/functions/binary/or.go
@@ -84,10 +84,8 @@ func makeOrBlock(
 		for iterIndex, valueIndex := range indices {
 			if valueIndex >= len(lValues) {
 				values[valueIndex] = rValues[iterIndex]
-			} else {
-				if math.IsNaN(values[valueIndex]) {
-					values[valueIndex] = rValues[iterIndex]
-				}
+			} else if math.IsNaN(values[valueIndex]) {
+				values[valueIndex] = rValues[iterIndex]
 			}
 		}
 

--- a/src/query/functions/binary/or.go
+++ b/src/query/functions/binary/or.go
@@ -21,13 +21,15 @@
 package binary
 
 import (
+	"math"
+
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/executor/transform"
 	"github.com/m3db/m3/src/query/models"
 )
 
-// OrType uses all values from left hand side, and appends values from the right hand side which do
-// not have corresponding tags on the right
+// OrType uses all values from left hand side, and appends values from the
+// right hand side which do not have corresponding tags on the right.
 const OrType = "or"
 
 func makeOrBlock(
@@ -36,17 +38,24 @@ func makeOrBlock(
 	controller *transform.Controller,
 	matching *VectorMatching,
 ) (block.Block, error) {
+	lMeta, lSeriesMetas := lIter.Meta(), lIter.SeriesMeta()
+	lMeta, lSeriesMetas = removeNameTags(lMeta, lSeriesMetas)
+
+	rMeta, rSeriesMetas := rIter.Meta(), rIter.SeriesMeta()
+	rMeta, rSeriesMetas = removeNameTags(rMeta, rSeriesMetas)
+
 	meta, lSeriesMetas, rSeriesMetas, err := combineMetaAndSeriesMeta(
-		lIter.Meta(),
-		rIter.Meta(),
-		lIter.SeriesMeta(),
-		rIter.SeriesMeta(),
+		lMeta,
+		rMeta,
+		lSeriesMetas,
+		rSeriesMetas,
 	)
+
 	if err != nil {
 		return nil, err
 	}
 
-	missingIndices, combinedSeriesMeta := missing(
+	indices, combinedSeriesMeta := mergeIndices(
 		matching,
 		lSeriesMetas,
 		rSeriesMetas,
@@ -61,11 +70,28 @@ func makeOrBlock(
 		return nil, err
 	}
 
-	index := 0
-	for ; lIter.Next(); index++ {
+	values := make([]float64, len(combinedSeriesMeta))
+	for index := 0; lIter.Next(); index++ {
+		if !rIter.Next() {
+			return nil, errRExhausted
+		}
+
 		lStep := lIter.Current()
 		lValues := lStep.Values()
-		if err := builder.AppendValues(index, lValues); err != nil {
+		copy(values, lValues)
+		rStep := rIter.Current()
+		rValues := rStep.Values()
+		for iterIndex, valueIndex := range indices {
+			if valueIndex >= len(lValues) {
+				values[valueIndex] = rValues[iterIndex]
+			} else {
+				if math.IsNaN(values[valueIndex]) {
+					values[valueIndex] = rValues[iterIndex]
+				}
+			}
+		}
+
+		if err := builder.AppendValues(index, values); err != nil {
 			return nil, err
 		}
 	}
@@ -74,34 +100,48 @@ func makeOrBlock(
 		return nil, err
 	}
 
-	if err = appendValuesAtIndices(missingIndices, rIter, builder); err != nil {
+	if rIter.Next() {
+		return nil, errLExhausted
+	}
+
+	if err = rIter.Err(); err != nil {
 		return nil, err
 	}
 
 	return builder.Build(), nil
 }
 
-// missing returns the slice of rhs indices for which there are no corresponding
-// indices on the lhs. It also returns the metadatas for the series at these
-// indices to avoid having to calculate this separately
-func missing(
+// mergeIndices returns a slice that maps rhs series to lhs series.
+//
+// NB(arnikola): if the series in the rhs does not exist in the lhs, it is
+// added after all lhs series have been added.
+// This function also combines the series metadatas for the entire block.
+func mergeIndices(
 	matching *VectorMatching,
 	lhs, rhs []block.SeriesMeta,
 ) ([]int, []block.SeriesMeta) {
 	idFunction := HashFunc(matching.On, matching.MatchingLabels...)
 	// The set of signatures for the left-hand side.
-	leftSigs := make(map[uint64]struct{}, len(lhs))
-	for _, meta := range lhs {
-		leftSigs[idFunction(meta.Tags)] = struct{}{}
+	leftSigs := make(map[uint64]int, len(lhs))
+	for i, meta := range lhs {
+		l := idFunction(meta.Tags)
+		leftSigs[l] = i
 	}
 
-	missing := make([]int, 0, initIndexSliceLength)
-	for i, rs := range rhs {
-		// If there's no matching entry in the left-hand side Vector, add the sample.
-		if _, ok := leftSigs[idFunction(rs.Tags)]; !ok {
-			missing = append(missing, i)
-			lhs = append(lhs, rs)
+	rIndices := make([]int, len(rhs))
+	rIndex := len(lhs)
+	for i, meta := range rhs {
+		// If there's no matching entry in the left-hand side Vector,
+		// add the sample.
+		r := idFunction(meta.Tags)
+		if matchingIndex, ok := leftSigs[r]; !ok {
+			rIndices[i] = rIndex
+			rIndex++
+			lhs = append(lhs, meta)
+		} else {
+			rIndices[i] = matchingIndex
 		}
 	}
-	return missing, lhs
+
+	return rIndices, lhs
 }

--- a/src/query/functions/binary/or_test.go
+++ b/src/query/functions/binary/or_test.go
@@ -96,7 +96,10 @@ func TestOrWithSomeValues(t *testing.T) {
 	test.EqualsWithNans(t, expected, sink.Values)
 }
 
-func generateMetaDataWithTagsInRange(fromRange, toRange int) []block.SeriesMeta {
+func generateMetaDataWithTagsInRange(
+	fromRange int,
+	toRange int,
+) []block.SeriesMeta {
 	length := toRange - fromRange
 	meta := make([]block.SeriesMeta, length)
 	for i := 0; i < length; i++ {
@@ -110,26 +113,51 @@ func generateMetaDataWithTagsInRange(fromRange, toRange int) []block.SeriesMeta 
 	return meta
 }
 
-var missingTests = []struct {
+var indexMatchingTests = []struct {
 	name     string
 	lhs      []block.SeriesMeta
 	rhs      []block.SeriesMeta
 	expected []int
 }{
-	{"equal tags", generateMetaDataWithTagsInRange(0, 5), generateMetaDataWithTagsInRange(0, 5), []int{}},
-	{"empty rhs", generateMetaDataWithTagsInRange(0, 5), []block.SeriesMeta{}, []int{}},
-	{"empty lhs", []block.SeriesMeta{}, generateMetaDataWithTagsInRange(0, 5), []int{0, 1, 2, 3, 4}},
-	{"longer rhs", generateMetaDataWithTagsInRange(0, 5), generateMetaDataWithTagsInRange(-1, 6), []int{0, 6}},
-	{"no overlap", generateMetaDataWithTagsInRange(0, 5), generateMetaDataWithTagsInRange(6, 9), []int{0, 1, 2}},
+	{
+		"equal tags",
+		generateMetaDataWithTagsInRange(0, 5),
+		generateMetaDataWithTagsInRange(0, 5),
+		[]int{0, 1, 2, 3, 4},
+	},
+	{
+		"empty rhs",
+		generateMetaDataWithTagsInRange(0, 5),
+		[]block.SeriesMeta{},
+		[]int{},
+	},
+	{
+		"empty lhs",
+		[]block.SeriesMeta{},
+		generateMetaDataWithTagsInRange(0, 5),
+		[]int{0, 1, 2, 3, 4},
+	},
+	{
+		"longer rhs",
+		generateMetaDataWithTagsInRange(0, 5),
+		generateMetaDataWithTagsInRange(-1, 6),
+		[]int{5, 0, 1, 2, 3, 4, 6},
+	},
+	{
+		"no overlap",
+		generateMetaDataWithTagsInRange(0, 5),
+		generateMetaDataWithTagsInRange(6, 9),
+		[]int{5, 6, 7},
+	},
 }
 
-func TestMissing(t *testing.T) {
+func TestIndexMerging(t *testing.T) {
 	matching := &VectorMatching{}
 
-	for _, tt := range missingTests {
+	for _, tt := range indexMatchingTests {
 		t.Run(tt.name, func(t *testing.T) {
-			missing, _ := missing(matching, tt.lhs, tt.rhs)
-			assert.Equal(t, tt.expected, missing)
+			matching, _ := mergeIndices(matching, tt.lhs, tt.rhs)
+			assert.Equal(t, tt.expected, matching)
 		})
 	}
 }
@@ -150,7 +178,7 @@ var orTests = []struct {
 		[][]float64{{1, 2}, {10, 20}},
 		test.NewSeriesMeta("a", 2),
 		[][]float64{{3, 4}, {30, 40}},
-		test.NewSeriesMeta("a", 2),
+		test.NewSeriesMetaWithoutName("a", 2),
 		[][]float64{{1, 2}, {10, 20}},
 		nil,
 	},
@@ -160,8 +188,18 @@ var orTests = []struct {
 		[][]float64{{1, 2}, {10, 20}},
 		test.NewSeriesMeta("a", 3),
 		[][]float64{{3, 4}, {30, 40}, {50, 60}},
-		test.NewSeriesMeta("a", 3),
+		test.NewSeriesMetaWithoutName("a", 3),
 		[][]float64{{1, 2}, {10, 20}, {50, 60}},
+		nil,
+	},
+	{
+		"valid, some overlap, updating NaNs",
+		test.NewSeriesMeta("a", 2),
+		[][]float64{{1, math.NaN()}, {math.NaN(), 20}},
+		test.NewSeriesMeta("a", 3),
+		[][]float64{{3, 4}, {30, 40}, {50, math.NaN()}},
+		test.NewSeriesMetaWithoutName("a", 3),
+		[][]float64{{1, 4}, {30, 20}, {50, math.NaN()}},
 		nil,
 	},
 	{
@@ -170,7 +208,10 @@ var orTests = []struct {
 		[][]float64{{1, 2}, {10, 20}},
 		test.NewSeriesMeta("b", 2),
 		[][]float64{{3, 4}, {30, 40}},
-		append(test.NewSeriesMeta("a", 2), test.NewSeriesMeta("b", 2)...),
+		append(
+			test.NewSeriesMetaWithoutName("a", 2),
+			test.NewSeriesMetaWithoutName("b", 2)...,
+		),
 		[][]float64{{1, 2}, {10, 20}, {3, 4}, {30, 40}},
 		nil,
 	},
@@ -180,7 +221,10 @@ var orTests = []struct {
 		[][]float64{{1, 2}, {10, 20}},
 		test.NewSeriesMeta("b", 3),
 		[][]float64{{3, 4}, {30, 40}, {300, 400}},
-		append(test.NewSeriesMeta("a", 2), test.NewSeriesMeta("b", 3)...),
+		append(
+			test.NewSeriesMetaWithoutName("a", 2),
+			test.NewSeriesMetaWithoutName("b", 3)...,
+		),
 		[][]float64{{1, 2}, {10, 20}, {3, 4}, {30, 40}, {300, 400}},
 		nil,
 	},
@@ -190,7 +234,10 @@ var orTests = []struct {
 		[][]float64{{1, 2}, {10, 20}, {100, 200}},
 		test.NewSeriesMeta("b", 2),
 		[][]float64{{3, 4}, {30, 40}},
-		append(test.NewSeriesMeta("a", 3), test.NewSeriesMeta("b", 2)...),
+		append(
+			test.NewSeriesMetaWithoutName("a", 3),
+			test.NewSeriesMetaWithoutName("b", 2)...,
+		),
 		[][]float64{{1, 2}, {10, 20}, {100, 200}, {3, 4}, {30, 40}},
 		nil,
 	},
@@ -200,7 +247,10 @@ var orTests = []struct {
 		[][]float64{{1, 2, 3}, {10, 20, 30}},
 		test.NewSeriesMeta("b", 2),
 		[][]float64{{3, 4}, {30, 40}},
-		append(test.NewSeriesMeta("a", 2), test.NewSeriesMeta("b", 2)...),
+		append(
+			test.NewSeriesMetaWithoutName("a", 2),
+			test.NewSeriesMetaWithoutName("b", 2)...,
+		),
 		[][]float64{{1, 2}, {10, 20}, {3, 4}, {30, 40}},
 		errMismatchedStepCounts,
 	},
@@ -210,7 +260,6 @@ func TestOrs(t *testing.T) {
 	now := time.Now()
 	for _, tt := range orTests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			op, err := NewOp(
 				OrType,
 				NodeParams{
@@ -283,15 +332,20 @@ func TestOrsBoundsError(t *testing.T) {
 		Duration: bounds.Duration,
 		StepSize: bounds.StepSize,
 	}
-	rhs := test.NewBlockFromValuesWithSeriesMeta(differentBounds, tt.rhsMeta, tt.rhs)
+	rhs := test.NewBlockFromValuesWithSeriesMeta(
+		differentBounds, tt.rhsMeta, tt.rhs)
 	err = node.Process(models.NoopQueryContext(), parser.NodeID(1), rhs)
 	require.EqualError(t, err, errMismatchedBounds.Error())
 }
 
 func createSeriesMeta() []block.SeriesMeta {
 	return []block.SeriesMeta{
-		{Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("foo"), Value: []byte("bar")}})},
-		{Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("baz"), Value: []byte("qux")}})},
+		{Tags: test.TagSliceToTags([]models.Tag{
+			{Name: []byte("foo"), Value: []byte("bar")},
+		})},
+		{Tags: test.TagSliceToTags([]models.Tag{
+			{Name: []byte("baz"), Value: []byte("qux")},
+		})},
 	}
 }
 
@@ -315,7 +369,9 @@ func TestOrCombinedMetadata(t *testing.T) {
 		StepSize: time.Minute,
 	}
 
-	strTags := test.StringTags{{"a", "b"}, {"c", "d"}, {"e", "f"}}
+	strTags := test.StringTags{
+		{N: "a", V: "b"}, {N: "c", V: "d"}, {N: "e", V: "f"},
+	}
 	lhsMeta := block.Metadata{
 		Bounds: bounds,
 		Tags:   test.StringTagsToTags(strTags),
@@ -330,7 +386,9 @@ func TestOrCombinedMetadata(t *testing.T) {
 	err = node.Process(models.NoopQueryContext(), parser.NodeID(0), lhs)
 	require.NoError(t, err)
 
-	strTags = test.StringTags{{"a", "b"}, {"c", "*d"}, {"g", "h"}}
+	strTags = test.StringTags{
+		{N: "a", V: "b"}, {N: "c", V: "*d"}, {N: "g", V: "h"},
+	}
 	rhsMeta := block.Metadata{
 		Bounds: bounds,
 		Tags:   test.StringTagsToTags(strTags),
@@ -348,17 +406,21 @@ func TestOrCombinedMetadata(t *testing.T) {
 	err = node.Process(models.NoopQueryContext(), parser.NodeID(1), rhs)
 	require.NoError(t, err)
 
-	test.EqualsWithNans(t, [][]float64{{1, 2}, {10, 20}, {3, 4}, {30, 40}}, sink.Values)
+	test.EqualsWithNans(t, [][]float64{
+		{1, 2}, {10, 20}, {3, 4}, {30, 40},
+	}, sink.Values)
 
 	assert.Equal(t, sink.Meta.Bounds, bounds)
-	exTags := test.TagSliceToTags([]models.Tag{{Name: []byte("a"), Value: []byte("b")}})
+	exTags := test.TagSliceToTags([]models.Tag{
+		{Name: []byte("a"), Value: []byte("b")},
+	})
 	assert.Equal(t, exTags.Tags, sink.Meta.Tags.Tags)
 
 	stringTags := []test.StringTags{
-		{{"c", "d"}, {"e", "f"}, {"foo", "bar"}},
-		{{"baz", "qux"}, {"c", "d"}, {"e", "f"}},
-		{{"c", "*d"}, {"foo", "bar"}, {"g", "h"}},
-		{{"baz", "qux"}, {"c", "*d"}, {"g", "h"}},
+		{{N: "c", V: "d"}, {N: "e", V: "f"}, {N: "foo", V: "bar"}},
+		{{N: "baz", V: "qux"}, {N: "c", V: "d"}, {N: "e", V: "f"}},
+		{{N: "c", V: "*d"}, {N: "foo", V: "bar"}, {N: "g", V: "h"}},
+		{{N: "baz", V: "qux"}, {N: "c", V: "*d"}, {N: "g", V: "h"}},
 	}
 
 	tags := test.StringTagsSliceToTagSlice(stringTags)

--- a/src/query/functions/binary/unless_test.go
+++ b/src/query/functions/binary/unless_test.go
@@ -35,64 +35,72 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func m(i int) indexMatcher {
+	return mm(i, i)
+}
+
+func mm(l, r int) indexMatcher {
+	return indexMatcher{lhsIndex: l, rhsIndex: r}
+}
+
 var distinctLeftTests = []struct {
-	name      string
-	lhs, rhs  []block.SeriesMeta
-	expectedL []int
+	name     string
+	lhs, rhs []block.SeriesMeta
+	expected []indexMatcher
 }{
 	{
 		"equal tags",
 		generateMetaDataWithTagsInRange(0, 5),
 		generateMetaDataWithTagsInRange(0, 5),
-		[]int{0, 1, 2, 3, 4},
+		[]indexMatcher{m(0), m(1), m(2), m(3), m(4)},
 	},
 	{
 		"empty rhs",
 		generateMetaDataWithTagsInRange(0, 5),
 		[]block.SeriesMeta{},
-		[]int{},
+		[]indexMatcher{},
 	},
 	{
 		"empty lhs",
 		[]block.SeriesMeta{},
 		generateMetaDataWithTagsInRange(0, 5),
-		[]int{-1, -1, -1, -1, -1},
+		[]indexMatcher{},
 	},
 	{
 		"longer lhs",
 		generateMetaDataWithTagsInRange(-1, 6),
 		generateMetaDataWithTagsInRange(0, 5),
-		[]int{1, 2, 3, 4, 5},
+		[]indexMatcher{mm(1, 0), mm(2, 1), mm(3, 2), mm(4, 3), mm(5, 4)},
 	},
 	{
 		"longer rhs",
 		generateMetaDataWithTagsInRange(0, 5),
 		generateMetaDataWithTagsInRange(-1, 6),
-		[]int{-1, 0, 1, 2, 3, 4, -1},
+		[]indexMatcher{mm(0, 1), mm(1, 2), mm(2, 3), mm(3, 4), mm(4, 5)},
 	},
 	{
 		"shorter lhs",
 		generateMetaDataWithTagsInRange(1, 4),
 		generateMetaDataWithTagsInRange(0, 5),
-		[]int{-1, 0, 1, 2, -1},
+		[]indexMatcher{mm(0, 1), mm(1, 2), mm(2, 3)},
 	},
 	{
 		"shorter rhs",
 		generateMetaDataWithTagsInRange(0, 5),
 		generateMetaDataWithTagsInRange(1, 4),
-		[]int{1, 2, 3},
+		[]indexMatcher{mm(1, 0), mm(2, 1), mm(3, 2)},
 	},
 	{
 		"partial overlap",
 		generateMetaDataWithTagsInRange(0, 5),
 		generateMetaDataWithTagsInRange(1, 6),
-		[]int{1, 2, 3, 4, -1},
+		[]indexMatcher{mm(1, 0), mm(2, 1), mm(3, 2), mm(4, 3)},
 	},
 	{
 		"no overlap",
 		generateMetaDataWithTagsInRange(0, 5),
 		generateMetaDataWithTagsInRange(6, 9),
-		[]int{-1, -1, -1},
+		[]indexMatcher{},
 	},
 }
 
@@ -101,7 +109,7 @@ func TestMatchingIndices(t *testing.T) {
 	for _, tt := range distinctLeftTests {
 		t.Run(tt.name, func(t *testing.T) {
 			excluded := matchingIndices(matching, tt.lhs, tt.rhs)
-			assert.Equal(t, tt.expectedL, excluded)
+			assert.Equal(t, tt.expected, excluded)
 		})
 	}
 }

--- a/src/query/functions/binary/unless_test.go
+++ b/src/query/functions/binary/unless_test.go
@@ -42,72 +42,79 @@ var distinctLeftTests = []struct {
 }{
 	{
 		"equal tags",
-		generateMetaDataWithTagsInRange(0, 5), generateMetaDataWithTagsInRange(0, 5),
-		[]int{},
+		generateMetaDataWithTagsInRange(0, 5),
+		generateMetaDataWithTagsInRange(0, 5),
+		[]int{0, 1, 2, 3, 4},
 	},
 	{
 		"empty rhs",
-		generateMetaDataWithTagsInRange(0, 5), []block.SeriesMeta{},
-		[]int{0, 1, 2, 3, 4},
+		generateMetaDataWithTagsInRange(0, 5),
+		[]block.SeriesMeta{},
+		[]int{},
 	},
 	{
 		"empty lhs",
-		[]block.SeriesMeta{}, generateMetaDataWithTagsInRange(0, 5),
-		[]int{},
+		[]block.SeriesMeta{},
+		generateMetaDataWithTagsInRange(0, 5),
+		[]int{-1, -1, -1, -1, -1},
 	},
 	{
 		"longer lhs",
-		generateMetaDataWithTagsInRange(-1, 6), generateMetaDataWithTagsInRange(0, 5),
-		[]int{0, 6},
+		generateMetaDataWithTagsInRange(-1, 6),
+		generateMetaDataWithTagsInRange(0, 5),
+		[]int{1, 2, 3, 4, 5},
 	},
 	{
 		"longer rhs",
-		generateMetaDataWithTagsInRange(0, 5), generateMetaDataWithTagsInRange(-1, 6),
-		[]int{},
+		generateMetaDataWithTagsInRange(0, 5),
+		generateMetaDataWithTagsInRange(-1, 6),
+		[]int{-1, 0, 1, 2, 3, 4, -1},
 	},
 	{
 		"shorter lhs",
-		generateMetaDataWithTagsInRange(1, 4), generateMetaDataWithTagsInRange(0, 5),
-		[]int{},
+		generateMetaDataWithTagsInRange(1, 4),
+		generateMetaDataWithTagsInRange(0, 5),
+		[]int{-1, 0, 1, 2, -1},
 	},
 	{
 		"shorter rhs",
-		generateMetaDataWithTagsInRange(0, 5), generateMetaDataWithTagsInRange(1, 4),
-		[]int{0, 4},
+		generateMetaDataWithTagsInRange(0, 5),
+		generateMetaDataWithTagsInRange(1, 4),
+		[]int{1, 2, 3},
 	},
 	{
 		"partial overlap",
-		generateMetaDataWithTagsInRange(0, 5), generateMetaDataWithTagsInRange(1, 6),
-		[]int{0},
+		generateMetaDataWithTagsInRange(0, 5),
+		generateMetaDataWithTagsInRange(1, 6),
+		[]int{1, 2, 3, 4, -1},
 	},
 	{
 		"no overlap",
-		generateMetaDataWithTagsInRange(0, 5), generateMetaDataWithTagsInRange(6, 9),
-		[]int{0, 1, 2, 3, 4},
+		generateMetaDataWithTagsInRange(0, 5),
+		generateMetaDataWithTagsInRange(6, 9),
+		[]int{-1, -1, -1},
 	},
 }
 
-func TestDistinctLeft(t *testing.T) {
+func TestMatchingIndices(t *testing.T) {
 	matching := &VectorMatching{}
-
 	for _, tt := range distinctLeftTests {
 		t.Run(tt.name, func(t *testing.T) {
-			excluded := distinctLeft(matching, tt.lhs, tt.rhs)
+			excluded := matchingIndices(matching, tt.lhs, tt.rhs)
 			assert.Equal(t, tt.expectedL, excluded)
 		})
 	}
 }
 
 var unlessTests = []struct {
-	name           string
-	lhsMeta        []block.SeriesMeta
-	lhs            [][]float64
-	rhsMeta        []block.SeriesMeta
-	rhs            [][]float64
-	expectedShared models.Tags
-	expectedMetas  []block.SeriesMeta
-	expected       [][]float64
-	err            error
+	name          string
+	lhsMeta       []block.SeriesMeta
+	lhs           [][]float64
+	rhsMeta       []block.SeriesMeta
+	rhs           [][]float64
+	expectedMetas []block.SeriesMeta
+	expected      [][]float64
+	err           error
 }{
 	{
 		"valid, equal tags",
@@ -115,20 +122,18 @@ var unlessTests = []struct {
 		[][]float64{{1, 2}, {10, 20}},
 		test.NewSeriesMeta("a", 2),
 		[][]float64{{3, 4}, {30, 40}},
-		models.EmptyTags(),
-		[]block.SeriesMeta{},
-		[][]float64{},
+		test.NewSeriesMetaWithoutName("a", 2),
+		[][]float64{{nan, nan}, {nan, nan}},
 		nil,
 	},
 	{
 		"valid, some overlap right",
 		test.NewSeriesMeta("a", 2),
-		[][]float64{{1, 2}, {10, 20}},
+		[][]float64{{nan, 2}, {10, 20}},
 		test.NewSeriesMeta("a", 3),
-		[][]float64{{3, 4}, {30, 40}, {50, 60}},
-		models.EmptyTags(),
-		[]block.SeriesMeta{},
-		[][]float64{},
+		[][]float64{{3, nan}, {30, 40}, {50, 60}},
+		test.NewSeriesMetaWithoutName("a", 2),
+		[][]float64{{nan, 2}, {nan, nan}},
 		nil,
 	},
 	{
@@ -136,10 +141,9 @@ var unlessTests = []struct {
 		test.NewSeriesMeta("a", 3),
 		[][]float64{{1, 2}, {10, 20}, {100, 200}},
 		test.NewSeriesMeta("a", 3)[1:],
-		[][]float64{{3, 4}, {30, 40}},
-		test.NewSeriesMeta("a", 1)[0].Tags,
-		[]block.SeriesMeta{{Tags: models.EmptyTags(), Name: []byte("a0")}},
-		[][]float64{{1, 2}},
+		[][]float64{{3, 4}, {nan, 40}},
+		test.NewSeriesMetaWithoutName("a", 3),
+		[][]float64{{1, 2}, {nan, nan}, {100, nan}},
 		nil,
 	},
 	{
@@ -147,42 +151,38 @@ var unlessTests = []struct {
 		test.NewSeriesMeta("a", 3),
 		[][]float64{{1, 2}, {10, 20}, {100, 200}},
 		test.NewSeriesMeta("a", 4)[1:],
-		[][]float64{{3, 4}, {30, 40}, {300, 400}},
-		test.NewSeriesMeta("a", 1)[0].Tags,
-		[]block.SeriesMeta{{Tags: models.EmptyTags(), Name: []byte("a0")}},
-		[][]float64{{1, 2}},
+		[][]float64{{3, nan}, {nan, 40}, {300, 400}},
+		test.NewSeriesMetaWithoutName("a", 3),
+		[][]float64{{1, 2}, {nan, 20}, {100, nan}},
 		nil,
 	},
 	{
-		"valid, equal size",
+		"valid, different tags",
 		test.NewSeriesMeta("a", 2),
 		[][]float64{{1, 2}, {10, 20}},
 		test.NewSeriesMeta("b", 2),
-		[][]float64{{3, 4}, {30, 40}},
-		models.EmptyTags(),
-		test.NewSeriesMeta("a", 2),
+		[][]float64{{nan, 4}, {30, 40}},
+		test.NewSeriesMetaWithoutName("a", 2),
 		[][]float64{{1, 2}, {10, 20}},
 		nil,
 	},
 	{
-		"valid, longer rhs",
+		"valid, different tags, longer rhs",
 		test.NewSeriesMeta("a", 2),
 		[][]float64{{1, 2}, {10, 20}},
 		test.NewSeriesMeta("b", 3),
 		[][]float64{{3, 4}, {30, 40}, {300, 400}},
-		models.EmptyTags(),
-		test.NewSeriesMeta("a", 2),
+		test.NewSeriesMetaWithoutName("a", 2),
 		[][]float64{{1, 2}, {10, 20}},
 		nil,
 	},
 	{
-		"valid, longer lhs",
+		"valid, different tags, longer lhs",
 		test.NewSeriesMeta("a", 3),
 		[][]float64{{1, 2}, {10, 20}, {100, 200}},
 		test.NewSeriesMeta("b", 2),
 		[][]float64{{3, 4}, {30, 40}},
-		models.EmptyTags(),
-		test.NewSeriesMeta("a", 3),
+		test.NewSeriesMetaWithoutName("a", 3),
 		[][]float64{{1, 2}, {10, 20}, {100, 200}},
 		nil,
 	},
@@ -192,8 +192,7 @@ var unlessTests = []struct {
 		[][]float64{{1, 2, 3}, {10, 20, 30}},
 		test.NewSeriesMeta("b", 2),
 		[][]float64{{3, 4}, {30, 40}},
-		models.EmptyTags(),
-		[]block.SeriesMeta{},
+		test.NewSeriesMetaWithoutName("a", 0),
 		[][]float64{},
 		errMismatchedStepCounts,
 	},
@@ -240,7 +239,7 @@ func TestUnless(t *testing.T) {
 			require.NoError(t, err)
 			test.EqualsWithNans(t, tt.expected, sink.Values)
 			meta := sink.Meta
-			assert.Equal(t, tt.expectedShared.Tags, meta.Tags.Tags)
+			assert.Equal(t, 0, meta.Tags.Len())
 			assert.True(t, meta.Bounds.Equals(bounds))
 			assert.Equal(t, tt.expectedMetas, sink.Metas)
 		})

--- a/src/query/functions/lazy/base_test.go
+++ b/src/query/functions/lazy/base_test.go
@@ -52,7 +52,7 @@ func testLazyOpts(timeOffset time.Duration, valOffset float64) block.LazyOptions
 	}
 	vt := func(val float64) float64 { return val * valOffset }
 
-	return block.NewLazyOpts().SetTimeTransform(tt).SetMetaTransform(mt).SetValueTransform(vt)
+	return block.NewLazyOptions().SetTimeTransform(tt).SetMetaTransform(mt).SetValueTransform(vt)
 }
 
 func TestOffsetOp(t *testing.T) {

--- a/src/query/functions/linear/histogram_quantile.go
+++ b/src/query/functions/linear/histogram_quantile.go
@@ -278,7 +278,7 @@ func setupBuilder(
 		idx++
 	}
 
-	meta.Tags, metas = utils.DedupeMetadata(metas)
+	meta.Tags, metas = utils.DedupeMetadata(metas, meta.Tags.Opts)
 	builder, err := controller.BlockBuilder(queryCtx, meta, metas)
 	if err != nil {
 		return nil, err

--- a/src/query/functions/utils/metadata.go
+++ b/src/query/functions/utils/metadata.go
@@ -42,9 +42,10 @@ func FlattenMetadata(
 // DedupeMetadata applies all shared tags from Metadata to each SeriesMeta
 func DedupeMetadata(
 	seriesMeta []block.SeriesMeta,
+	tagOptions models.TagOptions,
 ) (models.Tags, []block.SeriesMeta) {
 	if len(seriesMeta) == 0 {
-		return models.EmptyTags(), seriesMeta
+		return models.NewTags(0, tagOptions), seriesMeta
 	}
 
 	commonKeys := make([][]byte, 0, seriesMeta[0].Tags.Len())
@@ -77,7 +78,7 @@ func DedupeMetadata(
 		seriesMeta[i].Tags = meta.Tags.TagsWithoutKeys(commonKeys)
 	}
 
-	tags := models.NewTags(len(commonTags), seriesMeta[0].Tags.Opts)
+	tags := models.NewTags(len(commonTags), tagOptions)
 	for n, v := range commonTags {
 		tags = tags.AddTag(models.Tag{Name: []byte(n), Value: v})
 	}

--- a/src/query/functions/utils/metadata_test.go
+++ b/src/query/functions/utils/metadata_test.go
@@ -38,9 +38,13 @@ func TestFlattenMetadata(t *testing.T) {
 
 	seriesMetas := []block.SeriesMeta{
 		{Name: []byte("foo"),
-			Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("e"), Value: []byte("f")}})},
+			Tags: test.TagSliceToTags([]models.Tag{
+				{Name: []byte("e"), Value: []byte("f")},
+			})},
 		{Name: []byte("bar"),
-			Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("g"), Value: []byte("h")}})},
+			Tags: test.TagSliceToTags([]models.Tag{
+				{Name: []byte("g"), Value: []byte("h")}},
+			)},
 	}
 	flattened := FlattenMetadata(meta, seriesMetas)
 
@@ -74,36 +78,36 @@ var dedupeMetadataTests = []struct {
 	},
 	{
 		"single metas",
-		[]test.StringTags{{{"a", "b"}, {"c", "d"}}},
-		test.StringTags{{"a", "b"}, {"c", "d"}},
+		[]test.StringTags{{{N: "a", V: "b"}, {N: "c", V: "d"}}},
+		test.StringTags{{N: "a", V: "b"}, {N: "c", V: "d"}},
 		[]test.StringTags{{}},
 	},
 	{
 		"one common tag, longer first",
-		[]test.StringTags{{{"a", "b"}, {"c", "d"}}, {{"a", "b"}}},
-		test.StringTags{{"a", "b"}},
-		[]test.StringTags{{{"c", "d"}}, {}},
+		[]test.StringTags{{{N: "a", V: "b"}, {N: "c", V: "d"}}, {{N: "a", V: "b"}}},
+		test.StringTags{{N: "a", V: "b"}},
+		[]test.StringTags{{{N: "c", V: "d"}}, {}},
 	},
 	{
 		"one common tag, longer second",
-		[]test.StringTags{{{"a", "b"}}, {{"a", "b"}, {"c", "d"}}},
-		test.StringTags{{"a", "b"}},
-		[]test.StringTags{{}, {{"c", "d"}}},
+		[]test.StringTags{{{N: "a", V: "b"}}, {{N: "a", V: "b"}, {N: "c", V: "d"}}},
+		test.StringTags{{N: "a", V: "b"}},
+		[]test.StringTags{{}, {{N: "c", V: "d"}}},
 	},
 	{
 		"two common tags",
-		[]test.StringTags{{{"a", "b"}, {"c", "d"}}, {{"a", "b"},
-			{"c", "d"}}, {{"a", "b"}, {"c", "d"}}},
-		test.StringTags{{"a", "b"}, {"c", "d"}},
+		[]test.StringTags{{{N: "a", V: "b"}, {N: "c", V: "d"}}, {{N: "a", V: "b"},
+			{N: "c", V: "d"}}, {{N: "a", V: "b"}, {N: "c", V: "d"}}},
+		test.StringTags{{N: "a", V: "b"}, {N: "c", V: "d"}},
 		[]test.StringTags{{}, {}, {}},
 	},
 	{
 		"no common tags in one series",
-		[]test.StringTags{{{"a", "b"}, {"c", "d"}}, {{"a", "b"}, {"c", "d"}},
-			{{"a", "b*"}, {"c*", "d"}}},
+		[]test.StringTags{{{N: "a", V: "b"}, {N: "c", V: "d"}}, {{N: "a", V: "b"},
+			{N: "c", V: "d"}}, {{N: "a", V: "b*"}, {N: "c*", V: "d"}}},
 		test.StringTags{},
-		[]test.StringTags{{{"a", "b"}, {"c", "d"}}, {{"a", "b"},
-			{"c", "d"}}, {{"a", "b*"}, {"c*", "d"}}},
+		[]test.StringTags{{{N: "a", V: "b"}, {N: "c", V: "d"}}, {{N: "a", V: "b"},
+			{N: "c", V: "d"}}, {{N: "a", V: "b*"}, {N: "c*", V: "d"}}},
 	},
 }
 
@@ -118,7 +122,8 @@ func TestDedupeMetadata(t *testing.T) {
 				seriesMetas[i] = block.SeriesMeta{Tags: tags}
 			}
 
-			actual, actualSeriesMetas := DedupeMetadata(seriesMetas)
+			actual, actualSeriesMetas := DedupeMetadata(seriesMetas,
+				models.NewTagOptions())
 			exCommon := test.StringTagsToTags(tt.expectedCommon)
 			assert.Equal(t, exCommon, actual)
 

--- a/src/query/models/tags.go
+++ b/src/query/models/tags.go
@@ -26,9 +26,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cespare/xxhash"
 	"github.com/m3db/m3/src/query/models/strconv"
 	"github.com/m3db/m3/src/query/util/writer"
+
+	"github.com/cespare/xxhash"
 )
 
 // NewTags builds a tags with the given size and tag options.

--- a/src/query/models/tags.go
+++ b/src/query/models/tags.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"sort"
+	"strings"
 
 	"github.com/m3db/m3/src/query/models/strconv"
 	"github.com/m3db/m3/src/query/util/writer"
@@ -434,6 +435,15 @@ func (t Tags) HashedID() uint64 {
 	h := fnv.New64a()
 	h.Write(t.ID())
 	return h.Sum64()
+}
+
+func (t Tags) String() string {
+	tags := make([]string, len(t.Tags))
+	for i, tt := range t.Tags {
+		tags[i] = tt.String()
+	}
+
+	return strings.Join(tags, ", ")
 }
 
 func (t Tag) String() string {

--- a/src/query/models/tags.go
+++ b/src/query/models/tags.go
@@ -23,10 +23,10 @@ package models
 import (
 	"bytes"
 	"fmt"
-	"hash/fnv"
 	"sort"
 	"strings"
 
+	"github.com/cespare/xxhash"
 	"github.com/m3db/m3/src/query/models/strconv"
 	"github.com/m3db/m3/src/query/util/writer"
 )
@@ -432,9 +432,7 @@ func (t Tags) Normalize() Tags {
 
 // HashedID returns the hashed ID for the tags.
 func (t Tags) HashedID() uint64 {
-	h := fnv.New64a()
-	h.Write(t.ID())
-	return h.Sum64()
+	return xxhash.Sum64(t.ID())
 }
 
 func (t Tags) String() string {

--- a/src/query/models/tags_test.go
+++ b/src/query/models/tags_test.go
@@ -27,11 +27,10 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/cespare/xxhash"
-
 	"github.com/m3db/m3/src/query/util/writer"
 	xtest "github.com/m3db/m3/src/x/test"
 
+	"github.com/cespare/xxhash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/src/query/models/tags_test.go
+++ b/src/query/models/tags_test.go
@@ -23,10 +23,11 @@ package models
 import (
 	"bytes"
 	"fmt"
-	"hash/fnv"
 	"reflect"
 	"testing"
 	"unsafe"
+
+	"github.com/cespare/xxhash"
 
 	"github.com/m3db/m3/src/query/util/writer"
 	xtest "github.com/m3db/m3/src/x/test"
@@ -86,10 +87,7 @@ func TestHashedID(t *testing.T) {
 	tags := testLongTagIDOutOfOrder(t, TypeLegacy)
 	actual := tags.HashedID()
 
-	h := fnv.New64a()
-	h.Write([]byte("t1=v1,t2=v2,t3=v3,t4=v4,"))
-	expected := h.Sum64()
-
+	expected := xxhash.Sum64String("t1=v1,t2=v2,t3=v3,t4=v4,")
 	assert.Equal(t, expected, actual)
 }
 

--- a/src/query/parser/interface.go
+++ b/src/query/parser/interface.go
@@ -26,22 +26,23 @@ import (
 	"github.com/m3db/m3/src/query/models"
 )
 
-// Parser consists of the language specific representation of AST and can convert into a common DAG
+// Parser consists of the language specific representation of AST and can
+// convert into a common DAG.
 type Parser interface {
 	DAG() (Nodes, Edges, error)
 	String() string
 }
 
-// NodeID uniquely identifies all transforms in DAG
+// NodeID uniquely identifies all transforms in DAG.
 type NodeID string
 
-// Params is a function definition. It is immutable and contains no state
+// Params is a function definition. It is immutable and contains no state.
 type Params interface {
 	fmt.Stringer
 	OpType() string
 }
 
-// Nodes is a slice of Node
+// Nodes is a slice of Node objects.
 type Nodes []Node
 
 // Node represents an immutable node in the common DAG with a unique identifier.
@@ -55,7 +56,7 @@ func (t Node) String() string {
 	return fmt.Sprintf("ID: %s, Op: %s", t.ID, t.Op)
 }
 
-// Edge identifies parent-child relation between transforms
+// Edge identifies parent-child relation between transforms.
 type Edge struct {
 	ParentID NodeID
 	ChildID  NodeID
@@ -65,10 +66,10 @@ func (e Edge) String() string {
 	return fmt.Sprintf("parent: %s, child: %s", e.ParentID, e.ChildID)
 }
 
-// Edges is a slice of Edge
+// Edges is a slice of Edge objects.
 type Edges []Edge
 
-// NewTransformFromOperation creates a new transform
+// NewTransformFromOperation creates a new transform.
 func NewTransformFromOperation(Op Params, nextID int) Node {
 	return Node{
 		Op: Op,
@@ -76,7 +77,8 @@ func NewTransformFromOperation(Op Params, nextID int) Node {
 	}
 }
 
-// Source represents data sources which are handled differently than other transforms as they are always independent and can always be parallelized
+// Source represents data sources which are handled differently than other
+// transforms as they are always independent and can always be parallelized.
 type Source interface {
 	Execute(queryCtx *models.QueryContext) error
 }

--- a/src/query/parser/promql/item.go
+++ b/src/query/parser/promql/item.go
@@ -20,8 +20,9 @@
 
 package promql
 
-// ItemType which maps to ItemType in Prometheus. Note that this is temporary and
-// once we decide we want to use this approach then we will just expose the item types in Prometheus code base
+// ItemType which maps to ItemType in Prometheus. Note that this is temporary
+// and once we decide we want to use this approach then we will just expose the
+// item types in Prometheus code base.
 type ItemType int
 
 // nolint

--- a/src/query/parser/promql/parse_test.go
+++ b/src/query/parser/promql/parse_test.go
@@ -51,8 +51,10 @@ func TestDAGWithCountOp(t *testing.T) {
 	assert.Equal(t, transforms[1].ID, parser.NodeID("1"))
 	assert.Equal(t, transforms[1].Op.OpType(), aggregation.CountType)
 	assert.Len(t, edges, 1)
-	assert.Equal(t, edges[0].ParentID, parser.NodeID("0"), "fetch should be the parent")
-	assert.Equal(t, edges[0].ChildID, parser.NodeID("1"), "aggregation should be the child")
+	assert.Equal(t, edges[0].ParentID, parser.NodeID("0"),
+		"fetch should be the parent")
+	assert.Equal(t, edges[0].ChildID, parser.NodeID("1"),
+		"aggregation should be the child")
 }
 
 func TestDAGWithOffset(t *testing.T) {
@@ -67,8 +69,10 @@ func TestDAGWithOffset(t *testing.T) {
 	assert.Equal(t, transforms[1].ID, parser.NodeID("1"))
 	assert.Equal(t, transforms[1].Op.OpType(), lazy.OffsetType)
 	assert.Len(t, edges, 1)
-	assert.Equal(t, edges[0].ParentID, parser.NodeID("0"), "fetch should be the parent")
-	assert.Equal(t, edges[0].ChildID, parser.NodeID("1"), "offset should be the child")
+	assert.Equal(t, edges[0].ParentID, parser.NodeID("0"),
+		"fetch should be the parent")
+	assert.Equal(t, edges[0].ChildID, parser.NodeID("1"),
+		"offset should be the child")
 }
 
 func TestInvalidOffset(t *testing.T) {
@@ -255,6 +259,27 @@ func TestScalar(t *testing.T) {
 	assert.Equal(t, transforms[0].Op.OpType(), functions.FetchType)
 	assert.Equal(t, transforms[0].ID, parser.NodeID("0"))
 	assert.Len(t, edges, 0)
+}
+
+func TestVector(t *testing.T) {
+	vectorExprs := []string{
+		"vector(12)",
+		"vector(scalar(up))",
+		"vector(12 - scalar(vector(100)-2))",
+	}
+
+	for _, expr := range vectorExprs {
+		t.Run(expr, func(t *testing.T) {
+			p, err := Parse(expr, models.NewTagOptions())
+			require.NoError(t, err)
+			transforms, edges, err := p.DAG()
+			require.NoError(t, err)
+			assert.Len(t, transforms, 1)
+			assert.Equal(t, transforms[0].Op.OpType(), scalar.ScalarType)
+			assert.Equal(t, transforms[0].ID, parser.NodeID("0"))
+			assert.Len(t, edges, 0)
+		})
+	}
 }
 
 func TestTimeTypeParse(t *testing.T) {

--- a/src/query/parser/promql/resolve_scalars.go
+++ b/src/query/parser/promql/resolve_scalars.go
@@ -43,14 +43,18 @@ func resolveScalarArgument(expr pql.Expr) (float64, error) {
 	}
 
 	if nesting != 0 {
-		return 0, fmt.Errorf("promql.resolveScalarArgument: invalid nesting %d", nesting)
+		return 0, fmt.Errorf("promql.resolveScalarArgument: invalid nesting %d",
+			nesting)
 	}
 
 	return value, nil
 }
 
 // resolves an expression which should resolve to a scalar argument
-func resolveScalarArgumentWithNesting(expr pql.Expr, nesting int) (float64, int, error) {
+func resolveScalarArgumentWithNesting(
+	expr pql.Expr,
+	nesting int,
+) (float64, int, error) {
 	if expr == nil {
 		return 0, 0, errNilScalarArg
 	}
@@ -92,11 +96,11 @@ func resolveScalarArgumentWithNesting(expr pql.Expr, nesting int) (float64, int,
 
 	case *pql.Call:
 		// TODO: once these functions exist, use those constants here
-		// If the function called is `scalar`, evaluate inside and ensure a scalar
+		// If the function called is `scalar`, evaluate and ensure a scalar.
 		if n.Func.Name == "scalar" {
 			return resolveScalarArgumentWithNesting(n.Args[0], nesting+1)
 		} else if n.Func.Name == "vector" {
-			// If the function called is `vector`, evaluate inside and insure a vector
+			// If the function called is `vector`, evaluate and ensure a vector.
 			if nesting < 1 {
 				return 0, 0, errInvalidNestingVector
 			}
@@ -114,5 +118,6 @@ func resolveScalarArgumentWithNesting(expr pql.Expr, nesting int) (float64, int,
 		return resolveScalarArgumentWithNesting(n.Expr, nesting)
 	}
 
-	return 0, 0, fmt.Errorf("resolveScalarArgument: unhandled node type %T, %v", expr, expr)
+	return 0, 0, fmt.Errorf("resolveScalarArgument: unhandled node type %T, %v",
+		expr, expr)
 }

--- a/src/query/test/block.go
+++ b/src/query/test/block.go
@@ -30,22 +30,31 @@ import (
 	"github.com/m3db/m3/src/query/ts"
 )
 
-// ValueMod can be used to modify provided values for testing
+// ValueMod can be used to modify provided values for testing.
 type ValueMod func([]float64) []float64
 
-// NoopMod can be used to generate multi blocks when no value modification is needed
+// NoopMod can be used to generate multi blocks when no value
+// modification is needed.
 func NoopMod(v []float64) []float64 {
 	return v
 }
 
-// NewBlockFromValues creates a new block using the provided values
-func NewBlockFromValues(bounds models.Bounds, seriesValues [][]float64) block.Block {
+// NewBlockFromValues creates a new block using the provided values.
+func NewBlockFromValues(
+	bounds models.Bounds,
+	seriesValues [][]float64,
+) block.Block {
 	meta := NewSeriesMeta("dummy", len(seriesValues))
 	return NewBlockFromValuesWithSeriesMeta(bounds, meta, seriesValues)
 }
 
-// NewUnconsolidatedBlockFromDatapointsWithMeta creates a new unconsolidated block using the provided values and metadata
-func NewUnconsolidatedBlockFromDatapointsWithMeta(bounds models.Bounds, meta []block.SeriesMeta, seriesValues [][]float64) block.Block {
+// NewUnconsolidatedBlockFromDatapointsWithMeta creates a new unconsolidated
+// block using the provided values and metadata.
+func NewUnconsolidatedBlockFromDatapointsWithMeta(
+	bounds models.Bounds,
+	meta []block.SeriesMeta,
+	seriesValues [][]float64,
+) block.Block {
 	seriesList := make(ts.SeriesList, len(seriesValues))
 	for i, values := range seriesValues {
 		dps := seriesValuesToDatapoints(values, bounds)
@@ -61,13 +70,24 @@ func NewUnconsolidatedBlockFromDatapointsWithMeta(bounds models.Bounds, meta []b
 	return storage.NewMultiBlockWrapper(b)
 }
 
-// NewUnconsolidatedBlockFromDatapoints creates a new unconsolidated block using the provided values
-func NewUnconsolidatedBlockFromDatapoints(bounds models.Bounds, seriesValues [][]float64) block.Block {
+// NewUnconsolidatedBlockFromDatapoints creates a new unconsolidated block
+// using the provided values.
+func NewUnconsolidatedBlockFromDatapoints(
+	bounds models.Bounds,
+	seriesValues [][]float64,
+) block.Block {
 	meta := NewSeriesMeta("dummy", len(seriesValues))
-	return NewUnconsolidatedBlockFromDatapointsWithMeta(bounds, meta, seriesValues)
+	return NewUnconsolidatedBlockFromDatapointsWithMeta(
+		bounds,
+		meta,
+		seriesValues,
+	)
 }
 
-func seriesValuesToDatapoints(values []float64, bounds models.Bounds) ts.Datapoints {
+func seriesValuesToDatapoints(
+	values []float64,
+	bounds models.Bounds,
+) ts.Datapoints {
 	dps := make(ts.Datapoints, len(values))
 	for i, v := range values {
 		t, _ := bounds.TimeForIndex(i)
@@ -80,12 +100,19 @@ func seriesValuesToDatapoints(values []float64, bounds models.Bounds) ts.Datapoi
 	return dps
 }
 
-// NewMultiUnconsolidatedBlocksFromValues creates new blocks using the provided values and a modifier
-func NewMultiUnconsolidatedBlocksFromValues(bounds models.Bounds, seriesValues [][]float64, valueMod ValueMod, numBlocks int) []block.Block {
+// NewMultiUnconsolidatedBlocksFromValues creates
+// new blocks using the provided values and a modifier.
+func NewMultiUnconsolidatedBlocksFromValues(
+	bounds models.Bounds,
+	seriesValues [][]float64,
+	valueMod ValueMod,
+	numBlocks int,
+) []block.Block {
 	meta := NewSeriesMeta("dummy", len(seriesValues))
 	blocks := make([]block.Block, numBlocks)
 	for i := 0; i < numBlocks; i++ {
-		blocks[i] = NewUnconsolidatedBlockFromDatapointsWithMeta(bounds, meta, seriesValues)
+		blocks[i] = NewUnconsolidatedBlockFromDatapointsWithMeta(bounds,
+			meta, seriesValues)
 		// Avoid modifying the first value
 		for i, val := range seriesValues {
 			seriesValues[i] = valueMod(val)
@@ -96,13 +123,27 @@ func NewMultiUnconsolidatedBlocksFromValues(bounds models.Bounds, seriesValues [
 	return blocks
 }
 
-// NewSeriesMeta creates new metadata tags in the format [tagPrefix:i] for the number of series
+// NewSeriesMetaWithoutName creates new metadata tags in the format
+// [tagPrefix:i] for the number of series, without including the __name__.
+func NewSeriesMetaWithoutName(tagPrefix string, count int) []block.SeriesMeta {
+	return newSeriesMeta(tagPrefix, count, false)
+}
+
+// NewSeriesMeta creates new metadata tags in the format [tagPrefix:i]
+// for the number of series.
 func NewSeriesMeta(tagPrefix string, count int) []block.SeriesMeta {
+	return newSeriesMeta(tagPrefix, count, true)
+}
+
+func newSeriesMeta(tagPrefix string, count int, name bool) []block.SeriesMeta {
 	seriesMeta := make([]block.SeriesMeta, count)
 	for i := range seriesMeta {
 		tags := models.EmptyTags()
 		st := []byte(fmt.Sprintf("%s%d", tagPrefix, i))
-		tags = tags.AddTag(models.Tag{Name: []byte("__name__"), Value: st})
+		if name {
+			tags = tags.AddTag(models.Tag{Name: []byte("__name__"), Value: st})
+		}
+
 		tags = tags.AddTag(models.Tag{Name: st, Value: st})
 		seriesMeta[i] = block.SeriesMeta{
 			Name: st,
@@ -112,25 +153,37 @@ func NewSeriesMeta(tagPrefix string, count int) []block.SeriesMeta {
 	return seriesMeta
 }
 
-// NewBlockFromValuesWithSeriesMeta creates a new block using the provided values
+// NewBlockFromValuesWithSeriesMeta creates a new block using the
+// provided values.
 func NewBlockFromValuesWithSeriesMeta(
 	bounds models.Bounds,
 	seriesMeta []block.SeriesMeta,
 	seriesValues [][]float64,
 ) block.Block {
-	blockMeta := block.Metadata{Bounds: bounds, Tags: models.NewTags(0, models.NewTagOptions())}
+	blockMeta := block.Metadata{
+		Bounds: bounds,
+		Tags:   models.NewTags(0, models.NewTagOptions()),
+	}
 
-	return NewBlockFromValuesWithMetaAndSeriesMeta(blockMeta, seriesMeta, seriesValues)
+	return NewBlockFromValuesWithMetaAndSeriesMeta(
+		blockMeta,
+		seriesMeta,
+		seriesValues,
+	)
 }
 
-// NewBlockFromValuesWithMetaAndSeriesMeta creates a new block using the provided values
-// Note: panics on errors, since this is a testutil
+// NewBlockFromValuesWithMetaAndSeriesMeta creates a new block using the
+// provided values.
 func NewBlockFromValuesWithMetaAndSeriesMeta(
 	meta block.Metadata,
 	seriesMeta []block.SeriesMeta,
 	seriesValues [][]float64,
 ) block.Block {
-	columnBuilder := block.NewColumnBlockBuilder(models.NoopQueryContext(), meta, seriesMeta)
+	columnBuilder := block.NewColumnBlockBuilder(
+		models.NoopQueryContext(),
+		meta,
+		seriesMeta,
+	)
 
 	if err := columnBuilder.AddCols(len(seriesValues[0])); err != nil {
 		panic(err)
@@ -147,8 +200,12 @@ func NewBlockFromValuesWithMetaAndSeriesMeta(
 	return columnBuilder.Build()
 }
 
-// GenerateValuesAndBounds generates a list of sample values and bounds while allowing overrides
-func GenerateValuesAndBounds(vals [][]float64, b *models.Bounds) ([][]float64, models.Bounds) {
+// GenerateValuesAndBounds generates a list of sample values and bounds while
+// allowing overrides.
+func GenerateValuesAndBounds(
+	vals [][]float64,
+	b *models.Bounds,
+) ([][]float64, models.Bounds) {
 	values := vals
 	if values == nil {
 		values = [][]float64{


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an issue with queries such as `foo_bar_biz{qux="qaz"} or vector(1)`; `vector` would not be parsed correctly, and some binary matching logic was incorrect.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
Fixes a bug in binary and/or/unless functions.
```

```documentation-note
no
```
