### PR TITLE
[query] Allow Graphite query expressions to use colon as part of identifier

### DIFF
--- a/scripts/docker-integration-tests/carbon/expected/cbar.json
+++ b/scripts/docker-integration-tests/carbon/expected/cbar.json
@@ -1,0 +1,10 @@
+[
+    {
+      "id": "c:bar",
+      "text": "c:bar",
+      "leaf": 0,
+      "expandable": 1,
+      "allowChildren": 1
+    }
+  ]
+  

--- a/scripts/docker-integration-tests/carbon/expected/cbaz.json
+++ b/scripts/docker-integration-tests/carbon/expected/cbaz.json
@@ -1,0 +1,10 @@
+[
+    {
+      "id": "c:bar.c:baz",
+      "text": "c:baz",
+      "leaf": 1,
+      "expandable": 0,
+      "allowChildren": 0
+    }
+  ]
+  

--- a/scripts/docker-integration-tests/carbon/test.sh
+++ b/scripts/docker-integration-tests/carbon/test.sh
@@ -74,6 +74,11 @@ echo "foo.min.catch-all.baz 20 $t" | nc 0.0.0.0 7204
 echo "Attempting to read mean aggregated carbon metric"
 ATTEMPTS=10 TIMEOUT=1 retry_with_backoff read_carbon foo.min.catch-all.baz 15
 
+# Test writing and reading IDs with colons in them.
+t=$(date +%s)
+echo "foo.bar:baz.qux 42 $t" | nc 0.0.0.0 7204
+ATTEMPTS=20 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff read_carbon 'foo.bar:*.*' 42
+
 t=$(date +%s)
 echo "a 0 $t"             | nc 0.0.0.0 7204
 echo "a.bar 0 $t"         | nc 0.0.0.0 7204
@@ -81,6 +86,7 @@ echo "a.biz 0 $t"         | nc 0.0.0.0 7204
 echo "a.biz.cake 0 $t"    | nc 0.0.0.0 7204
 echo "a.bar.caw.daz 0 $t" | nc 0.0.0.0 7204
 echo "a.bag 0 $t"         | nc 0.0.0.0 7204
+echo "c:bar.c:baz 0 $t"   | nc 0.0.0.0 7204
 ATTEMPTS=10 TIMEOUT=1 retry_with_backoff find_carbon a* a.json
 ATTEMPTS=2 TIMEOUT=1 retry_with_backoff find_carbon a.b* a.b.json
 ATTEMPTS=2 TIMEOUT=1 retry_with_backoff find_carbon a.ba[rg] a.ba.json
@@ -89,3 +95,5 @@ ATTEMPTS=2 TIMEOUT=1 retry_with_backoff find_carbon a.b*.caw.* a.b.c.d.json
 ATTEMPTS=2 TIMEOUT=1 retry_with_backoff find_carbon x none.json
 ATTEMPTS=2 TIMEOUT=1 retry_with_backoff find_carbon a.d none.json
 ATTEMPTS=2 TIMEOUT=1 retry_with_backoff find_carbon *.*.*.*.* none.json
+ATTEMPTS=2 TIMEOUT=1 retry_with_backoff find_carbon c:* cbar.json
+ATTEMPTS=2 TIMEOUT=1 retry_with_backoff find_carbon c:bar.* cbaz.json

--- a/src/query/graphite/graphite/glob.go
+++ b/src/query/graphite/graphite/glob.go
@@ -33,7 +33,7 @@ const (
 	ValidIdentifierRunes = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
 		"abcdefghijklmnopqrstuvwxyz" +
 		"0123456789" +
-		"$-_'|<>%#/"
+		"$-_'|<>%#/:"
 )
 
 // GlobToRegexPattern converts a graphite-style glob into a regex pattern, with

--- a/src/query/graphite/graphite/glob_test.go
+++ b/src/query/graphite/graphite/glob_test.go
@@ -41,6 +41,11 @@ func TestGlobToRegexPattern(t *testing.T) {
 			regex:   []byte("barbaz"),
 		},
 		{
+			glob:    "barbaz:quxqaz",
+			isRegex: false,
+			regex:   []byte("barbaz:quxqaz"),
+		},
+		{
 			glob:    "foo\\+bar.'baz<1001>'.qux",
 			isRegex: true,
 			regex:   []byte("foo\\+bar\\.+\\'baz\\<1001\\>\\'\\.+qux"),
@@ -59,6 +64,11 @@ func TestGlobToRegexPattern(t *testing.T) {
 			glob:    "foo{0[3-9],1[0-9],20}",
 			isRegex: true,
 			regex:   []byte("foo(0[3-9]|1[0-9]|20)"),
+		},
+		{
+			glob:    "foo{0[3-9],1[0-9],20}:bar",
+			isRegex: true,
+			regex:   []byte("foo(0[3-9]|1[0-9]|20):bar"),
 		},
 	}
 

--- a/src/query/graphite/lexer/lexer.go
+++ b/src/query/graphite/lexer/lexer.go
@@ -46,8 +46,6 @@ const (
 	LParenthesis
 	// RParenthesis is the right parenthesis ")".
 	RParenthesis
-	// Colon is the ":" symbol.
-	Colon
 	// NotOperator is the exclamation sign - "!" symbol.
 	NotOperator
 	// Comma is a punctuation mark.
@@ -77,8 +75,6 @@ func (tt TokenType) String() string {
 		return "LParenthesis"
 	case RParenthesis:
 		return "RParenthesis"
-	case Colon:
-		return "Colon"
 	case NotOperator:
 		return "NotOperator"
 	case Comma:
@@ -96,7 +92,6 @@ func (tt TokenType) String() string {
 var symbols = map[rune]TokenType{
 	'(': LParenthesis,
 	')': RParenthesis,
-	':': Colon,
 	'!': NotOperator,
 	',': Comma,
 	'=': Equal,
@@ -123,8 +118,8 @@ const (
 	lowercaseLetters     = "abcdefghijklmnopqrstuvwxyz"
 	digits               = "0123456789"
 	exponentRunes        = "eE"
-	identifierStartRunes = uppercaseLetters + lowercaseLetters + "_" + "$"
-	identifierRunes      = identifierStartRunes + digits + "-"
+	identifierStartRunes = uppercaseLetters + lowercaseLetters + "_" + "-" + "$" + ":"
+	identifierRunes      = identifierStartRunes + digits
 	signs                = "+-"
 )
 
@@ -291,7 +286,7 @@ func (l *Lexer) identifierOrPattern() bool {
 		return l.pattern()
 	}
 
-	// Check if idenitifer is one of the reserved identifiers.
+	// Check if identifier is one of the reserved identifiers.
 	for text, identifier := range l.reservedIdentifiers {
 		if strings.ToLower(l.currentVal()) == text {
 			l.emit(identifier)
@@ -462,6 +457,7 @@ func (l *Lexer) emit(tt TokenType) {
 }
 
 func (l *Lexer) emitToken(tt TokenType, val string) {
+	fmt.Printf("!! emit token: type=%s, value=%s\n", tt.String(), val)
 	l.tokens <- &Token{
 		tokenType: tt,
 		value:     val,

--- a/src/query/graphite/lexer/lexer.go
+++ b/src/query/graphite/lexer/lexer.go
@@ -457,7 +457,6 @@ func (l *Lexer) emit(tt TokenType) {
 }
 
 func (l *Lexer) emitToken(tt TokenType, val string) {
-	fmt.Printf("!! emit token: type=%s, value=%s\n", tt.String(), val)
 	l.tokens <- &Token{
 		tokenType: tt,
 		value:     val,

--- a/src/query/graphite/lexer/lexer_test.go
+++ b/src/query/graphite/lexer/lexer_test.go
@@ -53,21 +53,13 @@ func TestLexer(t *testing.T) {
 			[]Token{{Pattern, "stats.foo.counts.bar.baz.status_code.?XX"}}, nil},
 		{"456.03", []Token{{Number, "456.03"}}, nil},
 		{"foo:bar", []Token{
-			{Identifier, "foo"},
-			{Colon, ":"},
-			{Identifier, "bar"}}, nil},
-		{"foo:bar  baz : q*x", []Token{
-			{Identifier, "foo"},
-			{Colon, ":"},
-			{Identifier, "bar"},
-			{Identifier, "baz"},
-			{Colon, ":"},
-			{Pattern, "q*x"}}, nil},
+			{Identifier, "foo:bar"}}, nil},
+		{"foo:bar  baz:q*x", []Token{
+			{Identifier, "foo:bar"},
+			{Pattern, "baz:q*x"}}, nil},
 		{"!service:dispatch.*", []Token{
 			{NotOperator, "!"},
-			{Identifier, "service"},
-			{Colon, ":"},
-			{Pattern, "dispatch.*"}}, nil},
+			{Pattern, "service:dispatch.*"}}, nil},
 		{"\"Whatever man\"", []Token{{String, "Whatever man"}}, nil}, // double quoted string
 		// no need to escape single quotes within double quoted string
 		{"\"Whatever 'man'\"", []Token{{String, "Whatever 'man'"}}, nil},
@@ -111,6 +103,22 @@ func TestLexer(t *testing.T) {
 				{Comma, ","},
 				{String, `\1.\2`},
 				{RParenthesis, ")"}}, nil},
+		{"sumSeries(stats.with:colon)",
+			[]Token{
+				{Identifier, "sumSeries"},
+				{LParenthesis, "("},
+				{Pattern, "stats.with:colon"},
+				{RParenthesis, ")"},
+			},
+			nil},
+		{"sumSeries(stats.with:colon.extended.pattern.*)",
+			[]Token{
+				{Identifier, "sumSeries"},
+				{LParenthesis, "("},
+				{Pattern, "stats.with:colon.extended.pattern.*"},
+				{RParenthesis, ")"},
+			},
+			nil},
 	}
 
 	for _, test := range lexerTestInput {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This allows Graphite query expressions to contain colons as part of the identifier since we allow this as part of the metric name when ingesting Carbon (which is valid).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Add support for Graphite query expressions to use colon as part of identifier or pattern
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
