### PR TITLE
[dbnode] Expose debug dump on /debug/dump

### DIFF
--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"text/template"
 	"time"
+	"net/http"
 
 	"github.com/m3db/m3/src/cluster/integration/etcd"
 	"github.com/m3db/m3/src/cluster/placement"
@@ -176,6 +177,11 @@ func TestIndexEnabledServer(t *testing.T) {
 			InterruptCh: interruptCh,
 		})
 		serverWg.Done()
+	}()
+	defer func(){
+		// Resetting DefaultServeMux to prevent multiple assignments
+		// to /debug/dump in Server.Run()
+		http.DefaultServeMux = http.NewServeMux()
 	}()
 
 	// Wait for bootstrap

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"text/template"
 	"time"
+	"net/http"
 
 	"github.com/m3db/m3/src/cluster/integration/etcd"
 	"github.com/m3db/m3/src/cluster/placement"
@@ -168,6 +169,11 @@ func TestConfig(t *testing.T) {
 			InterruptCh: interruptCh,
 		})
 		serverWg.Done()
+	}()
+	defer func(){
+		// Resetting DefaultServeMux to prevent multiple assignments
+		// to /debug/dump in Server.Run()
+		http.DefaultServeMux = http.NewServeMux()
 	}()
 
 	// Wait for bootstrap
@@ -312,6 +318,11 @@ func TestEmbeddedConfig(t *testing.T) {
 		})
 		serverWg.Done()
 	}()
+	defer func(){
+		// Resetting DefaultServeMux to prevent multiple assignments
+		// to /debug/dump in Server.Run()
+		http.DefaultServeMux = http.NewServeMux()
+	}()
 
 	// Wait for embedded KV to be up.
 	<-embeddedKVCh
@@ -437,6 +448,7 @@ func TestEmbeddedConfig(t *testing.T) {
 	// Wait for server to stop
 	interruptCh <- fmt.Errorf("test complete")
 	serverWg.Wait()
+	http.DefaultServeMux = new(http.ServeMux)
 }
 
 var (

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -448,7 +448,6 @@ func TestEmbeddedConfig(t *testing.T) {
 	// Wait for server to stop
 	interruptCh <- fmt.Errorf("test complete")
 	serverWg.Wait()
-	http.DefaultServeMux = new(http.ServeMux)
 }
 
 var (

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -297,6 +297,9 @@ func Run(runOpts RunOptions) {
 		cpuProfileDuration,
 		iopts,
 	)
+	if err != nil {
+		logger.Error("unable to create debug writer", zap.Error(err))
+	}
 
 	if cfg.Index.MaxQueryIDsConcurrency != 0 {
 		queryIDsWorkerPool := xsync.NewWorkerPool(cfg.Index.MaxQueryIDsConcurrency)
@@ -572,12 +575,10 @@ func Run(runOpts RunOptions) {
 	if cfg.DebugListenAddress != "" {
 		go func() {
 			mux := http.DefaultServeMux
-			if err == nil {
+			if debugWriter != nil {
 				if err = debugWriter.RegisterHandler("/debug/dump", mux); err != nil {
 					logger.Error("unable to register debug writer endpoint", zap.Error(err))
 				}
-			} else {
-				logger.Error("unable to create debug writer", zap.Error(err))
 			}
 
 			if err := http.ListenAndServe(cfg.DebugListenAddress, mux); err != nil {

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -576,7 +576,7 @@ func Run(runOpts RunOptions) {
 		go func() {
 			mux := http.DefaultServeMux
 			if debugWriter != nil {
-				if err = debugWriter.RegisterHandler("/debug/dump", mux); err != nil {
+				if err := debugWriter.RegisterHandler("/debug/dump", mux); err != nil {
 					logger.Error("unable to register debug writer endpoint", zap.Error(err))
 				}
 			}

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -68,6 +68,7 @@ import (
 	"github.com/m3db/m3/src/m3ninx/postings/roaring"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/context"
+	xdebug "github.com/m3db/m3/src/x/debug"
 	xdocs "github.com/m3db/m3/src/x/docs"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
@@ -564,9 +565,27 @@ func Run(runOpts RunOptions) {
 
 	if cfg.DebugListenAddress != "" {
 		go func() {
-			if err := http.ListenAndServe(cfg.DebugListenAddress, nil); err != nil {
+			mux := http.DefaultServeMux
+			cpuProfileDuration := 1 * time.Second
+			debugWriter, err := xdebug.NewZipWriterWithDefaultSources(
+				cpuProfileDuration,
+				iopts,
+			)
+			if err == nil {
+				if err = debugWriter.RegisterHandler("/debug/dump", mux); err != nil {
+					logger.Error("unable to register debug writer endpoint", zap.Error(err))
+				}
+			} else {
+				logger.Error("unable to create debug writer", zap.Error(err))
+			}
+
+			if err := http.ListenAndServe(cfg.DebugListenAddress, mux); err != nil {
 				logger.Error("debug server could not listen",
 					zap.String("address", cfg.DebugListenAddress), zap.Error(err))
+			} else {
+				logger.Info("debug server listening",
+					zap.String("address", cfg.DebugListenAddress),
+				)
 			}
 		}()
 	}

--- a/src/x/debug/debug_test.go
+++ b/src/x/debug/debug_test.go
@@ -131,6 +131,9 @@ func TestRegisterSourceSameName(t *testing.T) {
 
 func TestHTTPEndpoint(t *testing.T) {
 	mux := http.NewServeMux()
+
+	// Randomizing the path here so we avoid multiple tests
+	// registring the same endpoint.
 	path := fmt.Sprintf("/debug/%s", randStringBytes(10))
 
 	zw := NewZipWriter(instrument.NewOptions())

--- a/src/x/debug/debug_test.go
+++ b/src/x/debug/debug_test.go
@@ -133,7 +133,7 @@ func TestHTTPEndpoint(t *testing.T) {
 	mux := http.NewServeMux()
 
 	// Randomizing the path here so we avoid multiple tests
-	// registring the same endpoint.
+	// registering the same endpoint.
 	path := fmt.Sprintf("/debug/%s", randStringBytes(10))
 
 	zw := NewZipWriter(instrument.NewOptions())

--- a/src/x/debug/debug_test.go
+++ b/src/x/debug/debug_test.go
@@ -24,7 +24,9 @@ import (
 	"archive/zip"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -34,6 +36,16 @@ import (
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/stretchr/testify/require"
 )
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
 
 type fakeSource struct {
 	called    bool
@@ -119,7 +131,7 @@ func TestRegisterSourceSameName(t *testing.T) {
 
 func TestHTTPEndpoint(t *testing.T) {
 	mux := http.NewServeMux()
-	path := "/debug/dump"
+	path := fmt.Sprintf("/debug/%s", randStringBytes(10))
 
 	zw := NewZipWriter(instrument.NewOptions())
 	fs1 := &fakeSource{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Exposes debug dump (https://github.com/m3db/m3/pull/1767) to HTTP endpoint `/debug/dump`

**Special notes for your reviewer**:
Just wondering if we should make `cpuProfileDuration` (currently set to 1s) and the path (currently set to `/debug/dump`) configurable?

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
