### PR TITLE
[dbnode] Add Load() API and refactor buffer.Bootstrap() logic to take warm vs. cold writes into account

### DIFF
--- a/src/dbnode/storage/series/buffer_mock.go
+++ b/src/dbnode/storage/series/buffer_mock.go
@@ -221,28 +221,16 @@ func (mr *MockdatabaseBufferMockRecorder) Tick(versions, nsCtx interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockdatabaseBuffer)(nil).Tick), versions, nsCtx)
 }
 
-// Bootstrap mocks base method
-func (m *MockdatabaseBuffer) Bootstrap(bl block.DatabaseBlock, blockState BlockState) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Bootstrap", bl, blockState)
-}
-
-// Bootstrap indicates an expected call of Bootstrap
-func (mr *MockdatabaseBufferMockRecorder) Bootstrap(bl, blockState interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockdatabaseBuffer)(nil).Bootstrap), bl, blockState)
-}
-
 // Load mocks base method
-func (m *MockdatabaseBuffer) Load(bl block.DatabaseBlock) {
+func (m *MockdatabaseBuffer) Load(bl block.DatabaseBlock, writeType WriteType) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Load", bl)
+	m.ctrl.Call(m, "Load", bl, writeType)
 }
 
 // Load indicates an expected call of Load
-func (mr *MockdatabaseBufferMockRecorder) Load(bl interface{}) *gomock.Call {
+func (mr *MockdatabaseBufferMockRecorder) Load(bl, writeType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockdatabaseBuffer)(nil).Load), bl)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockdatabaseBuffer)(nil).Load), bl, writeType)
 }
 
 // Reset mocks base method

--- a/src/dbnode/storage/series/buffer_mock.go
+++ b/src/dbnode/storage/series/buffer_mock.go
@@ -222,15 +222,27 @@ func (mr *MockdatabaseBufferMockRecorder) Tick(versions, nsCtx interface{}) *gom
 }
 
 // Bootstrap mocks base method
-func (m *MockdatabaseBuffer) Bootstrap(bl block.DatabaseBlock) {
+func (m *MockdatabaseBuffer) Bootstrap(bl block.DatabaseBlock, blockState BlockState) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Bootstrap", bl)
+	m.ctrl.Call(m, "Bootstrap", bl, blockState)
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockdatabaseBufferMockRecorder) Bootstrap(bl interface{}) *gomock.Call {
+func (mr *MockdatabaseBufferMockRecorder) Bootstrap(bl, blockState interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockdatabaseBuffer)(nil).Bootstrap), bl)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockdatabaseBuffer)(nil).Bootstrap), bl, blockState)
+}
+
+// Load mocks base method
+func (m *MockdatabaseBuffer) Load(bl block.DatabaseBlock) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Load", bl)
+}
+
+// Load indicates an expected call of Load
+func (mr *MockdatabaseBufferMockRecorder) Load(bl interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockdatabaseBuffer)(nil).Load), bl)
 }
 
 // Reset mocks base method

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -1588,10 +1588,9 @@ func TestFetchBlocksForColdFlush(t *testing.T) {
 	requireReaderValuesEqual(t, []value{}, [][]xio.BlockReader{reader}, opts, nsCtx)
 }
 
-// TestBufferBootstrap tests the Bootstrap method, ensuring that blocks are successfully loaded into
+// TestBufferLoadWarmWrite tests the Load method, ensuring that blocks are successfully loaded into
 // the buffer and treated as warm writes.
-// TODO(rartoul): Fix/rename test
-func TestBufferBootstrap(t *testing.T) {
+func TestBufferLoadWarmWrite(t *testing.T) {
 	var (
 		opts      = newBufferTestOptions()
 		buffer    = newDatabaseBuffer()
@@ -1620,9 +1619,9 @@ func TestBufferBootstrap(t *testing.T) {
 	require.Equal(t, 0, coldFlushBlockStarts.Len())
 }
 
-// TestBufferLoad tests the Load method, ensuring that blocks are successfully loaded into
+// TestBufferLoadColdWrite tests the Load method, ensuring that blocks are successfully loaded into
 // the buffer and treated as cold writes.
-func TestBufferLoad(t *testing.T) {
+func TestBufferLoadColdWrite(t *testing.T) {
 	var (
 		opts      = newBufferTestOptions()
 		buffer    = newDatabaseBuffer()

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -1590,7 +1590,7 @@ func TestFetchBlocksForColdFlush(t *testing.T) {
 
 // TestBufferBootstrap tests the Bootstrap method, ensuring that blocks are successfully loaded into
 // the buffer and treated as warm writes.
-// TODO(rartoul): Test the cold case too?
+// TODO(rartoul): Fix/rename test
 func TestBufferBootstrap(t *testing.T) {
 	var (
 		opts      = newBufferTestOptions()
@@ -1608,7 +1608,7 @@ func TestBufferBootstrap(t *testing.T) {
 	data.IncRef()
 	segment := ts.Segment{Head: data}
 	block := block.NewDatabaseBlock(curr, blockSize, segment, opts.DatabaseBlockOptions(), nsCtx)
-	buffer.Bootstrap(block, BlockState{})
+	buffer.Load(block, WarmWrite)
 
 	// Ensure the bootstrapped block is loaded and readable.
 	encoded, err = buffer.ReadEncoded(context.NewContext(), curr, curr.Add(blockSize), nsCtx)
@@ -1639,7 +1639,7 @@ func TestBufferLoad(t *testing.T) {
 	data.IncRef()
 	segment := ts.Segment{Head: data}
 	block := block.NewDatabaseBlock(curr, blockSize, segment, opts.DatabaseBlockOptions(), nsCtx)
-	buffer.Load(block)
+	buffer.Load(block, ColdWrite)
 
 	// Ensure the bootstrapped block is loaded and readable.
 	encoded, err = buffer.ReadEncoded(context.NewContext(), curr, curr.Add(blockSize), nsCtx)

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -428,6 +428,7 @@ func (s *dbSeries) Bootstrap(
 		return result, nil
 	}
 
+	// TODO(rartoul): Branch coverage here.
 	for _, block := range bootstrappedBlocks.AllBlocks() {
 		blStartNano := xtime.ToUnixNano(block.StartTime())
 		blState := blockStates[blStartNano]

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -431,7 +431,24 @@ func (s *dbSeries) Bootstrap(
 	for _, block := range bootstrappedBlocks.AllBlocks() {
 		blStartNano := xtime.ToUnixNano(block.StartTime())
 		blState := blockStates[blStartNano]
-		s.buffer.Bootstrap(block, blState)
+		if !blState.WarmRetrievable {
+			// If the block being bootstrapped has never been warm flushed before then the block
+			// can be loaded into the buffer as a WarmWrite because a subsequent warm flush will
+			// ensure that it gets persisted to disk.
+			//
+			// If the ColdWrites feature is disabled then this branch should always be followed.
+			s.buffer.Load(block, WarmWrite)
+		} else {
+			// If the block being bootstrapped has been warm flushed before then the block should
+			// be loaded into the buffer as a ColdWrite so that a subsequent cold flush will ensure
+			// that it gets persisted to disk.
+			//
+			// This branch can be executed in the situation that a cold write was received for a block
+			// that had already been flushed to disk. Before the cold write could be persisted to disk
+			// via a cold flush, the node crashed and began bootsrapping itself. The cold write would be
+			// read out of the commitlog and would eventually be loaded into the buffer via this branch.
+			s.buffer.Load(block, ColdWrite)
+		}
 	}
 	result.NumBlocksMovedToBuffer += int64(bootstrappedBlocks.Len())
 
@@ -443,7 +460,17 @@ func (s *dbSeries) Load(blocks block.DatabaseSeriesBlocks) {
 	s.Lock()
 	defer s.Unlock()
 	for _, block := range blocks.AllBlocks() {
-		s.buffer.Load(block)
+		// Load may be called for any block start (including blocks that may or may not have
+		// been flushed yet). As a result, they're treated as cold writes to ensure they get merged
+		// with any existing data if the block is for a blockStart that has already been flushed.
+		//
+		// NB(rartoul): Using this method for block starts that have never been flushed yet will result
+		// in unnecessary cold flushes since the sequence will proceed as:
+		//
+		//     1. Warm flush block start X
+		//     2. Cold flush block start X (since there are "cold write" blocks here that were not
+		//          flushed as part of the warm flush since they were not marked as "warm writes").
+		s.buffer.Load(block, ColdWrite)
 	}
 }
 

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -431,7 +431,6 @@ func (s *dbSeries) Bootstrap(
 	s.loadWithLock(bootstrappedBlocks, blockStates)
 	result.NumBlocksMovedToBuffer += int64(bootstrappedBlocks.Len())
 
-	s.bs = bootstrapped
 	return result, nil
 }
 
@@ -446,7 +445,8 @@ func (s *dbSeries) Load(
 
 func (s *dbSeries) loadWithLock(
 	bootstrappedBlocks block.DatabaseSeriesBlocks,
-	blockStates map[xtime.UnixNano]BlockState) {
+	blockStates map[xtime.UnixNano]BlockState,
+) {
 	for _, block := range bootstrappedBlocks.AllBlocks() {
 		blStartNano := xtime.ToUnixNano(block.StartTime())
 		blState := blockStates[blStartNano]

--- a/src/dbnode/storage/series/series_all_test.go
+++ b/src/dbnode/storage/series/series_all_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	xtime "github.com/m3db/m3/src/x/time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/stretchr/testify/require"
 )
 
 var timeDistantFuture = time.Now().Add(10 * 365 * 24 * time.Hour)

--- a/src/dbnode/storage/series/series_mock.go
+++ b/src/dbnode/storage/series/series_mock.go
@@ -64,18 +64,18 @@ func (m *MockDatabaseSeries) EXPECT() *MockDatabaseSeriesMockRecorder {
 }
 
 // Bootstrap mocks base method
-func (m *MockDatabaseSeries) Bootstrap(arg0 block.DatabaseSeriesBlocks) (BootstrapResult, error) {
+func (m *MockDatabaseSeries) Bootstrap(arg0 block.DatabaseSeriesBlocks, arg1 map[time0.UnixNano]BlockState) (BootstrapResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", arg0)
+	ret := m.ctrl.Call(m, "Bootstrap", arg0, arg1)
 	ret0, _ := ret[0].(BootstrapResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockDatabaseSeriesMockRecorder) Bootstrap(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseSeriesMockRecorder) Bootstrap(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockDatabaseSeries)(nil).Bootstrap), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockDatabaseSeries)(nil).Bootstrap), arg0, arg1)
 }
 
 // Close mocks base method
@@ -189,6 +189,18 @@ func (m *MockDatabaseSeries) IsEmpty() bool {
 func (mr *MockDatabaseSeriesMockRecorder) IsEmpty() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsEmpty", reflect.TypeOf((*MockDatabaseSeries)(nil).IsEmpty))
+}
+
+// Load mocks base method
+func (m *MockDatabaseSeries) Load(arg0 block.DatabaseSeriesBlocks) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Load", arg0)
+}
+
+// Load indicates an expected call of Load
+func (mr *MockDatabaseSeriesMockRecorder) Load(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockDatabaseSeries)(nil).Load), arg0)
 }
 
 // NumActiveBlocks mocks base method

--- a/src/dbnode/storage/series/series_mock.go
+++ b/src/dbnode/storage/series/series_mock.go
@@ -192,15 +192,15 @@ func (mr *MockDatabaseSeriesMockRecorder) IsEmpty() *gomock.Call {
 }
 
 // Load mocks base method
-func (m *MockDatabaseSeries) Load(arg0 block.DatabaseSeriesBlocks) {
+func (m *MockDatabaseSeries) Load(arg0 block.DatabaseSeriesBlocks, arg1 map[time0.UnixNano]BlockState) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Load", arg0)
+	m.ctrl.Call(m, "Load", arg0, arg1)
 }
 
 // Load indicates an expected call of Load
-func (mr *MockDatabaseSeriesMockRecorder) Load(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseSeriesMockRecorder) Load(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockDatabaseSeries)(nil).Load), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockDatabaseSeries)(nil).Load), arg0, arg1)
 }
 
 // NumActiveBlocks mocks base method

--- a/src/dbnode/storage/series/series_parallel_test.go
+++ b/src/dbnode/storage/series/series_parallel_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/m3db/m3/src/x/ident"
 	xtime "github.com/m3db/m3/src/x/time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestSeriesWriteReadParallel is a regression test that was added to capture panics that might
@@ -46,7 +46,7 @@ func TestSeriesWriteReadParallel(t *testing.T) {
 		series            = NewDatabaseSeries(ident.StringID("foo"), ident.Tags{}, opts).(*dbSeries)
 	)
 
-	_, err := series.Bootstrap(nil)
+	_, err := series.Bootstrap(nil, nil)
 	assert.NoError(t, err)
 
 	ctx := context.NewContext()

--- a/src/dbnode/storage/series/series_test.go
+++ b/src/dbnode/storage/series/series_test.go
@@ -244,7 +244,8 @@ func TestSeriesBootstrapAndLoad(t *testing.T) {
 				blocks block.DatabaseSeriesBlocks,
 				blockStates map[xtime.UnixNano]BlockState,
 			) {
-				series.Bootstrap(blocks, blockStates)
+				_, err := series.Bootstrap(blocks, blockStates)
+				require.NoError(t, err)
 			}},
 	}
 
@@ -260,8 +261,6 @@ func TestSeriesBootstrapAndLoad(t *testing.T) {
 				return curr
 			}))
 			series := NewDatabaseSeries(ident.StringID("foo"), ident.Tags{}, opts).(*dbSeries)
-			_, err := series.Bootstrap(nil, nil)
-			require.NoError(t, err)
 
 			rawWrites := []value{
 				{curr.Add(mins(1)), 2, xtime.Second, nil},

--- a/src/dbnode/storage/series/series_test.go
+++ b/src/dbnode/storage/series/series_test.go
@@ -217,64 +217,123 @@ func TestSeriesWriteFlushRead(t *testing.T) {
 	requireReaderValuesEqual(t, data, results, opts, nsCtx)
 }
 
-// TestSeriesLoad tests the behavior the Load() method by ensuring that it actually loads data
-// into the series and that the data (merged with any existing data) can be retrieved.
-func TestSeriesLoad(t *testing.T) {
-	var (
-		opts      = newSeriesTestOptions()
-		blockSize = opts.RetentionOptions().BlockSize()
-		curr      = time.Now().Truncate(blockSize)
-		start     = curr
-	)
-	opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
-		return curr
-	}))
-	series := NewDatabaseSeries(ident.StringID("foo"), ident.Tags{}, opts).(*dbSeries)
-	_, err := series.Bootstrap(nil, nil)
-	require.NoError(t, err)
-
-	rawWrites := []value{
-		{curr.Add(mins(1)), 2, xtime.Second, nil},
-		{curr.Add(mins(3)), 3, xtime.Second, nil},
-		{curr.Add(mins(5)), 4, xtime.Second, nil},
+// TestSeriesLoad tests the behavior the Bootstrap()/Load()s method by ensuring that they actually load
+// data into the series and that the data (merged with any existing data) can be retrieved.
+//
+// It also ensures that blocks for blockStarts that have not been warm flushed yet are loaded as
+// warm write and block for blockStarts that have already been warm flushed are loaded as cold writes.
+func TestSeriesBootstrapAndLoad(t *testing.T) {
+	testCases := []struct {
+		title string
+		f     func(
+			series DatabaseSeries,
+			blocks block.DatabaseSeriesBlocks,
+			blockStates map[xtime.UnixNano]BlockState)
+	}{
+		{
+			title: "load",
+			f: func(series DatabaseSeries,
+				blocks block.DatabaseSeriesBlocks,
+				blockStates map[xtime.UnixNano]BlockState,
+			) {
+				series.Load(blocks, blockStates)
+			}},
+		{
+			title: "bootstrap",
+			f: func(series DatabaseSeries,
+				blocks block.DatabaseSeriesBlocks,
+				blockStates map[xtime.UnixNano]BlockState,
+			) {
+				series.Bootstrap(blocks, blockStates)
+			}},
 	}
 
-	for _, v := range rawWrites {
-		curr = v.timestamp
-		verifyWriteToSeries(t, series, v)
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			var (
+				opts      = newSeriesTestOptions()
+				blockSize = opts.RetentionOptions().BlockSize()
+				curr      = time.Now().Truncate(blockSize)
+				start     = curr
+			)
+			opts = opts.SetClockOptions(opts.ClockOptions().SetNowFn(func() time.Time {
+				return curr
+			}))
+			series := NewDatabaseSeries(ident.StringID("foo"), ident.Tags{}, opts).(*dbSeries)
+			_, err := series.Bootstrap(nil, nil)
+			require.NoError(t, err)
+
+			rawWrites := []value{
+				{curr.Add(mins(1)), 2, xtime.Second, nil},
+				{curr.Add(mins(3)), 3, xtime.Second, nil},
+				{curr.Add(mins(5)), 4, xtime.Second, nil},
+			}
+
+			for _, v := range rawWrites {
+				curr = v.timestamp
+				verifyWriteToSeries(t, series, v)
+			}
+
+			var (
+				loadWrites = []value{
+					// Ensure each value is in a separate block so since block.DatabaseSeriesBlocks
+					// can only store a single block per block start).
+					{curr.Add(blockSize), 5, xtime.Second, nil},
+					{curr.Add(2 * blockSize), 6, xtime.Second, nil},
+				}
+				nsCtx                        = namespace.Context{}
+				blockOpts                    = opts.DatabaseBlockOptions()
+				blocks                       = block.NewDatabaseSeriesBlocks(len(loadWrites))
+				alreadyWarmFlushedBlockStart = curr.Add(blockSize).Truncate(blockSize)
+				notYetWarmFlushedBlockStart  = curr.Add(2 * blockSize).Truncate(blockSize)
+				blockStates                  = map[xtime.UnixNano]BlockState{
+					// Exercise both code paths.
+					xtime.ToUnixNano(alreadyWarmFlushedBlockStart): BlockState{
+						WarmRetrievable: true,
+					},
+					xtime.ToUnixNano(notYetWarmFlushedBlockStart): BlockState{
+						WarmRetrievable: false,
+					},
+				}
+			)
+			for _, v := range loadWrites {
+				curr = v.timestamp
+				enc := opts.EncoderPool().Get()
+				blockStart := v.timestamp.Truncate(blockSize)
+				enc.Reset(blockStart, 0, nil)
+				dp := ts.Datapoint{Timestamp: v.timestamp, Value: v.value}
+				require.NoError(t, enc.Encode(dp, v.unit, nil))
+
+				dbBlock := block.NewDatabaseBlock(blockStart, blockSize, enc.Discard(), blockOpts, nsCtx)
+				blocks.AddBlock(dbBlock)
+			}
+
+			tc.f(series, blocks, blockStates)
+
+			t.Run("Data can be read", func(t *testing.T) {
+				ctx := context.NewContext()
+				defer ctx.Close()
+
+				results, err := series.ReadEncoded(ctx, start, start.Add(10*blockSize), nsCtx)
+				require.NoError(t, err)
+
+				expectedData := append(rawWrites, loadWrites...)
+				requireReaderValuesEqual(t, expectedData, results, opts, nsCtx)
+			})
+
+			t.Run("Unflushed blocks loaded as warm writes and flushed blocks loaded as cold writes", func(t *testing.T) {
+				optimizedTimes := series.ColdFlushBlockStarts(blockStates)
+
+				coldFlushBlockStarts := []xtime.UnixNano{}
+				optimizedTimes.ForEach(func(blockStart xtime.UnixNano) {
+					coldFlushBlockStarts = append(coldFlushBlockStarts, blockStart)
+				})
+
+				expectedColdFlushBlockStarts := []xtime.UnixNano{xtime.ToUnixNano(alreadyWarmFlushedBlockStart)}
+				require.Equal(t, expectedColdFlushBlockStarts, coldFlushBlockStarts)
+			})
+		})
 	}
-
-	var (
-		loadWrites = []value{
-			// Ensure each value is in a separate block so since block.DatabaseSeriesBlocks
-			// can only store a single block per block start).
-			{curr.Add(blockSize), 5, xtime.Second, nil},
-			{curr.Add(2 * blockSize), 6, xtime.Second, nil},
-		}
-		nsCtx     = namespace.Context{}
-		blockOpts = opts.DatabaseBlockOptions()
-		blocks    = block.NewDatabaseSeriesBlocks(len(loadWrites))
-	)
-	for _, v := range loadWrites {
-		curr = v.timestamp
-		enc := opts.EncoderPool().Get()
-		enc.Reset(v.timestamp.Truncate(blockSize), 0, nil)
-		dp := ts.Datapoint{Timestamp: v.timestamp, Value: v.value}
-		require.NoError(t, enc.Encode(dp, v.unit, nil))
-
-		dbBlock := block.NewDatabaseBlock(v.timestamp.Truncate(blockSize), blockSize, enc.Discard(), blockOpts, nsCtx)
-		blocks.AddBlock(dbBlock)
-	}
-	series.Load(blocks)
-
-	ctx := context.NewContext()
-	defer ctx.Close()
-
-	results, err := series.ReadEncoded(ctx, start, start.Add(10*blockSize), nsCtx)
-	require.NoError(t, err)
-
-	expectedData := append(rawWrites, loadWrites...)
-	requireReaderValuesEqual(t, expectedData, results, opts, nsCtx)
 }
 
 func TestSeriesReadEndBeforeStart(t *testing.T) {

--- a/src/dbnode/storage/series/types.go
+++ b/src/dbnode/storage/series/types.go
@@ -103,7 +103,11 @@ type DatabaseSeries interface {
 	IsBootstrapped() bool
 
 	// Bootstrap merges the raw series bootstrapped along with any buffered data.
-	Bootstrap(blocks block.DatabaseSeriesBlocks) (BootstrapResult, error)
+	Bootstrap(blocks block.DatabaseSeriesBlocks, blockStates map[xtime.UnixNano]BlockState) (BootstrapResult, error)
+
+	// Load does the same thing as Bootstrap except it should be used for data that did
+	// not originate from the Bootstrap process (like background repairs).
+	Load(blocks block.DatabaseSeriesBlocks)
 
 	// WarmFlush flushes the WarmWrites of this series for a given start time.
 	WarmFlush(
@@ -358,14 +362,6 @@ const (
 	// ColdWrite represents cold writes (outside the buffer past/future window).
 	ColdWrite
 )
-
-// BootstrapWriteType is the write type assigned for bootstraps.
-//
-// TODO(juchan): We can't know from a bootstrapped block whether data was
-// originally written as a ColdWrite or a WarmWrite. After implementing
-// persistence logic including ColdWrites, we need to revisit this to figure out
-// what write type makes sense for bootstraps.
-const BootstrapWriteType = WarmWrite
 
 // WriteTransformOptions describes transforms to run on incoming writes.
 type WriteTransformOptions struct {

--- a/src/dbnode/storage/series/types.go
+++ b/src/dbnode/storage/series/types.go
@@ -107,7 +107,7 @@ type DatabaseSeries interface {
 
 	// Load does the same thing as Bootstrap except it should be used for data that did
 	// not originate from the Bootstrap process (like background repairs).
-	Load(blocks block.DatabaseSeriesBlocks)
+	Load(blocks block.DatabaseSeriesBlocks, blockStates map[xtime.UnixNano]BlockState)
 
 	// WarmFlush flushes the WarmWrites of this series for a given start time.
 	WarmFlush(

--- a/src/dbnode/storage/series_wired_list_interaction_test.go
+++ b/src/dbnode/storage/series_wired_list_interaction_test.go
@@ -91,7 +91,7 @@ func TestSeriesWiredListConcurrentInteractions(t *testing.T) {
 	)
 
 	series.Reset(id, ident.Tags{}, nil, shard.seriesOnRetrieveBlock, shard, shard.seriesOpts)
-	series.Bootstrap(nil)
+	series.Bootstrap(nil, nil)
 	shard.Lock()
 	shard.insertNewShardEntryWithLock(lookup.NewEntry(series, 0))
 	shard.Unlock()

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1856,7 +1856,7 @@ func (s *dbShard) Bootstrap(
 		return true
 	})
 
-	// Now that this shard has finished bootstrapping attempt to cache all of its seekers. Cannot call
+	// Now that this shard has finished bootstrapping, attempt to cache all of its seekers. Cannot call
 	// this earlier as block lease verification will fail due to the shards not being bootstrapped
 	// (and as a result no leases can be verified since the flush state is not yet known).
 	if err := s.cacheShardIndices(); err != nil {

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1240,7 +1240,7 @@ func (s *dbShard) insertSeriesSync(
 	}
 
 	if s.newSeriesBootstrapped {
-		_, err := entry.Series.Bootstrap(nil)
+		_, err := entry.Series.Bootstrap(nil, nil)
 		if err != nil {
 			entry = nil // Don't increment the writer count for this series
 			return nil, err
@@ -1326,7 +1326,7 @@ func (s *dbShard) insertSeriesBatch(inserts []dbShardInsert) error {
 		// Insert still pending, perform the insert
 		entry = inserts[i].entry
 		if s.newSeriesBootstrapped {
-			_, err := entry.Series.Bootstrap(nil)
+			_, err := entry.Series.Bootstrap(nil, nil)
 			if err != nil {
 				s.metrics.insertAsyncBootstrapErrors.Inc(1)
 			}
@@ -1782,9 +1782,17 @@ func (s *dbShard) Bootstrap(
 	s.bootstrapState = Bootstrapping
 	s.Unlock()
 
+	// Iterate flushed time ranges to determine which blocks are retrievable. This step happens
+	// first because the flushState information is required for bootstrapping individual series
+	// (will be passed to series.Bootstrap() as BlockState).
+	s.bootstrapFlushStates()
+
 	var (
 		shardBootstrapResult = dbShardBootstrapResult{}
 		multiErr             = xerrors.NewMultiError()
+		// Safe to use the same snapshot for all the series since the block states can't change while
+		// this is running since no warm/cold flushes can occur while the bootstrap is ongoing.
+		blockStates = s.BlockStatesSnapshot()
 	)
 	for _, elem := range bootstrappedSeries.Iter() {
 		dbBlocks := elem.Value()
@@ -1816,7 +1824,7 @@ func (s *dbShard) Bootstrap(
 		}
 
 		// Cannot close blocks once done as series takes ref to these
-		bsResult, err := entry.Series.Bootstrap(dbBlocks.Blocks)
+		bsResult, err := entry.Series.Bootstrap(dbBlocks.Blocks, blockStates)
 		if err != nil {
 			multiErr = multiErr.Add(err)
 		}
@@ -1843,13 +1851,26 @@ func (s *dbShard) Bootstrap(
 		if series.IsBootstrapped() {
 			return true
 		}
-		_, err := series.Bootstrap(nil)
+		_, err := series.Bootstrap(nil, nil)
 		multiErr = multiErr.Add(err)
 		return true
 	})
 
-	// Now iterate flushed time ranges to determine which blocks are
-	// retrievable before servicing reads
+	// Now that this shard has finished bootstrapping attempt to cache all of its seekers. Cannot call
+	// this earlier as block lease verification will fail due to the shards not being bootstrapped
+	// (and as a result no leases can be verified since the flush state is not yet known).
+	if err := s.cacheShardIndices(); err != nil {
+		multiErr = multiErr.Add(err)
+	}
+
+	s.Lock()
+	s.bootstrapState = Bootstrapped
+	s.Unlock()
+
+	return multiErr.FinalError()
+}
+
+func (s *dbShard) bootstrapFlushStates() {
 	fsOpts := s.opts.CommitLogOptions().FilesystemOptions()
 	readInfoFilesResults := fs.ReadInfoFiles(fsOpts.FilePathPrefix(), s.namespace.ID(), s.shard,
 		fsOpts.InfoReaderBufferSize(), fsOpts.DecodingOptions())
@@ -1882,35 +1903,31 @@ func (s *dbShard) Bootstrap(
 			s.setFlushStateColdVersion(at, info.VolumeIndex)
 		}
 	}
+}
 
+func (s *dbShard) cacheShardIndices() error {
+	retrieverMgr := s.opts.DatabaseBlockRetrieverManager()
 	// May be nil depending on the caching policy.
-	if retrieverMgr := s.opts.DatabaseBlockRetrieverManager(); retrieverMgr != nil {
-		// Now that this shard has finished bootstrapping attempt to cache all of its seekers. Cannot call
-		// this earlier as block lease verification will fail due to the shards not being bootstrapped
-		// (and as a result no leases can be verified since the flush state is not yet known).
-		retriever, err := retrieverMgr.Retriever(s.namespace)
-		if err != nil {
-			multiErr = multiErr.Add(err)
-		} else {
-			s.logger.Debug("caching shard indices",
-				zap.Uint32("shard", s.ID()))
-			if err := retriever.CacheShardIndices([]uint32{s.ID()}); err != nil {
-				multiErr = multiErr.Add(err)
-				s.logger.Error("caching shard indices error",
-					zap.Uint32("shard", s.ID()),
-					zap.Error(err))
-			} else {
-				s.logger.Debug("caching shard indices completed successfully",
-					zap.Uint32("shard", s.ID()))
-			}
-		}
+	if retrieverMgr == nil {
+		return nil
 	}
 
-	s.Lock()
-	s.bootstrapState = Bootstrapped
-	s.Unlock()
+	retriever, err := retrieverMgr.Retriever(s.namespace)
+	if err != nil {
+		return err
+	}
 
-	return multiErr.FinalError()
+	s.logger.Debug("caching shard indices", zap.Uint32("shard", s.ID()))
+	if err := retriever.CacheShardIndices([]uint32{s.ID()}); err != nil {
+		s.logger.Error("caching shard indices error",
+			zap.Uint32("shard", s.ID()),
+			zap.Error(err))
+		return err
+	}
+
+	s.logger.Debug("caching shard indices completed successfully",
+		zap.Uint32("shard", s.ID()))
+	return nil
 }
 
 func (s *dbShard) WarmFlush(


### PR DESCRIPTION
This is the first P.R to begin the process of making it possible load data dynamically into a shard/series/buffer such that the data will be merged with any data in memory or on disk and successfully persisted. The ability to do so is a key requirements of the background repairs feature which is being actively developed.