### PR TITLE
[dbnode] Add initial implementation for cold writes index support

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -40,6 +40,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/storage/index/compaction"
 	"github.com/m3db/m3/src/dbnode/storage/index/convert"
+	"github.com/m3db/m3/src/dbnode/storage/series"
 	"github.com/m3db/m3/src/dbnode/tracepoint"
 	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/m3db/m3/src/m3ninx/idx"
@@ -525,6 +526,7 @@ func (i *nsIndex) writeBatches(
 		futureLimit         = now.Add(1 * i.bufferFuture)
 		pastLimit           = now.Add(-1 * i.bufferPast)
 		batchOptions        = batch.Options()
+		coldWritesEnabled   = i.nsMetadata.Options().ColdWritesEnabled()
 		forwardIndexDice    = i.forwardIndexDice
 		forwardIndexEnabled = forwardIndexDice.enabled
 
@@ -547,14 +549,16 @@ func (i *nsIndex) writeBatches(
 		func(idx int, entry index.WriteBatchEntry,
 			d doc.Document, _ index.WriteBatchEntryResult) {
 			ts := entry.Timestamp
-			if !futureLimit.After(ts) {
-				batch.MarkUnmarkedEntryError(m3dberrors.ErrTooFuture, idx)
-				return
-			}
+			if !coldWritesEnabled {
+				if !futureLimit.After(ts) {
+					batch.MarkUnmarkedEntryError(m3dberrors.ErrTooFuture, idx)
+					return
+				}
 
-			if !ts.After(pastLimit) {
-				batch.MarkUnmarkedEntryError(m3dberrors.ErrTooPast, idx)
-				return
+				if !ts.After(pastLimit) {
+					batch.MarkUnmarkedEntryError(m3dberrors.ErrTooPast, idx)
+					return
+				}
 			}
 
 			if forwardIndexDice.roll(ts) {
@@ -723,11 +727,26 @@ func (i *nsIndex) Tick(c context.Cancellable, tickStart time.Time) (namespaceInd
 	return result, multiErr.FinalError()
 }
 
-func (i *nsIndex) Flush(
+func (i *nsIndex) WarmFlush(
 	flush persist.IndexFlush,
 	shards []databaseShard,
 ) error {
-	flushable, err := i.flushableBlocks(shards)
+	return i.flush(flush, shards, series.WarmWrite)
+}
+
+func (i *nsIndex) ColdFlush(
+	flush persist.IndexFlush,
+	shards []databaseShard,
+) error {
+	return i.flush(flush, shards, series.ColdWrite)
+}
+
+func (i *nsIndex) flush(
+	flush persist.IndexFlush,
+	shards []databaseShard,
+	flushType series.WriteType,
+) error {
+	flushable, err := i.flushableBlocks(shards, flushType)
 	if err != nil {
 		return err
 	}
@@ -774,6 +793,7 @@ func (i *nsIndex) Flush(
 
 func (i *nsIndex) flushableBlocks(
 	shards []databaseShard,
+	flushType series.WriteType,
 ) ([]index.Block, error) {
 	i.state.RLock()
 	defer i.state.RUnlock()
@@ -782,7 +802,7 @@ func (i *nsIndex) flushableBlocks(
 	}
 	flushable := make([]index.Block, 0, len(i.state.blocksByTime))
 	for _, block := range i.state.blocksByTime {
-		if !i.canFlushBlock(block, shards) {
+		if !i.canFlushBlock(block, shards, flushType) {
 			continue
 		}
 		flushable = append(flushable, block)
@@ -793,11 +813,19 @@ func (i *nsIndex) flushableBlocks(
 func (i *nsIndex) canFlushBlock(
 	block index.Block,
 	shards []databaseShard,
+	flushType series.WriteType,
 ) bool {
 	// Check the block needs flushing because it is sealed and has
 	// any mutable segments that need to be evicted from memory
-	if !block.IsSealed() || !block.NeedsMutableSegmentsEvicted() {
-		return false
+	switch flushType {
+	case series.WarmWrite:
+		if !block.IsSealed() || !block.NeedsMutableSegmentsEvicted() {
+			return false
+		}
+	case series.ColdWrite:
+		if !block.IsSealed() || !block.NeedsColdFlushMutableSegmentsEvicted() {
+			return false
+		}
 	}
 
 	// Check all data files exist for the shards we own

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -109,6 +109,7 @@ type block struct {
 
 	foregroundSegments  []*readableSeg
 	backgroundSegments  []*readableSeg
+	sealedSegments      []*readableSeg
 	shardRangesSegments []blockShardRangesSegments
 
 	newFieldsAndTermsIteratorFn newFieldsAndTermsIteratorFn
@@ -122,6 +123,8 @@ type block struct {
 	nsMD                        namespace.Metadata
 
 	compact blockCompact
+
+	mutableSealedBlock Block
 
 	metrics blockMetrics
 	logger  *zap.Logger
@@ -165,6 +168,7 @@ type blockShardRangesSegments struct {
 type BlockOptions struct {
 	ForegroundCompactorMmapDocsData bool
 	BackgroundCompactorMmapDocsData bool
+	IsMutableSealedBlock            bool
 }
 
 // NewBlock returns a new Block, representing a complete reverse index for the
@@ -190,6 +194,19 @@ func NewBlock(
 	}
 	b.newFieldsAndTermsIteratorFn = newFieldsAndTermsIterator
 	b.newExecutorFn = b.executorWithRLock
+
+	// Create a sub block for storing mutable data after sealing for cold writes
+	if !opts.IsMutableSealedBlock && md.Options().ColdWritesEnabled() {
+		subOpts := opts
+		subOpts.IsMutableSealedBlock = true
+
+		subBlock, err := NewBlock(blockStart, md, subOpts, indexOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		b.mutableSealedBlock = subBlock
+	}
 
 	return b, nil
 }
@@ -401,12 +418,30 @@ func (b *block) addCompactedSegmentFromSegments(
 	return append(result, newReadableSeg(compacted, b.opts))
 }
 
+func (b *block) acceptWritesWithRLock() bool {
+	if b.state == blockStateOpen {
+		// If open accept writes
+		return true
+	}
+
+	// If sealed and cold writes enabled accept writes
+	return b.state == blockStateSealed &&
+		b.nsMD.Options().ColdWritesEnabled()
+}
+
 func (b *block) WriteBatch(inserts *WriteBatch) (WriteBatchResult, error) {
 	b.Lock()
-	if b.state != blockStateOpen {
+	if !b.acceptWritesWithRLock() {
 		b.Unlock()
 		return b.writeBatchResult(inserts, b.writeBatchErrorInvalidState(b.state))
 	}
+	if b.state == blockStateSealed {
+		// Performing sub block sealed write (with cold flushes)
+		subBlock := b.mutableSealedBlock
+		b.Unlock()
+		return subBlock.WriteBatch(inserts)
+	}
+
 	if b.compact.compactingForeground {
 		b.Unlock()
 		return b.writeBatchResult(inserts, errUnableToWriteBlockConcurrent)
@@ -1330,6 +1365,13 @@ func (b *block) NeedsMutableSegmentsEvicted() bool {
 	return anyMutableSegmentNeedsEviction
 }
 
+func (b *block) NeedsColdFlushMutableSegmentsEvicted() bool {
+	b.RLock()
+	defer b.RUnlock()
+
+	return b.mutableSealedBlock.NeedsMutableSegmentsEvicted()
+}
+
 func (b *block) EvictMutableSegments() error {
 	b.Lock()
 	defer b.Unlock()
@@ -1365,6 +1407,13 @@ func (b *block) EvictMutableSegments() error {
 	}
 
 	return multiErr.FinalError()
+}
+
+func (b *block) EvictColdFlushMutableSegments() error {
+	b.RLock()
+	defer b.RUnlock()
+
+	return b.mutableSealedBlock.EvictMutableSegments()
 }
 
 func (b *block) Close() error {

--- a/src/dbnode/storage/index/types.go
+++ b/src/dbnode/storage/index/types.go
@@ -351,6 +351,9 @@ type Block interface {
 	// data the mutable segments should have held at this time.
 	EvictMutableSegments() error
 
+	NeedsColdFlushMutableSegmentsEvicted() bool
+	EvictColdFlushMutableSegments() error
+
 	// Close will release any held resources and close the Block.
 	Close() error
 }

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1089,7 +1089,30 @@ func (n *dbNamespace) FlushIndex(
 	}
 
 	shards := n.GetOwnedShards()
-	err := n.reverseIndex.Flush(flush, shards)
+	err := n.reverseIndex.WarmFlush(flush, shards)
+	n.metrics.flushIndex.ReportSuccessOrError(err, n.nowFn().Sub(callStart))
+	return err
+}
+
+func (n *dbNamespace) ColdFlushIndex(
+	flush persist.IndexFlush,
+) error {
+	callStart := n.nowFn()
+	n.RLock()
+	if n.bootstrapState != Bootstrapped {
+		n.RUnlock()
+		n.metrics.flushIndex.ReportError(n.nowFn().Sub(callStart))
+		return errNamespaceNotBootstrapped
+	}
+	n.RUnlock()
+
+	if !n.nopts.FlushEnabled() || !n.nopts.ColdWritesEnabled() || !n.nopts.IndexOptions().Enabled() {
+		n.metrics.flushIndex.ReportSuccess(n.nowFn().Sub(callStart))
+		return nil
+	}
+
+	shards := n.GetOwnedShards()
+	err := n.reverseIndex.ColdFlush(flush, shards)
 	n.metrics.flushIndex.ReportSuccessOrError(err, n.nowFn().Sub(callStart))
 	return err
 }

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -352,6 +352,11 @@ type databaseNamespace interface {
 		flush persist.FlushPreparer,
 	) error
 
+	// ColdFlushIndex flushes unflushed in-memory indexes of ColdWrites.
+	ColdFlushIndex(
+		flush persist.IndexFlush,
+	) error
+
 	// Snapshot snapshots unflushed in-memory WarmWrites.
 	Snapshot(blockStart, snapshotTime time.Time, flush persist.SnapshotPreparer) error
 
@@ -554,9 +559,16 @@ type namespaceIndex interface {
 	// data eviction, and so on.
 	Tick(c context.Cancellable, tickStart time.Time) (namespaceIndexTickResult, error)
 
-	// Flush performs any flushes that the index has outstanding using
+	// WarmFlush performs any warm flushes that the index has outstanding using
 	// the owned shards of the database.
-	Flush(
+	WarmFlush(
+		flush persist.IndexFlush,
+		shards []databaseShard,
+	) error
+
+	// ColdFlush performs any cold flushes that the index has outstanding using
+	// the owned shards of the database.
+	ColdFlush(
 		flush persist.IndexFlush,
 		shards []databaseShard,
 	) error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This change adds the ability to write out indexed series written arbitrarily out of order in the past (cold writes).

TODO:
- [ ] Combine indexed cold writes into single segment, rather than appending each time cold flush needed.
- [ ] Comprehensive tests and integration tests.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
