### PR TITLE
[DBNode] - Dont clear customFields and nonCustomFields in Proto Encoder/Iterator…

### DIFF
--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -259,7 +259,20 @@ func (it *iterator) resetSchema(schemaDesc namespace.SchemaDescr) {
 	if schemaDesc == nil {
 		it.schemaDesc = nil
 		it.schema = nil
-		it.customFields = nil
+
+		// Clear but don't set to nil so they don't need to be reallocated
+		// next time.
+		customFields := it.customFields
+		for i := range customFields {
+			customFields[i] = customFieldState{}
+		}
+		it.customFields = customFields[:0]
+
+		nonCustomFields := it.nonCustomFields
+		for i := range nonCustomFields {
+			nonCustomFields[i] = marshalledField{}
+		}
+		it.nonCustomFields = nonCustomFields[:0]
 		return
 	}
 


### PR DESCRIPTION
Currently every time a proto encoder/iterator is reset it needs to reallocate a (potentially large) slice for custom and non-custom fields. This P.R changes the reset functionality to clear the slices, but not set them to nil, so that they can be reused within a pooled object and not reallocated each time.