### PR TITLE
[DBNode] - Add support for limiting the maximum number of outstanding write/read requests at the RPC level

### DIFF
--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -104,9 +104,11 @@ type DBConfiguration struct {
 	// The initial garbage collection target percentage.
 	GCPercentage int `yaml:"gcPercentage" validate:"max=100"`
 
+	// TODO(V1): Move to `limits`.
 	// Write new series limit per second to limit overwhelming during new ID bursts.
 	WriteNewSeriesLimitPerSecond int `yaml:"writeNewSeriesLimitPerSecond"`
 
+	// TODO(V1): Move to `limits`.
 	// Write new series backoff between batches of new series insertions.
 	WriteNewSeriesBackoffDuration time.Duration `yaml:"writeNewSeriesBackoffDuration"`
 
@@ -148,6 +150,10 @@ type DBConfiguration struct {
 
 	// Tracing configures opentracing. If not provided, tracing is disabled.
 	Tracing *opentracing.TracingConfiguration `yaml:"tracing"`
+
+	// Limits contains configuration for limits that can be applied to M3DB for the purposes
+	// of applying back-pressure or protecting the db nodes.
+	Limits Limits `yaml:"limits"`
 }
 
 // InitDefaultsAndValidate initializes all default values and validates the Configuration.

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -659,6 +659,9 @@ func TestConfiguration(t *testing.T) {
       headers: null
       baggage_restrictions: null
       throttler: null
+  limits:
+    maxOutstandingWriteRequests: 0
+    maxOutstandingReadRequests: 0
 coordinator: null
 `
 

--- a/src/cmd/services/m3dbnode/config/limits.go
+++ b/src/cmd/services/m3dbnode/config/limits.go
@@ -22,13 +22,13 @@ package config
 
 // Limits contains configuration for configurable limits that can be applied to M3DB.
 type Limits struct {
-	// MaxOutstandingWriteRequests controls the maximum number of outstanding write RPCs
+	// MaxOutstandingWriteRequests controls the maximum number of outstanding write requests
 	// that the server will allow before it begins rejecting requests. Note that this value
 	// is independent of the number of values that are being written (due to variable batch
-	// from the client) but is still very useful for enforcing backpressure due to the fact
+	// size from the client) but is still very useful for enforcing backpressure due to the fact
 	// that all writes within a single RPC are single-threaded.
 	MaxOutstandingWriteRequests int `yaml:"maxOutstandingWriteRequests" validate:"min=0"`
-	// MaxOutstandingReadRequests controls the maximum number of outstanding read RPCs that
+	// MaxOutstandingReadRequests controls the maximum number of outstanding read requests that
 	// the server will allow before it begins rejecting requests. Just like MaxOutstandingWriteRequests
 	// this value is independent of the number of time series being read.
 	MaxOutstandingReadRequests int `yaml:"maxOutstandingReadRequests" validate:"min=0"`

--- a/src/cmd/services/m3dbnode/config/limits.go
+++ b/src/cmd/services/m3dbnode/config/limits.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+// Limits contains configuration for configurable limits that can be applied to M3DB.
+type Limits struct {
+	// MaxOutstandingWriteRequests controls the maximum number of outstanding write RPCs
+	// that the server will allow before it begins rejecting requests. Note that this value
+	// is independent of the number of values that are being written (due to variable batch
+	// from the client) but is still very useful for enforcing backpressure due to the fact
+	// that all writes within a single RPC are single-threaded.
+	MaxOutstandingWriteRequests int `yaml:"maxOutstandingWriteRequests" validate:"min=0"`
+	// MaxOutstandingReadRequests controls the maximum number of outstanding read RPCs that
+	// the server will allow before it begins rejecting requests. Just like MaxOutstandingWriteRequests
+	// this value is independent of the number of time series being read.
+	MaxOutstandingReadRequests int `yaml:"maxOutstandingReadRequests" validate:"min=0"`
+}

--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -1545,7 +1545,6 @@ func (s *service) writeRPCCompleted() {
 	}
 
 	s.state.DecNumOutstandingWriteRPCs()
-	return
 }
 
 func (s *service) startReadRPCWithDB() (storage.Database, error) {
@@ -1577,7 +1576,6 @@ func (s *service) readRPCCompleted() {
 	}
 
 	s.state.DecNumOutstandingReadRPCs()
-	return
 }
 
 func (s *service) startRPCWithDB() (storage.Database, error) {

--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -174,17 +174,17 @@ func (s *serviceState) Health() (*rpc.NodeHealthResult_, bool) {
 func (s *serviceState) DBForWriteRPCWithLimit() (
 	db storage.Database, dbInitialized bool, rpcDoesNotExceedLimit bool) {
 	s.Lock()
+	defer s.Unlock()
+
 	if s.db == nil {
-		s.Unlock()
 		return nil, false, false
 	}
 	if s.numOutstandingWriteRPCs >= s.maxOutstandingWriteRPCs {
-		s.Unlock()
 		return nil, true, false
 	}
+
 	v := s.db
 	s.numOutstandingWriteRPCs++
-	s.Unlock()
 	return v, true, true
 }
 
@@ -197,17 +197,17 @@ func (s *serviceState) DecNumOutstandingWriteRPCs() {
 func (s *serviceState) DBForReadRPCWithLimit() (
 	db storage.Database, dbInitialized bool, requestDoesNotExceedLimit bool) {
 	s.Lock()
+	defer s.Unlock()
+
 	if s.db == nil {
-		s.Unlock()
 		return nil, false, false
 	}
 	if s.numOutstandingReadRPCs >= s.maxOutstandingReadRPCs {
-		s.Unlock()
 		return nil, true, false
 	}
+
 	v := s.db
 	s.numOutstandingReadRPCs++
-	s.Unlock()
 	return v, true, true
 }
 

--- a/src/dbnode/network/server/tchannelthrift/options.go
+++ b/src/dbnode/network/server/tchannelthrift/options.go
@@ -30,14 +30,16 @@ import (
 )
 
 type options struct {
-	clockOpts                clock.Options
-	instrumentOpts           instrument.Options
-	topologyInitializer      topology.Initializer
-	idPool                   ident.Pool
-	blockMetadataV2Pool      BlockMetadataV2Pool
-	blockMetadataV2SlicePool BlockMetadataV2SlicePool
-	tagEncoderPool           serialize.TagEncoderPool
-	tagDecoderPool           serialize.TagDecoderPool
+	clockOpts                   clock.Options
+	instrumentOpts              instrument.Options
+	topologyInitializer         topology.Initializer
+	idPool                      ident.Pool
+	blockMetadataV2Pool         BlockMetadataV2Pool
+	blockMetadataV2SlicePool    BlockMetadataV2SlicePool
+	tagEncoderPool              serialize.TagEncoderPool
+	tagDecoderPool              serialize.TagDecoderPool
+	maxOutstandingWriteRequests int
+	maxOutstandingReadRequests  int
 }
 
 // NewOptions creates new options
@@ -148,4 +150,24 @@ func (o *options) SetTagDecoderPool(value serialize.TagDecoderPool) Options {
 
 func (o *options) TagDecoderPool() serialize.TagDecoderPool {
 	return o.tagDecoderPool
+}
+
+func (o *options) SetMaxOutstandingWriteRequests(value int) Options {
+	opts := *o
+	opts.maxOutstandingWriteRequests = value
+	return &opts
+}
+
+func (o *options) MaxOutstandingWriteRequests() int {
+	return o.maxOutstandingWriteRequests
+}
+
+func (o *options) SetMaxOutstandingReadRequests(value int) Options {
+	opts := *o
+	opts.maxOutstandingReadRequests = value
+	return &opts
+}
+
+func (o *options) MaxOutstandingReadRequests() int {
+	return o.maxOutstandingReadRequests
 }

--- a/src/dbnode/network/server/tchannelthrift/types.go
+++ b/src/dbnode/network/server/tchannelthrift/types.go
@@ -77,4 +77,20 @@ type Options interface {
 
 	// TagDecoderPool returns the tag encoder pool.
 	TagDecoderPool() serialize.TagDecoderPool
+
+	// SetMaxOutstandingWriteRequests sets the maximum number of allowed
+	// outstanding write requests.
+	SetMaxOutstandingWriteRequests(value int) Options
+
+	// MaxOutstandingWriteRequests returns the maxinum number of allowed
+	// outstanding write requests.
+	MaxOutstandingWriteRequests() int
+
+	// SetMaxOutstandingReadRequests sets the maximum number of allowed
+	// outstanding read requests.
+	SetMaxOutstandingReadRequests(value int) Options
+
+	// MaxOutstandingReadRequests returns the maxinum number of allowed
+	// outstanding read requests.
+	MaxOutstandingReadRequests() int
 }

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -543,7 +543,9 @@ func Run(runOpts RunOptions) {
 		SetTopologyInitializer(envCfg.TopologyInitializer).
 		SetIdentifierPool(opts.IdentifierPool()).
 		SetTagEncoderPool(tagEncoderPool).
-		SetTagDecoderPool(tagDecoderPool)
+		SetTagDecoderPool(tagDecoderPool).
+		SetMaxOutstandingWriteRequests(cfg.Limits.MaxOutstandingWriteRequests).
+		SetMaxOutstandingReadRequests(cfg.Limits.MaxOutstandingReadRequests)
 
 	// Start servers before constructing the DB so orchestration tools can check health endpoints
 	// before topology is set.


### PR DESCRIPTION
While we still need to address [this proposal](https://github.com/m3db/proposal/issues/13) to solve the backpressure problem in depth, this P.R improves M3DB's ability to apply backpressure by supporting the ability to (optionally) limit the maximum number of outstanding write and read requests. This allows us to apply back pressure even earlier because in situations where the nodes are really overwhelmed many goroutines will get stuck allocating way before the commit log backpressure ever kicks in.

This P.R also allows us to size the writeBatchReq pool exactly to fit our requirements in the case that a maximum number of outstanding write requests has been configured.