### PR TITLE
Fix M3AGGREGATOR_HOST_ID in integration test

### DIFF
--- a/scripts/docker-integration-tests/aggregator/docker-compose.yml
+++ b/scripts/docker-integration-tests/aggregator/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     networks:
       - backend
     environment:
-      - M3AGGREGATOR_HOST_ID=m3aggregator01
+      - M3AGGREGATOR_HOST_ID=m3aggregator02
     image: "m3aggregator_integration:${REVISION}"
     volumes:
       - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"


### PR DESCRIPTION
The host id should not be the same on both containers. Having it the
same causes problems with aggregator leader election.

Without the fix:
     m3aggregator02_1   | {"level":"warn","ts":1564148579.7962255,"msg":"campaign is not enabled, no cutover shards"}
     m3aggregator01_1   | {"level":"warn","ts":1564148579.49419,"msg":"campaign is not enabled, no cutover shards"}
     m3aggregator02_1   | {"level":"error","ts":1564148581.3063626,"msg":"leader has not changed","electionKey":"shardset/1/lock","electionTTL":10,"leaderValue":"m3aggregator01:6000","error":"leader has not changed"}
     m3aggregator01_1   | {"level":"error","ts":1564148581.2203503,"msg":"leader has not changed","electionKey":"shardset/1/lock","electionTTL":10,"leaderValue":"m3aggregator01:6000","error":"leader has not changed"}
     m3aggregator02_1   | {"level":"error","ts":1564148581.454006,"msg":"leader has not changed","electionKey":"shardset/1/lock","electionTTL":10,"leaderValue":"m3aggregator01:6000","error":"leader has not changed"}
     m3aggregator01_1   | {"level":"info","ts":1564148581.2209077,"msg":"election state changed from follower to leader"}
     m3aggregator02_1   | {"level":"error","ts":1564148581.5944395,"msg":"leader has not changed","electionKey":"shardset/1/lock","electionTTL":10,"leaderValue":"m3aggregator01:6000","error":"leader has not changed"}

With the fix:
     m3aggregator01_1   | {"level":"warn","ts":1564154999.3122041,"msg":"campaign is not enabled, no cutover shards"}
     m3aggregator02_1   | {"level":"warn","ts":1564154999.447389,"msg":"campaign is not enabled, no cutover shards"}
     m3aggregator01_1   | {"level":"info","ts":1564155000.3356626,"msg":"election state changed from follower to leader"}
     m3aggregator02_1   | {"level":"info","ts":1564155000.4575346,"msg":"found valid new leader for the campaign","leader":"m3aggregator01:6000"}
     m3aggregator02_1   | {"level":"info","ts":1564155000.45759,"msg":"goal state changed to follower"}

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
