### PR TITLE
[kube] fix minor typo in sysctl-setter daemonset

### DIFF
--- a/kube/sysctl-daemonset.yaml
+++ b/kube/sysctl-daemonset.yaml
@@ -5,7 +5,7 @@
 # modify host sysctl values. This is designed for managed Kubernetes platforms
 # that may have restrictions like read-only root FS, inability to set startup
 # scripts, etc. In very rare circumstances should you use this, and should
-# intead opt to use your usual host provisioning tooling to set these values.
+# instead opt to use your usual host provisioning tooling to set these values.
 #
 # This daemonset pins to a specific SHA digest in the event that the M3DB Quay
 # repo is ever compromised. The manifest of this image can be verified here:


### PR DESCRIPTION
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:

```documentation-note
NONE
```
