### PR TITLE
[dbnode] Safe handling of concurrent bloom filters

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -57,10 +57,11 @@ Once you have identified a change you want to make, and gathered consensus by ta
 (0) If you have updated an interface that has been mocked, you need to update the generated `gomock `files.
 
 ```shell
-# Generate mocks for all top level packages, or...
-mach mock-gen
+# Generate mocks for all top level packages
+make mock-gen
 
-# ...replace xyz with the package you want to generate files for, e.g. dbnode
+# If you just want to generate it for a single package,
+# replace xyz with the package you want to generate files for, e.g. dbnode
 make mock-gen-xyz
 ```
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -54,10 +54,13 @@ M3 has an extensive, and ever increasing, set of tests to ensure we are able to 
 
 Once you have identified a change you want to make, and gathered consensus by talking to some devs, go ahead and make a branch with the changes. To test your changes:
 
-(0) If necessary, generate GoMock files
+(0) If you have updated an interface that has been mocked, you need to update the generated `gomock `files.
 
 ```shell
-# Replace xyz with the package you want to generate files for, e.g. dbnode
+# Generate mocks for all top level packages, or...
+mach mock-gen
+
+# ...replace xyz with the package you want to generate files for, e.g. dbnode
 make mock-gen-xyz
 ```
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -54,6 +54,13 @@ M3 has an extensive, and ever increasing, set of tests to ensure we are able to 
 
 Once you have identified a change you want to make, and gathered consensus by talking to some devs, go ahead and make a branch with the changes. To test your changes:
 
+(0) If necessary, generate GoMock files
+
+```shell
+# Replace xyz with the package you want to generate files for, e.g. dbnode
+make mock-gen-xyz
+```
+
 (1) Run unit tests locally
 ```
 go test ./... -v

--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -1071,6 +1071,21 @@ func (mr *MockDataFileSetSeekerManagerMockRecorder) Return(arg0, arg1, arg2 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Return", reflect.TypeOf((*MockDataFileSetSeekerManager)(nil).Return), arg0, arg1, arg2)
 }
 
+// Test mocks base method
+func (m *MockDataFileSetSeekerManager) Test(arg0 uint32, arg1 ident.ID, arg2 time.Time) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Test", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Test indicates an expected call of Test
+func (mr *MockDataFileSetSeekerManagerMockRecorder) Test(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Test", reflect.TypeOf((*MockDataFileSetSeekerManager)(nil).Test), arg0, arg1, arg2)
+}
+
 // MockConcurrentDataFileSetSeeker is a mock of ConcurrentDataFileSetSeeker interface
 type MockConcurrentDataFileSetSeeker struct {
 	ctrl     *gomock.Controller

--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -1028,21 +1028,6 @@ func (mr *MockDataFileSetSeekerManagerMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDataFileSetSeekerManager)(nil).Close))
 }
 
-// ConcurrentIDBloomFilter mocks base method
-func (m *MockDataFileSetSeekerManager) ConcurrentIDBloomFilter(arg0 uint32, arg1 time.Time) (*ManagedConcurrentBloomFilter, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConcurrentIDBloomFilter", arg0, arg1)
-	ret0, _ := ret[0].(*ManagedConcurrentBloomFilter)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ConcurrentIDBloomFilter indicates an expected call of ConcurrentIDBloomFilter
-func (mr *MockDataFileSetSeekerManagerMockRecorder) ConcurrentIDBloomFilter(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConcurrentIDBloomFilter", reflect.TypeOf((*MockDataFileSetSeekerManager)(nil).ConcurrentIDBloomFilter), arg0, arg1)
-}
-
 // Open mocks base method
 func (m *MockDataFileSetSeekerManager) Open(arg0 namespace.Metadata) error {
 	m.ctrl.T.Helper()

--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -1057,7 +1057,7 @@ func (mr *MockDataFileSetSeekerManagerMockRecorder) Return(arg0, arg1, arg2 inte
 }
 
 // Test mocks base method
-func (m *MockDataFileSetSeekerManager) Test(arg0 uint32, arg1 ident.ID, arg2 time.Time) (bool, error) {
+func (m *MockDataFileSetSeekerManager) Test(arg0 ident.ID, arg1 uint32, arg2 time.Time) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Test", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -415,7 +415,7 @@ func (r *blockRetriever) Stream(
 	}
 	r.RUnlock()
 
-	idExists, err := r.seekerMgr.Test(shard, id, startTime)
+	idExists, err := r.seekerMgr.Test(id, shard, startTime)
 	if err != nil {
 		return xio.EmptyBlockReader, err
 	}

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -415,14 +415,14 @@ func (r *blockRetriever) Stream(
 	}
 	r.RUnlock()
 
-	bloomFilter, err := r.seekerMgr.ConcurrentIDBloomFilter(shard, startTime)
+	idExists, err := r.seekerMgr.Test(shard, id, startTime)
 	if err != nil {
 		return xio.EmptyBlockReader, err
 	}
 
 	// If the ID is not in the seeker's bloom filter, then it's definitely not on
 	// disk and we can return immediately.
-	if !bloomFilter.Test(id.Bytes()) {
+	if !idExists {
 		// No need to call req.onRetrieve.OnRetrieveBlock if there is no data.
 		req.onRetrieved(ts.Segment{}, namespace.Context{})
 		return req.toBlock(), nil

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -34,7 +34,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/bloom"
 	"github.com/m3db/m3/src/dbnode/digest"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/index/convert"
@@ -653,14 +652,14 @@ func testBlockRetrieverHandlesSeekErrors(t *testing.T, ctrl *gomock.Controller, 
 		blockStart = time.Now().Truncate(rOpts.BlockSize())
 
 		// Always true because all the bits in 255 are set.
-		bloomBytes            = []byte{255, 255, 255, 255, 255, 255, 255, 255}
-		alwaysTrueBloomFilter = bloom.NewConcurrentReadOnlyBloomFilter(1, 1, bloomBytes)
-		managedBloomFilter    = newManagedConcurrentBloomFilter(alwaysTrueBloomFilter, bloomBytes)
+		//bloomBytes = []byte{255, 255, 255, 255, 255, 255, 255, 255}
+		//alwaysTrueBloomFilter = bloom.NewConcurrentReadOnlyBloomFilter(1, 1, bloomBytes)
+		//managedBloomFilter    = newManagedConcurrentBloomFilter(alwaysTrueBloomFilter, bloomBytes)
 	)
 
 	mockSeekerManager := NewMockDataFileSetSeekerManager(ctrl)
 	mockSeekerManager.EXPECT().Open(gomock.Any()).Return(nil)
-	mockSeekerManager.EXPECT().ConcurrentIDBloomFilter(gomock.Any(), gomock.Any()).Return(managedBloomFilter, nil)
+	mockSeekerManager.EXPECT().Test(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockSeekerManager.EXPECT().Borrow(gomock.Any(), gomock.Any()).Return(mockSeeker, nil)
 	mockSeekerManager.EXPECT().Return(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	mockSeekerManager.EXPECT().Close().Return(nil)

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -650,11 +650,6 @@ func testBlockRetrieverHandlesSeekErrors(t *testing.T, ctrl *gomock.Controller, 
 		nsCtx      = namespace.NewContextFrom(testNs1Metadata(t))
 		shard      = uint32(0)
 		blockStart = time.Now().Truncate(rOpts.BlockSize())
-
-		// Always true because all the bits in 255 are set.
-		//bloomBytes = []byte{255, 255, 255, 255, 255, 255, 255, 255}
-		//alwaysTrueBloomFilter = bloom.NewConcurrentReadOnlyBloomFilter(1, 1, bloomBytes)
-		//managedBloomFilter    = newManagedConcurrentBloomFilter(alwaysTrueBloomFilter, bloomBytes)
 	)
 
 	mockSeekerManager := NewMockDataFileSetSeekerManager(ctrl)

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -237,25 +237,6 @@ func (m *seekerManager) Test(shard uint32, id ident.ID, start time.Time) (bool, 
 	return seekersAndBloom.bloomFilter.Test(id.Bytes()), nil
 }
 
-func (m *seekerManager) ConcurrentIDBloomFilter(shard uint32, start time.Time) (*ManagedConcurrentBloomFilter, error) {
-	byTime := m.seekersByTime(shard)
-
-	// Try fast RLock() first.
-	byTime.RLock()
-	startNano := xtime.ToUnixNano(start)
-	seekers, ok := byTime.seekers[startNano]
-	byTime.RUnlock()
-
-	if ok && seekers.active.wg == nil {
-		return seekers.active.bloomFilter, nil
-	}
-
-	byTime.Lock()
-	seekersAndBloom, err := m.getOrOpenSeekersWithLock(startNano, byTime)
-	byTime.Unlock()
-	return seekersAndBloom.bloomFilter, err
-}
-
 func (m *seekerManager) Borrow(shard uint32, start time.Time) (ConcurrentDataFileSetSeeker, error) {
 	byTime := m.seekersByTime(shard)
 

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -209,7 +209,7 @@ func (m *seekerManager) CacheShardIndices(shards []uint32) error {
 	return multiErr.FinalError()
 }
 
-func (m *seekerManager) Test(shard uint32, id ident.ID, start time.Time) (bool, error) {
+func (m *seekerManager) Test(id ident.ID, shard uint32, start time.Time) (bool, error) {
 	byTime := m.seekersByTime(shard)
 
 	// Try fast RLock() first.

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -223,12 +223,13 @@ func (m *seekerManager) Test(shard uint32, id ident.ID, start time.Time) (bool, 
 	}
 
 	byTime.Lock()
-	seekersAndBloom, err := m.getOrOpenSeekersWithLock(startNano, byTime)
-	byTime.Unlock()
+	defer byTime.Unlock()
 
+	seekersAndBloom, err := m.getOrOpenSeekersWithLock(startNano, byTime)
 	if err != nil {
 		return false, err
 	}
+
 	return seekersAndBloom.bloomFilter.Test(id.Bytes()), nil
 }
 

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -216,10 +216,14 @@ func (m *seekerManager) Test(shard uint32, id ident.ID, start time.Time) (bool, 
 	byTime.RLock()
 	startNano := xtime.ToUnixNano(start)
 	seekers, ok := byTime.seekers[startNano]
-	byTime.RUnlock()
 
+	// Seekers are open: good to test but still hold RLock while doing so
 	if ok && seekers.active.wg == nil {
-		return seekers.active.bloomFilter.Test(id.Bytes()), nil
+		idExists := seekers.active.bloomFilter.Test(id.Bytes())
+		byTime.RUnlock()
+		return idExists, nil
+	} else {
+		byTime.RUnlock()
 	}
 
 	byTime.Lock()

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -246,7 +246,7 @@ type DataFileSetSeekerManager interface {
 
 	// Test checks if an ID exists in a concurrent ID bloom filter for a
 	// given shard, block, start time and volume.
-	Test(shard uint32, id ident.ID, start time.Time) (bool, error)
+	Test(id ident.ID, shard uint32, start time.Time) (bool, error)
 }
 
 // DataBlockRetriever provides a block retriever for TSDB file sets

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -244,10 +244,6 @@ type DataFileSetSeekerManager interface {
 	// Return returns an open seeker for a given shard, block start time, and volume.
 	Return(shard uint32, start time.Time, seeker ConcurrentDataFileSetSeeker) error
 
-	// ConcurrentIDBloomFilter returns a concurrent ID bloom filter for a given
-	// shard, block start time, and volume.
-	ConcurrentIDBloomFilter(shard uint32, start time.Time) (*ManagedConcurrentBloomFilter, error)
-
 	// Test checks if an ID exists in a concurrent ID bloom filter for a
 	// given shard, block, start time and volume.
 	Test(shard uint32, id ident.ID, start time.Time) (bool, error)

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -247,6 +247,10 @@ type DataFileSetSeekerManager interface {
 	// ConcurrentIDBloomFilter returns a concurrent ID bloom filter for a given
 	// shard, block start time, and volume.
 	ConcurrentIDBloomFilter(shard uint32, start time.Time) (*ManagedConcurrentBloomFilter, error)
+
+	// Test checks if an ID exists in a concurrent ID bloom filter for a
+	// given shard, block, start time and volume.
+	Test(shard uint32, id ident.ID, start time.Time) (bool, error)
 }
 
 // DataBlockRetriever provides a block retriever for TSDB file sets


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1760 

**Special notes for your reviewer**:

Right now bloom filters that are returned via `seekerManager.ConcurrentIDBloomFilter` https://github.com/m3db/m3/blob/04d9c0654c80688e79ac7ffb2f15dd7ab3b4e8f8/src/dbnode/persist/fs/seek_manager.go#L212 are not tracked, which can lead to errors if one goroutine tries to access it (e.g. search for an ID) while another has closed the filter in the meantime. 

This PR introduces the `Test` method on `DataFileSetSeekerManager` https://github.com/m3db/m3/blob/04d9c0654c80688e79ac7ffb2f15dd7ab3b4e8f8/src/dbnode/persist/fs/types.go#L168 which tests for an ID while the lock on a bloom filter is still being held, to avoid the above described scenario. `seekerManager.Test` is now being used in `blockRetriever.Stream` https://github.com/m3db/m3/blob/04d9c0654c80688e79ac7ffb2f15dd7ab3b4e8f8/src/dbnode/persist/fs/retriever.go#L386 instead of "manually" testing the ID existence on `ConcurrentIDBloomFilter`. Subsequently, `ConcurrentIDBloomFilter` has been removed from the `DataFileSetSeekerManager` API.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
