### PR TITLE
[dbnode] Fix panic when updating bootstrappers gauge on Promreporter with different label keys

### DIFF
--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -697,7 +697,7 @@ func Run(runOpts RunOptions) {
 	opts = opts.SetBootstrapProcessProvider(bs)
 	timeout := bootstrapConfigInitTimeout
 
-	bsGauge := instrument.NewStringListEmitter(scope, "bootstrappers", "bootstrapper")
+	bsGauge := instrument.NewStringListEmitter(scope, "bootstrappers")
 	if err := bsGauge.Start(cfg.Bootstrap.Bootstrappers); err != nil {
 		logger.Error("unable to start emitting bootstrap gauge",
 			zap.Strings("bootstrappers", cfg.Bootstrap.Bootstrappers),

--- a/src/x/instrument/string_list_emitter.go
+++ b/src/x/instrument/string_list_emitter.go
@@ -69,7 +69,7 @@ func NewStringListEmitter(scope tally.Scope, name string) *StringListEmitter {
 func (bge *StringListEmitter) newGauges(scope tally.Scope, sl []string) []tally.Gauge {
 	gauges := make([]tally.Gauge, len(sl))
 	for i, v := range sl {
-		name := fmt.Sprintf("%s%d", bge.name, i)
+		name := fmt.Sprintf("%s_%d", bge.name, i)
 		g := scope.Tagged(map[string]string{"type": v}).Gauge(name)
 		g.Update(1)
 		gauges[i] = g

--- a/src/x/instrument/string_list_emitter_test.go
+++ b/src/x/instrument/string_list_emitter_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
-	promreporter "github.com/uber-go/tally/prometheus"
 	"reflect"
 	"testing"
 )
@@ -39,8 +38,8 @@ var bootstrappers = [][]string{
 	{
 		"uninitialized_topology",
 		"filesystem",
-		"commitlog",
 		"peers",
+		"commitlog",
 	},
 	{
 		"a",
@@ -72,28 +71,32 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 	t.Run("TestNewBootstrapGaugeEmitter", func(t *testing.T) {
 		for _, bs := range bootstrappers {
 
-			bge := NewStringListEmitter(scope, "bootstrapper_bootstrappers", "bootstrapper")
+			bge := NewStringListEmitter(scope, "bootstrappers")
 			require.NotNil(t, bge)
-			require.NotNil(t, bge.gauge)
+			require.NotNil(t, bge.gauges)
+			require.Equal(t, 1, len(bge.gauges))
 
-			g := bge.newGauge(scope, bs)
+			g := bge.newGauges(scope, bs)
 			require.NotNil(t, g)
+			require.Equal(t, len(bs), len(g))
 
 			require.False(t, bge.running)
 
 			err := bge.UpdateStringList(bs)
 			require.Error(t, err)
-			require.NotNil(t, bge.gauge)
+			require.NotNil(t, bge.gauges)
+			require.Equal(t, 1, len(bge.gauges))
 
 			err = bge.Close()
 			require.Error(t, err)
 
 			err = bge.Start(bs)
 			require.NoError(t, err)
-			require.NotNil(t, bge.gauge)
+			require.NotNil(t, bge.gauges)
 			require.True(t, bge.running)
-			if !reflect.DeepEqual(g, bge.gauge) {
-				t.Errorf("expected: %#v, got: %#v", g, bge.gauge)
+			require.Equal(t, len(bs), len(bge.gauges))
+			if !reflect.DeepEqual(g, bge.gauges) {
+				t.Errorf("expected: %#v, got: %#v", g, bge.gauges)
 			}
 
 			err = bge.Close()
@@ -105,43 +108,55 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 	t.Run("TestEmitting", func(t *testing.T) {
 		scope := tally.NewTestScope("testScope", nil)
 		bs0 := bootstrappers[0]
-		bge := NewStringListEmitter(scope, "bootstrapper_bootstrappers", "bootstrapper")
+		bge := NewStringListEmitter(scope, "bootstrappers")
 		require.NotNil(t, bge)
-		require.NotNil(t, bge.gauge)
+		require.NotNil(t, bge.gauges)
+		require.Equal(t, len(bge.gauges), 1)
 
 		// Start
 		err := bge.Start(bs0)
 		require.NoError(t, err)
 		require.True(t, bge.running)
-		require.NotNil(t, bge.gauge)
+		require.NotNil(t, bge.gauges)
+		require.Equal(t, len(bge.gauges), len(bs0))
 
 		gauges := scope.Snapshot().Gauges()
-		require.Equal(t, 1, len(gauges), "length of gauges after start")
+		require.Equal(t, len(bs0), len(gauges), "length of gauges after start")
 
 		for _, id := range []string{
-			fmt.Sprintf("testScope.bootstrapper_bootstrappers+bootstrapper0=%s,bootstrapper1=%s,bootstrapper2=%s,bootstrapper3=%s", bs0[0], bs0[1], bs0[2], bs0[3]),
+			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs0[0]),
+			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs0[1]),
+			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs0[2]),
+			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs0[3]),
 		} {
 			g, ok := gauges[id]
 			require.True(t, ok)
 			require.Equal(t, float64(1), g.Value(), "gauge value after start")
 		}
 
-		// Update to new
+		// 	// Update to new
 		bs1 := bootstrappers[1]
 		err = bge.UpdateStringList(bs1)
 		require.NoError(t, err)
 		require.True(t, bge.running, "state of bootstrapGaugeEmitter after update")
-		require.NotNil(t, bge.gauge)
+		require.NotNil(t, bge.gauges)
+		require.Equal(t, len(bge.gauges), len(bs1))
 
 		gauges = scope.Snapshot().Gauges()
-		require.Equal(t, 2, len(gauges), "length of gauges after updating")
+		require.Equal(t, 8, len(gauges), "length of gauges after updating")
 		for i, id := range []string{
-			fmt.Sprintf("testScope.bootstrapper_bootstrappers+bootstrapper0=%s,bootstrapper1=%s,bootstrapper2=%s,bootstrapper3=%s", bs0[0], bs0[1], bs0[2], bs0[3]),
-			fmt.Sprintf("testScope.bootstrapper_bootstrappers+bootstrapper0=%s,bootstrapper1=%s,bootstrapper2=%s,bootstrapper3=%s", bs1[0], bs1[1], bs1[2], bs1[3]),
+			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs0[0]),
+			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs0[1]),
+			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs0[2]),
+			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs0[3]),
+			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs1[0]),
+			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs1[1]),
+			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs1[2]),
+			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs1[3]),
 		} {
 			g, ok := gauges[id]
 			require.True(t, ok)
-			if i == 0 {
+			if i < 4 {
 				require.Equal(t, float64(0), g.Value(), "first gauge value of after update")
 			} else {
 				require.Equal(t, float64(1), g.Value(), "second gauge value of after update")
@@ -152,17 +167,24 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 		err = bge.UpdateStringList(bs0)
 		require.NoError(t, err)
 		require.True(t, bge.running, "state of bootstrapGaugeEmitter after update")
-		require.NotNil(t, bge.gauge)
+		require.NotNil(t, bge.gauges)
+		require.Equal(t, len(bge.gauges), len(bs0))
 
 		gauges = scope.Snapshot().Gauges()
-		require.Equal(t, 2, len(gauges), "length of gauges after updating")
+		require.Equal(t, 8, len(gauges), "length of gauges after updating")
 		for i, id := range []string{
-			fmt.Sprintf("testScope.bootstrapper_bootstrappers+bootstrapper0=%s,bootstrapper1=%s,bootstrapper2=%s,bootstrapper3=%s", bs0[0], bs0[1], bs0[2], bs0[3]),
-			fmt.Sprintf("testScope.bootstrapper_bootstrappers+bootstrapper0=%s,bootstrapper1=%s,bootstrapper2=%s,bootstrapper3=%s", bs1[0], bs1[1], bs1[2], bs1[3]),
+			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs0[0]),
+			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs0[1]),
+			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs0[2]),
+			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs0[3]),
+			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs1[0]),
+			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs1[1]),
+			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs1[2]),
+			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs1[3]),
 		} {
 			g, ok := gauges[id]
 			require.True(t, ok)
-			if i == 0 {
+			if i < 4 {
 				require.Equal(t, float64(1), g.Value(), "first gauge value of after update")
 			} else {
 				require.Equal(t, float64(0), g.Value(), "second gauge value of after update")
@@ -172,21 +194,28 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 		// Update back to old again -- test emitting same metric twice
 		err = bge.UpdateStringList(bs0)
 		require.NoError(t, err)
-		require.True(t, bge.running, "state of bootstrapGaugeEmitter after emitting same metric twice")
-		require.NotNil(t, bge.gauge)
+		require.True(t, bge.running, "state of bootstrapGaugeEmitter after update")
+		require.NotNil(t, bge.gauges)
+		require.Equal(t, len(bge.gauges), len(bs0))
 
 		gauges = scope.Snapshot().Gauges()
-		require.Equal(t, 2, len(gauges), "length of gauges after updating")
+		require.Equal(t, 8, len(gauges), "length of gauges after updating")
 		for i, id := range []string{
-			fmt.Sprintf("testScope.bootstrapper_bootstrappers+bootstrapper0=%s,bootstrapper1=%s,bootstrapper2=%s,bootstrapper3=%s", bs0[0], bs0[1], bs0[2], bs0[3]),
-			fmt.Sprintf("testScope.bootstrapper_bootstrappers+bootstrapper0=%s,bootstrapper1=%s,bootstrapper2=%s,bootstrapper3=%s", bs1[0], bs1[1], bs1[2], bs1[3]),
+			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs0[0]),
+			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs0[1]),
+			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs0[2]),
+			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs0[3]),
+			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs1[0]),
+			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs1[1]),
+			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs1[2]),
+			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs1[3]),
 		} {
 			g, ok := gauges[id]
 			require.True(t, ok)
-			if i == 0 {
-				require.Equal(t, float64(1), g.Value(), "first gauge value of after emitting same metric twice")
+			if i < 4 {
+				require.Equal(t, float64(1), g.Value(), "first gauge value of after update")
 			} else {
-				require.Equal(t, float64(0), g.Value(), "second gauge value of after emitting same metric twice")
+				require.Equal(t, float64(0), g.Value(), "second gauge value of after update")
 			}
 		}
 
@@ -197,56 +226,25 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 	})
 
 	t.Run("MultipleLabelCombinations", func(t *testing.T) {
-		bge := NewStringListEmitter(scope, "bootstrapper_bootstrappers", "bootstrapper")
+		bge := NewStringListEmitter(scope, "bootstrappers")
 		require.NotNil(t, bge)
-		require.NotNil(t, bge.gauge)
+		require.NotNil(t, bge.gauges)
 
 		err := bge.Start(bootstrappers[0])
 		require.NoError(t, err)
 		require.True(t, bge.running)
-		require.NotNil(t, bge.gauge)
+		require.NotNil(t, bge.gauges)
 
 		// Update same Gauge with standard bootstrappers
 		for _, bs := range bootstrappers {
 			err = bge.UpdateStringList(bs)
 			require.NoError(t, err)
 			require.True(t, bge.running)
-			require.NotNil(t, bge.gauge)
+			require.NotNil(t, bge.gauges)
 		}
 
 		err = bge.Close()
 		require.NoError(t, err)
 		require.False(t, bge.running)
 	})
-}
-
-func TestStringListEmitterPrometheusScope(t *testing.T) {
-	r := promreporter.NewReporter(promreporter.Options{})
-	scope, closer := tally.NewRootScope(tally.ScopeOptions{
-		Prefix:         "",
-		Tags:           map[string]string{},
-		CachedReporter: r,
-	}, 0)
-	defer closer.Close()
-
-	bge := NewStringListEmitter(scope, "bootstrappers", "bootstrapper")
-	require.NotNil(t, bge)
-	require.NotNil(t, bge.gauge)
-
-	err := bge.Start(bootstrappers[0])
-	require.NoError(t, err)
-	require.True(t, bge.running)
-	require.NotNil(t, bge.gauge)
-
-	// Update same Gauge with standard bootstrappers
-	for _, bs := range bootstrappers {
-		err = bge.UpdateStringList(bs)
-		require.NoError(t, err)
-		require.True(t, bge.running)
-		require.NotNil(t, bge.gauge)
-	}
-
-	err = bge.Close()
-	require.NoError(t, err)
-	require.False(t, bge.running)
 }

--- a/src/x/instrument/string_list_emitter_test.go
+++ b/src/x/instrument/string_list_emitter_test.go
@@ -22,10 +22,12 @@ package instrument
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	promreporter "github.com/uber-go/tally/prometheus"
 )
 
 var bootstrappers = [][]string{
@@ -124,10 +126,10 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 		require.Equal(t, len(bs0), len(gauges), "length of gauges after start")
 
 		for _, id := range []string{
-			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs0[0]),
-			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs0[1]),
-			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs0[2]),
-			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs0[3]),
+			fmt.Sprintf("testScope.bootstrappers_0+type=%s", bs0[0]),
+			fmt.Sprintf("testScope.bootstrappers_1+type=%s", bs0[1]),
+			fmt.Sprintf("testScope.bootstrappers_2+type=%s", bs0[2]),
+			fmt.Sprintf("testScope.bootstrappers_3+type=%s", bs0[3]),
 		} {
 			g, ok := gauges[id]
 			require.True(t, ok)
@@ -145,14 +147,14 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 		gauges = scope.Snapshot().Gauges()
 		require.Equal(t, 8, len(gauges), "length of gauges after updating")
 		for i, id := range []string{
-			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs0[0]),
-			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs0[1]),
-			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs0[2]),
-			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs0[3]),
-			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs1[0]),
-			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs1[1]),
-			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs1[2]),
-			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs1[3]),
+			fmt.Sprintf("testScope.bootstrappers_0+type=%s", bs0[0]),
+			fmt.Sprintf("testScope.bootstrappers_1+type=%s", bs0[1]),
+			fmt.Sprintf("testScope.bootstrappers_2+type=%s", bs0[2]),
+			fmt.Sprintf("testScope.bootstrappers_3+type=%s", bs0[3]),
+			fmt.Sprintf("testScope.bootstrappers_0+type=%s", bs1[0]),
+			fmt.Sprintf("testScope.bootstrappers_1+type=%s", bs1[1]),
+			fmt.Sprintf("testScope.bootstrappers_2+type=%s", bs1[2]),
+			fmt.Sprintf("testScope.bootstrappers_3+type=%s", bs1[3]),
 		} {
 			g, ok := gauges[id]
 			require.True(t, ok)
@@ -173,14 +175,14 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 		gauges = scope.Snapshot().Gauges()
 		require.Equal(t, 8, len(gauges), "length of gauges after updating")
 		for i, id := range []string{
-			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs0[0]),
-			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs0[1]),
-			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs0[2]),
-			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs0[3]),
-			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs1[0]),
-			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs1[1]),
-			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs1[2]),
-			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs1[3]),
+			fmt.Sprintf("testScope.bootstrappers_0+type=%s", bs0[0]),
+			fmt.Sprintf("testScope.bootstrappers_1+type=%s", bs0[1]),
+			fmt.Sprintf("testScope.bootstrappers_2+type=%s", bs0[2]),
+			fmt.Sprintf("testScope.bootstrappers_3+type=%s", bs0[3]),
+			fmt.Sprintf("testScope.bootstrappers_0+type=%s", bs1[0]),
+			fmt.Sprintf("testScope.bootstrappers_1+type=%s", bs1[1]),
+			fmt.Sprintf("testScope.bootstrappers_2+type=%s", bs1[2]),
+			fmt.Sprintf("testScope.bootstrappers_3+type=%s", bs1[3]),
 		} {
 			g, ok := gauges[id]
 			require.True(t, ok)
@@ -201,14 +203,14 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 		gauges = scope.Snapshot().Gauges()
 		require.Equal(t, 8, len(gauges), "length of gauges after updating")
 		for i, id := range []string{
-			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs0[0]),
-			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs0[1]),
-			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs0[2]),
-			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs0[3]),
-			fmt.Sprintf("testScope.bootstrappers0+type=%s", bs1[0]),
-			fmt.Sprintf("testScope.bootstrappers1+type=%s", bs1[1]),
-			fmt.Sprintf("testScope.bootstrappers2+type=%s", bs1[2]),
-			fmt.Sprintf("testScope.bootstrappers3+type=%s", bs1[3]),
+			fmt.Sprintf("testScope.bootstrappers_0+type=%s", bs0[0]),
+			fmt.Sprintf("testScope.bootstrappers_1+type=%s", bs0[1]),
+			fmt.Sprintf("testScope.bootstrappers_2+type=%s", bs0[2]),
+			fmt.Sprintf("testScope.bootstrappers_3+type=%s", bs0[3]),
+			fmt.Sprintf("testScope.bootstrappers_0+type=%s", bs1[0]),
+			fmt.Sprintf("testScope.bootstrappers_1+type=%s", bs1[1]),
+			fmt.Sprintf("testScope.bootstrappers_2+type=%s", bs1[2]),
+			fmt.Sprintf("testScope.bootstrappers_3+type=%s", bs1[3]),
 		} {
 			g, ok := gauges[id]
 			require.True(t, ok)
@@ -247,4 +249,34 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, bge.running)
 	})
+}
+
+func TestStringListEmitterPrometheusScope(t *testing.T) {
+	r := promreporter.NewReporter(promreporter.Options{})
+	scope, closer := tally.NewRootScope(tally.ScopeOptions{
+		Prefix:         "",
+		Tags:           map[string]string{},
+		CachedReporter: r,
+	}, 0)
+	defer closer.Close()
+
+	bge := NewStringListEmitter(scope, "bootstrappers")
+	require.NotNil(t, bge)
+	require.NotNil(t, bge.gauges)
+
+	err := bge.Start(bootstrappers[0])
+	require.NoError(t, err)
+	require.True(t, bge.running)
+	require.NotNil(t, bge.gauges)
+
+	for _, bs := range bootstrappers {
+		err = bge.UpdateStringList(bs)
+		require.NoError(t, err)
+		require.True(t, bge.running)
+		require.NotNil(t, bge.gauges)
+	}
+
+	err = bge.Close()
+	require.NoError(t, err)
+	require.False(t, bge.running)
 }

--- a/src/x/instrument/string_list_emitter_test.go
+++ b/src/x/instrument/string_list_emitter_test.go
@@ -251,6 +251,7 @@ func TestBootstrapGaugeEmitterNoopScope(t *testing.T) {
 	})
 }
 
+// This test might timeout instead of just fail
 func TestStringListEmitterPrometheusScope(t *testing.T) {
 	r := promreporter.NewReporter(promreporter.Options{})
 	scope, closer := tally.NewRootScope(tally.ScopeOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The bootstrap gauge introduced with #1756 can lead to a panic, when the amount of label keys changes in regards to what it had been initialised with. For example, if `dbnode` has been started with four bootstrappers configured but this amount is changed to three during runtime, the Prometheus Reporter for tally will panic.

**Special notes for your reviewer**:
In this PR the exposition of the bootstrap order has been changed from a single to multiple gauges in `StringListEmitter`, where each gauge has different value for the label key `type`:

```
bootstrappers0{type="filesystem"} 1
bootstrappers1{type="peers"} 1
bootstrappers2{type="commitlog"} 1
bootstrappers3{type="uninitialized_topology"} 1
```

Changing the order will set the old metric/value combination to 0 and update the respective gauge with a new value of 1: 

```shell
$ curl http://localhost:7201/api/v1/database/config/bootstrappers -X POST -d '{"values":["filesystem","commitlog","peers", "uninitialized_topology"]}'
{"values":["filesystem","commitlog","peers","uninitialized_topology"]}

$ curl -s localhost:9004/metrics | grep bootstrappers | grep -v "#"
bootstrappers0{type="filesystem"} 1
bootstrappers1{type="commitlog"} 1
bootstrappers1{type="peers"} 0
bootstrappers2{type="commitlog"} 0
bootstrappers2{type="peers"} 1
bootstrappers3{type="uninitialized_topology"} 1
```
---
The unit test `TestStringListEmitterPrometheusScope` checks if metrics can be registered 
with the Promreporter from `github.com/uber-go/tally/prometheus`. I have seen that this test
timeouts rather than just fails, not really sure why.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
