### PR TITLE
[DBNode] - Make repairs actually repair data

### DIFF
--- a/scripts/docker-integration-tests/common.sh
+++ b/scripts/docker-integration-tests/common.sh
@@ -47,6 +47,70 @@ function setup_single_m3db_node {
   wait_for_db_init
 }
 
+function setup_three_m3db_nodes {
+  local dbnode_host_1=${DBNODE_HOST:-dbnode01}
+  local dbnode_host_2=${DBNODE_HOST:-dbnode02}
+  local dbnode_host_3=${DBNODE_HOST:-dbnode03}
+  local dbnode_port=${DBNODE_PORT:-9000}
+  local dbnode_host_1_health_port=${DBNODE_HEALTH_PORT:-9012}
+  local dbnode_host_2_health_port=${DBNODE_HEALTH_PORT:-9022}
+  local dbnode_host_3_health_port=${DBNODE_HEALTH_PORT:-9032}
+  local coordinator_port=${COORDINATOR_PORT:-7201}
+
+  echo "Wait for API to be available"
+  ATTEMPTS=100 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
+    '[ "$(curl -sSf 0.0.0.0:'"${coordinator_port}"'/api/v1/namespace | jq ".namespaces | length")" == "0" ]'
+
+  echo "Adding placement and agg namespace"
+  curl -vvvsSf -X POST 0.0.0.0:${coordinator_port}/api/v1/database/create -d '{
+    "type": "cluster",
+    "namespaceName": "agg",
+    "retentionTime": "6h",
+    "num_shards": 3,
+    "replicationFactor": 3,
+    "hosts": [
+      {
+          "id": "m3db_local_1",
+          "isolation_group": "rack-a",
+          "zone": "embedded",
+          "weight": 1024,
+          "address": "'"${dbnode_host_1}"'",
+          "port": '"${dbnode_port}"'
+      },
+      {
+          "id": "m3db_local_2",
+          "isolation_group": "rack-b",
+          "zone": "embedded",
+          "weight": 1024,
+          "address": "'"${dbnode_host_2}"'",
+          "port": '"${dbnode_port}"'
+      },
+      {
+          "id": "m3db_local_3",
+          "isolation_group": "rack-c",
+          "zone": "embedded",
+          "weight": 1024,
+          "address": "'"${dbnode_host_3}"'",
+          "port": '"${dbnode_port}"'
+      }
+    ]
+  }'
+
+  echo "Wait until placement is init'd"
+  ATTEMPTS=10 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
+    '[ "$(curl -sSf 0.0.0.0:'"${coordinator_port}"'/api/v1/placement | jq .placement.instances.m3db_local_1.id)" == \"m3db_local_1\" ]'
+
+  wait_for_namespaces
+
+  echo "Wait until bootstrapped"
+  ATTEMPTS=100 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
+    '[ "$(curl -sSf 0.0.0.0:'"${dbnode_host_1_health_port}"'/health | jq .bootstrapped)" == true ]'
+  ATTEMPTS=100 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
+    '[ "$(curl -sSf 0.0.0.0:'"${dbnode_host_2_health_port}"'/health | jq .bootstrapped)" == true ]'
+  ATTEMPTS=100 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
+    '[ "$(curl -sSf 0.0.0.0:'"${dbnode_host_3_health_port}"'/health | jq .bootstrapped)" == true ]'
+}
+
 function wait_for_db_init {
   local dbnode_host=${DBNODE_HOST:-dbnode01}
   local dbnode_port=${DBNODE_PORT:-9000}
@@ -80,6 +144,16 @@ function wait_for_db_init {
   ATTEMPTS=10 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
     '[ "$(curl -sSf 0.0.0.0:'"${coordinator_port}"'/api/v1/placement | jq .placement.instances.m3db_local.id)" == \"m3db_local\" ]'
 
+  wait_for_namespaces
+
+  echo "Wait until bootstrapped"
+  ATTEMPTS=100 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
+    '[ "$(curl -sSf 0.0.0.0:'"${dbnode_health_port}"'/health | jq .bootstrapped)" == true ]'
+}
+
+function wait_for_namespaces {
+  local coordinator_port=${COORDINATOR_PORT:-7201}
+
   echo "Wait until agg namespace is init'd"
   ATTEMPTS=10 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
     '[ "$(curl -sSf 0.0.0.0:'"${coordinator_port}"'/api/v1/namespace | jq .registry.namespaces.agg.indexOptions.enabled)" == true ]'
@@ -94,19 +168,19 @@ function wait_for_db_init {
   ATTEMPTS=10 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
     '[ "$(curl -sSf 0.0.0.0:'"${coordinator_port}"'/api/v1/namespace | jq .registry.namespaces.unagg.indexOptions.enabled)" == true ]'
 
-  echo "Adding coldWritesNoIndex namespace"
+  echo "Adding coldWritesRepairAndNoIndex namespace"
   curl -vvvsSf -X POST 0.0.0.0:${coordinator_port}/api/v1/services/m3db/namespace -d '{
-    "name": "coldWritesNoIndex",
+    "name": "coldWritesRepairAndNoIndex",
     "options": {
       "bootstrapEnabled": true,
       "flushEnabled": true,
       "writesToCommitLog": true,
       "cleanupEnabled": true,
       "snapshotEnabled": true,
-      "repairEnabled": false,
+      "repairEnabled": true,
       "coldWritesEnabled": true,
       "retentionOptions": {
-        "retentionPeriodDuration": "8h",
+        "retentionPeriodDuration": "4h",
         "blockSizeDuration": "1h",
         "bufferFutureDuration": "10m",
         "bufferPastDuration": "10m",
@@ -116,12 +190,8 @@ function wait_for_db_init {
     }
   }'
 
-  echo "Wait until coldWritesNoIndex namespace is init'd"
+  echo "Wait until coldWritesRepairAndNoIndex namespace is init'd"
   ATTEMPTS=10 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
-    '[ "$(curl -sSf 0.0.0.0:'"${coordinator_port}"'/api/v1/namespace | jq .registry.namespaces.coldWritesNoIndex.coldWritesEnabled)" == true ]'
-
-  echo "Wait until bootstrapped"
-  ATTEMPTS=100 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff  \
-    '[ "$(curl -sSf 0.0.0.0:'"${dbnode_health_port}"'/health | jq .bootstrapped)" == true ]'
+    '[ "$(curl -sSf 0.0.0.0:'"${coordinator_port}"'/api/v1/namespace | jq .registry.namespaces.coldWritesRepairAndNoIndex.coldWritesEnabled)" == true ]'
 }
 

--- a/scripts/docker-integration-tests/repair/docker-compose.yml
+++ b/scripts/docker-integration-tests/repair/docker-compose.yml
@@ -1,0 +1,60 @@
+version: "3.5"
+services:
+  dbnode01:
+    expose:
+      - "9000-9004"
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:9012:9002"
+      - "0.0.0.0:9013:9003"
+    networks:
+      - backend
+    image: "m3dbnode_integration:${REVISION}"
+    environment:
+      - M3DB_HOST_ID=m3db_local_1
+    volumes:
+      - "./m3dbnode.yml:/etc/m3dbnode/m3dbnode.yml"
+  dbnode02:
+    expose:
+      - "9000-9004"
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:9022:9002"
+      - "0.0.0.0:9023:9003"
+    networks:
+      - backend
+    image: "m3dbnode_integration:${REVISION}"
+    environment:
+      - M3DB_HOST_ID=m3db_local_2
+    volumes:
+      - "./m3dbnode.yml:/etc/m3dbnode/m3dbnode.yml"
+  dbnode03:
+    expose:
+      - "9000-9004"
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:9032:9002"
+      - "0.0.0.0:9033:9003"
+    networks:
+      - backend
+    image: "m3dbnode_integration:${REVISION}"
+    environment:
+      - M3DB_HOST_ID=m3db_local_3
+    volumes:
+      - "./m3dbnode.yml:/etc/m3dbnode/m3dbnode.yml"
+  coordinator01:
+    expose:
+      - "7201"
+      - "7203"
+      - "7204"
+    ports:
+      - "0.0.0.0:7201:7201"
+      - "0.0.0.0:7203:7203"
+      - "0.0.0.0:7204:7204"
+    networks:
+      - backend
+    image: "m3coordinator_integration:${REVISION}"
+    volumes:
+      - "./:/etc/m3coordinator/"
+networks:
+  backend:

--- a/scripts/docker-integration-tests/repair/m3coordinator.yml
+++ b/scripts/docker-integration-tests/repair/m3coordinator.yml
@@ -1,0 +1,46 @@
+listenAddress:
+  type: "config"
+  value: "0.0.0.0:7201"
+
+logging:
+  level: info
+
+metrics:
+  scope:
+    prefix: "coordinator"
+  prometheus:
+    handlerPath: /metrics
+    listenAddress: 0.0.0.0:7203 # until https://github.com/m3db/m3/issues/682 is resolved
+  sanitization: prometheus
+  samplingRate: 1.0
+  extended: none
+
+limits:
+  perQuery:
+    maxFetchedSeries: 100
+
+clusters:
+  - namespaces:
+      - namespace: agg
+        type: aggregated
+        retention: 10h
+        resolution: 15s
+      - namespace: unagg
+        type: unaggregated
+        retention: 10h
+    client:
+      config:
+        service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+            - zone: embedded
+              endpoints:
+                - dbnode01:2379
+      writeConsistencyLevel: majority
+      readConsistencyLevel: unstrict_majority
+
+tagOptions:
+  idScheme: quoted

--- a/scripts/docker-integration-tests/repair/m3dbnode.yml
+++ b/scripts/docker-integration-tests/repair/m3dbnode.yml
@@ -1,0 +1,86 @@
+db:
+  logging:
+    level: info
+
+  tracing:
+    backend: jaeger
+    jaeger:
+      reporter:
+        localAgentHostPort: jaeger:6831
+      sampler:
+        type: const
+        param: 1
+
+  metrics:
+    prometheus:
+      handlerPath: /metrics
+    sanitization: prometheus
+    samplingRate: 1.0
+    extended: detailed
+
+  listenAddress: 0.0.0.0:9000
+  clusterListenAddress: 0.0.0.0:9001
+  httpNodeListenAddress: 0.0.0.0:9002
+  httpClusterListenAddress: 0.0.0.0:9003
+  debugListenAddress: 0.0.0.0:9004
+
+  hostID:
+    resolver: environment
+    envVarName: M3DB_HOST_ID
+
+  client:
+    writeConsistencyLevel: majority
+    readConsistencyLevel: unstrict_majority
+
+  gcPercentage: 100
+
+  writeNewSeriesAsync: true
+  writeNewSeriesLimitPerSecond: 1048576
+  writeNewSeriesBackoffDuration: 2ms
+
+  bootstrap:
+    # Intentionally disable peers bootstrapper to ensure it doesn't interfere with test.
+    bootstrappers:
+        - filesystem
+        - commitlog
+        - uninitialized_topology
+    commitlog:
+      returnUnfulfilledForCorruptCommitLogFiles: false
+
+  cache:
+    series:
+      policy: lru
+    postingsList:
+      size: 262144
+
+  commitlog:
+    flushMaxBytes: 524288
+    flushEvery: 1s
+    queue:
+      calculationType: fixed
+      size: 2097152
+
+  fs:
+    filePathPrefix: /var/lib/m3db
+
+  config:
+      service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+              - zone: embedded
+                endpoints:
+                    - dbnode01:2379
+      seedNodes:
+          initialCluster:
+              - hostID: m3db_local_1
+                endpoint: http://dbnode01:2380
+
+  # Enable repairs.
+  repair:
+    enabled: true
+    throttle: 1ms
+    checkInterval: 1ms
+

--- a/scripts/docker-integration-tests/repair/test.sh
+++ b/scripts/docker-integration-tests/repair/test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -xe
+
+source $GOPATH/src/github.com/m3db/m3/scripts/docker-integration-tests/common.sh
+REVISION=$(git rev-parse HEAD)
+SCRIPT_PATH=$GOPATH/src/github.com/m3db/m3/scripts/docker-integration-tests/repair
+COMPOSE_FILE=$SCRIPT_PATH/docker-compose.yml
+export REVISION
+
+echo "Run m3dbnode and m3coordinator containers"
+docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes dbnode01
+docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes dbnode02
+docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes dbnode03
+docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes coordinator01
+
+# Think of this as a defer func() in golang
+function defer {
+  docker-compose -f ${COMPOSE_FILE} down || echo "unable to shutdown containers" # CI fails to stop all containers sometimes
+}
+trap defer EXIT
+
+setup_three_m3db_nodes
+
+function write_data {
+  namespace=$1
+  id=$2
+  timestamp=$3
+  value=$4
+  port=$5
+
+  respCode=$(curl -s -o /dev/null -X POST -w "%{http_code}" 0.0.0.0:"$port"/write -d '{
+    "namespace": "'"$namespace"'",
+    "id": "'"$id"'",
+    "datapoint": {
+      "timestamp":'"$timestamp"',
+      "value": '"$value"'
+    }
+  }')
+
+
+  if [[ $respCode -eq "200" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function read_all {
+  namespace=$1
+  id=$2
+  expected_datapoints=$3
+  port=$4
+
+  received_datapoints=$(curl -sSf -X POST 0.0.0.0:"$port"/fetch -d '{
+    "namespace": "'"$namespace"'",
+    "id": "'"$id"'",
+    "rangeStart": 0,
+    "rangeEnd":'"$(date +"%s")"'
+  }' | jq '.datapoints | length')
+
+  if [[ $expected_datapoints -eq $received_datapoints ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# Write 2 block sizes into the past to ensure its a repairable block since the current mutable
+# block will not be repaired. Use the node-specific port to ensure the write only goes to dbnode01
+# and not the other two nodes.
+echo "Write data for 'now - 2 * blockSize' to dbnode01"
+write_data "coldWritesRepairAndNoIndex" "foo" "$(($(date +"%s") - 60 * 60 * 2))" 12.3456789 9012
+
+# This should pass immediately since it was written to this node.
+echo "Expect to read the data back from dbnode01"
+read_all "coldWritesRepairAndNoIndex" "foo" 1 9012
+
+# These two should eventually suceed once a repair detects the mismatch.
+echo "Wait for the data to become available (via repairs) from dbnode02"
+ATTEMPTS=30 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff \
+  read_all "coldWritesRepairAndNoIndex" "foo" 1 9022
+
+echo "Wait for the data to become available (via repairs) from dbnode03"
+ATTEMPTS=10 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff \
+  read_all "coldWritesRepairAndNoIndex" "foo" 1 9022

--- a/scripts/docker-integration-tests/repair/test.sh
+++ b/scripts/docker-integration-tests/repair/test.sh
@@ -66,7 +66,7 @@ function read_all {
   fi
 }
 
-# Write 2 block sizes into the past to ensure its a repairable block since the current mutable
+# Write 2 block sizes into the past to ensure it's a repairable block since the current mutable
 # block will not be repaired. Use the node-specific port to ensure the write only goes to dbnode01
 # and not the other two nodes.
 echo "Write data for 'now - 2 * blockSize' to dbnode01"
@@ -76,7 +76,7 @@ write_data "coldWritesRepairAndNoIndex" "foo" "$(($(date +"%s") - 60 * 60 * 2))"
 echo "Expect to read the data back from dbnode01"
 read_all "coldWritesRepairAndNoIndex" "foo" 1 9012
 
-# These two should eventually suceed once a repair detects the mismatch.
+# These two should eventually succeed once a repair detects the mismatch.
 echo "Wait for the data to become available (via repairs) from dbnode02"
 ATTEMPTS=30 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff \
   read_all "coldWritesRepairAndNoIndex" "foo" 1 9022

--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -35,7 +35,6 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/peers"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/uninitialized"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
-	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/topology"
 )
 
@@ -109,6 +108,7 @@ type BootstrapConfigurationValidator interface {
 // New creates a bootstrap process based on the bootstrap configuration.
 func (bsc BootstrapConfiguration) New(
 	validator BootstrapConfigurationValidator,
+	rsOpts result.Options,
 	opts storage.Options,
 	topoMapProvider topology.MapProvider,
 	origin topology.Host,
@@ -119,19 +119,10 @@ func (bsc BootstrapConfiguration) New(
 	}
 
 	var (
-		mutableSegmentAlloc = index.NewBootstrapResultMutableSegmentAllocator(
-			opts.IndexOptions())
-		bs  bootstrap.BootstrapperProvider
-		err error
+		bs     bootstrap.BootstrapperProvider
+		err    error
+		fsOpts = opts.CommitLogOptions().FilesystemOptions()
 	)
-	rsOpts := result.NewOptions().
-		SetInstrumentOptions(opts.InstrumentOptions()).
-		SetDatabaseBlockOptions(opts.DatabaseBlockOptions()).
-		SetSeriesCachePolicy(opts.SeriesCachePolicy()).
-		SetIndexMutableSegmentAllocator(mutableSegmentAlloc)
-
-	fsOpts := opts.CommitLogOptions().FilesystemOptions()
-
 	// Start from the end of the list because the bootstrappers are ordered by precedence in descending order.
 	for i := len(bsc.Bootstrappers) - 1; i >= 0; i-- {
 		switch bsc.Bootstrappers[i] {

--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -305,15 +305,6 @@ type RepairPolicy struct {
 	// Enabled or disabled.
 	Enabled bool `yaml:"enabled"`
 
-	// The repair interval.
-	Interval time.Duration `yaml:"interval" validate:"nonzero"`
-
-	// The repair time offset.
-	Offset time.Duration `yaml:"offset" validate:"nonzero"`
-
-	// The repair time jitter.
-	Jitter time.Duration `yaml:"jitter" validate:"nonzero"`
-
 	// The repair throttle.
 	Throttle time.Duration `yaml:"throttle" validate:"nonzero"`
 

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/environment"
 	"github.com/m3db/m3/src/dbnode/storage"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/instrument"
@@ -127,9 +128,6 @@ db:
 
   repair:
       enabled: false
-      interval: 2h
-      offset: 30m
-      jitter: 1h
       throttle: 2m
       checkInterval: 1m
 
@@ -440,9 +438,6 @@ func TestConfiguration(t *testing.T) {
     blockSize: null
   repair:
     enabled: false
-    interval: 2h0m0s
-    offset: 30m0s
-    jitter: 1h0m0s
     throttle: 2m0s
     checkInterval: 1m0s
     debugShadowComparisonsEnabled: false
@@ -989,6 +984,6 @@ db:
 	adminClient := client.NewMockAdminClient(ctrl)
 
 	_, err = cfg.DB.Bootstrap.New(validator,
-		storage.DefaultTestOptions(), mapProvider, origin, adminClient)
+		result.NewOptions(), storage.DefaultTestOptions(), mapProvider, origin, adminClient)
 	require.NoError(t, err)
 }

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -173,7 +173,7 @@ db:
           lowWatermark: 0.01
           highWatermark: 0.02
           capacity: 4096
-      hostBlockMetadataSlicePool:
+      replicaMetadataSlicePool:
           size: 131072
           capacity: 3
           lowWatermark: 0.01
@@ -522,7 +522,7 @@ func TestConfiguration(t *testing.T) {
       lowWatermark: 0.01
       highWatermark: 0.02
       capacity: 4096
-    hostBlockMetadataSlicePool:
+    replicaMetadataSlicePool:
       size: 131072
       lowWatermark: 0.01
       highWatermark: 0.02

--- a/src/cmd/services/m3dbnode/config/pooling.go
+++ b/src/cmd/services/m3dbnode/config/pooling.go
@@ -149,7 +149,7 @@ var (
 			refillHighWaterMark: defaultRefillHighWaterMark,
 			capacity:            4096,
 		},
-		"hostBlockMetadataSlice": poolPolicyDefault{
+		"replicaMetadataSlice": poolPolicyDefault{
 			size:                131072,
 			refillLowWaterMark:  defaultRefillLowWaterMark,
 			refillHighWaterMark: defaultRefillHighWaterMark,
@@ -363,7 +363,7 @@ func (p *PoolingPolicy) InitDefaultsAndValidate() error {
 	if err := p.FetchBlocksMetadataResultsPool.initDefaultsAndValidate("fetchBlocksMetadataResults"); err != nil {
 		return err
 	}
-	if err := p.ReplicaMetadataSlicePool.initDefaultsAndValidate("hostBlockMetadataSlice"); err != nil {
+	if err := p.ReplicaMetadataSlicePool.initDefaultsAndValidate("replicaMetadataSlice"); err != nil {
 		return err
 	}
 	if err := p.BlockMetadataPool.initDefaultsAndValidate("blockMetadata"); err != nil {

--- a/src/cmd/services/m3dbnode/config/pooling.go
+++ b/src/cmd/services/m3dbnode/config/pooling.go
@@ -288,8 +288,8 @@ type PoolingPolicy struct {
 	// The policy for the FetchBlocksMetadataResults pool.
 	FetchBlocksMetadataResultsPool CapacityPoolPolicy `yaml:"fetchBlocksMetadataResultsPool"`
 
-	// The policy for the HostBlockMetadataSlice pool.
-	HostBlockMetadataSlicePool CapacityPoolPolicy `yaml:"hostBlockMetadataSlicePool"`
+	// The policy for the ReplicaMetadataSlicePool pool.
+	ReplicaMetadataSlicePool CapacityPoolPolicy `yaml:"replicaMetadataSlicePool"`
 
 	// The policy for the BlockMetadat pool.
 	BlockMetadataPool PoolPolicy `yaml:"blockMetadataPool"`
@@ -363,7 +363,7 @@ func (p *PoolingPolicy) InitDefaultsAndValidate() error {
 	if err := p.FetchBlocksMetadataResultsPool.initDefaultsAndValidate("fetchBlocksMetadataResults"); err != nil {
 		return err
 	}
-	if err := p.HostBlockMetadataSlicePool.initDefaultsAndValidate("hostBlockMetadataSlice"); err != nil {
+	if err := p.ReplicaMetadataSlicePool.initDefaultsAndValidate("hostBlockMetadataSlice"); err != nil {
 		return err
 	}
 	if err := p.BlockMetadataPool.initDefaultsAndValidate("blockMetadata"); err != nil {

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -24,13 +24,13 @@ package main_test
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"text/template"
 	"time"
-	"net/http"
 
 	"github.com/m3db/m3/src/cluster/integration/etcd"
 	"github.com/m3db/m3/src/cluster/placement"
@@ -178,7 +178,7 @@ func TestIndexEnabledServer(t *testing.T) {
 		})
 		serverWg.Done()
 	}()
-	defer func(){
+	defer func() {
 		// Resetting DefaultServeMux to prevent multiple assignments
 		// to /debug/dump in Server.Run()
 		http.DefaultServeMux = http.NewServeMux()
@@ -373,9 +373,6 @@ db:
 
     repair:
         enabled: false
-        interval: 2h
-        offset: 30m
-        jitter: 1h
         throttle: 2m
         checkInterval: 1m
 

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -417,7 +417,7 @@ db:
             capacity: 128
             lowWatermark: 0.01
             highWatermark: 0.02
-        hostBlockMetadataSlicePool:
+				replicaMetadataSlicePool:
             size: 128
             capacity: 3
             lowWatermark: 0.01

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -417,7 +417,7 @@ db:
             capacity: 128
             lowWatermark: 0.01
             highWatermark: 0.02
-				replicaMetadataSlicePool:
+        replicaMetadataSlicePool:
             size: 128
             capacity: 3
             lowWatermark: 0.01

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -24,12 +24,12 @@ package main_test
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"sync"
 	"testing"
 	"text/template"
 	"time"
-	"net/http"
 
 	"github.com/m3db/m3/src/cluster/integration/etcd"
 	"github.com/m3db/m3/src/cluster/placement"
@@ -170,7 +170,7 @@ func TestConfig(t *testing.T) {
 		})
 		serverWg.Done()
 	}()
-	defer func(){
+	defer func() {
 		// Resetting DefaultServeMux to prevent multiple assignments
 		// to /debug/dump in Server.Run()
 		http.DefaultServeMux = http.NewServeMux()
@@ -318,7 +318,7 @@ func TestEmbeddedConfig(t *testing.T) {
 		})
 		serverWg.Done()
 	}()
-	defer func(){
+	defer func() {
 		// Resetting DefaultServeMux to prevent multiple assignments
 		// to /debug/dump in Server.Run()
 		http.DefaultServeMux = http.NewServeMux()
@@ -527,9 +527,6 @@ db:
 
     repair:
         enabled: false
-        interval: 2h
-        offset: 30m
-        jitter: 1h
         throttle: 2m
         checkInterval: 1m
 

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -571,7 +571,7 @@ db:
             capacity: 128
             lowWatermark: 0.01
             highWatermark: 0.02
-				replicaMetadataSlicePool:
+        replicaMetadataSlicePool:
             size: 128
             capacity: 3
             lowWatermark: 0.01

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -571,7 +571,7 @@ db:
             capacity: 128
             lowWatermark: 0.01
             highWatermark: 0.02
-        hostBlockMetadataSlicePool:
+				replicaMetadataSlicePool:
             size: 128
             capacity: 3
             lowWatermark: 0.01

--- a/src/dbnode/config/m3dbnode-all-config.yml
+++ b/src/dbnode/config/m3dbnode-all-config.yml
@@ -154,9 +154,6 @@ db:
   # This feature is currently not working, do not enable.
   repair:
     enabled: false
-    interval: 2h
-    offset: 30m
-    jitter: 1h
     throttle: 2m
     checkInterval: 1m
 

--- a/src/dbnode/config/m3dbnode-all-config.yml
+++ b/src/dbnode/config/m3dbnode-all-config.yml
@@ -199,7 +199,7 @@ db:
         capacity: 4096
         lowWatermark: 0.7
         highWatermark: 1.0
-    hostBlockMetadataSlicePool:
+    replicaMetadataSlicePool:
         size: 131072
         capacity: 3
         lowWatermark: 0.7

--- a/src/dbnode/encoding/m3tsz/encoder_test.go
+++ b/src/dbnode/encoding/m3tsz/encoder_test.go
@@ -409,6 +409,23 @@ func TestEncoderLastEncoded(t *testing.T) {
 	})
 }
 
+func TestEncoderLenReturnsFinalStreamLength(t *testing.T) {
+	testMultiplePasses(t, multiplePassesTest{
+		postEncodeAll: func(enc *encoder, numDatapointsEncoded int) {
+			encLen := enc.Len()
+			stream, ok := enc.Stream(encoding.StreamOptions{})
+
+			var streamLen int
+			if ok {
+				segment, err := stream.Segment()
+				require.NoError(t, err)
+				streamLen = segment.Len()
+			}
+			require.Equal(t, streamLen, encLen)
+		},
+	})
+}
+
 type multiplePassesTest struct {
 	preEncodeAll        func(enc *encoder, numDatapointsToEncode int)
 	preEncodeDatapoint  func(enc *encoder, datapoint ts.Datapoint)

--- a/src/dbnode/encoding/proto/round_trip_prop_test.go
+++ b/src/dbnode/encoding/proto/round_trip_prop_test.go
@@ -163,10 +163,16 @@ func TestRoundTripProp(t *testing.T) {
 			enc.SetSchema(setSchemaDescr)
 		}
 
+		// Ensure that the Len() method always returns the length of the final stream that would
+		// be returned by a call to Stream().
+		encLen := enc.Len()
 		stream, ok := enc.Stream(encoding.StreamOptions{})
 		if !ok {
 			return true, nil
 		}
+		segment, err := stream.Segment()
+		require.NoError(t, err)
+		require.Equal(t, segment.Len(), encLen)
 
 		iter.Reset(stream, schemaDescr)
 

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -70,7 +70,7 @@ type Encoder interface {
 	// an error is returned.
 	LastEncoded() (ts.Datapoint, error)
 
-	// Len returns the length of the encoded encoded stream as returned by a call to Stream().
+	// Len returns the length of the encoded stream as returned by a call to Stream().
 	Len() int
 
 	// Reset resets the start time of the encoder and the internal state.

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -70,7 +70,7 @@ type Encoder interface {
 	// an error is returned.
 	LastEncoded() (ts.Datapoint, error)
 
-	// Len returns the length of the encoded bytes in the encoder.
+	// Len returns the length of the encoded encoded stream as returned by a call to Stream().
 	Len() int
 
 	// Reset resets the start time of the encoder and the internal state.

--- a/src/dbnode/integration/integration.go
+++ b/src/dbnode/integration/integration.go
@@ -114,6 +114,7 @@ type bootstrappableTestSetupOptions struct {
 	testStatsReporter           xmetrics.TestStatsReporter
 	disablePeersBootstrapper    bool
 	useTChannelClientForWriting bool
+	enableRepairs               bool
 }
 
 type closeFn func()
@@ -159,6 +160,7 @@ func newDefaultBootstrappableTestSetups(
 			bootstrapConsistencyLevel   = setupOpts[i].bootstrapConsistencyLevel
 			topologyInitializer         = setupOpts[i].topologyInitializer
 			testStatsReporter           = setupOpts[i].testStatsReporter
+			enableRepairs               = setupOpts[i].enableRepairs
 			origin                      topology.Host
 			instanceOpts                = newMultiAddrTestOptions(opts, instance)
 		)
@@ -291,6 +293,19 @@ func newDefaultBootstrappableTestSetups(
 		require.NoError(t, err)
 
 		setup.storageOpts = setup.storageOpts.SetBootstrapProcessProvider(provider)
+
+		if enableRepairs {
+			setup.storageOpts = setup.storageOpts.
+				SetRepairEnabled(true).
+				SetRepairOptions(
+					setup.storageOpts.RepairOptions().
+						SetRepairThrottle(time.Millisecond).
+						SetRepairCheckInterval(time.Millisecond).
+						SetAdminClient(adminClient).
+						SetDebugShadowComparisonsPercentage(1.0).
+						// Avoid log spam.
+						SetDebugShadowComparisonsEnabled(false))
+		}
 
 		setups = append(setups, setup)
 		appendCleanupFn(func() {

--- a/src/dbnode/integration/integration_data_verify.go
+++ b/src/dbnode/integration/integration_data_verify.go
@@ -21,9 +21,11 @@
 package integration
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -38,7 +40,6 @@ import (
 	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -212,6 +213,17 @@ func verifySeriesMapForRange(
 	return true
 }
 
+func containsSeries(ts *testSetup, namespace, seriesID ident.ID, start, end time.Time) (bool, error) {
+	req := rpc.NewFetchRequest()
+	req.NameSpace = namespace.String()
+	req.ID = seriesID.String()
+	req.RangeStart = xtime.ToNormalizedTime(start, time.Second)
+	req.RangeEnd = xtime.ToNormalizedTime(end, time.Second)
+	req.ResultTimeType = rpc.TimeType_UNIX_SECONDS
+	fetched, err := ts.fetch(req)
+	return len(fetched) != 0, err
+}
+
 func writeVerifyDebugOutput(
 	t *testing.T, filePath string, start, end time.Time, series generate.SeriesBlock) bool {
 	w, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
@@ -307,17 +319,35 @@ func createFileIfPrefixSet(t *testing.T, prefix, suffix string) (string, bool) {
 }
 
 func compareSeriesList(
-	t *testing.T,
 	expected generate.SeriesBlock,
 	actual generate.SeriesBlock,
-) {
+) error {
 	sort.Sort(expected)
 	sort.Sort(actual)
 
-	require.Equal(t, len(expected), len(actual))
+	if len(expected) != len(actual) {
+		return fmt.Errorf(
+			"number of expected series: %d did not match actual: %d",
+			len(expected), len(actual))
+	}
 
 	for i := range expected {
-		require.Equal(t, expected[i].ID.Bytes(), actual[i].ID.Bytes())
-		require.Equal(t, expected[i].Data, expected[i].Data)
+		if !bytes.Equal(expected[i].ID.Bytes(), actual[i].ID.Bytes()) {
+			return fmt.Errorf(
+				"series ID did not match, expected: %s, actual: %s",
+				expected[i].ID.String(), actual[i].ID.String())
+		}
+		if len(expected[i].Data) != len(actual[i].Data) {
+			return fmt.Errorf(
+				"data for series: %s did not match, expected: %d data points, actual: %d",
+				expected[i].ID.String(), len(expected[i].Data), len(actual[i].Data))
+		}
+		if !reflect.DeepEqual(expected[i].Data, actual[i].Data) {
+			return fmt.Errorf(
+				"data for series: %s did not match, expected: %v, actual: %v",
+				expected[i].ID.String(), expected[i].Data, actual[i].Data)
+		}
 	}
+
+	return nil
 }

--- a/src/dbnode/integration/repair_test.go
+++ b/src/dbnode/integration/repair_test.go
@@ -1,0 +1,270 @@
+// +build integration
+
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/integration/generate"
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/retention"
+	"github.com/m3db/m3/src/x/ident"
+	xtest "github.com/m3db/m3/src/x/test"
+	xtime "github.com/m3db/m3/src/x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepairDisjointSeries(t *testing.T) {
+	genRepairData := func(now time.Time, blockSize time.Duration) (
+		node0Data generate.SeriesBlocksByStart,
+		node1Data generate.SeriesBlocksByStart,
+		node2Data generate.SeriesBlocksByStart,
+		allData generate.SeriesBlocksByStart,
+	) {
+		currBlockStart := now.Truncate(blockSize)
+		node0Data = generate.BlocksByStart([]generate.BlockConfig{
+			{IDs: []string{"foo"}, NumPoints: 90, Start: currBlockStart.Add(-4 * blockSize)},
+		})
+		node1Data = generate.BlocksByStart([]generate.BlockConfig{
+			{IDs: []string{"bar"}, NumPoints: 90, Start: currBlockStart.Add(-4 * blockSize)},
+		})
+
+		allData = make(map[xtime.UnixNano]generate.SeriesBlock)
+		for start, data := range node0Data {
+			for _, series := range data {
+				allData[start] = append(allData[start], series)
+			}
+		}
+		for start, data := range node1Data {
+			for _, series := range data {
+				allData[start] = append(allData[start], series)
+			}
+		}
+		for start, data := range node2Data {
+			for _, series := range data {
+				allData[start] = append(allData[start], series)
+			}
+		}
+
+		return node0Data, node1Data, node2Data, allData
+	}
+
+	testRepair(t, genRepairData, testRepairOptions{})
+}
+
+func TestRepairMergeSeries(t *testing.T) {
+	genRepairData := func(now time.Time, blockSize time.Duration) (
+		node0Data generate.SeriesBlocksByStart,
+		node1Data generate.SeriesBlocksByStart,
+		node2Data generate.SeriesBlocksByStart,
+		allData generate.SeriesBlocksByStart,
+	) {
+		currBlockStart := now.Truncate(blockSize)
+		allData = generate.BlocksByStart([]generate.BlockConfig{
+			{IDs: []string{"foo", "baz"}, NumPoints: 90, Start: currBlockStart.Add(-4 * blockSize)},
+			{IDs: []string{"foo", "baz"}, NumPoints: 90, Start: currBlockStart.Add(-3 * blockSize)},
+			{IDs: []string{"foo", "baz"}, NumPoints: 90, Start: currBlockStart.Add(-2 * blockSize)}})
+		node0Data = make(map[xtime.UnixNano]generate.SeriesBlock)
+		node1Data = make(map[xtime.UnixNano]generate.SeriesBlock)
+
+		remainder := 0
+		appendSeries := func(target map[xtime.UnixNano]generate.SeriesBlock, start time.Time, s generate.Series) {
+			var dataWithMissing []generate.TestValue
+			for i := range s.Data {
+				if i%2 != remainder {
+					continue
+				}
+				dataWithMissing = append(dataWithMissing, s.Data[i])
+			}
+			target[xtime.ToUnixNano(start)] = append(
+				target[xtime.ToUnixNano(start)],
+				generate.Series{ID: s.ID, Data: dataWithMissing},
+			)
+			remainder = 1 - remainder
+		}
+		for start, data := range allData {
+			for _, series := range data {
+				appendSeries(node0Data, start.ToTime(), series)
+				appendSeries(node1Data, start.ToTime(), series)
+			}
+		}
+
+		return node0Data, node1Data, node2Data, allData
+	}
+
+	testRepair(t, genRepairData, testRepairOptions{})
+}
+
+func TestRepairDoesNotRepairCurrentBlock(t *testing.T) {
+	genRepairData := func(now time.Time, blockSize time.Duration) (
+		node0Data generate.SeriesBlocksByStart,
+		node1Data generate.SeriesBlocksByStart,
+		node2Data generate.SeriesBlocksByStart,
+		allData generate.SeriesBlocksByStart,
+	) {
+		currBlockStart := now.Truncate(blockSize)
+		node0Data = generate.BlocksByStart([]generate.BlockConfig{
+			// Write in previous block should be repaired.
+			{IDs: []string{"prevBlock1", "prevBlock2"}, NumPoints: 1, Start: currBlockStart.Add(-blockSize)},
+			// Write in current block, should not be repaired.
+			{IDs: []string{"currBlock1", "currBlock2"}, NumPoints: 1, Start: currBlockStart},
+		})
+
+		allData = make(map[xtime.UnixNano]generate.SeriesBlock)
+		for start, data := range node0Data {
+			if !start.ToTime().Equal(currBlockStart) {
+				allData[start] = data
+			}
+		}
+		require.Equal(t, 1, len(allData))
+
+		return node0Data, node1Data, node2Data, allData
+	}
+
+	currBlockSeries := []ident.ID{ident.StringID("currBlock1"), ident.StringID("currBlock2")}
+	testRepairOpts := testRepairOptions{
+		node1ShouldNotContainSeries: currBlockSeries,
+		node2ShouldNotContainSeries: currBlockSeries}
+	testRepair(t, genRepairData, testRepairOpts)
+}
+
+type genRepairDatafn func(
+	now time.Time,
+	blockSize time.Duration,
+) (
+	node0Data generate.SeriesBlocksByStart,
+	node1Data generate.SeriesBlocksByStart,
+	node2Data generate.SeriesBlocksByStart,
+	allData generate.SeriesBlocksByStart)
+
+type testRepairOptions struct {
+	node0ShouldNotContainSeries []ident.ID
+	node1ShouldNotContainSeries []ident.ID
+	node2ShouldNotContainSeries []ident.ID
+}
+
+func testRepair(
+	t *testing.T,
+	genRepairData genRepairDatafn,
+	testRepairOpts testRepairOptions,
+) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Test setups
+	log := xtest.NewLogger(t)
+	retentionOpts := retention.NewOptions().
+		SetRetentionPeriod(20 * time.Hour).
+		SetBlockSize(2 * time.Hour).
+		SetBufferPast(10 * time.Minute).
+		SetBufferFuture(2 * time.Minute)
+	nsOpts := namespace.NewOptions().
+		SetRepairEnabled(true).
+		// Explicitly ensure that the repair feature works even if cold writes is disabled
+		// at the namespace level.
+		SetColdWritesEnabled(false).
+		SetRetentionOptions(retentionOpts)
+	namesp, err := namespace.NewMetadata(testNamespaces[0], nsOpts)
+	require.NoError(t, err)
+	opts := newTestOptions(t).
+		SetNamespaces([]namespace.Metadata{namesp})
+
+	setupOpts := []bootstrappableTestSetupOptions{
+		{disablePeersBootstrapper: true, enableRepairs: true},
+		{disablePeersBootstrapper: true, enableRepairs: true},
+		{disablePeersBootstrapper: true, enableRepairs: true},
+	}
+	setups, closeFn := newDefaultBootstrappableTestSetups(t, opts, setupOpts)
+	defer closeFn()
+
+	// Ensure that the current time is set such that the previous block is flushable.
+	blockSize := retentionOpts.BlockSize()
+	now := setups[0].getNowFn().Truncate(blockSize).Add(retentionOpts.BufferPast()).Add(time.Second)
+	for _, setup := range setups {
+		setup.setNowFn(now)
+	}
+
+	node0Data, node1Data, node2Data, allData := genRepairData(now, blockSize)
+	if node0Data != nil {
+		require.NoError(t, writeTestDataToDisk(namesp, setups[0], node0Data, 0))
+	}
+	if node1Data != nil {
+		require.NoError(t, writeTestDataToDisk(namesp, setups[1], node1Data, 0))
+	}
+	if node2Data != nil {
+		require.NoError(t, writeTestDataToDisk(namesp, setups[2], node2Data, 0))
+	}
+
+	// Start the servers with filesystem bootstrappers.
+	setups.parallel(func(s *testSetup) {
+		if err := s.startServer(); err != nil {
+			panic(err)
+		}
+	})
+	log.Debug("servers are now up")
+
+	// Stop the servers
+	defer func() {
+		setups.parallel(func(s *testSetup) {
+			require.NoError(t, s.stopServer())
+		})
+		log.Debug("servers are now down")
+	}()
+
+	require.True(t, waitUntil(func() bool {
+		for _, setup := range setups {
+			if err := checkFlushedDataFiles(setup.shardSet, setup.storageOpts, namesp.ID(), allData); err != nil {
+				// Increment the time each time it fails to make sure background processes are able to proceed.
+				for _, s := range setups {
+					s.setNowFn(s.getNowFn().Add(time.Millisecond))
+				}
+				return false
+			}
+		}
+		return true
+	}, 60*time.Second))
+
+	// Verify in-memory data matches what we expect.
+	verifySeriesMaps(t, setups[0], namesp.ID(), allData)
+	verifySeriesMaps(t, setups[1], namesp.ID(), allData)
+	verifySeriesMaps(t, setups[2], namesp.ID(), allData)
+
+	for _, seriesID := range testRepairOpts.node0ShouldNotContainSeries {
+		contains, err := containsSeries(setups[0], namesp.ID(), seriesID, now.Add(-retentionOpts.RetentionPeriod()), now)
+		require.NoError(t, err)
+		require.False(t, contains)
+	}
+	for _, seriesID := range testRepairOpts.node1ShouldNotContainSeries {
+		contains, err := containsSeries(setups[1], namesp.ID(), seriesID, now.Add(-retentionOpts.RetentionPeriod()), now)
+		require.NoError(t, err)
+		require.False(t, contains)
+	}
+	for _, seriesID := range testRepairOpts.node2ShouldNotContainSeries {
+		contains, err := containsSeries(setups[2], namesp.ID(), seriesID, now.Add(-retentionOpts.RetentionPeriod()), now)
+		require.NoError(t, err)
+		require.False(t, contains)
+	}
+}

--- a/src/dbnode/integration/repair_test.go
+++ b/src/dbnode/integration/repair_test.go
@@ -1,6 +1,6 @@
 // +build integration
 
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/dbnode/integration/repair_test.go
+++ b/src/dbnode/integration/repair_test.go
@@ -174,7 +174,7 @@ func testRepair(
 		t.SkipNow()
 	}
 
-	// Test setups
+	// Test setups.
 	log := xtest.NewLogger(t)
 	retentionOpts := retention.NewOptions().
 		SetRetentionPeriod(20 * time.Hour).
@@ -226,7 +226,7 @@ func testRepair(
 	})
 	log.Debug("servers are now up")
 
-	// Stop the servers
+	// Stop the servers.
 	defer func() {
 		setups.parallel(func(s *testSetup) {
 			require.NoError(t, s.stopServer())

--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -537,7 +537,7 @@ func (s *service) readDatapoints(
 		return nil, err
 	}
 
-	// Resolve all futures and filter out any empty segments.
+	// Resolve all futures (block reads can be backed by async implementations) and filter out any empty segments.
 	filteredBlockReaderSliceOfSlices, err := xio.FilterEmptyBlockReadersInPlaceSliceOfSlices(encoded)
 	if err != nil {
 		return nil, err

--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -538,7 +538,7 @@ func (s *service) readDatapoints(
 	}
 
 	// Resolve all futures (block reads can be backed by async implementations) and filter out any empty segments.
-	filteredBlockReaderSliceOfSlices, err := xio.FilterEmptyBlockReadersInPlaceSliceOfSlices(encoded)
+	filteredBlockReaderSliceOfSlices, err := xio.FilterEmptyBlockReadersSliceOfSlicesInPlace(encoded)
 	if err != nil {
 		return nil, err
 	}

--- a/src/dbnode/storage/block/result.go
+++ b/src/dbnode/storage/block/result.go
@@ -234,6 +234,8 @@ func (it *filteredBlocksMetadataIter) Next() bool {
 			return false
 		}
 		tagsIter.Close()
+		// Set to nil so it doesn't get closed again later and trigger a double-put pooling bug.
+		it.res[it.resIdx].Tags = nil
 	}
 	it.metadata = NewMetadata(it.id, tags, block.Start,
 		block.Size, block.Checksum, block.LastRead)

--- a/src/dbnode/storage/block/result_test.go
+++ b/src/dbnode/storage/block/result_test.go
@@ -111,4 +111,10 @@ func TestFilteredBlocksMetadataIter(t *testing.T) {
 		assert.Equal(t, expected[i].Checksum, actual[i].Checksum)
 		assert.Equal(t, expected[i].LastRead, actual[i].LastRead)
 	}
+
+	for _, fetchMetadataResult := range res.Results() {
+		// Ensure that the consumed (and closed) tags are marked as nil so subsequent code paths
+		// can't trigger a double close.
+		require.Nil(t, fetchMetadataResult.Tags)
+	}
 }

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -128,9 +128,6 @@ func testNamespaceMap(t *testing.T) namespace.Map {
 func testRepairOptions(ctrl *gomock.Controller) repair.Options {
 	return repair.NewOptions().
 		SetAdminClient(client.NewMockAdminClient(ctrl)).
-		SetRepairInterval(time.Second).
-		SetRepairTimeOffset(500 * time.Millisecond).
-		SetRepairTimeJitter(300 * time.Millisecond).
 		SetRepairCheckInterval(100 * time.Millisecond)
 }
 

--- a/src/dbnode/storage/index/aggregate_results_test.go
+++ b/src/dbnode/storage/index/aggregate_results_test.go
@@ -22,12 +22,11 @@ package index
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
-	xtest "github.com/m3db/m3/src/x/test"
 	"github.com/m3db/m3/src/x/ident"
+	xtest "github.com/m3db/m3/src/x/test"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -401,7 +400,6 @@ func TestAggResultsReset(t *testing.T) {
 	aggResults, ok = res.(*aggregatedResults)
 	require.True(t, ok)
 	require.Equal(t, 100, aggResults.aggregateOpts.SizeLimit)
-	fmt.Println(aggResults.nsID.String())
 	require.Equal(t, newID.Bytes(), aggResults.nsID.Bytes())
 
 	// Ensure new NS is cloned

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -635,7 +635,7 @@ func TestNamespaceRepair(t *testing.T) {
 			}
 		}
 		shard.EXPECT().
-			Repair(gomock.Any(), gomock.Any(), repairTimeRange, repairer).
+			Repair(gomock.Any(), gomock.Any(), gomock.Any(), repairTimeRange, repairer).
 			Return(res, errs[i])
 		ns.shards[testShardIDs[i].ID()] = shard
 	}

--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -613,7 +613,7 @@ func (r shardRepairer) shadowCompare(
 		if err != nil {
 			return err
 		}
-		localSeriesDataBlocks, err := xio.FilterEmptyBlockReadersInPlaceSliceOfSlices(unfilteredLocalSeriesDataBlocks)
+		localSeriesDataBlocks, err := xio.FilterEmptyBlockReadersSliceOfSlicesInPlace(unfilteredLocalSeriesDataBlocks)
 		if err != nil {
 			return err
 		}

--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -513,8 +513,10 @@ func (r *dbRepairer) Repair() error {
 
 		// If we've made it this far that means that there were no unrepaired blocks which means we should
 		// repair the least recently repaired block instead.
-		if err := r.repairNamespaceBlockstart(n, leastRecentlyRepairedBlockStart); err != nil {
-			multiErr = multiErr.Add(err)
+		if !leastRecentlyRepairedBlockStart.IsZero() {
+			if err := r.repairNamespaceBlockstart(n, leastRecentlyRepairedBlockStart); err != nil {
+				multiErr = multiErr.Add(err)
+			}
 		}
 	}
 

--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/rand"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -34,6 +33,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/repair"
@@ -42,6 +42,7 @@ import (
 	"github.com/m3db/m3/src/x/dice"
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/jhump/protoreflect/dynamic"
@@ -56,6 +57,7 @@ var (
 
 type recordFn func(namespace ident.ID, shard databaseShard, diffRes repair.MetadataComparisonResult)
 
+// TODO(rartoul): See if we can find a way to guard against too much metadata.
 type shardRepairer struct {
 	opts     Options
 	rpopts   repair.Options
@@ -90,6 +92,7 @@ func (r shardRepairer) Options() repair.Options {
 func (r shardRepairer) Repair(
 	ctx context.Context,
 	nsCtx namespace.Context,
+	nsMeta namespace.Metadata,
 	tr xtime.Range,
 	shard databaseShard,
 ) (repair.MetadataComparisonResult, error) {
@@ -99,13 +102,12 @@ func (r shardRepairer) Repair(
 	}
 
 	var (
-		start    = tr.Start
-		end      = tr.End
-		origin   = session.Origin()
-		replicas = session.Replicas()
+		start  = tr.Start
+		end    = tr.End
+		origin = session.Origin()
 	)
 
-	metadata := repair.NewReplicaMetadataComparer(replicas, r.rpopts)
+	metadata := repair.NewReplicaMetadataComparer(origin, r.rpopts)
 	ctx.RegisterFinalizer(metadata)
 
 	// Add local metadata
@@ -117,6 +119,8 @@ func (r shardRepairer) Repair(
 		accumLocalMetadata = block.NewFetchBlocksMetadataResults()
 		pageToken          PageToken
 	)
+	// Safe to register since by the time this function completes we won't be using the metadata
+	// for anything anymore.
 	ctx.RegisterCloser(accumLocalMetadata)
 
 	for {
@@ -150,20 +154,20 @@ func (r shardRepairer) Repair(
 			r.logger.Error(
 				"Shadow compare failed",
 				zap.Error(err))
-			return repair.MetadataComparisonResult{}, err
 		}
 	}
 
 	localIter := block.NewFilteredBlocksMetadataIter(accumLocalMetadata)
-	err = metadata.AddLocalMetadata(origin, localIter)
+	err = metadata.AddLocalMetadata(localIter)
 	if err != nil {
 		return repair.MetadataComparisonResult{}, err
 	}
 
-	// Add peer metadata
+	rsOpts := r.opts.RepairOptions().ResultOptions()
+	// Add peer metadata.
 	level := r.rpopts.RepairConsistencyLevel()
 	peerIter, err := session.FetchBlocksMetadataFromPeers(nsCtx.ID, shard.ID(), start, end,
-		level, result.NewOptions())
+		level, rsOpts)
 	if err != nil {
 		return repair.MetadataComparisonResult{}, err
 	}
@@ -171,7 +175,58 @@ func (r shardRepairer) Repair(
 		return repair.MetadataComparisonResult{}, err
 	}
 
+	// TODO(rartoul): Pool this slice.
+	metadatas := []block.ReplicaMetadata{}
 	metadataRes := metadata.Compare()
+	for _, e := range metadataRes.ChecksumDifferences.Series().Iter() {
+		for blockStart, replicaMetadataBlocks := range e.Value().Metadata.Blocks() {
+			blStartTime := blockStart.ToTime()
+			blStartRange := xtime.Range{Start: blStartTime, End: blStartTime}
+			if !tr.Contains(blStartRange) {
+				instrument.EmitAndLogInvariantViolation(r.opts.InstrumentOptions(), func(l *zap.Logger) {
+					l.With(
+						zap.Time("blockStart", blockStart.ToTime()),
+						zap.String("namespace", nsMeta.ID().String()),
+						zap.Uint32("shard", shard.ID()),
+					).Error("repair received replica metadata for unrequested blockStart")
+				})
+				continue
+			}
+
+			for _, replicaMetadata := range replicaMetadataBlocks.Metadata() {
+				if replicaMetadata.Host.ID() == session.Origin().ID() {
+					// Don't request blocks for self metadata.
+					continue
+				}
+				metadatas = append(metadatas, replicaMetadata)
+			}
+		}
+	}
+
+	perSeriesReplicaIter, err := session.FetchBlocksFromPeers(nsMeta, shard.ID(), level, metadatas, rsOpts)
+	if err != nil {
+		return repair.MetadataComparisonResult{}, err
+	}
+
+	// TODO(rartoul): Copying the IDs for the purposes of the map key is wasteful. Considering using
+	// SetUnsafe or marking as NoFinalize() and making the map check IsNoFinalize().
+	numMismatchSeries := metadataRes.ChecksumDifferences.Series().Len()
+	results := result.NewShardResult(numMismatchSeries, rsOpts)
+	for perSeriesReplicaIter.Next() {
+		_, id, block := perSeriesReplicaIter.Current()
+		// TODO(rartoul): Handle tags in both branches: https://github.com/m3db/m3/issues/1848
+		if existing, ok := results.BlockAt(id, block.StartTime()); ok {
+			if err := existing.Merge(block); err != nil {
+				return repair.MetadataComparisonResult{}, err
+			}
+		} else {
+			results.AddBlock(id, ident.Tags{}, block)
+		}
+	}
+
+	if err := shard.Load(results.AllSeries()); err != nil {
+		return repair.MetadataComparisonResult{}, err
+	}
 
 	r.recordFn(nsCtx.ID, shard, metadataRes)
 
@@ -219,8 +274,8 @@ const (
 )
 
 type repairState struct {
+	LastAttempt time.Time
 	Status      repairStatus
-	NumFailures int
 }
 
 type namespaceRepairStateByTime map[xtime.UnixNano]repairState
@@ -270,6 +325,7 @@ func (r repairStatesByNs) setRepairState(
 // it with a mutex.
 type dbRepairer struct {
 	database         database
+	opts             Options
 	ropts            repair.Options
 	shardRepairer    databaseShardRepairer
 	repairStatesByNs repairStatesByNs
@@ -278,11 +334,8 @@ type dbRepairer struct {
 	sleepFn             sleepFn
 	nowFn               clock.NowFn
 	logger              *zap.Logger
-	repairInterval      time.Duration
-	repairTimeOffset    time.Duration
-	repairTimeJitter    time.Duration
 	repairCheckInterval time.Duration
-	repairMaxRetries    int
+	scope               tally.Scope
 	status              tally.Gauge
 
 	closedLock sync.Mutex
@@ -291,9 +344,11 @@ type dbRepairer struct {
 }
 
 func newDatabaseRepairer(database database, opts Options) (databaseRepairer, error) {
-	nowFn := opts.ClockOptions().NowFn()
-	scope := opts.InstrumentOptions().MetricsScope()
-	ropts := opts.RepairOptions()
+	var (
+		nowFn = opts.ClockOptions().NowFn()
+		scope = opts.InstrumentOptions().MetricsScope().SubScope("repair")
+		ropts = opts.RepairOptions()
+	)
 	if ropts == nil {
 		return nil, errNoRepairOptions
 	}
@@ -303,25 +358,17 @@ func newDatabaseRepairer(database database, opts Options) (databaseRepairer, err
 
 	shardRepairer := newShardRepairer(opts, ropts)
 
-	var jitter time.Duration
-	if repairJitter := ropts.RepairTimeJitter(); repairJitter > 0 {
-		src := rand.NewSource(nowFn().UnixNano())
-		jitter = time.Duration(float64(repairJitter) * (float64(src.Int63()) / float64(math.MaxInt64)))
-	}
-
 	r := &dbRepairer{
 		database:            database,
+		opts:                opts,
 		ropts:               ropts,
 		shardRepairer:       shardRepairer,
 		repairStatesByNs:    newRepairStates(),
 		sleepFn:             time.Sleep,
 		nowFn:               nowFn,
 		logger:              opts.InstrumentOptions().Logger(),
-		repairInterval:      ropts.RepairInterval(),
-		repairTimeOffset:    ropts.RepairTimeOffset(),
-		repairTimeJitter:    jitter,
 		repairCheckInterval: ropts.RepairCheckInterval(),
-		repairMaxRetries:    ropts.RepairMaxRetries(),
+		scope:               scope,
 		status:              scope.Gauge("repair"),
 	}
 	r.repairFn = r.Repair
@@ -330,8 +377,6 @@ func newDatabaseRepairer(database database, opts Options) (databaseRepairer, err
 }
 
 func (r *dbRepairer) run() {
-	var curIntervalStart time.Time
-
 	for {
 		r.closedLock.Lock()
 		closed := r.closed
@@ -343,61 +388,23 @@ func (r *dbRepairer) run() {
 
 		r.sleepFn(r.repairCheckInterval)
 
-		now := r.nowFn()
-		intervalStart := now.Truncate(r.repairInterval)
-
-		// If we haven't reached the offset yet, skip
-		target := intervalStart.Add(r.repairTimeOffset + r.repairTimeJitter)
-		if now.Before(target) {
-			continue
-		}
-
-		// If we are in the same interval, we must have already repaired, skip
-		if intervalStart.Equal(curIntervalStart) {
-			continue
-		}
-
-		curIntervalStart = intervalStart
 		if err := r.repairFn(); err != nil {
 			r.logger.Error("error repairing database", zap.Error(err))
 		}
 	}
 }
 
-func (r *dbRepairer) namespaceRepairTimeRanges(ns databaseNamespace) xtime.Ranges {
+func (r *dbRepairer) namespaceRepairTimeRange(ns databaseNamespace) xtime.Range {
 	var (
-		now       = r.nowFn()
-		rtopts    = ns.Options().RetentionOptions()
-		blockSize = rtopts.BlockSize()
-		start     = now.Add(-rtopts.RetentionPeriod()).Truncate(blockSize)
-		end       = now.Add(-rtopts.BufferPast()).Truncate(blockSize)
+		now    = r.nowFn()
+		rtopts = ns.Options().RetentionOptions()
 	)
-
-	targetRanges := xtime.NewRanges(xtime.Range{Start: start, End: end})
-	for tNano := range r.repairStatesByNs[ns.ID().String()] {
-		t := tNano.ToTime()
-		if !r.needsRepair(ns.ID(), t) {
-			targetRanges = targetRanges.RemoveRange(xtime.Range{Start: t, End: t.Add(blockSize)})
-		}
-	}
-
-	return targetRanges
-}
-
-func (r *dbRepairer) needsRepair(ns ident.ID, t time.Time) bool {
-	repairState, exists := r.repairStatesByNs.repairStates(ns, t)
-	if !exists {
-		return true
-	}
-	return repairState.Status == repairNotStarted ||
-		(repairState.Status == repairFailed && repairState.NumFailures < r.repairMaxRetries)
+	return xtime.Range{
+		Start: retention.FlushTimeStart(rtopts, now),
+		End:   retention.FlushTimeEnd(rtopts, now)}
 }
 
 func (r *dbRepairer) Start() {
-	if r.repairInterval <= 0 {
-		return
-	}
-
 	go r.run()
 }
 
@@ -407,6 +414,19 @@ func (r *dbRepairer) Stop() {
 	r.closedLock.Unlock()
 }
 
+// Repair will analyze the current repair state for each namespace/blockStart combination and pick one blockStart
+// per namespace to repair. It will prioritize blocks that have never been repaired over those that have been
+// repaired before, and it will priotize more recent blocks over older ones. If all blocks have been repaired
+// before then it will prioritize the least recently repaired block.
+//
+// The Repair function only attempts to repair one block at a time because this allows the background repair process
+// to run its prioritization logic more frequently. For example, if we attempted to repair all blocks in one pass,
+// even with appropriate backpressure, this could lead to situations where recent blocks are not repaired for a
+// substantial amount of time whereas with the current approach the longest delay between running the prioritization
+// logic is the amount of time it takes to repair one block for all shards.
+//
+// Long term we will want to move to a model that actually tracks state for individual shard/blockStart combinations,
+// not just blockStarts.
 func (r *dbRepairer) Repair() error {
 	// Don't attempt a repair if the database is not bootstrapped yet
 	if !r.database.IsBootstrapped() {
@@ -426,12 +446,79 @@ func (r *dbRepairer) Repair() error {
 	if err != nil {
 		return err
 	}
+
 	for _, n := range namespaces {
-		iter := r.namespaceRepairTimeRanges(n).Iter()
-		for iter.Next() {
-			multiErr = multiErr.Add(r.repairNamespaceWithTimeRange(n, iter.Value()))
+		repairRange := r.namespaceRepairTimeRange(n)
+		blockSize := n.Options().RetentionOptions().BlockSize()
+
+		// Iterating backwards will be exclusive on the start, but we want to be inclusive on the
+		// start so subtract a blocksize.
+		repairRange.Start = repairRange.Start.Add(-blockSize)
+
+		numUnrepairedBlocks := 0
+		repairRange.IterateBackwards(blockSize, func(blockStart time.Time) bool {
+			repairState, ok := r.repairStatesByNs.repairStates(n.ID(), blockStart)
+			if !ok || repairState.Status != repairSuccess {
+				numUnrepairedBlocks++
+			}
+
+			return true
+		})
+
+		r.scope.Tagged(map[string]string{
+			"namespace": n.ID().String(),
+		}).Gauge("num-unrepaired-blocks").Update(float64(numUnrepairedBlocks))
+
+		if numUnrepairedBlocks > 0 {
+			repairRange.IterateBackwards(blockSize, func(blockStart time.Time) bool {
+				repairState, ok := r.repairStatesByNs.repairStates(n.ID(), blockStart)
+				if !ok || repairState.Status != repairSuccess {
+					if err := r.repairNamespaceBlockstart(n, blockStart); err != nil {
+						multiErr = multiErr.Add(err)
+					}
+					// Only repair one block per namespace per iteration.
+					return false
+				}
+				return true
+			})
+
+			continue
+		}
+
+		var (
+			leastRecentlyRepairedBlockStart               time.Time
+			leastRecentlyRepairedBlockStartLastRepairTime time.Time
+			maxSecondsSinceLastBlockRepair                = r.scope.Tagged(map[string]string{
+				"namespace": n.ID().String(),
+			}).Gauge("max-seconds-since-last-block-repair")
+		)
+		repairRange.IterateBackwards(blockSize, func(blockStart time.Time) bool {
+			repairState, ok := r.repairStatesByNs.repairStates(n.ID(), blockStart)
+			if !ok {
+				// Should never happen.
+				instrument.EmitAndLogInvariantViolation(r.opts.InstrumentOptions(), func(l *zap.Logger) {
+					l.With(
+						zap.Time("blockStart", blockStart),
+						zap.String("namespace", n.ID().String()),
+					).Error("missing repair state in all-blocks-are-repaired branch")
+				})
+				return true
+			}
+
+			if leastRecentlyRepairedBlockStart.IsZero() || repairState.LastAttempt.Before(leastRecentlyRepairedBlockStartLastRepairTime) {
+				leastRecentlyRepairedBlockStart = blockStart
+				leastRecentlyRepairedBlockStartLastRepairTime = repairState.LastAttempt
+			}
+			return true
+		})
+
+		secondsSinceLastRepair := r.nowFn().Sub(leastRecentlyRepairedBlockStartLastRepairTime).Seconds()
+		maxSecondsSinceLastBlockRepair.Update(secondsSinceLastRepair)
+		if err := r.repairNamespaceBlockstart(n, leastRecentlyRepairedBlockStart); err != nil {
+			multiErr = multiErr.Add(err)
 		}
 	}
+
 	return multiErr.FinalError()
 }
 
@@ -443,31 +530,38 @@ func (r *dbRepairer) Report() {
 	}
 }
 
-func (r *dbRepairer) repairNamespaceWithTimeRange(n databaseNamespace, tr xtime.Range) error {
+func (r *dbRepairer) repairNamespaceBlockstart(n databaseNamespace, blockStart time.Time) error {
 	var (
-		rtopts    = n.Options().RetentionOptions()
-		blockSize = rtopts.BlockSize()
-		err       error
+		blockSize   = n.Options().RetentionOptions().BlockSize()
+		repairRange = xtime.Range{Start: blockStart, End: blockStart.Add(blockSize)}
+		repairTime  = r.nowFn()
 	)
-
-	// repair the namespace
-	if err = n.Repair(r.shardRepairer, tr); err != nil {
-		err = fmt.Errorf("namespace %s failed to repair time range %v: %v", n.ID().String(), tr, err)
+	if err := r.repairNamespaceWithTimeRange(n, repairRange); err != nil {
+		r.markRepairAttempt(n.ID(), blockStart, repairTime, repairFailed)
+		return err
 	}
 
-	// update repairer state
-	for t := tr.Start; t.Before(tr.End); t = t.Add(blockSize) {
-		repairState, _ := r.repairStatesByNs.repairStates(n.ID(), t)
-		if err == nil {
-			repairState.Status = repairSuccess
-		} else {
-			repairState.Status = repairFailed
-			repairState.NumFailures++
-		}
-		r.repairStatesByNs.setRepairState(n.ID(), t, repairState)
+	r.markRepairAttempt(n.ID(), blockStart, repairTime, repairSuccess)
+	return nil
+}
+
+func (r *dbRepairer) repairNamespaceWithTimeRange(n databaseNamespace, tr xtime.Range) error {
+	if err := n.Repair(r.shardRepairer, tr); err != nil {
+		return fmt.Errorf("namespace %s failed to repair time range %v: %v", n.ID().String(), tr, err)
 	}
 
-	return err
+	return nil
+}
+
+func (r *dbRepairer) markRepairAttempt(
+	namespace ident.ID,
+	blockStart time.Time,
+	repairTime time.Time,
+	repairStatus repairStatus) {
+	repairState, _ := r.repairStatesByNs.repairStates(namespace, blockStart)
+	repairState.Status = repairStatus
+	repairState.LastAttempt = repairTime
+	r.repairStatesByNs.setRepairState(namespace, blockStart, repairState)
 }
 
 var noOpRepairer databaseRepairer = repairerNoOp{}
@@ -512,10 +606,16 @@ func (r shardRepairer) shadowCompare(
 
 		tmpCtx.Reset()
 		defer tmpCtx.BlockingClose()
-		localSeriesDataBlocks, err := shard.ReadEncoded(tmpCtx, seriesID, start, end, nsCtx)
+
+		unfilteredLocalSeriesDataBlocks, err := shard.ReadEncoded(tmpCtx, seriesID, start, end, nsCtx)
 		if err != nil {
 			return err
 		}
+		localSeriesDataBlocks, err := xio.FilterEmptyBlockReadersInPlaceSliceOfSlices(unfilteredLocalSeriesDataBlocks)
+		if err != nil {
+			return err
+		}
+
 		localSeriesSliceOfSlices := xio.NewReaderSliceOfSlicesFromBlockReadersIterator(localSeriesDataBlocks)
 		localSeriesIter := r.opts.MultiReaderIteratorPool().Get()
 		localSeriesIter.ResetSliceOfSlices(localSeriesSliceOfSlices, nsCtx.Schema)

--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -465,7 +465,7 @@ func (r *dbRepairer) Repair() error {
 			leastRecentlyRepairedBlockStart               time.Time
 			leastRecentlyRepairedBlockStartLastRepairTime time.Time
 		)
-		repairRange.IterateBackwards(blockSize, func(blockStart time.Time) bool {
+		repairRange.IterateBackward(blockSize, func(blockStart time.Time) bool {
 			repairState, ok := r.repairStatesByNs.repairStates(n.ID(), blockStart)
 			if ok && (leastRecentlyRepairedBlockStart.IsZero() ||
 				repairState.LastAttempt.Before(leastRecentlyRepairedBlockStartLastRepairTime)) {

--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -513,10 +513,11 @@ func (r *dbRepairer) Repair() error {
 
 		// If we've made it this far that means that there were no unrepaired blocks which means we should
 		// repair the least recently repaired block instead.
-		if !leastRecentlyRepairedBlockStart.IsZero() {
-			if err := r.repairNamespaceBlockstart(n, leastRecentlyRepairedBlockStart); err != nil {
-				multiErr = multiErr.Add(err)
-			}
+		if leastRecentlyRepairedBlockStart.IsZero() {
+			continue
+		}
+		if err := r.repairNamespaceBlockstart(n, leastRecentlyRepairedBlockStart); err != nil {
+			multiErr = multiErr.Add(err)
 		}
 	}
 

--- a/src/dbnode/storage/repair/metadata.go
+++ b/src/dbnode/storage/repair/metadata.go
@@ -40,11 +40,11 @@ type replicaMetadataSlice struct {
 	pool     ReplicaMetadataSlicePool
 }
 
-func newReplicaMetadataSlice() HostBlockMetadataSlice {
+func newReplicaMetadataSlice() ReplicaMetadataSlice {
 	return &replicaMetadataSlice{}
 }
 
-func newPooledReplicaMetadataSlice(metadata []block.ReplicaMetadata, pool ReplicaMetadataSlicePool) HostBlockMetadataSlice {
+func newPooledReplicaMetadataSlice(metadata []block.ReplicaMetadata, pool ReplicaMetadataSlicePool) ReplicaMetadataSlice {
 	return &replicaMetadataSlice{metadata: metadata, pool: pool}
 }
 
@@ -72,11 +72,11 @@ func (s *replicaMetadataSlice) Close() {
 
 type replicaBlockMetadata struct {
 	start    time.Time
-	metadata HostBlockMetadataSlice
+	metadata ReplicaMetadataSlice
 }
 
 // NewReplicaBlockMetadata creates a new replica block metadata
-func NewReplicaBlockMetadata(start time.Time, p HostBlockMetadataSlice) ReplicaBlockMetadata {
+func NewReplicaBlockMetadata(start time.Time, p ReplicaMetadataSlice) ReplicaBlockMetadata {
 	return replicaBlockMetadata{start: start, metadata: p}
 }
 

--- a/src/dbnode/storage/repair/metadata_pool.go
+++ b/src/dbnode/storage/repair/metadata_pool.go
@@ -20,7 +20,10 @@
 
 package repair
 
-import "github.com/m3db/m3/src/x/pool"
+import (
+	"github.com/m3db/m3/src/dbnode/storage/block"
+	"github.com/m3db/m3/src/x/pool"
+)
 
 type hostBlockMetadataSlicePool struct {
 	pool     pool.ObjectPool
@@ -31,7 +34,7 @@ type hostBlockMetadataSlicePool struct {
 func NewHostBlockMetadataSlicePool(opts pool.ObjectPoolOptions, capacity int) HostBlockMetadataSlicePool {
 	p := &hostBlockMetadataSlicePool{pool: pool.NewObjectPool(opts), capacity: capacity}
 	p.pool.Init(func() interface{} {
-		metadata := make([]HostBlockMetadata, 0, capacity)
+		metadata := make([]block.ReplicaMetadata, 0, capacity)
 		return newPooledHostBlockMetadataSlice(metadata, p)
 	})
 	return p

--- a/src/dbnode/storage/repair/metadata_pool.go
+++ b/src/dbnode/storage/repair/metadata_pool.go
@@ -25,26 +25,26 @@ import (
 	"github.com/m3db/m3/src/x/pool"
 )
 
-type hostBlockMetadataSlicePool struct {
+type replicaMetadataSlicePool struct {
 	pool     pool.ObjectPool
 	capacity int
 }
 
-// NewHostBlockMetadataSlicePool creates a new hostBlockMetadataSlice pool
-func NewHostBlockMetadataSlicePool(opts pool.ObjectPoolOptions, capacity int) HostBlockMetadataSlicePool {
-	p := &hostBlockMetadataSlicePool{pool: pool.NewObjectPool(opts), capacity: capacity}
+// NewReplicaMetadataSlicePool creates a new replicaMetadataSlicePool pool
+func NewReplicaMetadataSlicePool(opts pool.ObjectPoolOptions, capacity int) ReplicaMetadataSlicePool {
+	p := &replicaMetadataSlicePool{pool: pool.NewObjectPool(opts), capacity: capacity}
 	p.pool.Init(func() interface{} {
 		metadata := make([]block.ReplicaMetadata, 0, capacity)
-		return newPooledHostBlockMetadataSlice(metadata, p)
+		return newPooledReplicaMetadataSlice(metadata, p)
 	})
 	return p
 }
 
-func (p *hostBlockMetadataSlicePool) Get() HostBlockMetadataSlice {
+func (p *replicaMetadataSlicePool) Get() HostBlockMetadataSlice {
 	return p.pool.Get().(HostBlockMetadataSlice)
 }
 
-func (p *hostBlockMetadataSlicePool) Put(res HostBlockMetadataSlice) {
+func (p *replicaMetadataSlicePool) Put(res HostBlockMetadataSlice) {
 	res.Reset()
 	p.pool.Put(res)
 }

--- a/src/dbnode/storage/repair/metadata_pool.go
+++ b/src/dbnode/storage/repair/metadata_pool.go
@@ -40,11 +40,11 @@ func NewReplicaMetadataSlicePool(opts pool.ObjectPoolOptions, capacity int) Repl
 	return p
 }
 
-func (p *replicaMetadataSlicePool) Get() HostBlockMetadataSlice {
-	return p.pool.Get().(HostBlockMetadataSlice)
+func (p *replicaMetadataSlicePool) Get() ReplicaMetadataSlice {
+	return p.pool.Get().(ReplicaMetadataSlice)
 }
 
-func (p *replicaMetadataSlicePool) Put(res HostBlockMetadataSlice) {
+func (p *replicaMetadataSlicePool) Put(res ReplicaMetadataSlice) {
 	res.Reset()
 	p.pool.Put(res)
 }

--- a/src/dbnode/storage/repair/metadata_pool_test.go
+++ b/src/dbnode/storage/repair/metadata_pool_test.go
@@ -23,6 +23,7 @@ package repair
 import (
 	"testing"
 
+	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/x/pool"
 
 	"github.com/stretchr/testify/require"
@@ -34,7 +35,7 @@ func TestHostBlockMetadataSlicePoolResetOnPut(t *testing.T) {
 	res := p.Get()
 
 	// Make res non-empty
-	res.Add(HostBlockMetadata{})
+	res.Add(block.ReplicaMetadata{})
 	require.Equal(t, 1, len(res.Metadata()))
 
 	// Return res to pool

--- a/src/dbnode/storage/repair/metadata_pool_test.go
+++ b/src/dbnode/storage/repair/metadata_pool_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHostBlockMetadataSlicePoolResetOnPut(t *testing.T) {
+func TestReplicaMetadataSlicePoolResetOnPut(t *testing.T) {
 	opts := pool.NewObjectPoolOptions().SetSize(1)
-	p := NewHostBlockMetadataSlicePool(opts, 64)
+	p := NewReplicaMetadataSlicePool(opts, 64)
 	res := p.Get()
 
 	// Make res non-empty

--- a/src/dbnode/storage/repair/metadata_test.go
+++ b/src/dbnode/storage/repair/metadata_test.go
@@ -44,11 +44,16 @@ func testRepairOptions() Options {
 }
 
 func TestReplicaBlockMetadataAdd(t *testing.T) {
+	meta1 := block.NewMetadata(
+		ident.StringID("some-id"), ident.Tags{}, time.Time{}, 1, nil, time.Time{})
+	meta2 := block.NewMetadata(
+		ident.StringID("some-id"), ident.Tags{}, time.Time{}, 2, new(uint32), time.Time{})
+
 	now := time.Now()
 	m := NewReplicaBlockMetadata(now, newHostBlockMetadataSlice())
-	inputs := []HostBlockMetadata{
-		{topology.NewHost("foo", "addrFoo"), 1, nil},
-		{topology.NewHost("bar", "addrBar"), 2, new(uint32)},
+	inputs := []block.ReplicaMetadata{
+		{Host: topology.NewHost("foo", "addrFoo"), Metadata: meta1},
+		{Host: topology.NewHost("bar", "addrBar"), Metadata: meta2},
 	}
 	for _, input := range inputs {
 		m.Add(input)
@@ -108,7 +113,7 @@ func TestReplicaSeriesMetadataGetOrAdd(t *testing.T) {
 type testBlock struct {
 	id     ident.ID
 	ts     time.Time
-	blocks []HostBlockMetadata
+	blocks []block.ReplicaMetadata
 }
 
 func assertEqual(t *testing.T, expected []testBlock, actual ReplicaSeriesMetadata) {
@@ -146,14 +151,14 @@ func TestReplicaMetadataComparerAddLocalMetadata(t *testing.T) {
 		localIter.EXPECT().Err().Return(nil),
 	)
 
-	m := NewReplicaMetadataComparer(3, testRepairOptions()).(replicaMetadataComparer)
-	err := m.AddLocalMetadata(origin, localIter)
+	m := NewReplicaMetadataComparer(origin, testRepairOptions()).(replicaMetadataComparer)
+	err := m.AddLocalMetadata(localIter)
 	require.NoError(t, err)
 
 	expected := []testBlock{
-		{inputBlocks[0].ID, inputBlocks[0].Start, []HostBlockMetadata{{origin, inputBlocks[0].Size, inputBlocks[0].Checksum}}},
-		{inputBlocks[1].ID, inputBlocks[1].Start, []HostBlockMetadata{{origin, inputBlocks[1].Size, inputBlocks[1].Checksum}}},
-		{inputBlocks[2].ID, inputBlocks[2].Start, []HostBlockMetadata{{origin, inputBlocks[2].Size, inputBlocks[2].Checksum}}},
+		{inputBlocks[0].ID, inputBlocks[0].Start, []block.ReplicaMetadata{{Host: origin, Metadata: inputBlocks[0]}}},
+		{inputBlocks[1].ID, inputBlocks[1].Start, []block.ReplicaMetadata{{Host: origin, Metadata: inputBlocks[1]}}},
+		{inputBlocks[2].ID, inputBlocks[2].Start, []block.ReplicaMetadata{{Host: origin, Metadata: inputBlocks[2]}}},
 	}
 	assertEqual(t, expected, m.metadata)
 }
@@ -164,28 +169,25 @@ func TestReplicaMetadataComparerAddPeerMetadata(t *testing.T) {
 
 	now := time.Now()
 	peerIter := client.NewMockPeerBlockMetadataIter(ctrl)
-	inputBlocks := []struct {
-		host topology.Host
-		meta block.Metadata
-	}{
+	inputBlocks := []block.ReplicaMetadata{
 		{
-			host: topology.NewHost("1", "addr1"),
-			meta: block.NewMetadata(ident.StringID("foo"), ident.Tags{},
+			Host: topology.NewHost("1", "addr1"),
+			Metadata: block.NewMetadata(ident.StringID("foo"), ident.Tags{},
 				now, int64(0), new(uint32), time.Time{}),
 		},
 		{
-			host: topology.NewHost("1", "addr1"),
-			meta: block.NewMetadata(ident.StringID("foo"), ident.Tags{},
+			Host: topology.NewHost("1", "addr1"),
+			Metadata: block.NewMetadata(ident.StringID("foo"), ident.Tags{},
 				now.Add(time.Second), int64(1), new(uint32), time.Time{}),
 		},
 		{
-			host: topology.NewHost("2", "addr2"),
-			meta: block.NewMetadata(ident.StringID("foo"), ident.Tags{},
+			Host: topology.NewHost("2", "addr2"),
+			Metadata: block.NewMetadata(ident.StringID("foo"), ident.Tags{},
 				now, int64(2), nil, time.Time{}),
 		},
 		{
-			host: topology.NewHost("2", "addr2"),
-			meta: block.NewMetadata(ident.StringID("bar"), ident.Tags{},
+			Host: topology.NewHost("2", "addr2"),
+			Metadata: block.NewMetadata(ident.StringID("bar"), ident.Tags{},
 				now.Add(time.Second), int64(3), nil, time.Time{}),
 		},
 	}
@@ -193,30 +195,30 @@ func TestReplicaMetadataComparerAddPeerMetadata(t *testing.T) {
 
 	gomock.InOrder(
 		peerIter.EXPECT().Next().Return(true),
-		peerIter.EXPECT().Current().Return(inputBlocks[0].host, inputBlocks[0].meta),
+		peerIter.EXPECT().Current().Return(inputBlocks[0].Host, inputBlocks[0].Metadata),
 		peerIter.EXPECT().Next().Return(true),
-		peerIter.EXPECT().Current().Return(inputBlocks[1].host, inputBlocks[1].meta),
+		peerIter.EXPECT().Current().Return(inputBlocks[1].Host, inputBlocks[1].Metadata),
 		peerIter.EXPECT().Next().Return(true),
-		peerIter.EXPECT().Current().Return(inputBlocks[2].host, inputBlocks[2].meta),
+		peerIter.EXPECT().Current().Return(inputBlocks[2].Host, inputBlocks[2].Metadata),
 		peerIter.EXPECT().Next().Return(true),
-		peerIter.EXPECT().Current().Return(inputBlocks[3].host, inputBlocks[3].meta),
+		peerIter.EXPECT().Current().Return(inputBlocks[3].Host, inputBlocks[3].Metadata),
 		peerIter.EXPECT().Next().Return(false),
 		peerIter.EXPECT().Err().Return(expectedErr),
 	)
 
-	m := NewReplicaMetadataComparer(3, testRepairOptions()).(replicaMetadataComparer)
+	m := NewReplicaMetadataComparer(inputBlocks[0].Host, testRepairOptions()).(replicaMetadataComparer)
 	require.Equal(t, expectedErr, m.AddPeerMetadata(peerIter))
 
 	expected := []testBlock{
-		{ident.StringID("foo"), inputBlocks[0].meta.Start, []HostBlockMetadata{
-			{inputBlocks[0].host, inputBlocks[0].meta.Size, inputBlocks[0].meta.Checksum},
-			{inputBlocks[2].host, inputBlocks[2].meta.Size, inputBlocks[2].meta.Checksum},
+		{ident.StringID("foo"), inputBlocks[0].Metadata.Start, []block.ReplicaMetadata{
+			inputBlocks[0],
+			inputBlocks[2],
 		}},
-		{ident.StringID("foo"), inputBlocks[1].meta.Start, []HostBlockMetadata{
-			{inputBlocks[1].host, inputBlocks[1].meta.Size, inputBlocks[1].meta.Checksum},
+		{ident.StringID("foo"), inputBlocks[1].Metadata.Start, []block.ReplicaMetadata{
+			inputBlocks[1],
 		}},
-		{ident.StringID("bar"), inputBlocks[3].meta.Start, []HostBlockMetadata{
-			{inputBlocks[3].host, inputBlocks[3].meta.Size, inputBlocks[3].meta.Checksum},
+		{ident.StringID("bar"), inputBlocks[3].Metadata.Start, []block.ReplicaMetadata{
+			inputBlocks[3],
 		}},
 	}
 	assertEqual(t, expected, m.metadata)
@@ -231,61 +233,75 @@ func TestReplicaMetadataComparerCompare(t *testing.T) {
 	metadata := NewReplicaSeriesMetadata()
 	defer metadata.Close()
 
-	inputs := []struct {
-		host        topology.Host
-		id          string
-		ts          time.Time
-		size        int64
-		checksum    uint32
-		hasChecksum bool
-	}{
-		{hosts[0], "foo", now, int64(1), uint32(10), true},
-		{hosts[1], "foo", now, int64(1), uint32(10), true},
-		{hosts[0], "bar", now.Add(time.Second), int64(0), uint32(10), true},
-		{hosts[1], "bar", now.Add(time.Second), int64(1), uint32(10), true},
-		{hosts[0], "baz", now.Add(2 * time.Second), int64(2), uint32(20), true},
-		{hosts[1], "baz", now.Add(2 * time.Second), int64(2), uint32(0), false},
-		{hosts[0], "gah", now.Add(3 * time.Second), int64(1), uint32(10), true},
+	ten := uint32(10)
+	twenty := uint32(20)
+	inputs := []block.ReplicaMetadata{
+		block.ReplicaMetadata{
+			Host:     hosts[0],
+			Metadata: block.NewMetadata(ident.StringID("foo"), ident.Tags{}, now, int64(1), &ten, time.Time{}),
+		},
+		block.ReplicaMetadata{
+			Host:     hosts[1],
+			Metadata: block.NewMetadata(ident.StringID("foo"), ident.Tags{}, now, int64(1), &ten, time.Time{}),
+		},
+		block.ReplicaMetadata{
+			Host:     hosts[0],
+			Metadata: block.NewMetadata(ident.StringID("bar"), ident.Tags{}, now.Add(time.Second), int64(0), &ten, time.Time{}),
+		},
+		block.ReplicaMetadata{
+			Host:     hosts[1],
+			Metadata: block.NewMetadata(ident.StringID("bar"), ident.Tags{}, now.Add(time.Second), int64(1), &ten, time.Time{}),
+		},
+		block.ReplicaMetadata{
+			Host:     hosts[0],
+			Metadata: block.NewMetadata(ident.StringID("baz"), ident.Tags{}, now.Add(2*time.Second), int64(2), &twenty, time.Time{}),
+		},
+		block.ReplicaMetadata{
+			Host:     hosts[1],
+			Metadata: block.NewMetadata(ident.StringID("baz"), ident.Tags{}, now.Add(2*time.Second), int64(2), nil, time.Time{}),
+		},
+		// Block only exists for host[1] but host[0] is the origin so should be consider a size/checksum mismatch.
+		block.ReplicaMetadata{
+			Host:     hosts[1],
+			Metadata: block.NewMetadata(ident.StringID("gah"), ident.Tags{}, now.Add(3*time.Second), int64(1), &ten, time.Time{}),
+		},
+		// Block only exists for host[0] but host[0] is also the origin so should not be considered a size/checksum mismatch
+		// since the peer not the origin is missing data.
+		block.ReplicaMetadata{
+			Host:     hosts[0],
+			Metadata: block.NewMetadata(ident.StringID("grr"), ident.Tags{}, now.Add(3*time.Second), int64(1), &ten, time.Time{}),
+		},
 	}
 	for _, input := range inputs {
-		var checkSum *uint32
-		if input.hasChecksum {
-			ckSum := input.checksum
-			checkSum = &ckSum
-		}
-		metadata.GetOrAdd(ident.StringID(input.id)).GetOrAdd(input.ts, testHostBlockMetadataSlicePool()).Add(HostBlockMetadata{
-			Host:     input.host,
-			Size:     input.size,
-			Checksum: checkSum,
-		})
+		metadata.GetOrAdd(input.Metadata.ID).GetOrAdd(input.Metadata.Start, testHostBlockMetadataSlicePool()).Add(input)
 	}
 
 	sizeExpected := []testBlock{
-		{ident.StringID("bar"), now.Add(time.Second), []HostBlockMetadata{
-			{hosts[0], int64(0), &inputs[2].checksum},
-			{hosts[1], int64(1), &inputs[3].checksum},
+		{ident.StringID("bar"), now.Add(time.Second), []block.ReplicaMetadata{
+			inputs[2],
+			inputs[3],
 		}},
-		{ident.StringID("gah"), now.Add(3 * time.Second), []HostBlockMetadata{
-			{hosts[0], int64(1), &inputs[6].checksum},
+		{ident.StringID("gah"), now.Add(3 * time.Second), []block.ReplicaMetadata{
+			inputs[6],
 		}},
 	}
 
 	checksumExpected := []testBlock{
-		{ident.StringID("baz"), now.Add(2 * time.Second), []HostBlockMetadata{
-			{hosts[0], int64(2), &inputs[4].checksum},
-			{hosts[1], int64(2), nil},
+		{ident.StringID("baz"), now.Add(2 * time.Second), []block.ReplicaMetadata{
+			inputs[4],
+			inputs[5],
 		}},
-		{ident.StringID("gah"), now.Add(3 * time.Second), []HostBlockMetadata{
-			{hosts[0], int64(1), &inputs[6].checksum},
+		{ident.StringID("gah"), now.Add(3 * time.Second), []block.ReplicaMetadata{
+			inputs[6],
 		}},
 	}
 
-	m := NewReplicaMetadataComparer(2, testRepairOptions()).(replicaMetadataComparer)
+	m := NewReplicaMetadataComparer(hosts[0], testRepairOptions()).(replicaMetadataComparer)
 	m.metadata = metadata
 
 	res := m.Compare()
-	require.Equal(t, int64(4), res.NumSeries)
-	require.Equal(t, int64(4), res.NumBlocks)
+	require.Equal(t, int64(5), res.NumSeries)
+	require.Equal(t, int64(5), res.NumBlocks)
 	assertEqual(t, sizeExpected, res.SizeDifferences)
 	assertEqual(t, checksumExpected, res.ChecksumDifferences)
 }

--- a/src/dbnode/storage/repair/metadata_test.go
+++ b/src/dbnode/storage/repair/metadata_test.go
@@ -35,8 +35,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testHostBlockMetadataSlicePool() HostBlockMetadataSlicePool {
-	return NewHostBlockMetadataSlicePool(nil, 0)
+func testReplicaMetadataSlicePool() ReplicaMetadataSlicePool {
+	return NewReplicaMetadataSlicePool(nil, 0)
 }
 
 func testRepairOptions() Options {
@@ -50,7 +50,7 @@ func TestReplicaBlockMetadataAdd(t *testing.T) {
 		ident.StringID("some-id"), ident.Tags{}, time.Time{}, 2, new(uint32), time.Time{})
 
 	now := time.Now()
-	m := NewReplicaBlockMetadata(now, newHostBlockMetadataSlice())
+	m := NewReplicaBlockMetadata(now, newReplicaMetadataSlice())
 	inputs := []block.ReplicaMetadata{
 		{Host: topology.NewHost("foo", "addrFoo"), Metadata: meta1},
 		{Host: topology.NewHost("bar", "addrBar"), Metadata: meta2},
@@ -64,7 +64,7 @@ func TestReplicaBlockMetadataAdd(t *testing.T) {
 
 func TestReplicaBlocksMetadataAdd(t *testing.T) {
 	now := time.Now()
-	block := NewReplicaBlockMetadata(now, newHostBlockMetadataSlice())
+	block := NewReplicaBlockMetadata(now, newReplicaMetadataSlice())
 	m := NewReplicaBlocksMetadata()
 	m.Add(block)
 
@@ -82,7 +82,7 @@ func TestReplicaBlocksMetadataGetOrAdd(t *testing.T) {
 	require.Equal(t, 0, len(m.Blocks()))
 
 	// Add a block
-	b := m.GetOrAdd(now, testHostBlockMetadataSlicePool())
+	b := m.GetOrAdd(now, testReplicaMetadataSlicePool())
 	require.Equal(t, now, b.Start())
 	blocks := m.Blocks()
 	require.Equal(t, 1, len(blocks))
@@ -91,7 +91,7 @@ func TestReplicaBlocksMetadataGetOrAdd(t *testing.T) {
 	require.Equal(t, now, block.Start())
 
 	// Add the same block and check we don't add new blocks
-	m.GetOrAdd(now, testHostBlockMetadataSlicePool())
+	m.GetOrAdd(now, testReplicaMetadataSlicePool())
 	require.Equal(t, 1, len(m.Blocks()))
 }
 
@@ -273,7 +273,7 @@ func TestReplicaMetadataComparerCompare(t *testing.T) {
 		},
 	}
 	for _, input := range inputs {
-		metadata.GetOrAdd(input.Metadata.ID).GetOrAdd(input.Metadata.Start, testHostBlockMetadataSlicePool()).Add(input)
+		metadata.GetOrAdd(input.Metadata.ID).GetOrAdd(input.Metadata.Start, testReplicaMetadataSlicePool()).Add(input)
 	}
 
 	sizeExpected := []testBlock{

--- a/src/dbnode/storage/repair/options.go
+++ b/src/dbnode/storage/repair/options.go
@@ -25,17 +25,14 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
 )
 
 const (
 	defaultRepairConsistencyLevel           = topology.ReadConsistencyLevelMajority
-	defaultRepairInterval                   = 2 * time.Hour
-	defaultRepairTimeOffset                 = 30 * time.Minute
-	defaultRepairTimeJitter                 = time.Hour
 	defaultRepairCheckInterval              = time.Minute
 	defaultRepairThrottle                   = 90 * time.Second
-	defaultRepairMaxRetries                 = 3
 	defaultRepairShardConcurrency           = 1
 	defaultDebugShadowComparisonsEnabled    = false
 	defaultDebugShadowComparisonsPercentage = 1.0
@@ -43,15 +40,10 @@ const (
 
 var (
 	errNoAdminClient                           = errors.New("no admin client in repair options")
-	errInvalidRepairInterval                   = errors.New("invalid repair interval in repair options")
-	errInvalidRepairTimeOffset                 = errors.New("invalid repair time offset in repair options")
-	errInvalidRepairTimeJitter                 = errors.New("invalid repair time jitter in repair options")
-	errTimeOffsetOrJitterTooBig                = errors.New("repair time offset plus jitter should be no more than repair interval")
 	errInvalidRepairCheckInterval              = errors.New("invalid repair check interval in repair options")
-	errRepairCheckIntervalTooBig               = errors.New("repair check interval too big in repair options")
 	errInvalidRepairThrottle                   = errors.New("invalid repair throttle in repair options")
-	errInvalidRepairMaxRetries                 = errors.New("invalid repair max retries in repair options")
 	errNoHostBlockMetadataSlicePool            = errors.New("no host block metadata pool in repair options")
+	errNoResultOptions                         = errors.New("no result options in repair options")
 	errInvalidDebugShadowComparisonsPercentage = errors.New("debug shadow comparisons percentage must be between 0 and 1")
 )
 
@@ -59,13 +51,10 @@ type options struct {
 	adminClient                      client.AdminClient
 	repairConsistencyLevel           topology.ReadConsistencyLevel
 	repairShardConcurrency           int
-	repairInterval                   time.Duration
-	repairTimeOffset                 time.Duration
-	repairTimeJitter                 time.Duration
 	repairCheckInterval              time.Duration
 	repairThrottle                   time.Duration
-	repairMaxRetries                 int
 	hostBlockMetadataSlicePool       HostBlockMetadataSlicePool
+	resultOptions                    result.Options
 	debugShadowComparisonsEnabled    bool
 	debugShadowComparisonsPercentage float64
 }
@@ -75,13 +64,10 @@ func NewOptions() Options {
 	return &options{
 		repairConsistencyLevel:           defaultRepairConsistencyLevel,
 		repairShardConcurrency:           defaultRepairShardConcurrency,
-		repairInterval:                   defaultRepairInterval,
-		repairTimeOffset:                 defaultRepairTimeOffset,
-		repairTimeJitter:                 defaultRepairTimeJitter,
 		repairCheckInterval:              defaultRepairCheckInterval,
 		repairThrottle:                   defaultRepairThrottle,
-		repairMaxRetries:                 defaultRepairMaxRetries,
 		hostBlockMetadataSlicePool:       NewHostBlockMetadataSlicePool(nil, 0),
+		resultOptions:                    result.NewOptions(),
 		debugShadowComparisonsEnabled:    defaultDebugShadowComparisonsEnabled,
 		debugShadowComparisonsPercentage: defaultDebugShadowComparisonsPercentage,
 	}
@@ -117,36 +103,6 @@ func (o *options) RepairShardConcurrency() int {
 	return o.repairShardConcurrency
 }
 
-func (o *options) SetRepairInterval(value time.Duration) Options {
-	opts := *o
-	opts.repairInterval = value
-	return &opts
-}
-
-func (o *options) RepairInterval() time.Duration {
-	return o.repairInterval
-}
-
-func (o *options) SetRepairTimeOffset(value time.Duration) Options {
-	opts := *o
-	opts.repairTimeOffset = value
-	return &opts
-}
-
-func (o *options) RepairTimeOffset() time.Duration {
-	return o.repairTimeOffset
-}
-
-func (o *options) SetRepairTimeJitter(value time.Duration) Options {
-	opts := *o
-	opts.repairTimeJitter = value
-	return &opts
-}
-
-func (o *options) RepairTimeJitter() time.Duration {
-	return o.repairTimeJitter
-}
-
 func (o *options) SetRepairCheckInterval(value time.Duration) Options {
 	opts := *o
 	opts.repairCheckInterval = value
@@ -167,16 +123,6 @@ func (o *options) RepairThrottle() time.Duration {
 	return o.repairThrottle
 }
 
-func (o *options) SetRepairMaxRetries(value int) Options {
-	opts := *o
-	opts.repairMaxRetries = value
-	return &opts
-}
-
-func (o *options) RepairMaxRetries() int {
-	return o.repairMaxRetries
-}
-
 func (o *options) SetHostBlockMetadataSlicePool(value HostBlockMetadataSlicePool) Options {
 	opts := *o
 	opts.hostBlockMetadataSlicePool = value
@@ -185,6 +131,16 @@ func (o *options) SetHostBlockMetadataSlicePool(value HostBlockMetadataSlicePool
 
 func (o *options) HostBlockMetadataSlicePool() HostBlockMetadataSlicePool {
 	return o.hostBlockMetadataSlicePool
+}
+
+func (o *options) SetResultOptions(value result.Options) Options {
+	opts := *o
+	opts.resultOptions = value
+	return &opts
+}
+
+func (o *options) ResultOptions() result.Options {
+	return o.resultOptions
 }
 
 func (o *options) SetDebugShadowComparisonsEnabled(value bool) Options {
@@ -211,32 +167,17 @@ func (o *options) Validate() error {
 	if o.adminClient == nil {
 		return errNoAdminClient
 	}
-	if o.repairInterval < 0 {
-		return errInvalidRepairInterval
-	}
-	if o.repairTimeOffset < 0 {
-		return errInvalidRepairTimeOffset
-	}
-	if o.repairTimeJitter < 0 {
-		return errInvalidRepairTimeJitter
-	}
-	if o.repairTimeOffset+o.repairTimeJitter > o.repairInterval {
-		return errTimeOffsetOrJitterTooBig
-	}
 	if o.repairCheckInterval < 0 {
 		return errInvalidRepairCheckInterval
-	}
-	if o.repairCheckInterval > o.repairInterval {
-		return errRepairCheckIntervalTooBig
 	}
 	if o.repairThrottle < 0 {
 		return errInvalidRepairThrottle
 	}
-	if o.repairMaxRetries < 0 {
-		return errInvalidRepairMaxRetries
-	}
 	if o.hostBlockMetadataSlicePool == nil {
 		return errNoHostBlockMetadataSlicePool
+	}
+	if o.resultOptions == nil {
+		return errNoResultOptions
 	}
 	if o.debugShadowComparisonsPercentage > 1.0 ||
 		o.debugShadowComparisonsPercentage < 0 {

--- a/src/dbnode/storage/repair/options.go
+++ b/src/dbnode/storage/repair/options.go
@@ -42,7 +42,7 @@ var (
 	errNoAdminClient                           = errors.New("no admin client in repair options")
 	errInvalidRepairCheckInterval              = errors.New("invalid repair check interval in repair options")
 	errInvalidRepairThrottle                   = errors.New("invalid repair throttle in repair options")
-	errNoHostBlockMetadataSlicePool            = errors.New("no host block metadata pool in repair options")
+	errNoReplicaMetadataSlicePool              = errors.New("no replica metadata pool in repair options")
 	errNoResultOptions                         = errors.New("no result options in repair options")
 	errInvalidDebugShadowComparisonsPercentage = errors.New("debug shadow comparisons percentage must be between 0 and 1")
 )
@@ -53,7 +53,7 @@ type options struct {
 	repairShardConcurrency           int
 	repairCheckInterval              time.Duration
 	repairThrottle                   time.Duration
-	hostBlockMetadataSlicePool       HostBlockMetadataSlicePool
+	replicaMetadataSlicePool         ReplicaMetadataSlicePool
 	resultOptions                    result.Options
 	debugShadowComparisonsEnabled    bool
 	debugShadowComparisonsPercentage float64
@@ -66,7 +66,7 @@ func NewOptions() Options {
 		repairShardConcurrency:           defaultRepairShardConcurrency,
 		repairCheckInterval:              defaultRepairCheckInterval,
 		repairThrottle:                   defaultRepairThrottle,
-		hostBlockMetadataSlicePool:       NewHostBlockMetadataSlicePool(nil, 0),
+		replicaMetadataSlicePool:         NewReplicaMetadataSlicePool(nil, 0),
 		resultOptions:                    result.NewOptions(),
 		debugShadowComparisonsEnabled:    defaultDebugShadowComparisonsEnabled,
 		debugShadowComparisonsPercentage: defaultDebugShadowComparisonsPercentage,
@@ -123,14 +123,14 @@ func (o *options) RepairThrottle() time.Duration {
 	return o.repairThrottle
 }
 
-func (o *options) SetHostBlockMetadataSlicePool(value HostBlockMetadataSlicePool) Options {
+func (o *options) SetReplicaMetadataSlicePool(value ReplicaMetadataSlicePool) Options {
 	opts := *o
-	opts.hostBlockMetadataSlicePool = value
+	opts.replicaMetadataSlicePool = value
 	return &opts
 }
 
-func (o *options) HostBlockMetadataSlicePool() HostBlockMetadataSlicePool {
-	return o.hostBlockMetadataSlicePool
+func (o *options) ReplicaMetadataSlicePool() ReplicaMetadataSlicePool {
+	return o.replicaMetadataSlicePool
 }
 
 func (o *options) SetResultOptions(value result.Options) Options {
@@ -173,8 +173,8 @@ func (o *options) Validate() error {
 	if o.repairThrottle < 0 {
 		return errInvalidRepairThrottle
 	}
-	if o.hostBlockMetadataSlicePool == nil {
-		return errNoHostBlockMetadataSlicePool
+	if o.replicaMetadataSlicePool == nil {
+		return errNoReplicaMetadataSlicePool
 	}
 	if o.resultOptions == nil {
 		return errNoResultOptions

--- a/src/dbnode/storage/repair/types.go
+++ b/src/dbnode/storage/repair/types.go
@@ -31,7 +31,7 @@ import (
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
-// ReplicaMetadataSlice captures a slice of hostBlockMetadata
+// ReplicaMetadataSlice captures a slice of block.ReplicaMetadata
 type ReplicaMetadataSlice interface {
 	// Add adds the metadata to the slice
 	Add(metadata block.ReplicaMetadata)
@@ -46,12 +46,12 @@ type ReplicaMetadataSlice interface {
 	Close()
 }
 
-// ReplicaMetadataSlicePool provides a pool for hostBlockMetadata slices
+// ReplicaMetadataSlicePool provides a pool for block.ReplicaMetadata slices
 type ReplicaMetadataSlicePool interface {
-	// Get returns a hostBlockMetadata slice
+	// Get returns a ReplicaMetadata slice
 	Get() ReplicaMetadataSlice
 
-	// Put puts a hostBlockMetadata slice back to pool
+	// Put puts a ReplicaMetadata slice back to pool
 	Put(m ReplicaMetadataSlice)
 }
 

--- a/src/dbnode/storage/repair/types.go
+++ b/src/dbnode/storage/repair/types.go
@@ -46,8 +46,8 @@ type HostBlockMetadataSlice interface {
 	Close()
 }
 
-// HostBlockMetadataSlicePool provides a pool for hostBlockMetadata slices
-type HostBlockMetadataSlicePool interface {
+// ReplicaMetadataSlicePool provides a pool for hostBlockMetadata slices
+type ReplicaMetadataSlicePool interface {
 	// Get returns a hostBlockMetadata slice
 	Get() HostBlockMetadataSlice
 
@@ -82,7 +82,7 @@ type ReplicaBlocksMetadata interface {
 	Add(block ReplicaBlockMetadata)
 
 	// GetOrAdd returns the blocks metadata for a start time, creating one if it doesn't exist
-	GetOrAdd(start time.Time, p HostBlockMetadataSlicePool) ReplicaBlockMetadata
+	GetOrAdd(start time.Time, p ReplicaMetadataSlicePool) ReplicaBlockMetadata
 
 	// Close performs cleanup
 	Close()
@@ -176,11 +176,11 @@ type Options interface {
 	// RepairThrottle returns the repair throttle.
 	RepairThrottle() time.Duration
 
-	// SetHostBlockMetadataSlicePool sets the hostBlockMetadataSlice pool.
-	SetHostBlockMetadataSlicePool(value HostBlockMetadataSlicePool) Options
+	// SetReplicaMetadataSlicePool sets the hostBlockMetadataSlice pool.
+	SetReplicaMetadataSlicePool(value ReplicaMetadataSlicePool) Options
 
-	// HostBlockMetadataSlicePool returns the hostBlockMetadataSlice pool.
-	HostBlockMetadataSlicePool() HostBlockMetadataSlicePool
+	// ReplicaMetadataSlicePool returns the hostBlockMetadataSlice pool.
+	ReplicaMetadataSlicePool() ReplicaMetadataSlicePool
 
 	// SetResultOptions sets the result options.
 	SetResultOptions(value result.Options) Options

--- a/src/dbnode/storage/repair/types.go
+++ b/src/dbnode/storage/repair/types.go
@@ -25,25 +25,19 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/storage/block"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/x/ident"
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
-// HostBlockMetadata contains a host along with block metadata from that host
-type HostBlockMetadata struct {
-	Host     topology.Host
-	Size     int64
-	Checksum *uint32
-}
-
 // HostBlockMetadataSlice captures a slice of hostBlockMetadata
 type HostBlockMetadataSlice interface {
 	// Add adds the metadata to the slice
-	Add(metadata HostBlockMetadata)
+	Add(metadata block.ReplicaMetadata)
 
 	// Metadata returns the metadata slice
-	Metadata() []HostBlockMetadata
+	Metadata() []block.ReplicaMetadata
 
 	// Reset resets the metadata slice
 	Reset()
@@ -67,10 +61,10 @@ type ReplicaBlockMetadata interface {
 	Start() time.Time
 
 	// Metadata returns the metadata from all hosts
-	Metadata() []HostBlockMetadata
+	Metadata() []block.ReplicaMetadata
 
 	// Add adds a metadata from a host
-	Add(metadata HostBlockMetadata)
+	Add(metadata block.ReplicaMetadata)
 
 	// Close performs cleanup
 	Close()
@@ -121,7 +115,7 @@ type ReplicaSeriesBlocksMetadata struct {
 // ReplicaMetadataComparer compares metadata from hosts in a replica set
 type ReplicaMetadataComparer interface {
 	// AddLocalMetadata adds metadata from local host
-	AddLocalMetadata(origin topology.Host, localIter block.FilteredBlocksMetadataIter) error
+	AddLocalMetadata(localIter block.FilteredBlocksMetadataIter) error
 
 	// AddPeerMetadata adds metadata from peers
 	AddPeerMetadata(peerIter client.PeerBlockMetadataIter) error
@@ -170,24 +164,6 @@ type Options interface {
 	// RepairShardConcurrency returns the concurrency in which to repair shards with.
 	RepairShardConcurrency() int
 
-	// SetRepairInterval sets the repair interval.
-	SetRepairInterval(value time.Duration) Options
-
-	// RepairInterval returns the repair interval.
-	RepairInterval() time.Duration
-
-	// SetRepairTimeOffset sets the repair time offset.
-	SetRepairTimeOffset(value time.Duration) Options
-
-	// RepairTimeOffset returns the repair time offset.
-	RepairTimeOffset() time.Duration
-
-	// SetRepairJitter sets the repair time jitter.
-	SetRepairTimeJitter(value time.Duration) Options
-
-	// RepairTimeJitter returns the repair time jitter.
-	RepairTimeJitter() time.Duration
-
 	// SetRepairCheckInterval sets the repair check interval.
 	SetRepairCheckInterval(value time.Duration) Options
 
@@ -200,17 +176,17 @@ type Options interface {
 	// RepairThrottle returns the repair throttle.
 	RepairThrottle() time.Duration
 
-	// SetRepairMaxRetries sets the max number of retries for a block start.
-	SetRepairMaxRetries(value int) Options
-
-	// MaxRepairRetries returns the max number of retries for a block start.
-	RepairMaxRetries() int
-
 	// SetHostBlockMetadataSlicePool sets the hostBlockMetadataSlice pool.
 	SetHostBlockMetadataSlicePool(value HostBlockMetadataSlicePool) Options
 
 	// HostBlockMetadataSlicePool returns the hostBlockMetadataSlice pool.
 	HostBlockMetadataSlicePool() HostBlockMetadataSlicePool
+
+	// SetResultOptions sets the result options.
+	SetResultOptions(value result.Options) Options
+
+	// ResultOptions returns the result options.
+	ResultOptions() result.Options
 
 	// SetDebugShadowComparisonsEnabled sets whether debug shadow comparisons are enabled.
 	SetDebugShadowComparisonsEnabled(value bool) Options

--- a/src/dbnode/storage/repair/types.go
+++ b/src/dbnode/storage/repair/types.go
@@ -31,8 +31,8 @@ import (
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
-// HostBlockMetadataSlice captures a slice of hostBlockMetadata
-type HostBlockMetadataSlice interface {
+// ReplicaMetadataSlice captures a slice of hostBlockMetadata
+type ReplicaMetadataSlice interface {
 	// Add adds the metadata to the slice
 	Add(metadata block.ReplicaMetadata)
 
@@ -49,10 +49,10 @@ type HostBlockMetadataSlice interface {
 // ReplicaMetadataSlicePool provides a pool for hostBlockMetadata slices
 type ReplicaMetadataSlicePool interface {
 	// Get returns a hostBlockMetadata slice
-	Get() HostBlockMetadataSlice
+	Get() ReplicaMetadataSlice
 
 	// Put puts a hostBlockMetadata slice back to pool
-	Put(m HostBlockMetadataSlice)
+	Put(m ReplicaMetadataSlice)
 }
 
 // ReplicaBlockMetadata captures the block metadata from hosts in a shard replica set
@@ -176,10 +176,10 @@ type Options interface {
 	// RepairThrottle returns the repair throttle.
 	RepairThrottle() time.Duration
 
-	// SetReplicaMetadataSlicePool sets the hostBlockMetadataSlice pool.
+	// SetReplicaMetadataSlicePool sets the replicaMetadataSlice pool.
 	SetReplicaMetadataSlicePool(value ReplicaMetadataSlicePool) Options
 
-	// ReplicaMetadataSlicePool returns the hostBlockMetadataSlice pool.
+	// ReplicaMetadataSlicePool returns the replicaMetadataSlice pool.
 	ReplicaMetadataSlicePool() ReplicaMetadataSlicePool
 
 	// SetResultOptions sets the result options.

--- a/src/dbnode/storage/repair_test.go
+++ b/src/dbnode/storage/repair_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/dbnode/storage/repair_test.go
+++ b/src/dbnode/storage/repair_test.go
@@ -21,7 +21,6 @@
 package storage
 
 import (
-	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -91,108 +90,6 @@ func TestDatabaseRepairerStartStop(t *testing.T) {
 	}
 }
 
-func TestDatabaseRepairerHaveNotReachedOffset(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	var (
-		repairInterval   = 2 * time.Hour
-		repairTimeOffset = time.Hour
-		now              = time.Now().Truncate(repairInterval).Add(30 * time.Minute)
-		repaired         = false
-		numIter          = 0
-	)
-
-	nowFn := func() time.Time { return now }
-	opts := DefaultTestOptions()
-	clockOpts := opts.ClockOptions().SetNowFn(nowFn)
-	repairOpts := testRepairOptions(ctrl).
-		SetRepairInterval(repairInterval).
-		SetRepairTimeOffset(repairTimeOffset)
-	opts = opts.
-		SetClockOptions(clockOpts.SetNowFn(nowFn)).
-		SetRepairOptions(repairOpts)
-	mockDatabase := NewMockdatabase(ctrl)
-	mockDatabase.EXPECT().Options().Return(opts).AnyTimes()
-
-	databaseRepairer, err := newDatabaseRepairer(mockDatabase, opts)
-	require.NoError(t, err)
-	repairer := databaseRepairer.(*dbRepairer)
-
-	repairer.repairFn = func() error {
-		repaired = true
-		return nil
-	}
-
-	repairer.sleepFn = func(_ time.Duration) {
-		if numIter == 0 {
-			repairer.closed = true
-		}
-		numIter++
-	}
-
-	repairer.run()
-	require.Equal(t, 1, numIter)
-	require.False(t, repaired)
-}
-
-func TestDatabaseRepairerOnlyOncePerInterval(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	var (
-		repairInterval   = 2 * time.Hour
-		repairTimeOffset = time.Hour
-		now              = time.Now().Truncate(repairInterval).Add(90 * time.Minute)
-		numRepairs       = 0
-		numIter          = 0
-	)
-
-	nowFn := func() time.Time {
-		switch numIter {
-		case 0:
-			return now
-		case 1:
-			return now.Add(time.Minute)
-		case 2:
-			return now.Add(time.Hour)
-		default:
-			return now.Add(2 * time.Hour)
-		}
-	}
-
-	opts := DefaultTestOptions()
-	clockOpts := opts.ClockOptions().SetNowFn(nowFn)
-	repairOpts := testRepairOptions(ctrl).
-		SetRepairInterval(repairInterval).
-		SetRepairTimeOffset(repairTimeOffset)
-	opts = opts.
-		SetClockOptions(clockOpts.SetNowFn(nowFn)).
-		SetRepairOptions(repairOpts)
-	mockDatabase := NewMockdatabase(ctrl)
-	mockDatabase.EXPECT().Options().Return(opts).AnyTimes()
-
-	databaseRepairer, err := newDatabaseRepairer(mockDatabase, opts)
-	require.NoError(t, err)
-	repairer := databaseRepairer.(*dbRepairer)
-
-	repairer.repairFn = func() error {
-		numRepairs++
-		return nil
-	}
-
-	repairer.sleepFn = func(_ time.Duration) {
-		if numIter == 3 {
-			repairer.closed = true
-		}
-		numIter++
-	}
-
-	repairer.run()
-	require.Equal(t, 4, numIter)
-	require.Equal(t, 2, numRepairs)
-}
-
 func TestDatabaseRepairerRepairNotBootstrapped(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -213,8 +110,7 @@ func TestDatabaseShardRepairerRepair(t *testing.T) {
 	defer ctrl.Finish()
 
 	session := client.NewMockAdminSession(ctrl)
-	session.EXPECT().Origin().Return(topology.NewHost("0", "addr0"))
-	session.EXPECT().Replicas().Return(2)
+	session.EXPECT().Origin().Return(topology.NewHost("0", "addr0")).AnyTimes()
 
 	mockClient := client.NewMockAdminClient(ctrl)
 	mockClient.EXPECT().DefaultAdminSession().Return(session, nil)
@@ -244,8 +140,8 @@ func TestDatabaseShardRepairerRepair(t *testing.T) {
 			IncludeLastRead:  false,
 		}
 
-		sizes     = []int64{1, 2, 3}
-		checksums = []uint32{4, 5, 6}
+		sizes     = []int64{1, 2, 3, 4}
+		checksums = []uint32{4, 5, 6, 7}
 		lastRead  = now.Add(-time.Minute)
 		shardID   = uint32(0)
 		shard     = NewMockdatabaseShard(ctrl)
@@ -276,27 +172,32 @@ func TestDatabaseShardRepairerRepair(t *testing.T) {
 		FetchBlocksMetadataV2(any, start, end, any, nonNilPageToken, fetchOpts).
 		Return(expectedResults, nil, nil)
 	shard.EXPECT().ID().Return(shardID).AnyTimes()
+	shard.EXPECT().Load(gomock.Any())
 
 	peerIter := client.NewMockPeerBlockMetadataIter(ctrl)
-	inputBlocks := []struct {
-		host topology.Host
-		meta block.Metadata
-	}{
-		{topology.NewHost("1", "addr1"), block.NewMetadata(ident.StringID("foo"), ident.Tags{},
-			now.Add(30*time.Minute), sizes[0], &checksums[0], lastRead)},
-		{topology.NewHost("1", "addr1"), block.NewMetadata(ident.StringID("foo"), ident.Tags{},
-			now.Add(time.Hour), sizes[0], &checksums[1], lastRead)},
-		{topology.NewHost("1", "addr1"), block.NewMetadata(ident.StringID("bar"), ident.Tags{},
-			now.Add(30*time.Minute), sizes[2], &checksums[2], lastRead)},
+	inputBlocks := []block.ReplicaMetadata{
+		{
+			Host:     topology.NewHost("1", "addr1"),
+			Metadata: block.NewMetadata(ident.StringID("foo"), ident.Tags{}, now.Add(30*time.Minute), sizes[0], &checksums[0], lastRead),
+		},
+		{
+			Host:     topology.NewHost("1", "addr1"),
+			Metadata: block.NewMetadata(ident.StringID("foo"), ident.Tags{}, now.Add(time.Hour), sizes[0], &checksums[1], lastRead),
+		},
+		{
+			Host: topology.NewHost("1", "addr1"),
+			// Mismatch checksum so should trigger repair of this series.
+			Metadata: block.NewMetadata(ident.StringID("bar"), ident.Tags{}, now.Add(30*time.Minute), sizes[2], &checksums[3], lastRead),
+		},
 	}
 
 	gomock.InOrder(
 		peerIter.EXPECT().Next().Return(true),
-		peerIter.EXPECT().Current().Return(inputBlocks[0].host, inputBlocks[0].meta),
+		peerIter.EXPECT().Current().Return(inputBlocks[0].Host, inputBlocks[0].Metadata),
 		peerIter.EXPECT().Next().Return(true),
-		peerIter.EXPECT().Current().Return(inputBlocks[1].host, inputBlocks[1].meta),
+		peerIter.EXPECT().Current().Return(inputBlocks[1].Host, inputBlocks[1].Metadata),
 		peerIter.EXPECT().Next().Return(true),
-		peerIter.EXPECT().Current().Return(inputBlocks[2].host, inputBlocks[2].meta),
+		peerIter.EXPECT().Current().Return(inputBlocks[2].Host, inputBlocks[2].Metadata),
 		peerIter.EXPECT().Next().Return(false),
 		peerIter.EXPECT().Err().Return(nil),
 	)
@@ -304,6 +205,21 @@ func TestDatabaseShardRepairerRepair(t *testing.T) {
 		FetchBlocksMetadataFromPeers(namespaceID, shardID, start, end,
 			rpOpts.RepairConsistencyLevel(), gomock.Any()).
 		Return(peerIter, nil)
+
+	peerBlocksIter := client.NewMockPeerBlocksIter(ctrl)
+	// TODO(rartoul): Add check for merging logic.
+	dbBlock := block.NewMockDatabaseBlock(ctrl)
+	dbBlock.EXPECT().StartTime().Return(inputBlocks[2].Metadata.Start).AnyTimes()
+	gomock.InOrder(
+		peerBlocksIter.EXPECT().Next().Return(true),
+		peerBlocksIter.EXPECT().Current().Return(inputBlocks[2].Host, inputBlocks[2].Metadata.ID, dbBlock),
+		peerBlocksIter.EXPECT().Next().Return(false),
+	)
+	nsMeta, err := namespace.NewMetadata(namespaceID, namespace.NewOptions())
+	require.NoError(t, err)
+	session.EXPECT().
+		FetchBlocksFromPeers(nsMeta, shardID, rpOpts.RepairConsistencyLevel(), inputBlocks[2:3], gomock.Any()).
+		Return(peerBlocksIter, nil)
 
 	var (
 		resNamespace ident.ID
@@ -319,166 +235,172 @@ func TestDatabaseShardRepairerRepair(t *testing.T) {
 		resDiff = diffRes
 	}
 
-	ctx := context.NewContext()
-	nsCtx := namespace.Context{ID: namespaceID}
-	repairer.Repair(ctx, nsCtx, repairTimeRange, shard)
+	var (
+		ctx   = context.NewContext()
+		nsCtx = namespace.Context{ID: namespaceID}
+	)
+	require.NoError(t, err)
+	repairer.Repair(ctx, nsCtx, nsMeta, repairTimeRange, shard)
+
 	require.Equal(t, namespaceID, resNamespace)
 	require.Equal(t, resShard, shard)
 	require.Equal(t, int64(2), resDiff.NumSeries)
 	require.Equal(t, int64(3), resDiff.NumBlocks)
-	require.Equal(t, 0, resDiff.ChecksumDifferences.Series().Len())
-	sizeDiffSeries := resDiff.SizeDifferences.Series()
-	require.Equal(t, 1, sizeDiffSeries.Len())
-	series, exists := sizeDiffSeries.Get(ident.StringID("foo"))
+
+	checksumDiffSeries := resDiff.ChecksumDifferences.Series()
+	require.Equal(t, 1, checksumDiffSeries.Len())
+	series, exists := checksumDiffSeries.Get(ident.StringID("bar"))
 	require.True(t, exists)
 	blocks := series.Metadata.Blocks()
 	require.Equal(t, 1, len(blocks))
-	block, exists := blocks[xtime.ToUnixNano(now.Add(time.Hour))]
+	currBlock, exists := blocks[xtime.ToUnixNano(now.Add(30*time.Minute))]
 	require.True(t, exists)
-	require.Equal(t, now.Add(time.Hour), block.Start())
-	expected := []repair.HostBlockMetadata{
-		{Host: topology.NewHost("0", "addr0"), Size: sizes[1], Checksum: &checksums[1]},
-		{Host: topology.NewHost("1", "addr1"), Size: sizes[0], Checksum: &checksums[1]},
+	require.Equal(t, now.Add(30*time.Minute), currBlock.Start())
+	expected := []block.ReplicaMetadata{
+		// Checksum difference for series "bar".
+		{Host: topology.NewHost("0", "addr0"), Metadata: block.NewMetadata(ident.StringID("bar"), ident.Tags{}, now.Add(30*time.Minute), sizes[2], &checksums[2], lastRead)},
+		{Host: topology.NewHost("1", "addr1"), Metadata: inputBlocks[2].Metadata},
 	}
-	require.Equal(t, expected, block.Metadata())
+	require.Equal(t, expected, currBlock.Metadata())
+
+	sizeDiffSeries := resDiff.SizeDifferences.Series()
+	require.Equal(t, 1, sizeDiffSeries.Len())
+	series, exists = sizeDiffSeries.Get(ident.StringID("foo"))
+	require.True(t, exists)
+	blocks = series.Metadata.Blocks()
+	require.Equal(t, 1, len(blocks))
+	currBlock, exists = blocks[xtime.ToUnixNano(now.Add(time.Hour))]
+	require.True(t, exists)
+	require.Equal(t, now.Add(time.Hour), currBlock.Start())
+	expected = []block.ReplicaMetadata{
+		// Size difference for series "foo".
+		{Host: topology.NewHost("0", "addr0"), Metadata: block.NewMetadata(ident.StringID("foo"), ident.Tags{}, now.Add(time.Hour), sizes[1], &checksums[1], lastRead)},
+		{Host: topology.NewHost("1", "addr1"), Metadata: inputBlocks[1].Metadata},
+	}
+	require.Equal(t, expected, currBlock.Metadata())
 }
 
-func TestRepairerRepairTimes(t *testing.T) {
+type expectedRepair struct {
+	repairRange xtime.Range
+}
+
+func TestDatabaseRepairPrioritizationLogic(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	now := time.Unix(188000, 0)
-	opts := DefaultTestOptions().SetRepairOptions(testRepairOptions(ctrl))
-	clockOpts := opts.ClockOptions()
-	opts = opts.SetClockOptions(clockOpts.SetNowFn(func() time.Time { return now }))
-	database := NewMockdatabase(ctrl)
-	database.EXPECT().Options().Return(opts).AnyTimes()
+	var (
+		rOpts = retention.NewOptions().
+			SetRetentionPeriod(retention.NewOptions().BlockSize() * 2)
+		nsOpts = namespace.NewOptions().
+			SetRetentionOptions(rOpts)
+		blockSize = rOpts.BlockSize()
 
-	inputTimes := []struct {
-		bs time.Time
-		rs repairState
+		// Set current time such that the previous block is flushable.
+		now = time.Now().Truncate(blockSize).Add(rOpts.BufferPast()).Add(time.Second)
+
+		flushTimeStart = retention.FlushTimeStart(rOpts, now)
+		flushTimeEnd   = retention.FlushTimeEnd(rOpts, now)
+
+		flushTimeStartNano = xtime.ToUnixNano(flushTimeStart)
+		flushTimeEndNano   = xtime.ToUnixNano(flushTimeEnd)
+	)
+	require.NoError(t, nsOpts.Validate())
+	// Ensure only two flushable blocks in retention to make test logic simpler.
+	require.Equal(t, blockSize, flushTimeEnd.Sub(flushTimeStart))
+
+	testCases := []struct {
+		title             string
+		repairState       repairStatesByNs
+		expectedNS1Repair expectedRepair
+		expectedNS2Repair expectedRepair
 	}{
-		{time.Unix(14400, 0), repairState{repairFailed, 2}},
-		{time.Unix(28800, 0), repairState{repairFailed, 3}},
-		{time.Unix(36000, 0), repairState{repairNotStarted, 0}},
-		{time.Unix(43200, 0), repairState{repairSuccess, 1}},
+		{
+			title:             "repairs most recent block if no repair state",
+			expectedNS1Repair: expectedRepair{xtime.Range{Start: flushTimeEnd, End: flushTimeEnd.Add(blockSize)}},
+			expectedNS2Repair: expectedRepair{xtime.Range{Start: flushTimeEnd, End: flushTimeEnd.Add(blockSize)}},
+		},
+		{
+			title: "repairs next unrepaired block in reverse order if some (but not all) blocks have been repaired",
+			repairState: repairStatesByNs{
+				"ns1": namespaceRepairStateByTime{
+					flushTimeEndNano: repairState{
+						Status:      repairSuccess,
+						LastAttempt: time.Time{},
+					},
+				},
+				"ns2": namespaceRepairStateByTime{
+					flushTimeEndNano: repairState{
+						Status:      repairSuccess,
+						LastAttempt: time.Time{},
+					},
+				},
+			},
+			expectedNS1Repair: expectedRepair{xtime.Range{Start: flushTimeStart, End: flushTimeStart.Add(blockSize)}},
+			expectedNS2Repair: expectedRepair{xtime.Range{Start: flushTimeStart, End: flushTimeStart.Add(blockSize)}},
+		},
+		{
+			title: "repairs least recently repaired block if all blocks have been repaired",
+			repairState: repairStatesByNs{
+				"ns1": namespaceRepairStateByTime{
+					flushTimeStartNano: repairState{
+						Status:      repairSuccess,
+						LastAttempt: time.Time{},
+					},
+					flushTimeEndNano: repairState{
+						Status:      repairSuccess,
+						LastAttempt: time.Time{}.Add(time.Second),
+					},
+				},
+				"ns2": namespaceRepairStateByTime{
+					flushTimeStartNano: repairState{
+						Status:      repairSuccess,
+						LastAttempt: time.Time{},
+					},
+					flushTimeEndNano: repairState{
+						Status:      repairSuccess,
+						LastAttempt: time.Time{}.Add(time.Second),
+					},
+				},
+			},
+			expectedNS1Repair: expectedRepair{xtime.Range{Start: flushTimeStart, End: flushTimeStart.Add(blockSize)}},
+			expectedNS2Repair: expectedRepair{xtime.Range{Start: flushTimeStart, End: flushTimeStart.Add(blockSize)}},
+		},
 	}
-	repairer, err := newDatabaseRepairer(database, opts)
-	require.NoError(t, err)
-	r := repairer.(*dbRepairer)
-	for _, input := range inputTimes {
-		r.repairStatesByNs.setRepairState(defaultTestNs1ID, input.bs, input.rs)
-	}
 
-	testNs, closer := newTestNamespace(t)
-	defer closer()
-	res := r.namespaceRepairTimeRanges(testNs)
-	expectedRanges := xtime.Ranges{}.
-		AddRange(xtime.Range{Start: time.Unix(14400, 0), End: time.Unix(28800, 0)}).
-		AddRange(xtime.Range{Start: time.Unix(36000, 0), End: time.Unix(43200, 0)}).
-		AddRange(xtime.Range{Start: time.Unix(50400, 0), End: time.Unix(187200, 0)})
-	require.Equal(t, expectedRanges, res)
-}
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			opts := DefaultTestOptions().SetRepairOptions(testRepairOptions(ctrl))
+			mockDatabase := NewMockdatabase(ctrl)
 
-func TestRepairerRepairWithTime(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	repairTimeRange := xtime.Range{Start: time.Unix(7200, 0), End: time.Unix(14400, 0)}
-	opts := DefaultTestOptions().SetRepairOptions(testRepairOptions(ctrl))
-	database := NewMockdatabase(ctrl)
-	database.EXPECT().Options().Return(opts).AnyTimes()
-
-	repairer, err := newDatabaseRepairer(database, opts)
-	require.NoError(t, err)
-	r := repairer.(*dbRepairer)
-
-	inputs := []struct {
-		name string
-		err  error
-	}{
-		{"foo", errors.New("some error")},
-		{"bar", errors.New("some other error")},
-		{"baz", nil},
-	}
-	for _, input := range inputs {
-		ns := NewMockdatabaseNamespace(ctrl)
-		id := ident.StringID(input.name)
-		ropts := retention.NewOptions()
-		nsOpts := namespace.NewMockOptions(ctrl)
-		nsOpts.EXPECT().RetentionOptions().Return(ropts)
-		ns.EXPECT().Options().Return(nsOpts)
-		ns.EXPECT().Repair(gomock.Not(nil), repairTimeRange).Return(input.err)
-		ns.EXPECT().ID().Return(id).AnyTimes()
-		err := r.repairNamespaceWithTimeRange(ns, repairTimeRange)
-		rs, ok := r.repairStatesByNs.repairStates(id, time.Unix(7200, 0))
-		require.True(t, ok)
-		if input.err == nil {
+			databaseRepairer, err := newDatabaseRepairer(mockDatabase, opts)
 			require.NoError(t, err)
-			require.Equal(t, repairState{Status: repairSuccess}, rs)
-		} else {
-			require.Error(t, err)
-			require.Equal(t, repairState{Status: repairFailed, NumFailures: 1}, rs)
-		}
+			repairer := databaseRepairer.(*dbRepairer)
+			repairer.nowFn = func() time.Time {
+				return now
+			}
+			if tc.repairState == nil {
+				tc.repairState = repairStatesByNs{}
+			}
+			repairer.repairStatesByNs = tc.repairState
+
+			mockDatabase.EXPECT().IsBootstrapped().Return(true)
+
+			var (
+				ns1        = NewMockdatabaseNamespace(ctrl)
+				ns2        = NewMockdatabaseNamespace(ctrl)
+				namespaces = []databaseNamespace{ns1, ns2}
+			)
+			ns1.EXPECT().Options().Return(nsOpts).AnyTimes()
+			ns2.EXPECT().Options().Return(nsOpts).AnyTimes()
+
+			ns1.EXPECT().ID().Return(ident.StringID("ns1")).AnyTimes()
+			ns2.EXPECT().ID().Return(ident.StringID("ns2")).AnyTimes()
+
+			ns1.EXPECT().Repair(gomock.Any(), tc.expectedNS1Repair.repairRange)
+			ns2.EXPECT().Repair(gomock.Any(), tc.expectedNS2Repair.repairRange)
+
+			mockDatabase.EXPECT().GetOwnedNamespaces().Return(namespaces, nil)
+			require.Nil(t, repairer.Repair())
+		})
 	}
-}
-
-func TestRepairerTimesMultipleNamespaces(t *testing.T) {
-	// tf2(i) returns the start time of the i_th 2 hour block since epoch
-	tf2 := func(i int) time.Time {
-		return time.Unix(int64(i*7200), 0)
-	}
-	// tf4(i) returns the start time of the i_th 4 hour block since epoch
-	tf4 := func(i int) time.Time {
-		return tf2(2 * i)
-	}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	now := time.Unix(188000, 0)
-	opts := DefaultTestOptions().SetRepairOptions(testRepairOptions(ctrl))
-	clockOpts := opts.ClockOptions()
-	opts = opts.SetClockOptions(clockOpts.SetNowFn(func() time.Time { return now }))
-	database := NewMockdatabase(ctrl)
-	database.EXPECT().Options().Return(opts).AnyTimes()
-
-	inputTimes := []struct {
-		ns ident.ID
-		bs time.Time
-		rs repairState
-	}{
-		{defaultTestNs1ID, tf2(2), repairState{repairFailed, 2}},
-		{defaultTestNs1ID, tf2(4), repairState{repairFailed, 3}},
-		{defaultTestNs1ID, tf2(5), repairState{repairNotStarted, 0}},
-		{defaultTestNs1ID, tf2(6), repairState{repairSuccess, 1}},
-		{defaultTestNs2ID, tf4(1), repairState{repairFailed, 1}},
-		{defaultTestNs2ID, tf4(2), repairState{repairFailed, 3}},
-		{defaultTestNs2ID, tf4(4), repairState{repairNotStarted, 0}},
-		{defaultTestNs2ID, tf4(6), repairState{repairSuccess, 1}},
-	}
-	repairer, err := newDatabaseRepairer(database, opts)
-	require.NoError(t, err)
-	r := repairer.(*dbRepairer)
-	for _, input := range inputTimes {
-		r.repairStatesByNs.setRepairState(input.ns, input.bs, input.rs)
-	}
-
-	testNs1, closer1 := newTestNamespaceWithIDOpts(t, defaultTestNs1ID, defaultTestNs1Opts)
-	defer closer1()
-	res := r.namespaceRepairTimeRanges(testNs1)
-	expectedRanges := xtime.Ranges{}.
-		AddRange(xtime.Range{Start: tf2(2), End: tf2(4)}).
-		AddRange(xtime.Range{Start: tf2(5), End: tf2(6)}).
-		AddRange(xtime.Range{Start: tf2(7), End: tf2(26)})
-	require.Equal(t, expectedRanges, res)
-
-	testNs2, closer2 := newTestNamespaceWithIDOpts(t, defaultTestNs2ID, defaultTestNs2Opts)
-	defer closer2()
-	res = r.namespaceRepairTimeRanges(testNs2)
-	expectedRanges = xtime.Ranges{}.
-		AddRange(xtime.Range{Start: tf4(1), End: tf4(2)}).
-		AddRange(xtime.Range{Start: tf4(3), End: tf4(6)}).
-		AddRange(xtime.Range{Start: tf4(7), End: tf4(13)})
-	require.Equal(t, expectedRanges, res)
 }

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -2421,10 +2421,11 @@ func (s *dbShard) CleanupCompactedFileSets() error {
 func (s *dbShard) Repair(
 	ctx context.Context,
 	nsCtx namespace.Context,
+	nsMeta namespace.Metadata,
 	tr xtime.Range,
 	repairer databaseShardRepairer,
 ) (repair.MetadataComparisonResult, error) {
-	return repairer.Repair(ctx, nsCtx, tr, s)
+	return repairer.Repair(ctx, nsCtx, nsMeta, tr, s)
 }
 
 func (s *dbShard) TagsFromSeriesID(seriesID ident.ID) (ident.Tags, bool, error) {

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -1820,18 +1820,18 @@ func (mr *MockdatabaseShardMockRecorder) CleanupCompactedFileSets() *gomock.Call
 }
 
 // Repair mocks base method
-func (m *MockdatabaseShard) Repair(ctx context.Context, nsCtx namespace.Context, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
+func (m *MockdatabaseShard) Repair(ctx context.Context, nsCtx namespace.Context, nsMeta namespace.Metadata, tr time0.Range, repairer databaseShardRepairer) (repair.MetadataComparisonResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Repair", ctx, nsCtx, tr, repairer)
+	ret := m.ctrl.Call(m, "Repair", ctx, nsCtx, nsMeta, tr, repairer)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Repair indicates an expected call of Repair
-func (mr *MockdatabaseShardMockRecorder) Repair(ctx, nsCtx, tr, repairer interface{}) *gomock.Call {
+func (mr *MockdatabaseShardMockRecorder) Repair(ctx, nsCtx, nsMeta, tr, repairer interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShard)(nil).Repair), ctx, nsCtx, tr, repairer)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShard)(nil).Repair), ctx, nsCtx, nsMeta, tr, repairer)
 }
 
 // TagsFromSeriesID mocks base method
@@ -2457,18 +2457,18 @@ func (mr *MockdatabaseShardRepairerMockRecorder) Options() *gomock.Call {
 }
 
 // Repair mocks base method
-func (m *MockdatabaseShardRepairer) Repair(ctx context.Context, nsCtx namespace.Context, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
+func (m *MockdatabaseShardRepairer) Repair(ctx context.Context, nsCtx namespace.Context, nsMeta namespace.Metadata, tr time0.Range, shard databaseShard) (repair.MetadataComparisonResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Repair", ctx, nsCtx, tr, shard)
+	ret := m.ctrl.Call(m, "Repair", ctx, nsCtx, nsMeta, tr, shard)
 	ret0, _ := ret[0].(repair.MetadataComparisonResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Repair indicates an expected call of Repair
-func (mr *MockdatabaseShardRepairerMockRecorder) Repair(ctx, nsCtx, tr, shard interface{}) *gomock.Call {
+func (mr *MockdatabaseShardRepairerMockRecorder) Repair(ctx, nsCtx, nsMeta, tr, shard interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShardRepairer)(nil).Repair), ctx, nsCtx, tr, shard)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Repair", reflect.TypeOf((*MockdatabaseShardRepairer)(nil).Repair), ctx, nsCtx, nsMeta, tr, shard)
 }
 
 // MockdatabaseRepairer is a mock of databaseRepairer interface

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -507,6 +507,7 @@ type databaseShard interface {
 	Repair(
 		ctx context.Context,
 		nsCtx namespace.Context,
+		nsMeta namespace.Metadata,
 		tr xtime.Range,
 		repairer databaseShardRepairer,
 	) (repair.MetadataComparisonResult, error)
@@ -680,6 +681,7 @@ type databaseShardRepairer interface {
 	Repair(
 		ctx context.Context,
 		nsCtx namespace.Context,
+		nsMeta namespace.Metadata,
 		tr xtime.Range,
 		shard databaseShard,
 	) (repair.MetadataComparisonResult, error)

--- a/src/dbnode/x/xio/block_reader.go
+++ b/src/dbnode/x/xio/block_reader.go
@@ -77,7 +77,7 @@ func FilterEmptyBlockReadersInPlaceSliceOfSlices(brSliceOfSlices [][]BlockReader
 	return filteredSliceOfSlices, nil
 }
 
-// FilterEmptyBlockReadersInPlace is the same as FilterEmptyBlockReadersInPlaceSliceOfSlices exception for
+// FilterEmptyBlockReadersInPlace is the same as FilterEmptyBlockReadersInPlaceSliceOfSlices except for
 // one dimensional slices instead of two.
 func FilterEmptyBlockReadersInPlace(brs []BlockReader) ([]BlockReader, error) {
 	filtered := brs[:0]

--- a/src/dbnode/x/xio/block_reader.go
+++ b/src/dbnode/x/xio/block_reader.go
@@ -57,13 +57,13 @@ func (b *BlockReader) ResetWindowed(segment ts.Segment, start time.Time, blockSi
 	b.BlockSize = blockSize
 }
 
-// FilterEmptyBlockReadersInPlaceSliceOfSlices filters a [][]BlockReader in place (I.E by modifying
+// FilterEmptyBlockReadersSliceOfSlicesInPlace filters a [][]BlockReader in place (I.E by modifying
 // the existing data structures instead of allocating new ones) such that the returned [][]BlockReader
 // will only contain BlockReaders that contain non-empty segments.
 //
 // Note that if any of the Block/Segment readers are backed by async implementations then this function
 // will not return until all of the async execution has completed.
-func FilterEmptyBlockReadersInPlaceSliceOfSlices(brSliceOfSlices [][]BlockReader) ([][]BlockReader, error) {
+func FilterEmptyBlockReadersSliceOfSlicesInPlace(brSliceOfSlices [][]BlockReader) ([][]BlockReader, error) {
 	filteredSliceOfSlices := brSliceOfSlices[:0]
 	for _, brSlice := range brSliceOfSlices {
 		filteredBrSlice, err := FilterEmptyBlockReadersInPlace(brSlice)
@@ -77,11 +77,14 @@ func FilterEmptyBlockReadersInPlaceSliceOfSlices(brSliceOfSlices [][]BlockReader
 	return filteredSliceOfSlices, nil
 }
 
-// FilterEmptyBlockReadersInPlace is the same as FilterEmptyBlockReadersInPlaceSliceOfSlices except for
+// FilterEmptyBlockReadersInPlace is the same as FilterEmptyBlockReadersSliceOfSlicesInPlace except for
 // one dimensional slices instead of two.
 func FilterEmptyBlockReadersInPlace(brs []BlockReader) ([]BlockReader, error) {
 	filtered := brs[:0]
 	for _, br := range brs {
+		if br.SegmentReader == nil {
+			continue
+		}
 		segment, err := br.Segment()
 		if err != nil {
 			return nil, err

--- a/src/x/time/range.go
+++ b/src/x/time/range.go
@@ -135,9 +135,9 @@ func (r Range) Subtract(other Range) []Range {
 	return res
 }
 
-// IterateForwards iterates through a time range by step size in the
+// IterateForward iterates through a time range by step size in the
 // forwards direction.
-func (r Range) IterateForwards(stepSize time.Duration, f func(t time.Time) bool) {
+func (r Range) IterateForward(stepSize time.Duration, f func(t time.Time) (shouldContinue bool)) {
 	for t := r.Start; t.Before(r.End); t = t.Add(stepSize) {
 		if shouldContinue := f(t); !shouldContinue {
 			break
@@ -145,9 +145,9 @@ func (r Range) IterateForwards(stepSize time.Duration, f func(t time.Time) bool)
 	}
 }
 
-// IterateBackwards iterates through a time range by step size in the
+// IterateBackward iterates through a time range by step size in the
 // backwards direction.
-func (r Range) IterateBackwards(stepSize time.Duration, f func(t time.Time) bool) {
+func (r Range) IterateBackward(stepSize time.Duration, f func(t time.Time) (shouldContinue bool)) {
 	for t := r.End; t.After(r.Start); t = t.Add(-stepSize) {
 		if shouldContinue := f(t); !shouldContinue {
 			break

--- a/src/x/time/range.go
+++ b/src/x/time/range.go
@@ -135,6 +135,26 @@ func (r Range) Subtract(other Range) []Range {
 	return res
 }
 
+// IterateForwards iterates through a time range by step size in the
+// forwards direction.
+func (r Range) IterateForwards(stepSize time.Duration, f func(t time.Time) bool) {
+	for t := r.Start; t.Before(r.End); t = t.Add(stepSize) {
+		if shouldContinue := f(t); !shouldContinue {
+			break
+		}
+	}
+}
+
+// IterateBackwards iterates through a time range by step size in the
+// backwards direction.
+func (r Range) IterateBackwards(stepSize time.Duration, f func(t time.Time) bool) {
+	for t := r.End; t.After(r.Start); t = t.Add(-stepSize) {
+		if shouldContinue := f(t); !shouldContinue {
+			break
+		}
+	}
+}
+
 // String returns the string representation of the range.
 func (r Range) String() string {
 	return fmt.Sprintf("(%v,%v)", r.Start, r.End)

--- a/src/x/time/range_test.go
+++ b/src/x/time/range_test.go
@@ -21,6 +21,7 @@
 package time
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -335,6 +336,84 @@ func TestRangeSubtract(t *testing.T) {
 	}
 	for i := 0; i < len(input); i++ {
 		require.Equal(t, expected[i], input[i].r1.Subtract(input[i].r2))
+	}
+}
+
+func TestRangeIterateForwards(t *testing.T) {
+	testCases := []struct {
+		r        Range
+		stepSize time.Duration
+		expected []time.Time
+	}{
+		{
+			r:        Range{Start: time.Time{}, End: time.Time{}},
+			stepSize: time.Second,
+		},
+		{
+			r:        Range{Start: time.Time{}, End: time.Time{}.Add(time.Millisecond)},
+			stepSize: time.Second,
+			expected: []time.Time{time.Time{}},
+		},
+		{
+			r:        Range{Start: time.Time{}, End: time.Time{}.Add(time.Second)},
+			stepSize: time.Second,
+			expected: []time.Time{time.Time{}},
+		},
+		{
+			r:        Range{Start: time.Time{}, End: time.Time{}.Add(3 * time.Second)},
+			stepSize: time.Second,
+			expected: []time.Time{time.Time{}, time.Time{}.Add(time.Second), time.Time{}.Add(2 * time.Second)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s", tc.r.String()), func(t *testing.T) {
+			var actual []time.Time
+			tc.r.IterateForwards(tc.stepSize, func(currStep time.Time) bool {
+				actual = append(actual, currStep)
+				return true
+			})
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestRangeIterateBackwards(t *testing.T) {
+	testCases := []struct {
+		r        Range
+		stepSize time.Duration
+		expected []time.Time
+	}{
+		{
+			r:        Range{Start: time.Time{}, End: time.Time{}},
+			stepSize: time.Second,
+		},
+		{
+			r:        Range{Start: time.Time{}, End: time.Time{}.Add(time.Millisecond)},
+			stepSize: time.Second,
+			expected: []time.Time{time.Time{}.Add(time.Millisecond)},
+		},
+		{
+			r:        Range{Start: time.Time{}, End: time.Time{}.Add(time.Second)},
+			stepSize: time.Second,
+			expected: []time.Time{time.Time{}.Add(time.Second)},
+		},
+		{
+			r:        Range{Start: time.Time{}, End: time.Time{}.Add(3 * time.Second)},
+			stepSize: time.Second,
+			expected: []time.Time{time.Time{}.Add(3 * time.Second), time.Time{}.Add(2 * time.Second), time.Time{}.Add(time.Second)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s", tc.r.String()), func(t *testing.T) {
+			var actual []time.Time
+			tc.r.IterateBackwards(tc.stepSize, func(currStep time.Time) bool {
+				actual = append(actual, currStep)
+				return true
+			})
+			require.Equal(t, tc.expected, actual)
+		})
 	}
 }
 

--- a/src/x/time/range_test.go
+++ b/src/x/time/range_test.go
@@ -339,7 +339,7 @@ func TestRangeSubtract(t *testing.T) {
 	}
 }
 
-func TestRangeIterateForwards(t *testing.T) {
+func TestRangeIterateForward(t *testing.T) {
 	testCases := []struct {
 		r        Range
 		stepSize time.Duration
@@ -369,7 +369,7 @@ func TestRangeIterateForwards(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s", tc.r.String()), func(t *testing.T) {
 			var actual []time.Time
-			tc.r.IterateForwards(tc.stepSize, func(currStep time.Time) bool {
+			tc.r.IterateForward(tc.stepSize, func(currStep time.Time) bool {
 				actual = append(actual, currStep)
 				return true
 			})
@@ -378,7 +378,7 @@ func TestRangeIterateForwards(t *testing.T) {
 	}
 }
 
-func TestRangeIterateBackwards(t *testing.T) {
+func TestRangeIterateBackward(t *testing.T) {
 	testCases := []struct {
 		r        Range
 		stepSize time.Duration
@@ -408,7 +408,7 @@ func TestRangeIterateBackwards(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s", tc.r.String()), func(t *testing.T) {
 			var actual []time.Time
-			tc.r.IterateBackwards(tc.stepSize, func(currStep time.Time) bool {
+			tc.r.IterateBackward(tc.stepSize, func(currStep time.Time) bool {
 				actual = append(actual, currStep)
 				return true
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
This P.R changes the background repairs feature from simply emitting metrics/logs about data mismatches between node to actually repairing the mismatches.

It also re-writes the repair scheduling logic to a "repairing all the time" model that is more congruent with the fact that M3DB now supports out of order writes.

Includes a combination of unit tests, several integration tests, and a docker integration test.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
No.

**Does this PR require updating code package or user-facing documentation?**:
No.
