### PR TITLE
[aggregator] Make YAML serialization roundtrip for config types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.11.1 (pending)
+
+## Features
+
+- **m3aggregator:** Make YAML serialization roundtrip for config related types (#1864)
+
 # 0.11.0
 
 ## Migration Disclaimer

--- a/src/metrics/aggregation/id.go
+++ b/src/metrics/aggregation/id.go
@@ -118,6 +118,14 @@ func (id *ID) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (id ID) MarshalYAML() (interface{}, error) {
+	aggTypes, err := id.Types()
+	if err != nil {
+		return nil, fmt.Errorf("invalid aggregation id %v: %v", id, err)
+	}
+	return aggTypes, nil
+}
+
 // UnmarshalYAML unmarshals YAML-encoded data into an ID.
 func (id *ID) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var aggTypes Types

--- a/src/metrics/aggregation/type.go
+++ b/src/metrics/aggregation/type.go
@@ -22,7 +22,6 @@ package aggregation
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/m3db/m3/src/metrics/generated/proto/aggregationpb"
@@ -200,37 +199,17 @@ func (a Type) Proto() (aggregationpb.AggregationType, error) {
 	return s, nil
 }
 
-// MarshalJSON returns the JSON encoding of an aggregation type.
-func (a Type) MarshalJSON() ([]byte, error) {
+// MarshalText returns the text encoding of an aggregation type.
+func (a Type) MarshalText() ([]byte, error) {
 	if !a.IsValid() {
 		return nil, fmt.Errorf("invalid aggregation type %s", a.String())
 	}
-	marshalled := strconv.Quote(a.String())
-	return []byte(marshalled), nil
+	return []byte(a.String()), nil
 }
 
-// UnmarshalJSON unmarshals JSON-encoded data into an aggregation type.
-func (a *Type) UnmarshalJSON(data []byte) error {
+// UnmarshalText unmarshals text-encoded data into an aggregation type.
+func (a *Type) UnmarshalText(data []byte) error {
 	str := string(data)
-	unquoted, err := strconv.Unquote(str)
-	if err != nil {
-		return err
-	}
-	parsed, err := ParseType(unquoted)
-	if err != nil {
-		return err
-	}
-	*a = parsed
-	return nil
-}
-
-// UnmarshalYAML unmarshals aggregation type from a string.
-func (a *Type) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	if err := unmarshal(&str); err != nil {
-		return err
-	}
-
 	parsed, err := ParseType(str)
 	if err != nil {
 		return err

--- a/src/metrics/pipeline/type.go
+++ b/src/metrics/pipeline/type.go
@@ -95,29 +95,14 @@ func (op AggregationOp) String() string {
 	return op.Type.String()
 }
 
-// MarshalJSON returns the JSON encoding of an aggregation operation.
-func (op AggregationOp) MarshalJSON() ([]byte, error) {
-	return json.Marshal(op.Type)
+// MarshalText returns the text encoding of an aggregation operation.
+func (op AggregationOp) MarshalText() ([]byte, error) {
+	return op.Type.MarshalText()
 }
 
-// UnmarshalJSON unmarshals JSON-encoded data into an aggregation operation.
-func (op *AggregationOp) UnmarshalJSON(data []byte) error {
-	var t aggregation.Type
-	if err := json.Unmarshal(data, &t); err != nil {
-		return err
-	}
-	op.Type = t
-	return nil
-}
-
-// UnmarshalYAML unmarshals YAML-encoded data into an aggregation operation.
-func (op *AggregationOp) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var t aggregation.Type
-	if err := unmarshal(&t); err != nil {
-		return err
-	}
-	op.Type = t
-	return nil
+// UnmarshalText unmarshals text-encoded data into an aggregation operation.
+func (op *AggregationOp) UnmarshalText(data []byte) error {
+	return op.Type.UnmarshalText(data)
 }
 
 // TransformationOp is a transformation operation.
@@ -171,29 +156,14 @@ func (op *TransformationOp) FromProto(pb *pipelinepb.TransformationOp) error {
 	return op.Type.FromProto(pb.Type)
 }
 
-// MarshalJSON returns the JSON encoding of a transformation operation.
-func (op TransformationOp) MarshalJSON() ([]byte, error) {
-	return json.Marshal(op.Type)
+// UnmarshalText extracts this type from its textual representation.
+func (op *TransformationOp) UnmarshalText(text []byte) error {
+	return op.Type.UnmarshalText(text)
 }
 
-// UnmarshalJSON unmarshals JSON-encoded data into a transformation operation.
-func (op *TransformationOp) UnmarshalJSON(data []byte) error {
-	var t transformation.Type
-	if err := json.Unmarshal(data, &t); err != nil {
-		return err
-	}
-	op.Type = t
-	return nil
-}
-
-// UnmarshalYAML unmarshals YAML-encoded data into a transformation operation.
-func (op *TransformationOp) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var t transformation.Type
-	if err := unmarshal(&t); err != nil {
-		return err
-	}
-	op.Type = t
-	return nil
+// MarshalText serializes this type to its textual representation.
+func (op TransformationOp) MarshalText() (text []byte, err error) {
+	return op.Type.MarshalText()
 }
 
 // RollupOp is a rollup operation.
@@ -325,6 +295,11 @@ func (op *RollupOp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	*op = converted.RollupOp()
 	return nil
+}
+
+// MarshalYAML returns the YAML representation of this type.
+func (op RollupOp) MarshalYAML() (interface{}, error) {
+	return newRollupMarshaler(op), nil
 }
 
 type rollupMarshaler struct {
@@ -469,6 +444,11 @@ func (u *OpUnion) UnmarshalJSON(data []byte) error {
 	}
 	*u = union
 	return nil
+}
+
+// MarshalJSON returns the JSON encoding of an operation union.
+func (u OpUnion) MarshalYAML() (interface{}, error) {
+	return newUnionMarshaler(u)
 }
 
 // UnmarshalYAML unmarshals YAML-encoded data into an operation union.
@@ -633,4 +613,9 @@ func (p *Pipeline) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	p.operations = operations
 	return nil
+}
+
+// MarshalYAML returns the YAML representation.
+func (p Pipeline) MarshalYAML() (interface{}, error) {
+	return p.operations, nil
 }

--- a/src/metrics/policy/policy.go
+++ b/src/metrics/policy/policy.go
@@ -22,7 +22,6 @@ package policy
 
 import (
 	"errors"
-	"strconv"
 	"strings"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
@@ -105,35 +104,14 @@ func (p Policy) String() string {
 	return p.StoragePolicy.String() + policyAggregationTypeSeparator + p.AggregationID.String()
 }
 
-// MarshalJSON returns the JSON encoding of a policy.
-func (p Policy) MarshalJSON() ([]byte, error) {
-	marshalled := strconv.Quote(p.String())
-	return []byte(marshalled), nil
+// MarshalText returns the text encoding of a policy.
+func (p Policy) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
 }
 
-// UnmarshalJSON unmarshals JSON-encoded data into a policy.
-func (p *Policy) UnmarshalJSON(data []byte) error {
-	str := string(data)
-	unquoted, err := strconv.Unquote(str)
-	if err != nil {
-		return err
-	}
-	parsed, err := ParsePolicy(unquoted)
-	if err != nil {
-		return err
-	}
-	*p = parsed
-	return nil
-}
-
-// UnmarshalYAML unmarshals a policy value from a string.
-func (p *Policy) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	if err := unmarshal(&str); err != nil {
-		return err
-	}
-
-	parsed, err := ParsePolicy(str)
+// UnmarshalText unmarshals text-encoded data into a policy.
+func (p *Policy) UnmarshalText(data []byte) error {
+	parsed, err := ParsePolicy(string(data))
 	if err != nil {
 		return err
 	}
@@ -204,13 +182,10 @@ func (p Policies) Equals(other Policies) bool {
 	return true
 }
 
-// UnmarshalYAML unmarshals a drop policy value from a string.
-func (p *DropPolicy) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	if err := unmarshal(&str); err != nil {
-		return err
-	}
-
+// UnmarshalText unmarshals a drop policy value from a string.
+// Empty string defaults to DefaultDropPolicy.
+func (p *DropPolicy) UnmarshalText(data []byte) error {
+	str := string(data)
 	// Allow default string value (not specified) to mean default
 	if str == "" {
 		*p = DefaultDropPolicy
@@ -224,6 +199,11 @@ func (p *DropPolicy) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	*p = parsed
 	return nil
+}
+
+// MarshalText marshals a drop policy to a string.
+func (p DropPolicy) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
 }
 
 // ParseDropPolicy parses a drop policy.

--- a/src/metrics/policy/storage_policy.go
+++ b/src/metrics/policy/storage_policy.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -124,33 +123,14 @@ func (p *StoragePolicy) FromProto(pb policypb.StoragePolicy) error {
 	return nil
 }
 
-// MarshalJSON returns the JSON encoding of a storage policy.
-func (p StoragePolicy) MarshalJSON() ([]byte, error) {
-	marshalled := strconv.Quote(p.String())
-	return []byte(marshalled), nil
+// MarshalText returns the text encoding of a storage policy.
+func (p StoragePolicy) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
 }
 
-// UnmarshalJSON unmarshals JSON-encoded data into a storage policy.
-func (p *StoragePolicy) UnmarshalJSON(data []byte) error {
+// UnmarshalText unmarshals text-encoded data into a storage policy.
+func (p *StoragePolicy) UnmarshalText(data []byte) error {
 	str := string(data)
-	unquoted, err := strconv.Unquote(str)
-	if err != nil {
-		return err
-	}
-	parsed, err := ParseStoragePolicy(unquoted)
-	if err != nil {
-		return err
-	}
-	*p = parsed
-	return nil
-}
-
-// UnmarshalYAML unmarshals a storage policy value from a string.
-func (p *StoragePolicy) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	if err := unmarshal(&str); err != nil {
-		return err
-	}
 	parsed, err := ParseStoragePolicy(str)
 	if err != nil {
 		return err

--- a/src/metrics/transformation/type.go
+++ b/src/metrics/transformation/type.go
@@ -22,7 +22,6 @@ package transformation
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/m3db/m3/src/metrics/generated/proto/transformationpb"
 )
@@ -120,43 +119,22 @@ func (t *Type) FromProto(pb transformationpb.TransformationType) error {
 	return nil
 }
 
-// MarshalJSON returns the JSON encoding of a transformation type.
-func (t Type) MarshalJSON() ([]byte, error) {
+// UnmarshalText extracts this type from the textual representation
+func (t *Type) UnmarshalText(text []byte) error {
+	parsed, err := ParseType(string(text))
+	if err != nil {
+		return err
+	}
+	*t = parsed
+	return nil
+}
+
+// MarshalText serializes this type to its textual representation.
+func (t Type) MarshalText() (text []byte, err error) {
 	if !t.IsValid() {
 		return nil, fmt.Errorf("invalid aggregation type %s", t.String())
 	}
-	marshalled := strconv.Quote(t.String())
-	return []byte(marshalled), nil
-}
-
-// UnmarshalJSON unmarshals JSON-encoded data into a transformation type.
-func (t *Type) UnmarshalJSON(data []byte) error {
-	str := string(data)
-	unquoted, err := strconv.Unquote(str)
-	if err != nil {
-		return err
-	}
-	parsed, err := ParseType(unquoted)
-	if err != nil {
-		return err
-	}
-	*t = parsed
-	return nil
-}
-
-// UnmarshalYAML unmarshals YAML-encoded data into a transformation type.
-func (t *Type) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	if err := unmarshal(&str); err != nil {
-		return err
-	}
-
-	parsed, err := ParseType(str)
-	if err != nil {
-		return err
-	}
-	*t = parsed
-	return nil
+	return []byte(t.String()), nil
 }
 
 // ParseType parses a transformation type.

--- a/src/x/test/testmarshal/marshal.go
+++ b/src/x/test/testmarshal/marshal.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package testmarshal provides some assertions around marshalling/unmarshalling
+// (serialization/deserialization) behavior for types. It is intended to reduce
+// boilerplate in tests of the form:
+//
+// func TestMyTypeUnmarshals(t *testing.T) {
+// 		type MyType struct{}
+// 		var mt MyType
+// 		require.NoError(t, json.Unmarshal([]byte("{}"), &mt))
+// 		assert.Equal(t, MyType{}, mt)
+// }
+//
+// with assertion calls:
+// func TestMyTypeUnmarshals(t *testing.T) {
+// 		type MyType struct{}
+//      testmarshal.AssertUnmarshals(t, testmarshal.JSONMarshaler, MyType{}, []byte("{}"))
+// }
+package testmarshal
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+// Marshaler represents a serialization protocol, e.g. JSON or YAML
+type Marshaler interface {
+	// Marshal converts a Go type into bytes
+	Marshal(interface{}) ([]byte, error)
+
+	// Unmarshal converts bytes into a Go type.
+	Unmarshal([]byte, interface{}) error
+
+	// ID identifies the protocol, mostly for use in test naming.
+	ID() string
+}
+
+var (
+	// JSONMarshaler uses the encoding/json package to marshal types
+	JSONMarshaler Marshaler = simpleMarshaler{
+		id:        "json",
+		marshal:   json.Marshal,
+		unmarshal: json.Unmarshal,
+	}
+
+	// YAMLMarshaler uses the gopkg.in/yaml.v2 package to marshal types
+	YAMLMarshaler Marshaler = simpleMarshaler{
+		id:        "yaml",
+		marshal:   yaml.Marshal,
+		unmarshal: yaml.Unmarshal,
+	}
+
+	// TextMarshaler marshals types which implement both encoding.TextMarshaler
+	// and encoding.TextUnmarshaler
+	TextMarshaler Marshaler = simpleMarshaler{
+		id: "text",
+		marshal: func(i interface{}) ([]byte, error) {
+			switch m := i.(type) {
+			case encoding.TextMarshaler:
+				return m.MarshalText()
+			default:
+				return nil, fmt.Errorf("not an encoding.TextMarshaler")
+			}
+		},
+		unmarshal: func(bytes []byte, i interface{}) error {
+			switch m := i.(type) {
+			case encoding.TextUnmarshaler:
+				return m.UnmarshalText(bytes)
+			default:
+				return fmt.Errorf("not an encoding.TextUnmarshaler")
+			}
+		},
+	}
+)
+
+type simpleMarshaler struct {
+	marshal   func(interface{}) ([]byte, error)
+	unmarshal func([]byte, interface{}) error
+	id        string
+}
+
+func (sm simpleMarshaler) Marshal(v interface{}) ([]byte, error) {
+	return sm.marshal(v)
+}
+
+func (sm simpleMarshaler) Unmarshal(d []byte, v interface{}) error {
+	return sm.unmarshal(d, v)
+}
+
+func (sm simpleMarshaler) ID() string {
+	return sm.id
+}
+
+// AssertMarshalingRoundtrips checks that the marshaller "roundtrips" example
+// i.e.:
+// marshaler.Unmarshal(marshaler.Marshal(example)) == example.
+//
+// It is intended to replace tests of the form:
+//
+// func TestMyTypeRoundtrips(t *testing.T) {
+// 	type MyType struct{}
+// 	mt := MyType{}
+// 	d, err := json.Marshal(mt)
+// 	require.NoError(t, err)
+//
+// 	var revived MyType
+// 	require.NoError(t, json.Unmarshal(d, &revived))
+// 	assert.Equal(t, mt, revived)
+// }
+//
+// with:
+
+// func TestMyTypeRoundtrips(t *testing.T) {
+// 	type MyType struct{}
+// 	testmarshal.AssertMarshalingRoundtrips(t, testmarshal.JSONMarshaler, MyType{})
+// }
+func AssertMarshalingRoundtrips(t *testing.T, marshaller Marshaler, example interface{}) bool {
+	d, err := marshaller.Marshal(example)
+	if !assert.NoError(t, err) {
+		return false
+	}
+	reconstituted, err := unmarshalIntoNewValueOfType(marshaller, example, d)
+	if !assert.NoError(t, err) {
+		return false
+	}
+
+	return assert.Equal(t, example, reconstituted)
+}
+
+// AssertUnmarshals checks that the given data successfully unmarshals into a
+// value which assert.Equal's expected.
+// It is intended to replace tests of the form:
+//
+// func TestMyTypeUnmarshals(t *testing.T) {
+// 	type MyType struct{}
+// 	var mt MyType
+// 	require.NoError(t, json.Unmarshal([]byte("{}"), &mt))
+// 	assert.Equal(t, MyType{}, mt)
+// }
+//
+// with:
+
+// func TestMyTypeUnmarshals(t *testing.T) {
+//      type MyType struct{}
+//      testmarshal.AssertUnmarshals(t, testmarshal.JSONMarshaler, MyType{}, []byte("{}"))
+// }
+
+func AssertUnmarshals(t *testing.T, marshaller Marshaler, expected interface{}, data []byte) bool {
+	unmarshalled, err := unmarshalIntoNewValueOfType(marshaller, expected, data)
+	if !assert.NoError(t, err) {
+		return false
+	}
+
+	return assert.Equal(t, expected, unmarshalled)
+}
+
+// AssertMarshals checks that the given value marshals into data equal
+// to expectedData.
+//  It is intended to replace tests of the form:
+//
+// func TestMyTypeMarshals(t *testing.T) {
+// 	type MyType struct{}
+//    mt := MyType{}
+//    d, err := json.Marshal(mt)
+//    require.NoError(t, err)
+//    assert.Equal(t, d, []byte("{}"))
+// }
+//
+// with:
+//
+// func TestMyTypeUnmarshals(t *testing.T) {
+// 	 type MyType struct{}
+// 	 testmarshal.AssertMarshals(t, testmarshal.JSONMarshaler, MyType{}, []byte("{}"))
+// }
+func AssertMarshals(t *testing.T, marshaller Marshaler, toMarshal interface{}, expectedData []byte) bool {
+	marshalled, err := marshaller.Marshal(toMarshal)
+	if !assert.NoError(t, err) {
+		return false
+	}
+
+	return assert.Equal(t, string(expectedData), string(marshalled))
+}
+
+// unmarshalIntoNewValueOfType is a helper to unmarshal a new instance of the same type as value
+// from data.
+func unmarshalIntoNewValueOfType(marshaller Marshaler, value interface{}, data []byte) (interface{}, error) {
+	ptrToUnmarshalTarget := reflect.New(reflect.ValueOf(value).Type())
+	unmarshalTarget := ptrToUnmarshalTarget.Elem()
+	if err := marshaller.Unmarshal(data, ptrToUnmarshalTarget.Interface()); err != nil {
+		return nil, err
+	}
+	return unmarshalTarget.Interface(), nil
+}
+
+// Require wraps an Assert call and turns it into a require.* call (fails if
+// the assert fails).
+func Require(t *testing.T, b bool) {
+	if !b {
+		t.FailNow()
+	}
+}
+
+// TestMarshalersRoundtrip is a helper which runs a test for each provided marshaller
+// on each example in examples (a slice of any type). The test checks that the
+// marshaler "roundtrips" for each example, i.e.:
+// marshaler.Unmarshal(marshaler.Marshal(example)) == example.
+func TestMarshalersRoundtrip(t *testing.T, examples interface{}, marshallers []Marshaler) {
+	for _, m := range marshallers {
+		t.Run(m.ID(), func(t *testing.T) {
+			v := reflect.ValueOf(examples)
+			if v.Type().Kind() != reflect.Slice {
+				t.Fatalf("examples must be a slice; got %+v", examples)
+			}
+
+			// taken from https://stackoverflow.com/questions/14025833/range-over-interface-which-stores-a-slice
+			for i := 0; i < v.Len(); i++ {
+				example := v.Index(i).Interface()
+				Require(t, AssertMarshalingRoundtrips(t, m, example))
+			}
+		})
+
+	}
+}

--- a/src/x/test/testmarshal/marshal_test.go
+++ b/src/x/test/testmarshal/marshal_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testmarshal
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMarshallingAssertMethods(t *testing.T) {
+	cases := []struct {
+		Name         string
+		Serialized   map[string][]byte
+		Deserialized interface{}
+	}{{
+		Name: "primitive_type",
+		Serialized: map[string][]byte{
+			"json": []byte("1"),
+			"yaml": []byte("1\n"),
+		},
+		Deserialized: 1,
+	},
+	}
+
+	marshallers := []struct {
+		Name       string
+		Marshaller Marshaler
+	}{{
+		Name:       "json",
+		Marshaller: JSONMarshaler,
+	}, {
+		Name:       "yaml",
+		Marshaller: YAMLMarshaler,
+	}}
+
+	for _, tc := range cases {
+		for _, marshaller := range marshallers {
+			serialized, ok := tc.Serialized[marshaller.Name]
+			if !ok {
+				// skip this marshaller
+				continue
+			}
+
+			t.Run(fmt.Sprintf("%s/%s", tc.Name, marshaller.Name), func(t *testing.T) {
+				AssertMarshals(t, marshaller.Marshaller, tc.Deserialized, serialized)
+				AssertUnmarshals(t, marshaller.Marshaller, tc.Deserialized, serialized)
+				AssertMarshalingRoundtrips(t, marshaller.Marshaller, serialized)
+			})
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Many of our types (24 in my last count) implement `UnmarshalYAML` but not `MarshalYAML`. This means (in most cases) that the types don't "roundtrip" in YAML--you can't serialize to YAML and get the same object back. 

This PR fixes that issue, adding MarshalYAML methods where needed, and switching to the use of (Un)MarshalText where possible. Both YAML and JSON respect the [TextMarshaler](https://golang.org/pkg/encoding/#TextMarshaler) interfaces; for types which we marshal as their string representation, e.g. `StoragePolicy`, this saves a bit of boilerplate. 

N.B.: I haven't fixed this issue for *every* type it affects; unfortunately, the fix + testing is pretty manual, despite the helpers. I can file a separate issue for that if desired.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**: 
NONE

