### PR TITLE
[ci] Update ci to get glide collapsed in buildkit

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -126,3 +126,4 @@ steps:
           formatter:
             type: details
           context: test-summary
+    <<: *common

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,6 +45,7 @@ steps:
         formatter:
           type: details
         context: test-summary
+    <<: *common
   - name: "Big Unit %n"
     command: make clean install-vendor test-ci-big-unit
     parallelism: 2

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,7 +120,7 @@ steps:
             - label: big-unit
               artifact_path: test_big_junit.xml
               type: junit
-            - label: unit
+            - label: integration
               artifact_path: "*test_integration_junit.xml"
               type: junit
           formatter:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,6 @@ steps:
           import: github.com/m3db/m3
     <<: *common
   - name: "Unit %n"
-    label: "unit"
     command: make clean install-vendor test-ci-unit
     parallelism: 4
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,10 @@ common: &common
     # Allow manual retries.
     manual: true
 
+test-artifacts: &test_artifacts
+  artifact_paths:
+    - "test_junit.xml"
+
 steps:
   - name: "Codegen"
     command: make clean install-vendor test-all-gen
@@ -20,6 +24,7 @@ steps:
           import: github.com/m3db/m3
     <<: *common
   - name: "Unit %n"
+    label: "unit"
     command: make clean install-vendor test-ci-unit
     parallelism: 4
     plugins:
@@ -27,6 +32,19 @@ steps:
         run: app
         workdir: /go/src/github.com/m3db/m3
     <<: *common
+    <<: *test_artifacts
+  - wait: ~
+    continue_on_failure: true
+  - label: annotate
+    plugins:
+      - bugcrowd/test-summary#v1.9.1:
+        inputs:
+          - label: unit
+            artifact_path: test_junit.xml
+            type: junit
+        formatter:
+          type: details
+        context: test-summary
   - name: "Big Unit %n"
     command: make clean install-vendor test-ci-big-unit
     parallelism: 2

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,9 +9,8 @@ common: &common
     # Allow manual retries.
     manual: true
 
-test-artifacts: &test_artifacts
   artifact_paths:
-    - "test_junit.xml"
+    - "*junit.xml"
 
 steps:
   - name: "Codegen"
@@ -31,20 +30,6 @@ steps:
       docker-compose#v2.5.1:
         run: app
         workdir: /go/src/github.com/m3db/m3
-    <<: *common
-    <<: *test_artifacts
-  - wait: ~
-    continue_on_failure: true
-  - label: annotate
-    plugins:
-      - bugcrowd/test-summary#v1.9.1:
-        inputs:
-          - label: unit
-            artifact_path: test_junit.xml
-            type: junit
-        formatter:
-          type: details
-        context: test-summary
     <<: *common
   - name: "Big Unit %n"
     command: make clean install-vendor test-ci-big-unit
@@ -123,3 +108,21 @@ steps:
       automatic:
         limit: 1
       manual: true
+  - wait: ~
+    continue_on_failure: true
+  - label: annotate
+    plugins:
+      - bugcrowd/test-summary#v1.9.1:
+          inputs:
+            - label: unit
+              artifact_path: test_junit.xml
+              type: junit
+            - label: big-unit
+              artifact_path: test_big_junit.xml
+              type: junit
+            - label: unit
+              artifact_path: "*test_integration_junit.xml"
+              type: junit
+          formatter:
+            type: details
+          context: test-summary

--- a/Makefile
+++ b/Makefile
@@ -368,10 +368,12 @@ test-ci-big-unit-$(SUBDIR):
 .PHONY: test-ci-integration-$(SUBDIR)
 test-ci-integration-$(SUBDIR):
 	@echo "--- test-ci-integration $(SUBDIR)"
-	SRC_ROOT=./src/$(SUBDIR) PANIC_ON_INVARIANT_VIOLATED=true INTEGRATION_TIMEOUT=4m TEST_SERIES_CACHE_POLICY=$(cache_policy) make test-base-ci-integration
+	SRC_ROOT=./src/$(SUBDIR) PANIC_ON_INVARIANT_VIOLATED=true INTEGRATION_TIMEOUT=4m TEST_SERIES_CACHE_POLICY=$(cache_policy) make test-base-ci-integration \
+		|| touch test.failed
 	@echo "--- uploading coverage report"
 	$(codecov_push) -f $(coverfile) -F $(SUBDIR)
 	mv $(test_integration_junit_xml) $(SUBDIR)_$(test_integration_junit_xml)
+	@exit $(call test_exit_code)
 
 .PHONY: metalint-$(SUBDIR)
 metalint-$(SUBDIR): install-gometalinter install-linter-badtime install-linter-importorder

--- a/Makefile
+++ b/Makefile
@@ -254,21 +254,16 @@ SUBDIR_TARGETS := \
 	all-gen         \
 	metalint
 
-
-install-go-junit-report:
-	go get github.com/jstemmer/go-junit-report
-
 .PHONY: test-ci-unit
 test-ci-unit: install-go-junit-report test-base
 	$(process_coverfile) $(coverfile)
-	go-junit-report < $(test_log) > test_junit.xml
 
 .PHONY: test-ci-big-unit
-test-ci-big-unit: test-big-base
+test-ci-big-unit: install-go-junit-report test-big-base
 	$(process_coverfile) $(coverfile)
 
 .PHONY: test-ci-integration
-test-ci-integration:
+test-ci-integration: install-go-junit-report
 	INTEGRATION_TIMEOUT=4m TEST_SERIES_CACHE_POLICY=$(cache_policy) make test-base-ci-integration
 	$(process_coverfile) $(coverfile)
 
@@ -348,6 +343,7 @@ test-html-$(SUBDIR):
 test-integration-$(SUBDIR):
 	@echo test-integration $(SUBDIR)
 	SRC_ROOT=./src/$(SUBDIR) make test-base-integration
+	mv
 
 # Usage: make test-single-integration name=<test_name>
 .PHONY: test-single-integration-$(SUBDIR)
@@ -360,7 +356,6 @@ test-ci-unit-$(SUBDIR):
 	SRC_ROOT=./src/$(SUBDIR) make test-base
 	@echo "--- uploading coverage report"
 	$(codecov_push) -f $(coverfile) -F $(SUBDIR)
-	go-junit-report < $(test_log) > test_junit.xml
 
 
 .PHONY: test-ci-big-unit-$(SUBDIR)
@@ -376,6 +371,7 @@ test-ci-integration-$(SUBDIR):
 	SRC_ROOT=./src/$(SUBDIR) PANIC_ON_INVARIANT_VIOLATED=true INTEGRATION_TIMEOUT=4m TEST_SERIES_CACHE_POLICY=$(cache_policy) make test-base-ci-integration
 	@echo "--- uploading coverage report"
 	$(codecov_push) -f $(coverfile) -F $(SUBDIR)
+	mv $(test_integration_junit_xml) $(SUBDIR)_$(test_integration_junit_xml)
 
 .PHONY: metalint-$(SUBDIR)
 metalint-$(SUBDIR): install-gometalinter install-linter-badtime install-linter-importorder

--- a/Makefile
+++ b/Makefile
@@ -255,15 +255,15 @@ SUBDIR_TARGETS := \
 	metalint
 
 .PHONY: test-ci-unit
-test-ci-unit: install-go-junit-report test-base
+test-ci-unit: test-base
 	$(process_coverfile) $(coverfile)
 
 .PHONY: test-ci-big-unit
-test-ci-big-unit: install-go-junit-report test-big-base
+test-ci-big-unit: test-big-base
 	$(process_coverfile) $(coverfile)
 
 .PHONY: test-ci-integration
-test-ci-integration: install-go-junit-report
+test-ci-integration:
 	INTEGRATION_TIMEOUT=4m TEST_SERIES_CACHE_POLICY=$(cache_policy) make test-base-ci-integration
 	$(process_coverfile) $(coverfile)
 
@@ -343,7 +343,6 @@ test-html-$(SUBDIR):
 test-integration-$(SUBDIR):
 	@echo test-integration $(SUBDIR)
 	SRC_ROOT=./src/$(SUBDIR) make test-base-integration
-	mv
 
 # Usage: make test-single-integration name=<test_name>
 .PHONY: test-single-integration-$(SUBDIR)
@@ -368,12 +367,10 @@ test-ci-big-unit-$(SUBDIR):
 .PHONY: test-ci-integration-$(SUBDIR)
 test-ci-integration-$(SUBDIR):
 	@echo "--- test-ci-integration $(SUBDIR)"
-	SRC_ROOT=./src/$(SUBDIR) PANIC_ON_INVARIANT_VIOLATED=true INTEGRATION_TIMEOUT=4m TEST_SERIES_CACHE_POLICY=$(cache_policy) make test-base-ci-integration \
-		|| touch test.failed
+	SRC_ROOT=./src/$(SUBDIR) PANIC_ON_INVARIANT_VIOLATED=true INTEGRATION_TIMEOUT=4m TEST_SERIES_CACHE_POLICY=$(cache_policy) \
+		make test-base-ci-integration-$(SUBDIR)
 	@echo "--- uploading coverage report"
 	$(codecov_push) -f $(coverfile) -F $(SUBDIR)
-	mv $(test_integration_junit_xml) $(SUBDIR)_$(test_integration_junit_xml)
-	@exit $(call test_exit_code)
 
 .PHONY: metalint-$(SUBDIR)
 metalint-$(SUBDIR): install-gometalinter install-linter-badtime install-linter-importorder

--- a/Makefile
+++ b/Makefile
@@ -254,9 +254,14 @@ SUBDIR_TARGETS := \
 	all-gen         \
 	metalint
 
+
+install-go-junit-report:
+	go get github.com/jstemmer/go-junit-report
+
 .PHONY: test-ci-unit
-test-ci-unit: test-base
+test-ci-unit: install-go-junit-report test-base
 	$(process_coverfile) $(coverfile)
+	go-junit-report < $(test_log) > test_junit.xml
 
 .PHONY: test-ci-big-unit
 test-ci-big-unit: test-big-base
@@ -355,6 +360,8 @@ test-ci-unit-$(SUBDIR):
 	SRC_ROOT=./src/$(SUBDIR) make test-base
 	@echo "--- uploading coverage report"
 	$(codecov_push) -f $(coverfile) -F $(SUBDIR)
+	go-junit-report < $(test_log) > test_junit.xml
+
 
 .PHONY: test-ci-big-unit-$(SUBDIR)
 test-ci-big-unit-$(SUBDIR):

--- a/src/aggregator/aggregation/common_test.go
+++ b/src/aggregator/aggregation/common_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFailure(t *testing.T) {
+	t.Fatal("Fail now; remove me")
+}
+
 func TestStdev(t *testing.T) {
 	require.InDelta(t, 29.01149, stdev(100, 338350, 5050), 0.001)
 }

--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -52,6 +52,10 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestFailure(t *testing.T) {
+	t.Fatal("Fail now; remove me")
+}
+
 // TestIndexEnabledServer tests booting a server using file based configuration.
 func TestIndexEnabledServer(t *testing.T) {
 	if testing.Short() {

--- a/src/foo/foo.go
+++ b/src/foo/foo.go
@@ -1,0 +1,1 @@
+package foo

--- a/src/foo/foo_test.go
+++ b/src/foo/foo_test.go
@@ -1,0 +1,11 @@
+package foo
+
+import "testing"
+
+func TestFoo(t *testing.T) {
+
+}
+
+func TestFooFail(t *testing.T) {
+	t.Fatal("failure!")
+}

--- a/src/msg/integration/integration_test.go
+++ b/src/msg/integration/integration_test.go
@@ -38,6 +38,10 @@ const (
 	maxRF        = 3
 )
 
+func TestFailure(t *testing.T) {
+	t.Fatal("Fail now; remove me")
+}
+
 func TestSharedConsumer(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates .ci submodule to pull in https://github.com/m3db/ci-scripts/pull/88 (collapses glide output) in buildkite.


**Does this PR introduce a user-facing and/or backwards incompatible change?**:

```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:

```documentation-note
NONE
```
