### PR TITLE
[DBNode] - Fix bug in Protobuf encoding when time units are changed

### DIFF
--- a/src/dbnode/encoding/m3tsz/timestamp_encoder.go
+++ b/src/dbnode/encoding/m3tsz/timestamp_encoder.go
@@ -42,8 +42,10 @@ type TimestampEncoder struct {
 
 	TimeUnit xtime.Unit
 
-	timeUnitWasWritten bool
-	hasWrittenFirst    bool // Only taken into account if using the WriteTime() API.
+	// Used to keep track of time unit changes that occur directly via the WriteTimeUnit()
+	// API as opposed to indirectly via the WriteTime() API.
+	timeUnitChanged bool
+	hasWrittenFirst bool // Only taken into account if using the WriteTime() API.
 }
 
 // NewTimestampEncoder creates a new TimestampEncoder.
@@ -53,7 +55,6 @@ func NewTimestampEncoder(
 		PrevTime: start,
 		TimeUnit: initialTimeUnit(start, timeUnit),
 		Options:  opts,
-		// skipTimeUnitWrites: true,
 	}
 }
 
@@ -89,14 +90,14 @@ func (enc *TimestampEncoder) WriteNextTime(
 
 	timeDelta := currTime.Sub(enc.PrevTime)
 	enc.PrevTime = currTime
-	if tuChanged || enc.timeUnitWasWritten {
+	if tuChanged || enc.timeUnitChanged {
 		enc.writeDeltaOfDeltaTimeUnitChanged(stream, enc.PrevTimeDelta, timeDelta)
 		// NB(xichen): if the time unit has changed, we reset the time delta to zero
 		// because we can't guarantee that dt is a multiple of the new time unit, which
 		// means we can't guarantee that the delta of delta when encoding the next
 		// data point is a multiple of the new time unit.
 		enc.PrevTimeDelta = 0
-		enc.timeUnitWasWritten = false
+		enc.timeUnitChanged = false
 		return nil
 	}
 	err := enc.writeDeltaOfDeltaTimeUnitUnchanged(
@@ -110,7 +111,7 @@ func (enc *TimestampEncoder) WriteNextTime(
 func (enc *TimestampEncoder) WriteTimeUnit(stream encoding.OStream, timeUnit xtime.Unit) {
 	stream.WriteByte(byte(timeUnit))
 	enc.TimeUnit = timeUnit
-	enc.timeUnitWasWritten = true
+	enc.timeUnitChanged = true
 }
 
 // maybeWriteTimeUnitChange encodes the time unit and returns true if the time unit has

--- a/src/dbnode/encoding/m3tsz/timestamp_encoder.go
+++ b/src/dbnode/encoding/m3tsz/timestamp_encoder.go
@@ -45,7 +45,8 @@ type TimestampEncoder struct {
 	// Used to keep track of time unit changes that occur directly via the WriteTimeUnit()
 	// API as opposed to indirectly via the WriteTime() API.
 	timeUnitEncodedManually bool
-	hasWrittenFirst         bool // Only taken into account if using the WriteTime() API.
+	// Only taken into account if using the WriteTime() API.
+	hasWrittenFirst bool
 }
 
 // NewTimestampEncoder creates a new TimestampEncoder.

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -168,6 +168,7 @@ func (it *iterator) Next() bool {
 		}
 
 		if timeUnitHasChangedControlBit == opCodeTimeUnitChange {
+			fmt.Println("iterator found time unit change control bit, reading new time unit")
 			if err := it.tsIterator.ReadTimeUnit(it.stream); err != nil {
 				it.err = fmt.Errorf("%s error reading new time unit: %v", itErrPrefix, err)
 				return false

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -168,7 +168,6 @@ func (it *iterator) Next() bool {
 		}
 
 		if timeUnitHasChangedControlBit == opCodeTimeUnitChange {
-			fmt.Println("iterator found time unit change control bit, reading new time unit")
 			if err := it.tsIterator.ReadTimeUnit(it.stream); err != nil {
 				it.err = fmt.Errorf("%s error reading new time unit: %v", itErrPrefix, err)
 				return false

--- a/src/dbnode/encoding/proto/iterator.go
+++ b/src/dbnode/encoding/proto/iterator.go
@@ -172,12 +172,6 @@ func (it *iterator) Next() bool {
 				it.err = fmt.Errorf("%s error reading new time unit: %v", itErrPrefix, err)
 				return false
 			}
-
-			if !it.consumedFirstMessage {
-				// Don't interpret the initial time unit as a "change" since the encoder special
-				// cases the first one.
-				it.tsIterator.TimeUnitChanged = false
-			}
 		}
 
 		if schemaHasChangedControlBit == opCodeSchemaChange {

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -60,6 +60,7 @@ func init() {
 func TestRoundTrip(t *testing.T) {
 	testCases := []struct {
 		timestamp  time.Time
+		unit       xtime.Unit
 		latitude   float64
 		longitude  float64
 		epoch      int64
@@ -67,11 +68,13 @@ func TestRoundTrip(t *testing.T) {
 		attributes map[string]string
 	}{
 		{
+			unit:      xtime.Second,
 			latitude:  0.1,
 			longitude: 1.1,
 			epoch:     -1,
 		},
 		{
+			unit:       xtime.Nanosecond,
 			latitude:   0.1,
 			longitude:  1.1,
 			epoch:      0,
@@ -79,6 +82,7 @@ func TestRoundTrip(t *testing.T) {
 			attributes: map[string]string{"key1": "val1"},
 		},
 		{
+			unit:       xtime.Nanosecond,
 			latitude:   0.2,
 			longitude:  2.2,
 			epoch:      1,
@@ -86,18 +90,21 @@ func TestRoundTrip(t *testing.T) {
 			attributes: map[string]string{"key1": "val1"},
 		},
 		{
+			unit:       xtime.Millisecond,
 			latitude:   0.3,
 			longitude:  2.3,
 			epoch:      2,
 			deliveryID: []byte("123123123123"),
 		},
 		{
+			unit:       xtime.Second,
 			latitude:   0.4,
 			longitude:  2.4,
 			epoch:      3,
 			attributes: map[string]string{"key1": "val1"},
 		},
 		{
+			unit:       xtime.Second,
 			latitude:   0.5,
 			longitude:  2.5,
 			epoch:      4,
@@ -108,11 +115,13 @@ func TestRoundTrip(t *testing.T) {
 			},
 		},
 		{
+			unit:       xtime.Millisecond,
 			latitude:   0.6,
 			longitude:  2.6,
 			deliveryID: nil,
 		},
 		{
+			unit:       xtime.Nanosecond,
 			latitude:   0.5,
 			longitude:  2.5,
 			deliveryID: []byte("789789789789"),
@@ -129,10 +138,12 @@ func TestRoundTrip(t *testing.T) {
 		marshalledVL, err := vl.Marshal()
 		require.NoError(t, err)
 
-		currTime := curr.Add(time.Duration(i) * time.Second)
+		duration, err := xtime.DurationFromUnit(tc.unit)
+		require.NoError(t, err)
+		currTime := curr.Add(time.Duration(i) * duration)
 		testCases[i].timestamp = currTime
 		// Encoder should ignore value so we set it to make sure it gets ignored.
-		err = enc.Encode(ts.Datapoint{Timestamp: currTime, Value: float64(i)}, xtime.Second, marshalledVL)
+		err = enc.Encode(ts.Datapoint{Timestamp: currTime, Value: float64(i)}, tc.unit, marshalledVL)
 		require.NoError(t, err)
 
 		lastEncoded, err := enc.LastEncoded()
@@ -144,12 +155,12 @@ func TestRoundTrip(t *testing.T) {
 
 	// Add some sanity to make sure that the compression (especially string compression)
 	// is working properly.
-	numExpectedBytes := 233
+	numExpectedBytes := 281
 	require.Equal(t, numExpectedBytes, enc.Stats().CompressedBytes)
 
 	rawBytes, err := enc.Bytes()
 	require.NoError(t, err)
-	require.Equal(t, numExpectedBytes, len(rawBytes))
+	// require.Equal(t, numExpectedBytes, len(rawBytes))
 
 	buff := bytes.NewBuffer(rawBytes)
 	iter := NewIterator(buff, namespace.GetTestSchemaDescr(testVLSchema), testEncodingOptions)
@@ -163,13 +174,14 @@ func TestRoundTrip(t *testing.T) {
 		m := dynamic.NewMessage(testVLSchema)
 		require.NoError(t, m.Unmarshal(annotation))
 
-		fmt.Println(m.String())
-		require.Equal(t, unit, xtime.Second)
-		require.True(t, tc.timestamp.Equal(dp.Timestamp))
+		require.Equal(t, unit, testCases[i].unit)
+		require.True(t,
+			tc.timestamp.Equal(dp.Timestamp),
+			fmt.Sprintf("expected: %s, got: %s", tc.timestamp.String(), dp.Timestamp.String()))
 		// Value is meaningless for proto so should always be zero
 		// regardless of whats written.
 		require.Equal(t, float64(0), dp.Value)
-		require.Equal(t, xtime.Second, unit)
+		require.Equal(t, tc.unit, unit)
 		require.Equal(t, tc.latitude, m.GetFieldByName("latitude"))
 		require.Equal(t, tc.longitude, m.GetFieldByName("longitude"))
 		require.Equal(t, tc.epoch, m.GetFieldByName("epoch"))

--- a/src/dbnode/encoding/proto/round_trip_test.go
+++ b/src/dbnode/encoding/proto/round_trip_test.go
@@ -160,7 +160,7 @@ func TestRoundTrip(t *testing.T) {
 
 	rawBytes, err := enc.Bytes()
 	require.NoError(t, err)
-	// require.Equal(t, numExpectedBytes, len(rawBytes))
+	require.Equal(t, numExpectedBytes, len(rawBytes))
 
 	buff := bytes.NewBuffer(rawBytes)
 	iter := NewIterator(buff, namespace.GetTestSchemaDescr(testVLSchema), testEncodingOptions)


### PR DESCRIPTION
Current the Protobuf encoder/iterator misbehaves when time units are changed mid-stream and generates invalid data. This P.R fixes the issue and adds a unit test.