### PR TITLE
[dbnode] Fix perf regression not returning pooled encoded tags

### DIFF
--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -8,6 +8,7 @@ require 'etc'
 
 # Boxes available at: https://vagrantcloud.com/search
 $BOX=ENV['BOX']
+$BOX_NUM=ENV['BOX_NUM']
 $GOOGLE_PROJECT_ID = ENV['GOOGLE_PROJECT_ID']
 $GOOGLE_JSON_KEY_LOCATION = ENV['GOOGLE_JSON_KEY_LOCATION']
 $USER = ENV['USER']
@@ -43,12 +44,13 @@ Vagrant.configure("2") do |config|
     google.google_project_id = $GOOGLE_PROJECT_ID
     google.google_json_key_location = $GOOGLE_JSON_KEY_LOCATION
 
-    google.name = "m3-dev-" + $USER
+    google.name = "m3-dev" + $BOX_NUM + "-" + $USER
     google.image_family = "ubuntu-1604-lts"
     google.zone = "us-central1-f"
     google.metadata = {}
     google.tags = ['vagrantbox', 'dev']
     google.disk_size = '50' # 50gb
+    google.disk_type = 'pd-ssd'
     google.autodelete_disk = true
 
     override.ssh.username = $USER

--- a/src/cmd/services/m3dbnode/config/pooling.go
+++ b/src/cmd/services/m3dbnode/config/pooling.go
@@ -35,7 +35,7 @@ const (
 const (
 	defaultMaxFinalizerCapacity     = 4
 	defaultBlockAllocSize           = 16
-	defaultThriftBytesPoolAllocSize = 1024
+	defaultThriftBytesPoolAllocSize = 2048
 )
 
 type poolPolicyDefault struct {

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -1149,7 +1149,10 @@ func withEncodingAndPoolingOptions(
 	scope := opts.InstrumentOptions().MetricsScope()
 
 	// Set the max bytes pool byte slice alloc size for the thrift pooling.
-	apachethrift.SetMaxBytesPoolAlloc(policy.ThriftBytesPoolAllocSizeOrDefault())
+	thriftBytesAllocSize := policy.ThriftBytesPoolAllocSizeOrDefault()
+	logger.Info("set thrift bytes pool alloc size",
+		zap.Int("size", thriftBytesAllocSize))
+	apachethrift.SetMaxBytesPoolAlloc(thriftBytesAllocSize)
 
 	bytesPoolOpts := pool.NewObjectPoolOptions().
 		SetInstrumentOptions(iopts.SetMetricsScope(scope.SubScope("bytes-pool")))

--- a/src/dbnode/ts/types.go
+++ b/src/dbnode/ts/types.go
@@ -57,6 +57,11 @@ type BatchWrite struct {
 	// is usually coming from over the wire) and is superseded by the Tags
 	// in Write.Series which will get set by the Shard object.
 	TagIter ident.TagIterator
+	// EncodedTags is used by the commit log, but also held onto as a reference
+	// here so that it can be returned to the pool after the write to commit log
+	// completes (since the Write.Series gets overwritten in SetOutcome so can't
+	// use the reference there for returning to the pool).
+	EncodedTags EncodedTags
 	// Used to help the caller tie errors back to an index in their
 	// own collection.
 	OriginalIndex int

--- a/src/dbnode/ts/write_batch.go
+++ b/src/dbnode/ts/write_batch.go
@@ -119,6 +119,8 @@ func (b *writeBatch) Iter() []BatchWrite {
 func (b *writeBatch) SetOutcome(idx int, series Series, err error) {
 	b.writes[idx].SkipWrite = false
 	b.writes[idx].Write.Series = series
+	// Make sure that the EncodedTags does not get clobbered
+	b.writes[idx].Write.Series.EncodedTags = b.writes[idx].EncodedTags
 	b.writes[idx].Err = err
 }
 
@@ -141,7 +143,7 @@ func (b *writeBatch) SetFinalizeAnnotationFn(f FinalizeAnnotationFn) {
 func (b *writeBatch) Finalize() {
 	if b.finalizeEncodedTagsFn != nil {
 		for _, write := range b.writes {
-			encodedTags := write.Write.Series.EncodedTags
+			encodedTags := write.EncodedTags
 			if encodedTags == nil {
 				continue
 			}
@@ -210,6 +212,7 @@ func newBatchWriterWrite(
 			Annotation: annotation,
 		},
 		TagIter:       tagIter,
+		EncodedTags:   encodedTags,
 		OriginalIndex: originalIndex,
 	}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The PR for improving tag encoding in the commit log failed to return encoded tags to the pool due to `SetOutcome` in the `WriteBatch` clobbering the `Write.Series.EncodedTags` field when result from the namespace/shard is returned.

This makes sure it is not clobbered, I've verified the fix restores and also improves the overall write performance of the DB nodes.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
