### PR TITLE
[DBnode] Return error in M3DB client if proto mode is enabled and trying to read from namespace with no known schema

### DIFF
--- a/src/dbnode/client/client_mock.go
+++ b/src/dbnode/client/client_mock.go
@@ -1074,6 +1074,20 @@ func (mr *MockOptionsMockRecorder) SetEncodingProto(encodingOpts interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEncodingProto", reflect.TypeOf((*MockOptions)(nil).SetEncodingProto), encodingOpts)
 }
 
+// IsSetEncodingProto mocks base method
+func (m *MockOptions) IsSetEncodingProto() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSetEncodingProto")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSetEncodingProto indicates an expected call of IsSetEncodingProto
+func (mr *MockOptionsMockRecorder) IsSetEncodingProto() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSetEncodingProto", reflect.TypeOf((*MockOptions)(nil).IsSetEncodingProto))
+}
+
 // SetRuntimeOptionsManager mocks base method
 func (m *MockOptions) SetRuntimeOptionsManager(value runtime.OptionsManager) Options {
 	m.ctrl.T.Helper()
@@ -2313,6 +2327,20 @@ func (m *MockAdminOptions) SetEncodingProto(encodingOpts encoding.Options) Optio
 func (mr *MockAdminOptionsMockRecorder) SetEncodingProto(encodingOpts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEncodingProto", reflect.TypeOf((*MockAdminOptions)(nil).SetEncodingProto), encodingOpts)
+}
+
+// IsSetEncodingProto mocks base method
+func (m *MockAdminOptions) IsSetEncodingProto() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSetEncodingProto")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsSetEncodingProto indicates an expected call of IsSetEncodingProto
+func (mr *MockAdminOptionsMockRecorder) IsSetEncodingProto() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSetEncodingProto", reflect.TypeOf((*MockAdminOptions)(nil).IsSetEncodingProto))
 }
 
 // SetRuntimeOptionsManager mocks base method

--- a/src/dbnode/client/options.go
+++ b/src/dbnode/client/options.go
@@ -31,8 +31,8 @@ import (
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
 	"github.com/m3db/m3/src/dbnode/encoding/proto"
-	m3dbruntime "github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	m3dbruntime "github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
@@ -245,6 +245,7 @@ type options struct {
 	fetchSeriesBlocksBatchTimeout           time.Duration
 	fetchSeriesBlocksBatchConcurrency       int
 	schemaRegistry                          namespace.SchemaRegistry
+	isProtoEnabled                          bool
 }
 
 // NewOptions creates a new set of client options with defaults
@@ -360,6 +361,7 @@ func (o *options) SetEncodingM3TSZ() Options {
 	opts.readerIteratorAllocate = func(r io.Reader, _ namespace.SchemaDescr) encoding.ReaderIterator {
 		return m3tsz.NewReaderIterator(r, m3tsz.DefaultIntOptimizationEnabled, encoding.NewOptions())
 	}
+	opts.isProtoEnabled = false
 	return &opts
 }
 
@@ -368,7 +370,12 @@ func (o *options) SetEncodingProto(encodingOpts encoding.Options) Options {
 	opts.readerIteratorAllocate = func(r io.Reader, descr namespace.SchemaDescr) encoding.ReaderIterator {
 		return proto.NewIterator(r, descr, encodingOpts)
 	}
+	opts.isProtoEnabled = true
 	return &opts
+}
+
+func (o *options) IsSetEncodingProto() bool {
+	return o.isProtoEnabled
 }
 
 func (o *options) SetRuntimeOptionsManager(value m3dbruntime.OptionsManager) Options {

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -1408,6 +1408,7 @@ func (s *session) fetchIDsAttempt(
 	if err != nil {
 		return nil, err
 	}
+
 	var (
 		wg                     sync.WaitGroup
 		allPending             int32

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -1207,7 +1207,10 @@ func (s *session) FetchTaggedIDs(
 func (s *session) fetchTaggedAttempt(
 	ns ident.ID, q index.Query, opts index.QueryOptions,
 ) (encoding.SeriesIterators, bool, error) {
-	nsCtx := namespace.NewContextFor(ns, s.opts.SchemaRegistry())
+	nsCtx, err := s.nsCtxFor(ns)
+	if err != nil {
+		return nil, false, err
+	}
 	s.state.RLock()
 	if s.state.status != statusOpen {
 		s.state.RUnlock()
@@ -1401,6 +1404,10 @@ func (s *session) fetchIDsAttempt(
 	inputIDs ident.Iterator,
 	startInclusive, endExclusive time.Time,
 ) (encoding.SeriesIterators, error) {
+	nsCtx, err := s.nsCtxFor(inputNamespace)
+	if err != nil {
+		return nil, err
+	}
 	var (
 		wg                     sync.WaitGroup
 		allPending             int32
@@ -1414,7 +1421,6 @@ func (s *session) fetchIDsAttempt(
 		fetchBatchOpsByHostIdx [][]*fetchBatchOp
 		success                = false
 		startFetchAttempt      = s.nowFn()
-		nsCtx                  = namespace.NewContextFor(inputNamespace, s.opts.SchemaRegistry())
 	)
 
 	// NB(prateek): need to make a copy of inputNamespace and inputIDs to control
@@ -1922,8 +1928,11 @@ func (s *session) FetchBootstrapBlocksFromPeers(
 	start, end time.Time,
 	opts result.Options,
 ) (result.ShardResult, error) {
+	nsCtx, err := s.nsCtxFromMetadata(nsMetadata)
+	if err != nil {
+		return nil, err
+	}
 	var (
-		nsCtx  = namespace.NewContextFrom(nsMetadata)
 		result = newBulkBlocksResult(nsCtx, s.opts, opts,
 			s.pools.tagDecoder, s.pools.id)
 		doneCh   = make(chan struct{})
@@ -1988,14 +1997,16 @@ func (s *session) FetchBlocksFromPeers(
 	metadatas []block.ReplicaMetadata,
 	opts result.Options,
 ) (PeerBlocksIter, error) {
-
+	nsCtx, err := s.nsCtxFromMetadata(nsMetadata)
+	if err != nil {
+		return nil, err
+	}
 	var (
 		logger   = opts.InstrumentOptions().Logger()
 		level    = newStaticRuntimeReadConsistencyLevel(consistencyLevel)
 		complete = int64(0)
 		doneCh   = make(chan error, 1)
 		outputCh = make(chan peerBlocksDatapoint, 4096)
-		nsCtx    = namespace.NewContextFrom(nsMetadata)
 		result   = newStreamBlocksResult(nsCtx, s.opts, opts, outputCh,
 			s.pools.tagDecoder.Get(), s.pools.id)
 		onDone = func(err error) {
@@ -3007,6 +3018,22 @@ func (s *session) cloneFinalizable(id ident.ID) ident.ID {
 		return id
 	}
 	return s.pools.id.Clone(id)
+}
+
+func (s *session) nsCtxFromMetadata(nsMeta namespace.Metadata) (namespace.Context, error) {
+	nsCtx := namespace.NewContextFrom(nsMeta)
+	if s.opts.IsSetEncodingProto() && nsCtx.Schema == nil {
+		return nsCtx, fmt.Errorf("no protobuf schema found for namespace: %s", nsMeta.ID().String())
+	}
+	return nsCtx, nil
+}
+
+func (s *session) nsCtxFor(ns ident.ID) (namespace.Context, error) {
+	nsCtx := namespace.NewContextFor(ns, s.opts.SchemaRegistry())
+	if s.opts.IsSetEncodingProto() && nsCtx.Schema == nil {
+		return nsCtx, fmt.Errorf("no protobuf schema found for namespace: %s", ns.String())
+	}
+	return nsCtx, nil
 }
 
 type reason int

--- a/src/dbnode/client/session_fetch_test.go
+++ b/src/dbnode/client/session_fetch_test.go
@@ -162,7 +162,13 @@ func testSessionFetchIDs(t *testing.T, testOpts testOptions) {
 		fetches = testOpts.setFetchAnn(fetches)
 	}
 
-	fetchBatchOps, enqueueWg := prepareTestFetchEnqueues(t, ctrl, session, fetches)
+	expectedFetches := fetches
+	if testOpts.expectedErr != nil {
+		// If an error is expected then don't setup any go mock expectation for the host queues since
+		// they will never be fulfilled and will hang the test.
+		expectedFetches = nil
+	}
+	fetchBatchOps, enqueueWg := prepareTestFetchEnqueues(t, ctrl, session, expectedFetches)
 
 	go func() {
 		// Fulfill fetch ops once enqueued

--- a/src/dbnode/client/session_test.go
+++ b/src/dbnode/client/session_test.go
@@ -31,10 +31,10 @@ import (
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/x/xpool"
-	"github.com/m3db/m3/src/x/serialize"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
 	xretry "github.com/m3db/m3/src/x/retry"
+	"github.com/m3db/m3/src/x/serialize"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -349,7 +349,7 @@ func mockHostQueues(
 					enqueueWg.Done()
 				}
 				return nil
-			}).Return(nil)
+			}).Return(nil).AnyTimes()
 		}
 		if len(hostEnqueueFns) > 0 {
 			expectNextEnqueueFn(hostEnqueueFns)

--- a/src/dbnode/client/session_test.go
+++ b/src/dbnode/client/session_test.go
@@ -349,7 +349,7 @@ func mockHostQueues(
 					enqueueWg.Done()
 				}
 				return nil
-			}).Return(nil).AnyTimes()
+			}).Return(nil)
 		}
 		if len(hostEnqueueFns) > 0 {
 			expectNextEnqueueFn(hostEnqueueFns)

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -26,11 +26,11 @@ import (
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/index"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
@@ -235,6 +235,9 @@ type Options interface {
 
 	// SetEncodingProto sets proto encoding.
 	SetEncodingProto(encodingOpts encoding.Options) Options
+
+	// IsSetEncodingProto returns whether proto encoding is set.
+	IsSetEncodingProto() bool
 
 	// SetRuntimeOptionsManager sets the runtime options manager, it is optional
 	SetRuntimeOptionsManager(value runtime.OptionsManager) Options


### PR DESCRIPTION
Existing implementation would silently return zero results instead of an error if proto mode was enabled but the provided namespace did not have a known schema.