### PR TITLE
Fixed error format

### DIFF
--- a/src/dbnode/client/replicated_session.go
+++ b/src/dbnode/client/replicated_session.go
@@ -162,7 +162,7 @@ func (s replicatedSession) replicate(params replicatedParams) error {
 			}
 			if err != nil {
 				s.metrics.replicateError.Inc(1)
-				s.log.Error("could not replicate write: %v", zap.Error(err))
+				s.log.Error("could not replicate write", zap.Error(err))
 			}
 			if s.outCh != nil {
 				s.outCh <- err


### PR DESCRIPTION
Remove redundant error format string from replicate error (zap doesn't need format string)