### PR TITLE
Create subscope for async sessions

### DIFF
--- a/src/dbnode/client/replicated_session.go
+++ b/src/dbnode/client/replicated_session.go
@@ -129,7 +129,7 @@ func (s *replicatedSession) setAsyncSessions(opts []Options) error {
 	sessions := make([]clientSession, 0, len(opts))
 	for i, oo := range opts {
 		subscope := oo.InstrumentOptions().MetricsScope().SubScope(fmt.Sprintf("async-%d", i))
-		oo.SetInstrumentOptions(oo.InstrumentOptions().SetMetricsScope(subscope))
+		oo = oo.SetInstrumentOptions(oo.InstrumentOptions().SetMetricsScope(subscope))
 
 		session, err := s.newSessionFn(oo)
 		if err != nil {

--- a/src/dbnode/client/replicated_session.go
+++ b/src/dbnode/client/replicated_session.go
@@ -21,6 +21,7 @@
 package client
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/encoding"
@@ -126,7 +127,10 @@ func (s *replicatedSession) setSession(opts Options) error {
 
 func (s *replicatedSession) setAsyncSessions(opts []Options) error {
 	sessions := make([]clientSession, 0, len(opts))
-	for _, oo := range opts {
+	for i, oo := range opts {
+		subscope := oo.InstrumentOptions().MetricsScope().SubScope(fmt.Sprintf("async-%d", i))
+		oo.SetInstrumentOptions(oo.InstrumentOptions().SetMetricsScope(subscope))
+
 		session, err := s.newSessionFn(oo)
 		if err != nil {
 			return err

--- a/src/dbnode/client/replicated_session_test.go
+++ b/src/dbnode/client/replicated_session_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/instrument"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
 	"github.com/stretchr/testify/suite"
@@ -144,11 +145,14 @@ func (s *replicatedSessionTestSuite) TestSetAsyncSessions() {
 	opts := optionsWithAsyncSessions(false, 0)
 	session := NewMockclientSession(s.mockCtrl)
 	newSessionFunc := newSessionFnWithSession(session)
+
 	s.initReplicatedSession(opts, newSessionFunc)
 
 	sessionOpts := []Options{}
 	for i := 0; i < 3; i++ {
 		o := NewMockAdminOptions(s.mockCtrl)
+		o.EXPECT().InstrumentOptions().AnyTimes().Return(instrument.NewOptions())
+		o.EXPECT().SetInstrumentOptions(gomock.Any()).Return(o)
 		sessionOpts = append(sessionOpts, o)
 	}
 


### PR DESCRIPTION
Sync and async sessions in replicated sessions all use the same scope for reporting metrics. This PR adds a subscope for each async session such that their metrics may be separated from one another.