### PR TITLE
[query] Graphite fetches truncated to resolution

### DIFF
--- a/scripts/docker-integration-tests/carbon/test.sh
+++ b/scripts/docker-integration-tests/carbon/test.sh
@@ -53,7 +53,7 @@ t=$(date +%s)
 echo "foo.min.aggregate.baz 41 $t" | nc 0.0.0.0 7204
 echo "foo.min.aggregate.baz 42 $t" | nc 0.0.0.0 7204
 echo "Attempting to read min aggregated carbon metric"
-ATTEMPTS=10 TIMEOUT=1 retry_with_backoff read_carbon foo.min.aggregate.baz 41
+ATTEMPTS=20 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff read_carbon foo.min.aggregate.baz 41
 
 echo "Writing out a carbon metric that should not be aggregated"
 t=$(date +%s)
@@ -64,7 +64,7 @@ t=$(date +%s)
 echo "foo.min.already-aggregated.baz 42 $t" | nc 0.0.0.0 7204
 echo "foo.min.already-aggregated.baz 43 $t" | nc 0.0.0.0 7204
 echo "Attempting to read unaggregated carbon metric"
-ATTEMPTS=10 TIMEOUT=1 retry_with_backoff read_carbon foo.min.already-aggregated.baz 43
+ATTEMPTS=20 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff read_carbon foo.min.already-aggregated.baz 43
 
 echo "Writing out a carbon metric that should should use the default mean aggregation"
 t=$(date +%s)
@@ -72,7 +72,7 @@ t=$(date +%s)
 echo "foo.min.catch-all.baz 10 $t" | nc 0.0.0.0 7204
 echo "foo.min.catch-all.baz 20 $t" | nc 0.0.0.0 7204
 echo "Attempting to read mean aggregated carbon metric"
-ATTEMPTS=10 TIMEOUT=1 retry_with_backoff read_carbon foo.min.catch-all.baz 15
+ATTEMPTS=20 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff read_carbon foo.min.catch-all.baz 15
 
 # Test writing and reading IDs with colons in them.
 t=$(date +%s)

--- a/src/query/api/v1/handler/graphite/render_test.go
+++ b/src/query/api/v1/handler/graphite/render_test.go
@@ -105,11 +105,11 @@ func TestParseQueryResults(t *testing.T) {
 
 	buf, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
-	firstTimestamp := truncateStart.Unix() + 10
+	exTimestamp := truncateStart.Unix() + 10
 	expected := fmt.Sprintf(
 		`[{"target":"series_name","datapoints":[[3.000000,%d],`+
-			`[3.000000,%d]],"step_size_ms":%d}]`,
-		firstTimestamp, firstTimestamp+10, resolution/time.Millisecond)
+			`[3.000000,%d],[null,%d]],"step_size_ms":%d}]`,
+		exTimestamp, exTimestamp+10, exTimestamp+20, resolution/time.Millisecond)
 
 	require.Equal(t, expected, string(buf))
 }
@@ -121,7 +121,7 @@ func TestParseQueryResultsMaxDatapoints(t *testing.T) {
 	endStr := "03/07/15"
 	start, err := graphite.ParseTime(startStr, time.Now(), 0)
 	require.NoError(t, err)
-	_, err = graphite.ParseTime(endStr, time.Now(), 0)
+	end, err := graphite.ParseTime(endStr, time.Now(), 0)
 	require.NoError(t, err)
 
 	resolution := 10 * time.Second
@@ -154,10 +154,10 @@ func TestParseQueryResultsMaxDatapoints(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expected resolution should be in milliseconds and subsume all datapoints.
-	stepSize := resolution / time.Millisecond * 4
+	exStep := end.Sub(start) / time.Millisecond
 	expected := fmt.Sprintf(
 		`[{"target":"a","datapoints":[[4.000000,%d]],"step_size_ms":%d}]`,
-		start.Unix(), stepSize)
+		start.Unix(), exStep)
 
 	require.Equal(t, expected, string(buf))
 }

--- a/src/query/api/v1/handler/graphite/render_test.go
+++ b/src/query/api/v1/handler/graphite/render_test.go
@@ -74,8 +74,9 @@ func TestParseQueryNoResults(t *testing.T) {
 
 func TestParseQueryResults(t *testing.T) {
 	mockStorage := mock.NewMockStorage()
-	start := time.Now().Add(-30 * time.Minute)
 	resolution := 10 * time.Second
+	truncateStart := time.Now().Add(-30 * time.Minute).Truncate(resolution)
+	start := truncateStart.Add(time.Second)
 	vals := ts.NewFixedStepValues(resolution, 3, 3, start)
 	tags := models.NewTags(0, nil)
 	tags = tags.AddTag(models.Tag{Name: graphite.TagName(0), Value: []byte("foo")})
@@ -104,10 +105,11 @@ func TestParseQueryResults(t *testing.T) {
 
 	buf, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
+	firstTimestamp := truncateStart.Unix() + 10
 	expected := fmt.Sprintf(
 		`[{"target":"series_name","datapoints":[[3.000000,%d],`+
-			`[3.000000,%d],[3.000000,%d]],"step_size_ms":%d}]`,
-		start.Unix(), start.Unix()+10, start.Unix()+20, resolution/time.Millisecond)
+			`[3.000000,%d]],"step_size_ms":%d}]`,
+		firstTimestamp, firstTimestamp+10, resolution/time.Millisecond)
 
 	require.Equal(t, expected, string(buf))
 }
@@ -119,7 +121,7 @@ func TestParseQueryResultsMaxDatapoints(t *testing.T) {
 	endStr := "03/07/15"
 	start, err := graphite.ParseTime(startStr, time.Now(), 0)
 	require.NoError(t, err)
-	end, err := graphite.ParseTime(endStr, time.Now(), 0)
+	_, err = graphite.ParseTime(endStr, time.Now(), 0)
 	require.NoError(t, err)
 
 	resolution := 10 * time.Second
@@ -138,7 +140,10 @@ func TestParseQueryResultsMaxDatapoints(t *testing.T) {
 		models.QueryContextOptions{}, nil, instrument.NewOptions())
 
 	req := newGraphiteReadHTTPRequest(t)
-	req.URL.RawQuery = "target=foo.bar&from=" + startStr + "&until=" + endStr + "&maxDataPoints=1"
+	req.URL.RawQuery = fmt.Sprintf(
+		"target=foo.bar&from=%s&until=%s&maxDataPoints=1",
+		startStr, endStr,
+	)
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
 
@@ -148,9 +153,11 @@ func TestParseQueryResultsMaxDatapoints(t *testing.T) {
 	buf, err := ioutil.ReadAll(res.Body)
 	require.NoError(t, err)
 
+	// Expected resolution should be in milliseconds and subsume all datapoints.
+	stepSize := resolution / time.Millisecond * 4
 	expected := fmt.Sprintf(
 		`[{"target":"a","datapoints":[[4.000000,%d]],"step_size_ms":%d}]`,
-		start.Unix(), end.Sub(start)/time.Millisecond)
+		start.Unix(), stepSize)
 
 	require.Equal(t, expected, string(buf))
 }
@@ -158,8 +165,11 @@ func TestParseQueryResultsMaxDatapoints(t *testing.T) {
 func TestParseQueryResultsMultiTarget(t *testing.T) {
 	mockStorage := mock.NewMockStorage()
 	minsAgo := 12
-	start := time.Now().Add(-1 * time.Duration(minsAgo) * time.Minute)
 	resolution := 10 * time.Second
+	start := time.Now().
+		Add(-1 * time.Duration(minsAgo) * time.Minute).
+		Truncate(resolution)
+
 	vals := ts.NewFixedStepValues(resolution, 3, 3, start)
 	seriesList := ts.SeriesList{
 		ts.NewSeries([]byte("a"), vals, models.NewTags(0, nil)),
@@ -175,8 +185,10 @@ func TestParseQueryResultsMultiTarget(t *testing.T) {
 		models.QueryContextOptions{}, nil, instrument.NewOptions())
 
 	req := newGraphiteReadHTTPRequest(t)
-	req.URL.RawQuery = fmt.Sprintf("target=foo.bar&target=baz.qux&from=%d&until=%d",
-		start.Unix(), start.Unix()+30)
+	req.URL.RawQuery = fmt.Sprintf(
+		"target=foo.bar&target=baz.qux&from=%d&until=%d",
+		start.Unix(), start.Unix()+30,
+	)
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
 
@@ -228,8 +240,10 @@ func TestParseQueryResultsMultiTargetWithLimits(t *testing.T) {
 				models.QueryContextOptions{}, nil, instrument.NewOptions())
 
 			req := newGraphiteReadHTTPRequest(t)
-			req.URL.RawQuery = fmt.Sprintf("target=foo.bar&target=bar.baz&from=%d&until=%d",
-				start.Unix(), start.Unix()+30)
+			req.URL.RawQuery = fmt.Sprintf(
+				"target=foo.bar&target=bar.baz&from=%d&until=%d",
+				start.Unix(), start.Unix()+30,
+			)
 			recorder := httptest.NewRecorder()
 			h.ServeHTTP(recorder, req)
 

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -169,7 +169,7 @@ func translateTimeseries(
 				continue
 			}
 
-			if ts.After(end) {
+			if !ts.Before(end) {
 				// No more valid datapoints.
 				break
 			}

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -147,7 +147,6 @@ func translateTimeseries(
 	m3list := result.SeriesList
 	series := make([]*ts.Series, len(m3list))
 	resolutions := result.Metadata.Resolutions
-	fmt.Println("Resolutions", resolutions)
 	if len(series) != len(resolutions) {
 		return nil, fmt.Errorf("number of timeseries %d does not match number of "+
 			"resolutions %d", len(series), len(resolutions))
@@ -163,7 +162,6 @@ func translateTimeseries(
 		length := int(end.Sub(start) / resolution)
 		millisPerStep := int(resolution / time.Millisecond)
 		values := ts.NewValues(ctx, millisPerStep, length)
-		dataLength := 0
 		for _, datapoint := range m3series.Values().Datapoints() {
 			ts := datapoint.Timestamp
 			if ts.Before(start) {
@@ -176,16 +174,12 @@ func translateTimeseries(
 				break
 			}
 
-			dataLength++
 			index := int(datapoint.Timestamp.Sub(start) / resolution)
 			values.SetValueAt(index, datapoint.Value)
 		}
 
-		// NB: depending on bounds alignment vs resolution, some datapoints may not
-		// fit in the truncated period, so the output should be sanitized.
-		truncatedValues := values.Slice(0, dataLength)
 		name := string(m3series.Name())
-		series[i] = ts.NewSeries(ctx, name, start, truncatedValues)
+		series[i] = ts.NewSeries(ctx, name, start, values)
 	}
 
 	return series, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Graphite fetches would always be truncated to start point, which can cause flapping when refreshing a series.

**Special notes for your reviewer**:
-

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
None
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
None
```
