### PR TITLE
[coordinator] Fix default worker pool size for m3msg ingester

### DIFF
--- a/scripts/development/m3_stack/m3coordinator.yml
+++ b/scripts/development/m3_stack/m3coordinator.yml
@@ -40,9 +40,9 @@ clusters:
 
 ingest:
   ingester:
-    workerPoolSize: 100
+    workerPoolSize: 10000
     opPool:
-      size: 100
+      size: 10000
     retry:
       maxRetries: 3
       jitter: true

--- a/scripts/docker-integration-tests/aggregator/m3coordinator.yml
+++ b/scripts/docker-integration-tests/aggregator/m3coordinator.yml
@@ -83,9 +83,9 @@ downsample:
 
 ingest:
   ingester:
-    workerPoolSize: 100
+    workerPoolSize: 10000
     opPool:
-      size: 100
+      size: 10000
     retry:
       maxRetries: 3
       jitter: true

--- a/scripts/vagrant/provision/manifests/m3coordinator-two.yaml
+++ b/scripts/vagrant/provision/manifests/m3coordinator-two.yaml
@@ -37,9 +37,9 @@ data:
                 - http://etcd-0.etcd:2379
     ingest:
       ingester:
-        workerPoolSize: 100
+        workerPoolSize: 10000
         opPool:
-          size: 100
+          size: 10000
         retry:
           maxRetries: 3
           jitter: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Previously all config references to the worker pool size for the coordinator was 100 which is far too small for concurrent writes to M3DB for production workloads when aggregator sends metrics to the coordinators over m3msg.

This raises the default to a sane 10000.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
