### PR TITLE
[dbnode] Fix overzealous log message for missing schema with non-protobuf namespace

### DIFF
--- a/src/dbnode/namespace/schema_registry.go
+++ b/src/dbnode/namespace/schema_registry.go
@@ -31,6 +31,18 @@ import (
 	"go.uber.org/zap"
 )
 
+func newSchemaHistoryNotFoundError(nsIDStr string) error {
+	return &schemaHistoryNotFoundError{nsIDStr}
+}
+
+type schemaHistoryNotFoundError struct {
+	nsIDStr string
+}
+
+func (s *schemaHistoryNotFoundError) Error() string {
+	return fmt.Sprintf("schema history is not found for %s", s.nsIDStr)
+}
+
 type schemaRegistry struct {
 	sync.RWMutex
 
@@ -125,7 +137,7 @@ func (sr *schemaRegistry) getSchemaHistory(nsIDStr string) (SchemaHistory, error
 
 	history, ok := sr.registry[nsIDStr]
 	if !ok {
-		return nil, fmt.Errorf("schema history is not found for %v", nsIDStr)
+		return nil, newSchemaHistoryNotFoundError(nsIDStr)
 	}
 	return history.Get().(SchemaHistory), nil
 }

--- a/src/dbnode/namespace/schema_registry_updater.go
+++ b/src/dbnode/namespace/schema_registry_updater.go
@@ -22,6 +22,7 @@ package namespace
 
 import (
 	"fmt"
+	"strings"
 
 	xerrors "github.com/m3db/m3/src/x/errors"
 
@@ -38,7 +39,8 @@ func UpdateSchemaRegistry(newNamespaces Map, schemaReg SchemaRegistry, log *zap.
 			curSchemaNone = true
 		)
 		curSchema, err := schemaReg.GetLatestSchema(metadata.ID())
-		if err != nil {
+		// NB(bodu): Schema history not found is a valid error as this occurs on initial bootstrap for the db.
+		if err != nil && !strings.Contains(err.Error(), "schema history is not found for") {
 			multiErr = multiErr.Add(fmt.Errorf("cannot get latest namespace schema: %v", err))
 			continue
 		}

--- a/src/dbnode/namespace/schema_registry_updater.go
+++ b/src/dbnode/namespace/schema_registry_updater.go
@@ -33,35 +33,53 @@ func UpdateSchemaRegistry(newNamespaces Map, schemaReg SchemaRegistry, log *zap.
 	schemaUpdates := newNamespaces.Metadatas()
 	merr := xerrors.NewMultiError()
 	for _, metadata := range schemaUpdates {
-		curSchemaID := "none"
+		var (
+			curSchemaID = "none"
+			curSchemaNone = true
+		)
 		curSchema, err := schemaReg.GetLatestSchema(metadata.ID())
+		if err != nil {
+			merr = merr.Add(fmt.Errorf("cannot get latest namespace schema: %v", err))
+			continue
+		}
+
 		if curSchema != nil {
+			curSchemaNone = false
 			curSchemaID = curSchema.DeployId()
 			if len(curSchemaID) == 0 {
-				log.Warn("can not update namespace schema with empty deploy ID", zap.Stringer("namespace", metadata.ID()),
+				msg := "namespace schema update invalid with empty deploy ID"
+				log.Warn(msg, zap.Stringer("namespace", metadata.ID()),
 					zap.String("currentSchemaID", curSchemaID))
-				merr = merr.Add(fmt.Errorf("can not update namespace(%v) schema with empty deploy ID", metadata.ID().String()))
+				merr = merr.Add(fmt.Errorf("%s: namespace=%s", msg, metadata.ID().String()))
 				continue
 			}
 		}
+
 		// Log schema update.
 		latestSchema, found := metadata.Options().SchemaHistory().GetLatest()
 		if !found {
-			log.Warn("can not update namespace schema to empty", zap.Stringer("namespace", metadata.ID()),
-				zap.String("currentSchema", curSchemaID))
-			merr = merr.Add(fmt.Errorf("can not update namespace(%v) schema to empty", metadata.ID().String()))
+			if !curSchemaNone {
+				// NB(r): Only interpret this as a warning/error if already had a schema
+				// otherwise this is just a namespace that is not using protobuf schemas.
+				msg := "namespace schema not found on update"
+				log.Warn(msg, zap.Stringer("namespace", metadata.ID()),
+					zap.String("currentSchema", curSchemaID))
+				merr = merr.Add(fmt.Errorf("%s: namespace=%s", msg, metadata.ID().String()))
+			}
 			continue
 		}
+
 		log.Info("updating database namespace schema", zap.Stringer("namespace", metadata.ID()),
 			zap.String("currentSchema", curSchemaID), zap.String("latestSchema", latestSchema.DeployId()))
 
 		err = schemaReg.SetSchemaHistory(metadata.ID(), metadata.Options().SchemaHistory())
 		if err != nil {
-			log.Warn("failed to update latest schema for namespace",
+			msg := "namespace schema failed to update to latest schema"
+			log.Warn(msg,
 				zap.Stringer("namespace", metadata.ID()),
 				zap.Error(err))
-			merr = merr.Add(fmt.Errorf("failed to update latest schema for namespace %v, error: %v",
-				metadata.ID().String(), err))
+			merr = merr.Add(fmt.Errorf("%s: namespace=%s, error=%v",
+				msg, metadata.ID().String(), err))
 		}
 	}
 	if merr.Empty() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This was confusing as an operator since this is not an error state, it is the regular expected case when operating a DB node with namespaces that are not configured with protobuf schemas.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
