### PR TITLE
[build] Use constant modification time when generating statik files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,7 @@ build-ui-ctl-statik-gen: build-ui-ctl-statik license-gen-ctl
 .PHONY: build-ui-ctl-statik
 build-ui-ctl-statik: build-ui-ctl install-tools
 	mkdir -p ./src/ctl/generated/ui
-	$(retool_bin_path)/statik -f -src ./src/ctl/ui/build -dest ./src/ctl/generated/ui -p statik
+	$(retool_bin_path)/statik -m -f -src ./src/ctl/ui/build -dest ./src/ctl/generated/ui -p statik
 
 .PHONY: node-yarn-run
 node-yarn-run:


### PR DESCRIPTION
Running `make services` will eventually execute the `build-ui-ctl-statik` target. This target unconditionally runs `statik` to generate the file `src/ctl/generated/ui/statik/statik.go`. By default, `statik` will include the time at which it is run in the file that it generates. This has the unfortunate consequence that running `make services` modifies the code base though. Since we unconditionally run `statik` we can set the `-m` flag to ensure that `statik` includes a constant modification time in the output that it generates, thereby ensuring that the file it generates is deterministic.