### PR TITLE
[build] Fix glide 

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,4 +1,4 @@
-hash: 6f999e6981ec189be9b4b4f8c7f4860c3ab304c39ec75bf8e7531094a32cb259
+hash: 54d750cfc681a3acbdc3a39a51626e0ed1804f93fce5955ca5676d9940eabd6b
 updated: 2019-10-04T13:32:26.527615-04:00
 imports:
 - name: github.com/alecthomas/units
@@ -455,6 +455,8 @@ imports:
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
 - name: go.uber.org/atomic
   version: df976f2515e274675050de7b3f42545de80594fd
+- name: go.uber.org/config
+  version: 46dea54a68b3e94c239093186902985c7ced97b5
 - name: go.uber.org/multierr
   version: 71e610a0e48dbda460d9c18adca8b5f2de04a7c1
 - name: go.uber.org/zap

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 54d750cfc681a3acbdc3a39a51626e0ed1804f93fce5955ca5676d9940eabd6b
-updated: 2019-10-22T14:33:44.916139609-04:00
+hash: 6f999e6981ec189be9b4b4f8c7f4860c3ab304c39ec75bf8e7531094a32cb259
+updated: 2019-10-04T13:32:26.527615-04:00
 imports:
 - name: github.com/alecthomas/units
   version: f65c72e2690dc4b403c8bd637baf4611cd4c069b
@@ -112,7 +112,7 @@ imports:
   subpackages:
   - capnslog
 - name: github.com/couchbase/vellum
-  version: 462e86d8716b36a1397b30ef77fb11105065a232
+  version: 41f2deade2cfab59facd263e918d7c05f656c2e9
   subpackages:
   - utf8
 - name: github.com/davecgh/go-spew
@@ -130,12 +130,12 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-kit/kit
-  version: fbab14bd4c487151b206c2a41ecfbb015e32c1e0
+  version: dc489b75b9cdbf29c739534c2aa777cabb034954
   subpackages:
   - log
   - log/level
 - name: github.com/go-logfmt/logfmt
-  version: 07c9b44f60d7ffdfb7d8efe1ad539965737836dc
+  version: 432dd90af23366a89a611c020003fc8ba281ae5d
 - name: github.com/go-playground/locales
   version: 630ebbb602847eba93e75ae38bbc7bb7abcf1ff3
   subpackages:
@@ -143,7 +143,7 @@ imports:
 - name: github.com/go-playground/universal-translator
   version: 71201497bace774495daed26a3874fd339e0b538
 - name: github.com/gogo/protobuf
-  version: 5628607bb4c51c3157aacc3a50f0ab707582b805
+  version: 0ca988a254f991240804bf9821f3450d87ccbb1b
   subpackages:
   - gogoproto
   - jsonpb
@@ -199,7 +199,7 @@ imports:
   - runtime/internal
   - utilities
 - name: github.com/hashicorp/hcl
-  version: 99e2f22d1c94b272184d97dd9d252866409100ab
+  version: cf7d376da96d9cecec7c7483cec2735efe54a410
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -281,7 +281,7 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: 3536a929edddb9a5b34bd6861dc4a9647cb459fe
 - name: github.com/oklog/ulid
-  version: be3bccf06dda9a40aa6800c4736ac77f2fef987f
+  version: e51a56f2a4c1bf73c967ca6d45d5366bade31943
 - name: github.com/opentracing-contrib/go-stdlib
   version: cf7a6c988dc994e945d2715565026f3cc8718689
   subpackages:
@@ -297,9 +297,9 @@ imports:
 - name: github.com/pborman/uuid
   version: adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1
 - name: github.com/pelletier/go-toml
-  version: 728039f679cbcd4f6a54e080d2219a4c4928c546
+  version: 8fe62057ea2d46ce44254c98e84e810044dbe197
 - name: github.com/pilosa/pilosa
-  version: 29e6bd29d7db38d17be01cea3a452e554089b108
+  version: bc9747cc0f19702d9753de7ea9375d8311dfc706
   subpackages:
   - logger
   - stats
@@ -377,7 +377,7 @@ imports:
   subpackages:
   - mem
 - name: github.com/spf13/cast
-  version: 8c9545af88b134710ab1cd196795e7f2388358d7
+  version: f31dc0aaab5a2feeca5c41783abbc347731fd08e
 - name: github.com/spf13/cobra
   version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f
   subpackages:
@@ -455,11 +455,6 @@ imports:
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
 - name: go.uber.org/atomic
   version: df976f2515e274675050de7b3f42545de80594fd
-- name: go.uber.org/config
-  version: c9c3d11a88c1a266ced73d92e22e1d36d2bc2ed6
-  subpackages:
-  - internal/merge
-  - internal/unreachable
 - name: go.uber.org/multierr
   version: 71e610a0e48dbda460d9c18adca8b5f2de04a7c1
 - name: go.uber.org/zap
@@ -532,7 +527,7 @@ imports:
   - protobuf/ptype
   - protobuf/source_context
 - name: google.golang.org/grpc
-  version: 401e0e00e4bb830a10496d64cd95e068c5bf50de
+  version: 5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e
   subpackages:
   - balancer
   - codes
@@ -577,12 +572,12 @@ imports:
   vcs: git
 testImports:
 - name: github.com/glycerine/go-unsnap-stream
-  version: f9677308dec2b35e76737f9713df328ad11b1fea
+  version: 98d31706395aaac22e29676617f2ee37bee55b5a
 - name: github.com/mschoch/smat
   version: 90eadee771aeab36e8bf796039b8c261bebebe4f
 - name: github.com/philhofer/fwd
   version: bb6d471dc95d4fe11e432687f8b70ff496cf3136
 - name: github.com/tinylib/msgp
-  version: ade0ca4ace05af96235d107023ab018ee921309c
+  version: efe20429c9b7b2a358aba9ba2d40ad56d966ce00
   subpackages:
   - msgp

--- a/glide.yaml
+++ b/glide.yaml
@@ -246,3 +246,6 @@ import:
     subpackages:
       - unix
     version: c178f38b412c7b426e4e97be2e75d11ff7b8d4d4
+
+  - package: go.uber.org/config
+    version: ^1.3.1

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,173 +1,248 @@
 package: github.com/m3db/m3
 import:
-- package: github.com/m3db/bitset
-  version: 07973db6b78acb62ac207d0538055e874b49d90d
-- package: github.com/m3db/bloom
-  version: 47fe1193cdb900de7193d1f3d26ea9b2cbf6fb31
-- package: github.com/m3db/stackmurmur3
-  version: 744c0229c12ed0e4f8cb9d081a2692b3300bf705
-- package: github.com/m3db/stackadler32
-  version: bfebcd73ef6ffe0ee30489227f0330c39064b674
-- package: github.com/MichaelTJones/pcg
-  version: df440c6ed7ed8897ac98a408365e5e89c7becf1a
-- package: github.com/willf/bitset
-  version: e553b05586428962bf7058d1044519d87ca72d74
-- package: github.com/cespare/xxhash
-  version: 48099fad606eafc26e3a569fad19ff510fff4df6
-- package: github.com/coreos/etcd
-  version: 3.2.10
-- package: github.com/pkg/errors
-  version: ^0.8
-- package: github.com/apache/thrift
-  version: 0.9.3-pool-read-binary-3
-  repo: https://github.com/m3db/thrift
-  vcs: git
-  subpackages:
-  - lib/go/thrift
-- package: github.com/golang/mock
-  version: ^1
-  subpackages:
-  - gomock
-- package: github.com/golang/protobuf
-  version: ^1.1.0
-  subpackages:
-  - proto
-  - ptypes/timestamp
-  - jsonpb
-- package: github.com/gogo/protobuf
-  version: ^1
-- package: github.com/jhump/protoreflect
-  version: e0795ed1d1ada047d01e90243863def21db467fc
-- package: go.uber.org/zap
-  version: f85c78b1dd998214c5f2138155b320a4a43fbe36
-- package: github.com/opentracing/opentracing-go
-  version: 1.0.2
-- package: github.com/spaolacci/murmur3
-  version: 9f5d223c60793748f04a9d5b4b4eacddfc1f755d
-- package: github.com/uber/tchannel-go
-  version: v1.12.0
-  subpackages:
-  - thrift
-- package: gopkg.in/vmihailenco/msgpack.v2
-  version: a1382b1ce0c749733b814157c245e02cc1f41076
-  repo: https://github.com/vmihailenco/msgpack.git
-  vcs: git
-- package: github.com/uber-go/tally
-  version: ^3.3.10
-- package: golang.org/x/net
-  version: ab5485076ff3407ad2d02db054635913f017b0ed
-  repo: https://github.com/golang/net
-  vcs: git
-- package: google.golang.org/appengine
-  version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
-  subpackages:
-  - datastore
-- package: github.com/pborman/getopt
-  version: ec82d864f599c39673eef89f91b93fa5576567a1
-- package: github.com/spf13/cobra
-  version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f
-  subpackages:
-  - cobra
-- package: github.com/spf13/pflag
-  version: 4f9190456aed1c2113ca51ea9b89219747458dc1
-- package: github.com/spf13/viper
-  version: ^1.0.0
-- package: github.com/RoaringBitmap/roaring
-  version: ^0.4
-- package: github.com/uber-go/atomic
-  version: ^1.2.0
-- package: github.com/satori/go.uuid
-  version: ^1.2.0
-- package: github.com/m3db/vellum
-  version: e766292d14de216c324bb60b17320af72dee59c6
-- package: github.com/edsrzf/mmap-go
-  version: 0bce6a6887123b67a60366d2c9fe2dfb74289d2e
-- package: github.com/m3db/pilosa
-  version: ac8920c6e1abe06e2b0a3deba79a9910c39700e6
-  subpackages:
-  - roaring
-- package: github.com/stretchr/testify
-  version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
-  subpackages:
-  - require
-- package: github.com/fortytw2/leaktest
-  version: b433bbd6d743c1854040b39062a3916ed5f78fe8
-- package: github.com/sergi/go-diff
-  version: feef008d51ad2b3778f85d387ccf91735543008d
-- package: github.com/golang/snappy
-  version: 553a641470496b2327abcac10b36396bd98e45c9
-- package: github.com/gorilla/mux
-  version: ^1.6.0
-- package: github.com/pborman/uuid
-  version: ^1.1.0
-- package: gopkg.in/alecthomas/kingpin.v2
-  version: ^2.2.6
-  repo: https://github.com/alecthomas/kingpin.git
-  vcs: git
-- package: github.com/pkg/profile
-  version: 5b67d428864e92711fcbd2f8629456121a56d91f
-- package: golang.org/x/sync
-  subpackages:
-  - errgroup
-- package: github.com/google/go-cmp
-  version: ^0.3
-  subpackages:
-  - cmp
-- package: github.com/hydrogen18/stalecucumber
-  version: 9b38526d4bdf8e197c31344777fc28f7f48d250d
-- package: github.com/c2h5oh/datasize
-  version: 4eba002a5eaea69cf8d235a388fc6b65ae68d2dd
-- package: github.com/prometheus/prometheus
-  version: ~2.12.0
-- package: github.com/prometheus/common
-  version: ~0.7.0
-- package: github.com/m3db/prometheus_client_golang
-  version: 8ae269d24972b8695572fa6b2e3718b5ea82d6b4
-- package: github.com/m3db/prometheus_client_model
-  version: 8b2299a4bf7d7fc10835527021716d4b4a6e8700
-- package: github.com/m3db/prometheus_common
-  version: 25aaa3dff79bb48116615ebe1dea6a494b74ce77
-- package: github.com/m3db/prometheus_procfs
-  version: 1878d9fbb537119d24b21ca07effd591627cd160
-- package: github.com/coreos/pkg
-  version: "4"
-  subpackages:
-  - capnslog
-- package: github.com/uber/jaeger-lib
-  version: ^2.0.0
-- package: github.com/uber/jaeger-client-go
-  version: ~2.16.0
-- package: github.com/opentracing-contrib/go-stdlib
-  version: cf7a6c988dc994e945d2715565026f3cc8718689
-- package: google.golang.org/grpc
-  version: ~1.7.3
-  subpackages:
-  - codes
-- package: gopkg.in/validator.v2
-  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
-  repo: https://github.com/go-validator/validator.git
-  vcs: git
-- package: gopkg.in/go-playground/validator.v9
-  version: a021b2ec9a8a8bb970f3f15bc42617cb520e8a64
-  repo: https://github.com/go-playground/validator.git
-  vcs: git
-- package: github.com/go-playground/universal-translator
-  version: 71201497bace774495daed26a3874fd339e0b538
-- package: gopkg.in/yaml.v2
-  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
-  repo: https://github.com/go-yaml/yaml.git
-  vcs: git
-- package: github.com/russross/blackfriday
-  version: ^2.0.1
-- package: github.com/mauricelam/genny
-  version: eb2c5232c885956af3565a20ecf48555cab2b9bc
-- package: github.com/leanovate/gopter
-  version: e2604588f4db2d2e5eb78ae75d615516f55873e3
-- package: github.com/rakyll/statik
-  version: ^0.1.6
-- package: golang.org/x/sys
-  version: c178f38b412c7b426e4e97be2e75d11ff7b8d4d4
-  subpackages:
-  - unix
-- package: go.uber.org/config
-  version: ^1.3.1
+  - package: github.com/m3db/bitset
+    version: 07973db6b78acb62ac207d0538055e874b49d90d
+
+  - package: github.com/m3db/bloom
+    version: 47fe1193cdb900de7193d1f3d26ea9b2cbf6fb31
+
+  - package: github.com/m3db/stackmurmur3
+    version: 744c0229c12ed0e4f8cb9d081a2692b3300bf705
+
+  - package: github.com/m3db/stackadler32
+    version: bfebcd73ef6ffe0ee30489227f0330c39064b674
+
+  - package: github.com/MichaelTJones/pcg
+    version: df440c6ed7ed8897ac98a408365e5e89c7becf1a
+
+  - package: github.com/willf/bitset
+    version: e553b05586428962bf7058d1044519d87ca72d74
+
+  - package: github.com/cespare/xxhash
+    version: 48099fad606eafc26e3a569fad19ff510fff4df6
+
+  - package: github.com/coreos/etcd
+    version: 3.2.10
+
+  - package: github.com/pkg/errors
+    version: ^0.8
+
+  - package: github.com/apache/thrift
+    version: 0.9.3-pool-read-binary-3
+    subpackages:
+      - lib/go/thrift
+    repo: https://github.com/m3db/thrift
+    vcs: git
+
+  - package: github.com/golang/mock
+    version: ^1
+    subpackages:
+      - gomock
+
+  - package: github.com/golang/protobuf
+    version: ^1.1.0
+    subpackages:
+      - proto
+      - ptypes/timestamp
+      - jsonpb
+
+  - package: github.com/gogo/protobuf
+    version: ^1
+
+  - package: github.com/jhump/protoreflect
+    version: e0795ed1d1ada047d01e90243863def21db467fc
+
+  - package: go.uber.org/zap
+    version: f85c78b1dd998214c5f2138155b320a4a43fbe36
+
+  - package: github.com/opentracing/opentracing-go
+    version: 1.0.2
+
+  - package: github.com/spaolacci/murmur3
+    version: 9f5d223c60793748f04a9d5b4b4eacddfc1f755d
+
+  - package: github.com/uber/tchannel-go
+    version: v1.12.0
+    subpackages:
+      - thrift
+
+  - package: gopkg.in/vmihailenco/msgpack.v2
+    version: a1382b1ce0c749733b814157c245e02cc1f41076
+    repo: https://github.com/vmihailenco/msgpack.git
+    vcs: git
+
+  - package: github.com/uber-go/tally
+    version: ^3.3.10
+
+  - package: golang.org/x/net
+    version: ab5485076ff3407ad2d02db054635913f017b0ed
+    repo: https://github.com/golang/net
+    vcs: git
+
+  - package: google.golang.org/appengine/datastore
+    version: 2e4a801b39fc199db615bfca7d0b9f8cd9580599
+
+  - package: github.com/pborman/getopt
+    version: ec82d864f599c39673eef89f91b93fa5576567a1
+
+  - package: github.com/spf13/cobra
+    version: 7c674d9e72017ed25f6d2b5e497a1368086b6a6f
+    subpackages:
+      - cobra
+
+  - package: github.com/spf13/pflag
+    version: 4f9190456aed1c2113ca51ea9b89219747458dc1
+
+  - package: github.com/spf13/viper
+    version: ^1.0.0
+
+  - package: github.com/RoaringBitmap/roaring
+    version: ^0.4
+
+  - package: github.com/uber-go/atomic
+    version: ^1.2.0
+
+  - package: github.com/satori/go.uuid
+    version: ^1.2.0
+
+  # NB(r): make sure to use the master commit for vellum
+  # once all upstream changes are complete in github.com/m3db/vellum.
+  - package: github.com/m3db/vellum
+    version: e766292d14de216c324bb60b17320af72dee59c6
+
+  - package: github.com/edsrzf/mmap-go # un-used but required for a compile time dep from vellum
+    version: 0bce6a6887123b67a60366d2c9fe2dfb74289d2e
+
+  # NB(r): make sure to use the master commit for pilosa
+  # once all upstream changes are complete in github.com/pilosa/pilosa.
+  - package: github.com/m3db/pilosa/roaring
+    version: ac8920c6e1abe06e2b0a3deba79a9910c39700e6
+
+  # NB(prateek): ideally, the following dependencies would be under testImport, but
+  # Glide doesn't like that. https://github.com/Masterminds/glide/issues/564
+  - package: github.com/stretchr/testify
+    version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
+    subpackages:
+      - require
+
+  - package: github.com/fortytw2/leaktest
+    version: b433bbd6d743c1854040b39062a3916ed5f78fe8
+
+  - package: github.com/sergi/go-diff
+    version: feef008d51ad2b3778f85d387ccf91735543008d
+
+  - package: github.com/golang/snappy
+    version: 553a641470496b2327abcac10b36396bd98e45c9
+
+  - package: github.com/gorilla/mux
+    version: ^1.6.0
+
+  - package: github.com/pborman/uuid
+    version: ^1.1.0
+
+  - package: gopkg.in/alecthomas/kingpin.v2
+    version: ^2.2.6
+    repo: https://github.com/alecthomas/kingpin.git
+    vcs: git
+
+  - package: github.com/pkg/profile
+    version: 5b67d428864e92711fcbd2f8629456121a56d91f
+
+  - package: golang.org/x/sync
+    subpackages:
+      - errgroup
+
+  - package: github.com/google/go-cmp
+    version: ^0.3
+    subpackages:
+      - cmp
+
+  - package: github.com/hydrogen18/stalecucumber
+    version: 9b38526d4bdf8e197c31344777fc28f7f48d250d
+
+  - package: github.com/c2h5oh/datasize
+    version: 4eba002a5eaea69cf8d235a388fc6b65ae68d2dd
+
+  # START_PROMETHEUS_DEPS
+  - package: github.com/prometheus/prometheus
+    version: ~2.12.0
+
+  # To avoid prometheus/prometheus dependencies from breaking,
+  # pin the transitive dependencies
+  - package: github.com/prometheus/common
+    version: ~0.7.0
+  # END_PROMETHEUS_DEPS
+
+  # START_TALLY_PROMETHEUS_DEPS
+  - package: github.com/m3db/prometheus_client_golang
+    version: 8ae269d24972b8695572fa6b2e3718b5ea82d6b4
+
+  - package: github.com/m3db/prometheus_client_model
+    version: 8b2299a4bf7d7fc10835527021716d4b4a6e8700
+
+  - package: github.com/m3db/prometheus_common
+    version: 25aaa3dff79bb48116615ebe1dea6a494b74ce77
+
+  - package: github.com/m3db/prometheus_procfs
+    version: 1878d9fbb537119d24b21ca07effd591627cd160
+  # END_PROMETHEUS_DEPS
+
+  - package: github.com/coreos/pkg
+    version: 4
+    subpackages:
+      - capnslog
+
+  # START_JAEGER_DEPS
+  - package: github.com/uber/jaeger-lib
+    version: ^2.0.0
+
+  - package: github.com/uber/jaeger-client-go
+    version: ~2.16.0
+
+  - package: github.com/opentracing-contrib/go-stdlib
+    # Pin this on recommendation of the repo (no stable release yet). Still arguably better than rewriting
+    # the same code.
+    version: cf7a6c988dc994e945d2715565026f3cc8718689
+
+  # END_JAEGER_DEPS
+
+  # To avoid conflicting packages not resolving the latest GRPC
+  - package: google.golang.org/grpc
+    version: ~1.7.3
+    subpackages:
+      - codes
+
+  - package: gopkg.in/validator.v2
+    version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
+    repo: https://github.com/go-validator/validator.git
+    vcs: git
+
+  - package: gopkg.in/go-playground/validator.v9
+    version: a021b2ec9a8a8bb970f3f15bc42617cb520e8a64
+    repo: https://github.com/go-playground/validator.git
+    vcs: git
+
+  - package: github.com/go-playground/universal-translator
+    version: 71201497bace774495daed26a3874fd339e0b538
+
+  - package: gopkg.in/yaml.v2
+    version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+    repo: https://github.com/go-yaml/yaml.git
+    vcs: git
+
+  - package: github.com/russross/blackfriday
+    version: ^2.0.1
+
+  - package: github.com/mauricelam/genny
+    version: eb2c5232c885956af3565a20ecf48555cab2b9bc
+
+  - package: github.com/leanovate/gopter
+    version: e2604588f4db2d2e5eb78ae75d615516f55873e3
+
+  - package: github.com/rakyll/statik
+    version: ^0.1.6
+
+  - package: golang.org/x/sys
+    subpackages:
+      - unix
+    version: c178f38b412c7b426e4e97be2e75d11ff7b8d4d4


### PR DESCRIPTION
**What this PR does / why we need it**:
In my previous [diff](https://github.com/m3db/m3/pull/2016) I added go.uber.org/config as a dependency using `glide get`. For my attempt to do things the right way, glide helpfully reverted many of our dependencies to a later version: https://pastebin.com/87uuRpfH

**Special notes for your reviewer**:

Look at the individual commits for a better view of the diff (this should be landed atomically, which is why I didn't stack).

**Does this PR introduce a user-facing and/or backwards incompatible change?**:

```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:

```documentation-note
NONE
```
