### PR TITLE
[query] Add latency metrics to remote reads

### DIFF
--- a/src/query/api/v1/handler/prometheus/native/read.go
+++ b/src/query/api/v1/handler/prometheus/native/read.go
@@ -117,12 +117,14 @@ func NewPromReadHandler(
 	keepNans bool,
 	instrumentOpts instrument.Options,
 ) *PromReadHandler {
+	taggedScope := instrumentOpts.MetricsScope().
+		Tagged(map[string]string{"handler": "remote-read"})
 	h := &PromReadHandler{
 		engine:              engine,
 		fetchOptionsBuilder: fetchOptionsBuilder,
 		tagOpts:             tagOpts,
 		limitsCfg:           limitsCfg,
-		promReadMetrics:     newPromReadMetrics(instrumentOpts.MetricsScope()),
+		promReadMetrics:     newPromReadMetrics(taggedScope),
 		timeoutOps:          timeoutOpts,
 		keepNans:            keepNans,
 		instrumentOpts:      instrumentOpts,
@@ -134,7 +136,6 @@ func NewPromReadHandler(
 
 func (h *PromReadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	timer := h.promReadMetrics.fetchTimerSuccess.Start()
-
 	fetchOpts, rErr := h.fetchOptionsBuilder.NewFetchOptions(r)
 	if rErr != nil {
 		xhttp.Error(w, rErr.Inner(), rErr.Code())

--- a/src/query/api/v1/handler/prometheus/native/read.go
+++ b/src/query/api/v1/handler/prometheus/native/read.go
@@ -118,7 +118,7 @@ func NewPromReadHandler(
 	instrumentOpts instrument.Options,
 ) *PromReadHandler {
 	taggedScope := instrumentOpts.MetricsScope().
-		Tagged(map[string]string{"handler": "remote-read"})
+		Tagged(map[string]string{"handler": "native-read"})
 	h := &PromReadHandler{
 		engine:              engine,
 		fetchOptionsBuilder: fetchOptionsBuilder,

--- a/src/query/api/v1/handler/prometheus/remote/read.go
+++ b/src/query/api/v1/handler/prometheus/remote/read.go
@@ -70,10 +70,11 @@ func NewPromReadHandler(
 	keepEmpty bool,
 	instrumentOpts instrument.Options,
 ) http.Handler {
-	subScope := instrumentOpts.MetricsScope().SubScope("remote")
+	taggedScope := instrumentOpts.MetricsScope().
+		Tagged(map[string]string{"handler": "remote-read"})
 	return &PromReadHandler{
 		engine:              engine,
-		promReadMetrics:     newPromReadMetrics(subScope),
+		promReadMetrics:     newPromReadMetrics(taggedScope),
 		timeoutOpts:         timeoutOpts,
 		fetchOptionsBuilder: fetchOptionsBuilder,
 		keepEmpty:           keepEmpty,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds metrics for latency on the remote read path

