### PR TITLE
[coordinator] Add experimental API support for writing annotated samples

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -134,6 +134,9 @@ type Configuration struct {
 	// ResultOptions are the results options for query.
 	ResultOptions ResultOptions `yaml:"resultOptions"`
 
+	// Experimental is the configuration for the experimental API group.
+	Experimental ExperimentalAPIConfiguration `yaml:"experimental"`
+
 	// Cache configurations.
 	//
 	// Deprecated: cache configurations are no longer supported. Remove from file
@@ -511,4 +514,9 @@ func TagOptionsFromConfig(cfg TagOptionsConfiguration) (models.TagOptions, error
 	}
 
 	return opts, nil
+}
+
+// ExperimentalAPIConfiguration is the configuration for the experimental API group.
+type ExperimentalAPIConfiguration struct {
+	Enabled bool `yaml:"enabled"`
 }

--- a/src/query/api/experimental/annotated/handler.go
+++ b/src/query/api/experimental/annotated/handler.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package annotated
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/m3db/m3/src/cmd/services/m3coordinator/ingest"
+	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/query/api/v1/handler"
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+	"github.com/m3db/m3/src/query/models"
+	xhttp "github.com/m3db/m3/src/x/net/http"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/uber-go/tally"
+)
+
+const (
+	// WriteURL is the URL for the annotated write handler.
+	WriteURL = handler.RoutePrefixExperimental + "/prom/remote/annotated/write"
+
+	// WriteHTTPMethod is the HTTP method for the annotated write handler.
+	WriteHTTPMethod = http.MethodPost
+)
+
+var errEmptyBody = errors.New("request body is empty")
+
+type Handler struct {
+	writer     ingest.DownsamplerAndWriter
+	tagOptions models.TagOptions
+	metrics    handlerMetrics
+}
+
+// NewHandler returns a new HTTP handler for writing annotated datapoints.
+func NewHandler(
+	writer ingest.DownsamplerAndWriter, tagOptions models.TagOptions, scope tally.Scope,
+) *Handler {
+	return &Handler{
+		writer:     writer,
+		tagOptions: tagOptions,
+		metrics:    newHandlerMetrics(scope),
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Body == nil {
+		h.metrics.writeErrorsClient.Inc(1)
+		xhttp.Error(w, errEmptyBody, http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	req, err := parseRequest(r.Body)
+	if err != nil {
+		h.metrics.writeErrorsClient.Inc(1)
+		xhttp.Error(w, err, http.StatusBadRequest)
+		return
+	}
+
+	iter := newIter(req.Timeseries, h.tagOptions)
+	batchErr := h.writer.WriteBatch(r.Context(), iter, ingest.WriteOptions{})
+	if batchErr != nil {
+		var foundInternalErr bool
+		for _, err := range batchErr.Errors() {
+			if client.IsBadRequestError(err) {
+				continue
+			}
+			foundInternalErr = true
+			break
+		}
+
+		var (
+			status  = http.StatusBadRequest
+			counter = h.metrics.writeErrorsClient
+		)
+		if foundInternalErr {
+			status = http.StatusInternalServerError
+			counter = h.metrics.writeErrorsServer
+		}
+		counter.Inc(1)
+
+		err = fmt.Errorf(
+			"unable to write metric batch, encountered %d errors: %v", len(batchErr.Errors()), batchErr.Error(),
+		)
+		xhttp.Error(w, err, status)
+		return
+	}
+
+	h.metrics.writeSuccess.Inc(1)
+	w.WriteHeader(http.StatusOK)
+}
+
+func parseRequest(r io.Reader) (prompb.AnnotatedWriteRequest, error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return prompb.AnnotatedWriteRequest{}, err
+	}
+
+	data, err = snappy.Decode(nil, data)
+	if err != nil {
+		return prompb.AnnotatedWriteRequest{}, fmt.Errorf("unable to decode request body: %v", err)
+	}
+
+	var req prompb.AnnotatedWriteRequest
+	if err := proto.Unmarshal(data, &req); err != nil {
+		return prompb.AnnotatedWriteRequest{}, fmt.Errorf("unable to unmarshal request: %v", err)
+	}
+
+	return req, nil
+}
+
+type handlerMetrics struct {
+	writeSuccess      tally.Counter
+	writeErrorsServer tally.Counter
+	writeErrorsClient tally.Counter
+}
+
+func newHandlerMetrics(s tally.Scope) handlerMetrics {
+	return handlerMetrics{
+		writeSuccess:      s.SubScope("write").Counter("success"),
+		writeErrorsServer: s.SubScope("write").Tagged(map[string]string{"code": "5XX"}).Counter("errors"),
+		writeErrorsClient: s.SubScope("write").Tagged(map[string]string{"code": "4XX"}).Counter("errors"),
+	}
+}

--- a/src/query/api/experimental/annotated/handler_test.go
+++ b/src/query/api/experimental/annotated/handler_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package annotated
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/iotest"
+
+	"github.com/m3db/m3/src/cmd/services/m3coordinator/ingest"
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+	"github.com/m3db/m3/src/query/models"
+	xerrors "github.com/m3db/m3/src/x/errors"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/mock/gomock"
+	"github.com/golang/snappy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+)
+
+var testWriteRequest = prompb.AnnotatedWriteRequest{
+	Timeseries: []prompb.AnnotatedTimeSeries{
+		prompb.AnnotatedTimeSeries{
+			Labels: []prompb.Label{
+				prompb.Label{Name: []byte("__name__"), Value: []byte("requests")},
+				prompb.Label{Name: []byte("status_code"), Value: []byte("200")},
+			},
+			Samples: []prompb.AnnotatedSample{
+				prompb.AnnotatedSample{
+					Value:      4.2,
+					Timestamp:  testTimestampMillis,
+					Annotation: []byte("foo"),
+				},
+				prompb.AnnotatedSample{
+					Value:      3.14,
+					Timestamp:  testTimestampMillis + 10000,
+					Annotation: []byte("bar"),
+				},
+			},
+		},
+		prompb.AnnotatedTimeSeries{
+			Labels: []prompb.Label{
+				prompb.Label{Name: []byte("__name__"), Value: []byte("requests")},
+				prompb.Label{Name: []byte("status_code"), Value: []byte("500")},
+			},
+			Samples: []prompb.AnnotatedSample{
+				prompb.AnnotatedSample{
+					Value:      6.28,
+					Timestamp:  testTimestampMillis,
+					Annotation: []byte("baz"),
+				},
+			},
+		},
+	},
+}
+
+func TestHandlerServeHTTP(t *testing.T) {
+	tests := []struct {
+		name       string
+		reqFn      func(t *testing.T) *http.Request
+		handlerFn  func(ctrl *gomock.Controller) *Handler
+		wantStatus int
+	}{
+		{
+			name: "successful request",
+			reqFn: func(t *testing.T) *http.Request {
+				data, err := proto.Marshal(&testWriteRequest)
+				require.NoError(t, err)
+
+				data = snappy.Encode(nil, data)
+				buf := bytes.NewBuffer(data)
+				return httptest.NewRequest(WriteHTTPMethod, WriteURL, buf)
+			},
+			handlerFn: func(ctrl *gomock.Controller) *Handler {
+				w := ingest.NewMockDownsamplerAndWriter(ctrl)
+				w.EXPECT().WriteBatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				return NewHandler(w, models.NewTagOptions(), tally.NoopScope)
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "internal error",
+			reqFn: func(t *testing.T) *http.Request {
+				data, err := proto.Marshal(&testWriteRequest)
+				require.NoError(t, err)
+
+				data = snappy.Encode(nil, data)
+				buf := bytes.NewBuffer(data)
+				return httptest.NewRequest(WriteHTTPMethod, WriteURL, buf)
+			},
+			handlerFn: func(ctrl *gomock.Controller) *Handler {
+				var (
+					w   = ingest.NewMockDownsamplerAndWriter(ctrl)
+					err = xerrors.NewMultiError()
+				)
+				err = err.Add(errors.New("test error"))
+				w.EXPECT().WriteBatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(err)
+				return NewHandler(w, models.NewTagOptions(), tally.NoopScope)
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "bad request",
+			reqFn: func(t *testing.T) *http.Request {
+				data, err := proto.Marshal(&testWriteRequest)
+				require.NoError(t, err)
+
+				data = snappy.Encode(nil, data)
+				buf := bytes.NewBuffer(data)
+				return httptest.NewRequest(WriteHTTPMethod, WriteURL, buf)
+			},
+			handlerFn: func(ctrl *gomock.Controller) *Handler {
+				var (
+					w   = ingest.NewMockDownsamplerAndWriter(ctrl)
+					err = xerrors.NewMultiError()
+				)
+				err = err.Add(xerrors.NewInvalidParamsError(errors.New("invalid params")))
+				w.EXPECT().WriteBatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(err)
+				return NewHandler(w, models.NewTagOptions(), tally.NoopScope)
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "empty body",
+			reqFn: func(_ *testing.T) *http.Request {
+				return httptest.NewRequest(WriteHTTPMethod, WriteURL, nil)
+			},
+			handlerFn: func(ctrl *gomock.Controller) *Handler {
+				w := ingest.NewMockDownsamplerAndWriter(ctrl)
+				return NewHandler(w, models.NewTagOptions(), tally.NoopScope)
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			var (
+				h = tt.handlerFn(ctrl)
+				r = tt.reqFn(t)
+				w = httptest.NewRecorder()
+			)
+			h.ServeHTTP(w, r)
+
+			resp := w.Result()
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+		})
+	}
+}
+
+func TestParseRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		inputFn func(t *testing.T) io.Reader
+		want    prompb.AnnotatedWriteRequest
+		wantErr string
+	}{
+		{
+			name: "valid write request",
+			inputFn: func(t *testing.T) io.Reader {
+				data, err := proto.Marshal(&testWriteRequest)
+				require.NoError(t, err)
+
+				data = snappy.Encode(nil, data)
+
+				return bytes.NewBuffer(data)
+			},
+			want: testWriteRequest,
+		},
+		{
+			name: "reader returns error",
+			inputFn: func(t *testing.T) io.Reader {
+				return iotest.TimeoutReader(bytes.NewBuffer([]byte("invalid")))
+			},
+			wantErr: "timeout",
+		},
+		{
+			name: "invalid snappy payload",
+			inputFn: func(_ *testing.T) io.Reader {
+				return bytes.NewBuffer([]byte("invalid"))
+			},
+			wantErr: "unable to decode request body: snappy: corrupt input",
+		},
+		{
+			name: "invalid write request",
+			inputFn: func(t *testing.T) io.Reader {
+				data := snappy.Encode(nil, []byte("invalid"))
+				return bytes.NewBuffer(data)
+			},
+			wantErr: "unable to unmarshal request: unexpected EOF",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := tt.inputFn(t)
+			actual, err := parseRequest(input)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, actual)
+		})
+	}
+}

--- a/src/query/api/experimental/annotated/iter.go
+++ b/src/query/api/experimental/annotated/iter.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package annotated
+
+import (
+	"github.com/m3db/m3/src/cmd/services/m3coordinator/ingest"
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/storage"
+	"github.com/m3db/m3/src/query/ts"
+	xtime "github.com/m3db/m3/src/x/time"
+)
+
+type datapoint struct {
+	ts.Datapoint
+
+	annotation []byte
+}
+
+func sampleToDatapoint(s prompb.AnnotatedSample) datapoint {
+	return datapoint{
+		Datapoint: ts.Datapoint{
+			Timestamp: storage.PromTimestampToTime(s.Timestamp),
+			Value:     s.Value,
+		},
+		annotation: s.Annotation,
+	}
+}
+
+var _ ingest.DownsampleAndWriteIter = &iter{}
+
+type iter struct {
+	idx        int
+	tags       []models.Tags
+	datapoints []datapoint
+}
+
+func newIter(
+	timeseries []prompb.AnnotatedTimeSeries, tagOpts models.TagOptions,
+) *iter {
+	var (
+		tags       = make([]models.Tags, 0, len(timeseries))
+		datapoints = make([]datapoint, 0, len(timeseries))
+	)
+	for _, ts := range timeseries {
+		t := storage.PromLabelsToM3Tags(ts.Labels, tagOpts)
+		for _, s := range ts.Samples {
+			tags = append(tags, t)
+			datapoints = append(datapoints, sampleToDatapoint(s))
+		}
+	}
+
+	return &iter{
+		idx:        -1,
+		tags:       tags,
+		datapoints: datapoints,
+	}
+}
+
+func (i *iter) Next() bool {
+	i.idx++
+	return i.idx < len(i.tags)
+}
+
+func (i *iter) Current() (models.Tags, ts.Datapoints, xtime.Unit, []byte) {
+	if len(i.tags) == 0 || i.idx < 0 || i.idx >= len(i.tags) {
+		return models.EmptyTags(), nil, 0, nil
+	}
+	curr := i.datapoints[i.idx]
+	return i.tags[i.idx], ts.Datapoints{curr.Datapoint}, xtime.Millisecond, curr.annotation
+}
+
+func (i *iter) Reset() error {
+	i.idx = -1
+	return nil
+}
+
+func (i *iter) Error() error {
+	return nil
+}

--- a/src/query/api/experimental/annotated/iter_test.go
+++ b/src/query/api/experimental/annotated/iter_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package annotated
+
+import (
+	"testing"
+
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/storage"
+	"github.com/m3db/m3/src/query/ts"
+	xtime "github.com/m3db/m3/src/x/time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testTimestampMillis = 1575000000000
+
+var testTimeseries = []prompb.AnnotatedTimeSeries{
+	prompb.AnnotatedTimeSeries{
+		Labels: []prompb.Label{
+			prompb.Label{Name: []byte("__name__"), Value: []byte("requests")},
+			prompb.Label{Name: []byte("status_code"), Value: []byte("200")},
+		},
+		Samples: []prompb.AnnotatedSample{
+			prompb.AnnotatedSample{
+				Value:      4.2,
+				Timestamp:  testTimestampMillis,
+				Annotation: []byte("foo"),
+			},
+			prompb.AnnotatedSample{
+				Value:      3.14,
+				Timestamp:  testTimestampMillis + 10000,
+				Annotation: []byte("bar"),
+			},
+		},
+	},
+	prompb.AnnotatedTimeSeries{
+		Labels: []prompb.Label{
+			prompb.Label{Name: []byte("__name__"), Value: []byte("requests")},
+			prompb.Label{Name: []byte("status_code"), Value: []byte("500")},
+		},
+		Samples: []prompb.AnnotatedSample{
+			prompb.AnnotatedSample{
+				Value:      6.28,
+				Timestamp:  testTimestampMillis,
+				Annotation: []byte("baz"),
+			},
+		},
+	},
+}
+
+func TestIter(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []prompb.AnnotatedTimeSeries
+		wants []iterOutput
+	}{
+		{
+			name:  "valid input",
+			input: testTimeseries,
+			wants: []iterOutput{
+				iterOutput{
+					tags: models.Tags{
+						Opts: models.NewTagOptions(),
+						Tags: []models.Tag{
+							models.Tag{Name: []byte("__name__"), Value: []byte("requests")},
+							models.Tag{Name: []byte("status_code"), Value: []byte("200")},
+						},
+					},
+					datapoints: ts.Datapoints{
+						ts.Datapoint{
+							Timestamp: storage.PromTimestampToTime(testTimestampMillis),
+							Value:     4.2,
+						},
+					},
+					unit:       xtime.Millisecond,
+					annotation: []byte("foo"),
+				},
+				iterOutput{
+					tags: models.Tags{
+						Opts: models.NewTagOptions(),
+						Tags: []models.Tag{
+							models.Tag{Name: []byte("__name__"), Value: []byte("requests")},
+							models.Tag{Name: []byte("status_code"), Value: []byte("200")},
+						},
+					},
+					datapoints: ts.Datapoints{
+						ts.Datapoint{
+							Timestamp: storage.PromTimestampToTime(testTimestampMillis + 10000),
+							Value:     3.14,
+						},
+					},
+					unit:       xtime.Millisecond,
+					annotation: []byte("bar"),
+				},
+				iterOutput{
+					tags: models.Tags{
+						Opts: models.NewTagOptions(),
+						Tags: []models.Tag{
+							models.Tag{Name: []byte("__name__"), Value: []byte("requests")},
+							models.Tag{Name: []byte("status_code"), Value: []byte("500")},
+						},
+					},
+					datapoints: ts.Datapoints{
+						ts.Datapoint{
+							Timestamp: storage.PromTimestampToTime(testTimestampMillis),
+							Value:     6.28,
+						},
+					},
+					unit:       xtime.Millisecond,
+					annotation: []byte("baz"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			iter := newIter(tt.input, models.NewTagOptions())
+			for _, want := range tt.wants {
+				testOutput(t, iter, want)
+			}
+
+			// Range over the wants values a second time so we can test resetting the iterator.
+			require.Nil(t, iter.Reset())
+			for _, e := range tt.wants {
+				testOutput(t, iter, e)
+			}
+
+			require.Nil(t, iter.Error())
+		})
+	}
+}
+
+func testOutput(t *testing.T, iter *iter, want iterOutput) {
+	require.True(t, iter.Next())
+
+	tags, datapoints, unit, annotation := iter.Current()
+	assert.Equal(t, want.tags, tags)
+	assert.Equal(t, want.datapoints, datapoints)
+	assert.Equal(t, want.unit, unit)
+	assert.Equal(t, want.annotation, annotation)
+}
+
+type iterOutput struct {
+	tags       models.Tags
+	datapoints ts.Datapoints
+	unit       xtime.Unit
+	annotation []byte
+}

--- a/src/query/api/v1/handler/types.go
+++ b/src/query/api/v1/handler/types.go
@@ -29,4 +29,7 @@ const (
 
 	// RoutePrefixV1 is the v1 prefix for all coordinator routes
 	RoutePrefixV1 = "/api/v1"
+
+	// RoutePrefixExperimenta is the experimental prefix for all coordinator routes
+	RoutePrefixExperimental = "/api/experimental"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an experimental API group to the coordinator for handling annotated metric write requests.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:

```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:

```documentation-note
NONE
```
