### PR TITLE
[dbnode] Make index memory RSS usage flat block over block

### DIFF
--- a/src/dbnode/persist/fs/index_read.go
+++ b/src/dbnode/persist/fs/index_read.go
@@ -201,11 +201,16 @@ func (r *indexReader) ReadSegmentFileSet() (
 			segmentType: idxpersist.IndexSegmentType(segment.SegmentType),
 		}
 	)
-	closeFiles := func() {
+	success := false
+	defer func() {
+		// Do not close opened files if read finishes sucessfully.
+		if success {
+			return
+		}
 		for _, file := range result.files {
 			file.Close()
 		}
-	}
+	}()
 	for _, file := range segment.Files {
 		segFileType := idxpersist.IndexSegmentFileType(file.SegmentFileType)
 
@@ -218,7 +223,6 @@ func (r *indexReader) ReadSegmentFileSet() (
 			filePath = filesetIndexSegmentFilePathFromTime(r.namespaceDir, r.start, r.volumeIndex,
 				r.currIdx, segFileType)
 		default:
-			closeFiles()
 			return nil, fmt.Errorf("unknown fileset type: %s", r.fileSetType)
 		}
 
@@ -234,7 +238,6 @@ func (r *indexReader) ReadSegmentFileSet() (
 			},
 		})
 		if err != nil {
-			closeFiles()
 			return nil, err
 		}
 
@@ -248,10 +251,16 @@ func (r *indexReader) ReadSegmentFileSet() (
 			segmentFileType: segFileType,
 			digest:          digest.Checksum(bytes),
 		})
+
+		// NB(bodu): Free mmaped bytes after we take the checksum so we don't get memory spikes at bootstrap time.
+		if err := mmap.MadviseDontNeed(bytes); err != nil {
+			return nil, err
+		}
 	}
 
 	r.currIdx++
 	r.readDigests.segments = append(r.readDigests.segments, digests)
+	success = true
 	return result, nil
 }
 

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -1259,6 +1259,7 @@ func (b *block) Tick(c context.Cancellable) (BlockTickResult, error) {
 		for _, seg := range group.segments {
 			result.NumSegments++
 			result.NumDocs += seg.Size()
+			// TODO(bodu): Revist this and implement a more sophisticated free strategy.
 			if immSeg, ok := seg.(segment.ImmutableSegment); ok {
 				if err := immSeg.FreeMmap(); err != nil {
 					multiErr.Add(err)

--- a/src/dbnode/storage/index/compaction/compactor.go
+++ b/src/dbnode/storage/index/compaction/compactor.go
@@ -32,8 +32,8 @@ import (
 	"github.com/m3db/m3/src/m3ninx/index/segment/builder"
 	"github.com/m3db/m3/src/m3ninx/index/segment/fst"
 	"github.com/m3db/m3/src/m3ninx/index/segment/fst/encoding/docs"
-	"github.com/m3db/m3/src/x/mmap"
 	xerrors "github.com/m3db/m3/src/x/errors"
+	"github.com/m3db/m3/src/x/mmap"
 )
 
 var (
@@ -175,6 +175,10 @@ func (c *Compactor) CompactUsingBuilder(
 		}
 
 		// Reset docs batch for reuse
+		var empty doc.Document
+		for i := range batch {
+			batch[i] = empty
+		}
 		batch = batch[:0]
 		return nil
 	}

--- a/src/dbnode/storage/index/read_through_segment.go
+++ b/src/dbnode/storage/index/read_through_segment.go
@@ -140,6 +140,14 @@ func (r *ReadThroughSegment) ContainsField(field []byte) (bool, error) {
 	return r.segment.ContainsField(field)
 }
 
+// FreeMmap frees the mmapped data if any.
+func (r *ReadThroughSegment) FreeMmap() error {
+	if immSeg, ok := r.segment.(segment.ImmutableSegment); ok {
+		return immSeg.FreeMmap()
+	}
+	return nil
+}
+
 // Size is a pass through call to the segment, since there's no
 // postings lists to cache for queries.
 func (r *ReadThroughSegment) Size() int64 {

--- a/src/m3ninx/index/segment/fst/segment.go
+++ b/src/m3ninx/index/segment/fst/segment.go
@@ -299,24 +299,24 @@ func (r *fsSegment) FreeMmap() error {
 	multiErr := xerrors.NewMultiError()
 
 	// NB(bodu): PostingsData, FSTTermsData and FSTFieldsData always present.
-	if err := mmap.Free(r.data.PostingsData); err != nil {
+	if err := mmap.MadviseDontNeed(r.data.PostingsData); err != nil {
 		multiErr = multiErr.Add(err)
 	}
-	if err := mmap.Free(r.data.FSTTermsData); err != nil {
+	if err := mmap.MadviseDontNeed(r.data.FSTTermsData); err != nil {
 		multiErr = multiErr.Add(err)
 	}
-	if err := mmap.Free(r.data.FSTFieldsData); err != nil {
+	if err := mmap.MadviseDontNeed(r.data.FSTFieldsData); err != nil {
 		multiErr = multiErr.Add(err)
 	}
 
 	// DocsData and DocsIdxData are not always present.
 	if r.data.DocsData != nil {
-		if err := mmap.Free(r.data.DocsData); err != nil {
+		if err := mmap.MadviseDontNeed(r.data.DocsData); err != nil {
 			multiErr = multiErr.Add(err)
 		}
 	}
 	if r.data.DocsIdxData != nil {
-		if err := mmap.Free(r.data.DocsIdxData); err != nil {
+		if err := mmap.MadviseDontNeed(r.data.DocsIdxData); err != nil {
 			multiErr = multiErr.Add(err)
 		}
 	}

--- a/src/m3ninx/index/segment/fst/segment.go
+++ b/src/m3ninx/index/segment/fst/segment.go
@@ -37,6 +37,9 @@ import (
 	"github.com/m3db/m3/src/m3ninx/postings/roaring"
 	"github.com/m3db/m3/src/m3ninx/x"
 	"github.com/m3db/m3/src/x/context"
+	xerrors "github.com/m3db/m3/src/x/errors"
+	"github.com/m3db/m3/src/x/mmap"
+
 	pilosaroaring "github.com/m3db/pilosa/roaring"
 	"github.com/m3db/vellum"
 )
@@ -290,6 +293,35 @@ func (r *fsSegment) TermsIterable() sgmt.TermsIterable {
 		fieldsIter:   newFSTTermsIter(),
 		postingsIter: newFSTTermsPostingsIter(),
 	}
+}
+
+func (r *fsSegment) FreeMmap() error {
+	multiErr := xerrors.NewMultiError()
+
+	// NB(bodu): PostingsData, FSTTermsData and FSTFieldsData always present.
+	if err := mmap.Free(r.data.PostingsData); err != nil {
+		multiErr = multiErr.Add(err)
+	}
+	if err := mmap.Free(r.data.FSTTermsData); err != nil {
+		multiErr = multiErr.Add(err)
+	}
+	if err := mmap.Free(r.data.FSTFieldsData); err != nil {
+		multiErr = multiErr.Add(err)
+	}
+
+	// DocsData and DocsIdxData are not always present.
+	if r.data.DocsData != nil {
+		if err := mmap.Free(r.data.DocsData); err != nil {
+			multiErr = multiErr.Add(err)
+		}
+	}
+	if r.data.DocsIdxData != nil {
+		if err := mmap.Free(r.data.DocsIdxData); err != nil {
+			multiErr = multiErr.Add(err)
+		}
+	}
+
+	return multiErr.FinalError()
 }
 
 // termsIterable allows multiple term lookups to share the same roaring

--- a/src/m3ninx/index/segment/segment_mock.go
+++ b/src/m3ninx/index/segment/segment_mock.go
@@ -738,6 +738,144 @@ func (mr *MockMutableSegmentMockRecorder) IsSealed() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSealed", reflect.TypeOf((*MockMutableSegment)(nil).IsSealed))
 }
 
+// MockImmutableSegment is a mock of ImmutableSegment interface
+type MockImmutableSegment struct {
+	ctrl     *gomock.Controller
+	recorder *MockImmutableSegmentMockRecorder
+}
+
+// MockImmutableSegmentMockRecorder is the mock recorder for MockImmutableSegment
+type MockImmutableSegmentMockRecorder struct {
+	mock *MockImmutableSegment
+}
+
+// NewMockImmutableSegment creates a new mock instance
+func NewMockImmutableSegment(ctrl *gomock.Controller) *MockImmutableSegment {
+	mock := &MockImmutableSegment{ctrl: ctrl}
+	mock.recorder = &MockImmutableSegmentMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockImmutableSegment) EXPECT() *MockImmutableSegmentMockRecorder {
+	return m.recorder
+}
+
+// FieldsIterable mocks base method
+func (m *MockImmutableSegment) FieldsIterable() FieldsIterable {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FieldsIterable")
+	ret0, _ := ret[0].(FieldsIterable)
+	return ret0
+}
+
+// FieldsIterable indicates an expected call of FieldsIterable
+func (mr *MockImmutableSegmentMockRecorder) FieldsIterable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FieldsIterable", reflect.TypeOf((*MockImmutableSegment)(nil).FieldsIterable))
+}
+
+// TermsIterable mocks base method
+func (m *MockImmutableSegment) TermsIterable() TermsIterable {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TermsIterable")
+	ret0, _ := ret[0].(TermsIterable)
+	return ret0
+}
+
+// TermsIterable indicates an expected call of TermsIterable
+func (mr *MockImmutableSegmentMockRecorder) TermsIterable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TermsIterable", reflect.TypeOf((*MockImmutableSegment)(nil).TermsIterable))
+}
+
+// Size mocks base method
+func (m *MockImmutableSegment) Size() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// Size indicates an expected call of Size
+func (mr *MockImmutableSegmentMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockImmutableSegment)(nil).Size))
+}
+
+// ContainsID mocks base method
+func (m *MockImmutableSegment) ContainsID(docID []byte) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainsID", docID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainsID indicates an expected call of ContainsID
+func (mr *MockImmutableSegmentMockRecorder) ContainsID(docID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsID", reflect.TypeOf((*MockImmutableSegment)(nil).ContainsID), docID)
+}
+
+// ContainsField mocks base method
+func (m *MockImmutableSegment) ContainsField(field []byte) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainsField", field)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainsField indicates an expected call of ContainsField
+func (mr *MockImmutableSegmentMockRecorder) ContainsField(field interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsField", reflect.TypeOf((*MockImmutableSegment)(nil).ContainsField), field)
+}
+
+// Reader mocks base method
+func (m *MockImmutableSegment) Reader() (index.Reader, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reader")
+	ret0, _ := ret[0].(index.Reader)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Reader indicates an expected call of Reader
+func (mr *MockImmutableSegmentMockRecorder) Reader() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reader", reflect.TypeOf((*MockImmutableSegment)(nil).Reader))
+}
+
+// Close mocks base method
+func (m *MockImmutableSegment) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close
+func (mr *MockImmutableSegmentMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockImmutableSegment)(nil).Close))
+}
+
+// FreeMmap mocks base method
+func (m *MockImmutableSegment) FreeMmap() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FreeMmap")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FreeMmap indicates an expected call of FreeMmap
+func (mr *MockImmutableSegmentMockRecorder) FreeMmap() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FreeMmap", reflect.TypeOf((*MockImmutableSegment)(nil).FreeMmap))
+}
+
 // MockBuilder is a mock of Builder interface
 type MockBuilder struct {
 	ctrl     *gomock.Controller

--- a/src/m3ninx/index/segment/types.go
+++ b/src/m3ninx/index/segment/types.go
@@ -144,6 +144,13 @@ type MutableSegment interface {
 	IsSealed() bool
 }
 
+// ImmutableSegment is segment that has been written to disk.
+type ImmutableSegment interface {
+	Segment
+
+	FreeMmap() error
+}
+
 // Builder is a builder that can be used to construct segments.
 type Builder interface {
 	FieldsIterable

--- a/src/x/instrument/invariant.go
+++ b/src/x/instrument/invariant.go
@@ -69,13 +69,11 @@ func EmitInvariantViolation(opts Options) {
 // with a supplied logger that is pre-configured with an invariant violated field. Optionally panics
 // if the ShouldPanicEnvironmentVariableName is set to "true".
 func EmitAndLogInvariantViolation(opts Options, f func(l *zap.Logger)) {
-	EmitInvariantViolation(opts)
-
 	logger := opts.Logger().With(
 		zap.String(InvariantViolatedLogFieldName, InvariantViolatedLogFieldValue))
 	f(logger)
 
-	panicIfEnvSet()
+	EmitInvariantViolation(opts)
 }
 
 // InvariantErrorf constructs a new error, prefixed with a string indicating that an invariant

--- a/src/x/mmap/mmap_linux.go
+++ b/src/x/mmap/mmap_linux.go
@@ -110,7 +110,14 @@ func Munmap(b []byte) error {
 	return nil
 }
 
-// Free mmapped memory.
-func Free(b []byte) error {
+// MadviseDontNeed frees mmapped memory.
+// `MADV_DONTNEED` informs the kernel to free the mmapped pages right away instead of waiting for memory pressure.
+// NB(bodu): DO NOT FREE anonymously mapped memory or else it will null all of the underlying bytes as the
+// memory is not file backed.
+func MadviseDontNeed(b []byte) error {
+	// Do nothing if there's no data.
+	if len(b) == 0 {
+		return nil
+	}
 	return syscall.Madvise(b, syscall.MADV_DONTNEED)
 }

--- a/src/x/mmap/mmap_linux.go
+++ b/src/x/mmap/mmap_linux.go
@@ -109,3 +109,8 @@ func Munmap(b []byte) error {
 
 	return nil
 }
+
+// Free mmapped memory.
+func Free(b []byte) error {
+	return syscall.Madvise(b, syscall.MADV_DONTNEED)
+}

--- a/src/x/mmap/mmap_other.go
+++ b/src/x/mmap/mmap_other.go
@@ -83,12 +83,20 @@ func Munmap(b []byte) error {
 	return nil
 }
 
-// Free mmapped memory.
-func Free(b []byte) error {
+// MadviseDontNeed frees mmapped memory.
+// `MADV_DONTNEED` informs the kernel to free the mmapped pages right away instead of waiting for memory pressure.
+// NB(bodu): DO NOT FREE anonymously mapped memory or else it will null all of the underlying bytes as the
+// memory is not file backed.
+func MadviseDontNeed(b []byte) error {
+	// Do nothing if there's no data.
+	if len(b) == 0 {
+		return nil
+	}
 	return madvise(b, syscall.MADV_DONTNEED)
 }
 
-// This is required because the unix package does not support the madvise system call on OS X.
+// This is required because the unix package does not support the madvise system call.
+// This works generically for other non linux platforms.
 func madvise(b []byte, advice int) (err error) {
 	_, _, e1 := syscall.Syscall(syscall.SYS_MADVISE, uintptr(unsafe.Pointer(&b[0])),
 		uintptr(len(b)), uintptr(advice))


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, memory usage scales w/ the size of the index up until retention. This is due to flushed index segment files being mmap'ed into memory and remaining in memory after we take a checksum. This PR naively frees file backed mmap'ed memory pages every Tick.

**Special notes for your reviewer**:
Left a `TODO` for implementing a more sophisticated free strategy in the future.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
- Reduce index memory usage.
```

**Does this PR require updating code package or user-facing documentation?**:
No.