### PR TITLE
[coordinator] Ensure Prometheus handlers use consistent set of labels

### DIFF
--- a/src/query/api/experimental/annotated/handler.go
+++ b/src/query/api/experimental/annotated/handler.go
@@ -62,7 +62,7 @@ func NewHandler(
 	return &Handler{
 		writer:     writer,
 		tagOptions: tagOptions,
-		metrics:    newHandlerMetrics(scope),
+		metrics:    newHandlerMetrics(scope.Tagged(map[string]string{"handler": "annotated-write"})),
 	}
 }
 

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -121,7 +121,9 @@ func NewPromWriteHandler(
 		return nil, errNoNowFn
 	}
 
-	metrics, err := newPromWriteMetrics(instrumentOpts.MetricsScope())
+	metrics, err := newPromWriteMetrics(instrumentOpts.MetricsScope().
+		Tagged(map[string]string{"handler": "remote-write"}),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/src/query/api/v1/handler/prometheus/remote/write_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/write_test.go
@@ -143,7 +143,7 @@ func TestWriteErrorMetricCount(t *testing.T) {
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
 	foundMetric := xclock.WaitUntil(func() bool {
-		found, ok := scope.Snapshot().Counters()["write.errors+code=4XX,test=error-metric-test"]
+		found, ok := scope.Snapshot().Counters()["write.errors+code=4XX,handler=remote-write,test=error-metric-test"]
 		return ok && found.Value() == 1
 	}, 5*time.Second)
 	require.True(t, foundMetric)
@@ -193,7 +193,7 @@ func TestWriteDatapointDelayMetric(t *testing.T) {
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
 	foundMetric := xclock.WaitUntil(func() bool {
-		values, found := scope.Snapshot().Histograms()["ingest.latency+test=delay-metric-test"]
+		values, found := scope.Snapshot().Histograms()["ingest.latency+handler=remote-write,test=delay-metric-test"]
 		if !found {
 			return false
 		}

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -211,7 +211,10 @@ func (h *Handler) RegisterRoutes() error {
 	}
 
 	nativeSourceInstrumentOpts := h.instrumentOpts.
-		SetMetricsScope(h.instrumentOpts.MetricsScope().Tagged(nativeSource))
+		SetMetricsScope(h.instrumentOpts.MetricsScope().
+			Tagged(nativeSource).
+			Tagged(v1APIGroup),
+		)
 	nativePromReadHandler := native.NewPromReadHandler(h.engine,
 		h.fetchOptionsBuilder, h.tagOptions, &h.config.Limits,
 		h.timeoutOpts, keepNans, nativeSourceInstrumentOpts)

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -70,6 +70,9 @@ var (
 	remoteSource = map[string]string{"source": "remote"}
 	nativeSource = map[string]string{"source": "native"}
 
+	v1APIGroup           = map[string]string{"api_group": "v1"}
+	experimentalAPIGroup = map[string]string{"api_group": "experimental"}
+
 	defaultTimeout = 30 * time.Second
 )
 
@@ -194,7 +197,10 @@ func (h *Handler) RegisterRoutes() error {
 
 	// Prometheus remote read/write endpoints
 	remoteSourceInstrumentOpts := h.instrumentOpts.
-		SetMetricsScope(h.instrumentOpts.MetricsScope().Tagged(remoteSource))
+		SetMetricsScope(h.instrumentOpts.MetricsScope().
+			Tagged(remoteSource).
+			Tagged(v1APIGroup),
+		)
 
 	promRemoteReadHandler := remote.NewPromReadHandler(h.engine,
 		h.fetchOptionsBuilder, h.timeoutOpts, keepNans, remoteSourceInstrumentOpts)
@@ -328,7 +334,9 @@ func (h *Handler) RegisterRoutes() error {
 			experimentalAnnotatedWriteHandler := annotated.NewHandler(
 				h.downsamplerAndWriter,
 				h.tagOptions,
-				h.instrumentOpts.MetricsScope().Tagged(map[string]string{"api_group": "experimental"}),
+				h.instrumentOpts.MetricsScope().
+					Tagged(remoteSource).
+					Tagged(experimentalAPIGroup),
 			)
 			h.router.HandleFunc(annotated.WriteURL,
 				wrapped(experimentalAnnotatedWriteHandler).ServeHTTP,


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure the Prometheus remote write handlers use a consistent set of labels.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:

```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:

```documentation-note
NONE
```
