### PR TITLE
[dbnode] Support cold index writes

### DIFF
--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -76,9 +76,10 @@ type FetchBlockResult struct {
 
 // FetchBlocksMetadataOptions are options used when fetching blocks metadata.
 type FetchBlocksMetadataOptions struct {
-	IncludeSizes     bool
-	IncludeChecksums bool
-	IncludeLastRead  bool
+	IncludeSizes        bool
+	IncludeChecksums    bool
+	IncludeLastRead     bool
+	OnlyFetchTokenBlock bool
 }
 
 // FetchBlockMetadataResult captures the block start time, the block size, and any errors encountered

--- a/src/dbnode/storage/index/index_mock.go
+++ b/src/dbnode/storage/index/index_mock.go
@@ -812,6 +812,34 @@ func (mr *MockBlockMockRecorder) EvictMutableSegments() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictMutableSegments", reflect.TypeOf((*MockBlock)(nil).EvictMutableSegments))
 }
 
+// NeedsColdFlushMutableSegmentsEvicted mocks base method
+func (m *MockBlock) NeedsColdFlushMutableSegmentsEvicted() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeedsColdFlushMutableSegmentsEvicted")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NeedsColdFlushMutableSegmentsEvicted indicates an expected call of NeedsColdFlushMutableSegmentsEvicted
+func (mr *MockBlockMockRecorder) NeedsColdFlushMutableSegmentsEvicted() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedsColdFlushMutableSegmentsEvicted", reflect.TypeOf((*MockBlock)(nil).NeedsColdFlushMutableSegmentsEvicted))
+}
+
+// EvictColdFlushMutableSegments mocks base method
+func (m *MockBlock) EvictColdFlushMutableSegments() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EvictColdFlushMutableSegments")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EvictColdFlushMutableSegments indicates an expected call of EvictColdFlushMutableSegments
+func (mr *MockBlockMockRecorder) EvictColdFlushMutableSegments() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictColdFlushMutableSegments", reflect.TypeOf((*MockBlock)(nil).EvictColdFlushMutableSegments))
+}
+
 // Close mocks base method
 func (m *MockBlock) Close() error {
 	m.ctrl.T.Helper()

--- a/src/dbnode/storage/index/types.go
+++ b/src/dbnode/storage/index/types.go
@@ -352,6 +352,9 @@ type Block interface {
 	// data the mutable segments should have held at this time.
 	EvictMutableSegments() error
 
+	NeedsColdFlushMutableSegmentsEvicted() bool
+	EvictColdFlushMutableSegments() error
+
 	// Close will release any held resources and close the Block.
 	Close() error
 }

--- a/src/dbnode/storage/index/types.go
+++ b/src/dbnode/storage/index/types.go
@@ -69,6 +69,17 @@ const (
 	AggregateTagNames
 )
 
+// FlushType specifies what type of data we are flushing.
+type FlushType int
+
+const (
+	// WarmFlush flushes all warm writes to disk.
+	WarmFlush FlushType = iota
+
+	// ColdFlush flushes all cold writes to disk.
+	ColdFlush
+)
+
 // Query is a rich end user query to describe a set of constraints on required IDs.
 type Query struct {
 	idx.Query

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -154,7 +154,7 @@ func TestNamespaceIndexFlushSuccess(t *testing.T) {
 	mockBlock.EXPECT().AddResults(gomock.Any()).Return(nil)
 	mockBlock.EXPECT().EvictMutableSegments().Return(nil)
 
-	require.NoError(t, idx.Flush(mockFlush, shards))
+	require.NoError(t, idx.WarmFlush(mockFlush, shards))
 	require.True(t, persistCalled)
 	require.True(t, persistClosed)
 }
@@ -191,7 +191,7 @@ func TestNamespaceIndexFlushShardStateNotSuccess(t *testing.T) {
 
 	mockFlush := persist.NewMockIndexFlush(ctrl)
 
-	require.NoError(t, idx.Flush(mockFlush, shards))
+	require.NoError(t, idx.WarmFlush(mockFlush, shards))
 }
 
 func TestNamespaceIndexFlushSuccessMultipleShards(t *testing.T) {
@@ -268,7 +268,7 @@ func TestNamespaceIndexFlushSuccessMultipleShards(t *testing.T) {
 	mockBlock.EXPECT().AddResults(gomock.Any()).Return(nil)
 	mockBlock.EXPECT().EvictMutableSegments().Return(nil)
 
-	require.NoError(t, idx.Flush(mockFlush, shards))
+	require.NoError(t, idx.WarmFlush(mockFlush, shards))
 	require.Equal(t, 2, numPersistCalls)
 	require.True(t, persistClosed)
 }

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -146,10 +146,10 @@ func TestNamespaceIndexFlushSuccess(t *testing.T) {
 	})).Return(preparedPersist, nil)
 
 	results := block.NewMockFetchBlocksMetadataResults(ctrl)
-	results.EXPECT().Results().Return(nil)
-	results.EXPECT().Close()
+	results.EXPECT().Results().Return(nil).AnyTimes()
+	results.EXPECT().Close().AnyTimes()
 	mockShard.EXPECT().FetchBlocksMetadataV2(gomock.Any(), blockTime, blockTime.Add(test.indexBlockSize),
-		gomock.Any(), gomock.Any(), block.FetchBlocksMetadataOptions{}).Return(results, nil, nil)
+		gomock.Any(), gomock.Any(), block.FetchBlocksMetadataOptions{OnlyFetchTokenBlock: true}).Return(results, nil, nil).AnyTimes()
 
 	mockBlock.EXPECT().AddResults(gomock.Any()).Return(nil)
 	mockBlock.EXPECT().EvictMutableSegments().Return(nil)
@@ -254,16 +254,16 @@ func TestNamespaceIndexFlushSuccessMultipleShards(t *testing.T) {
 	})).Return(preparedPersist, nil)
 
 	results1 := block.NewMockFetchBlocksMetadataResults(ctrl)
-	results1.EXPECT().Results().Return(nil)
-	results1.EXPECT().Close()
+	results1.EXPECT().Results().Return(nil).AnyTimes()
+	results1.EXPECT().Close().AnyTimes()
 	mockShard1.EXPECT().FetchBlocksMetadataV2(gomock.Any(), blockTime, blockTime.Add(test.indexBlockSize),
-		gomock.Any(), gomock.Any(), block.FetchBlocksMetadataOptions{}).Return(results1, nil, nil)
+		gomock.Any(), gomock.Any(), block.FetchBlocksMetadataOptions{OnlyFetchTokenBlock: true}).Return(results1, nil, nil).AnyTimes()
 
 	results2 := block.NewMockFetchBlocksMetadataResults(ctrl)
-	results2.EXPECT().Results().Return(nil)
-	results2.EXPECT().Close()
+	results2.EXPECT().Results().Return(nil).AnyTimes()
+	results2.EXPECT().Close().AnyTimes()
 	mockShard2.EXPECT().FetchBlocksMetadataV2(gomock.Any(), blockTime, blockTime.Add(test.indexBlockSize),
-		gomock.Any(), gomock.Any(), block.FetchBlocksMetadataOptions{}).Return(results2, nil, nil)
+		gomock.Any(), gomock.Any(), block.FetchBlocksMetadataOptions{OnlyFetchTokenBlock: true}).Return(results2, nil, nil).AnyTimes()
 
 	mockBlock.EXPECT().AddResults(gomock.Any()).Return(nil)
 	mockBlock.EXPECT().EvictMutableSegments().Return(nil)

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1115,7 +1115,30 @@ func (n *dbNamespace) FlushIndex(flush persist.IndexFlush) error {
 	}
 
 	shards := n.GetOwnedShards()
-	err := n.reverseIndex.Flush(flush, shards)
+	err := n.reverseIndex.WarmFlush(flush, shards)
+	n.metrics.flushIndex.ReportSuccessOrError(err, n.nowFn().Sub(callStart))
+	return err
+}
+
+func (n *dbNamespace) ColdFlushIndex(
+	flush persist.IndexFlush,
+) error {
+	callStart := n.nowFn()
+	n.RLock()
+	if n.bootstrapState != Bootstrapped {
+		n.RUnlock()
+		n.metrics.flushIndex.ReportError(n.nowFn().Sub(callStart))
+		return errNamespaceNotBootstrapped
+	}
+	n.RUnlock()
+
+	if !n.nopts.FlushEnabled() || !n.nopts.ColdWritesEnabled() || !n.nopts.IndexOptions().Enabled() {
+		n.metrics.flushIndex.ReportSuccess(n.nowFn().Sub(callStart))
+		return nil
+	}
+
+	shards := n.GetOwnedShards()
+	err := n.reverseIndex.ColdFlush(flush, shards)
 	n.metrics.flushIndex.ReportSuccessOrError(err, n.nowFn().Sub(callStart))
 	return err
 }

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1701,6 +1701,11 @@ func (s *dbShard) FetchBlocksMetadataV2(
 			continue
 		}
 
+		// NB(bodu): If specified, we only want to return results for the token block.
+		if opts.OnlyFetchTokenBlock && !blockStart.Equal(tokenBlockStart) {
+			return result, nil, nil
+		}
+
 		var pos readerPosition
 		if !tokenBlockStart.IsZero() {
 			// Was previously seeking through a previous block, need to validate

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -1357,6 +1357,20 @@ func (mr *MockdatabaseNamespaceMockRecorder) ColdFlush(flush interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ColdFlush", reflect.TypeOf((*MockdatabaseNamespace)(nil).ColdFlush), flush)
 }
 
+// ColdFlushIndex mocks base method
+func (m *MockdatabaseNamespace) ColdFlushIndex(flush persist.IndexFlush) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ColdFlushIndex", flush)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ColdFlushIndex indicates an expected call of ColdFlushIndex
+func (mr *MockdatabaseNamespaceMockRecorder) ColdFlushIndex(flush interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ColdFlushIndex", reflect.TypeOf((*MockdatabaseNamespace)(nil).ColdFlushIndex), flush)
+}
+
 // Snapshot mocks base method
 func (m *MockdatabaseNamespace) Snapshot(blockStart, snapshotTime time.Time, flush persist.SnapshotPreparer) error {
 	m.ctrl.T.Helper()
@@ -2060,18 +2074,32 @@ func (mr *MocknamespaceIndexMockRecorder) Tick(c, startTime interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MocknamespaceIndex)(nil).Tick), c, startTime)
 }
 
-// Flush mocks base method
-func (m *MocknamespaceIndex) Flush(flush persist.IndexFlush, shards []databaseShard) error {
+// WarmFlush mocks base method
+func (m *MocknamespaceIndex) WarmFlush(flush persist.IndexFlush, shards []databaseShard) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Flush", flush, shards)
+	ret := m.ctrl.Call(m, "WarmFlush", flush, shards)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Flush indicates an expected call of Flush
-func (mr *MocknamespaceIndexMockRecorder) Flush(flush, shards interface{}) *gomock.Call {
+// WarmFlush indicates an expected call of WarmFlush
+func (mr *MocknamespaceIndexMockRecorder) WarmFlush(flush, shards interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MocknamespaceIndex)(nil).Flush), flush, shards)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WarmFlush", reflect.TypeOf((*MocknamespaceIndex)(nil).WarmFlush), flush, shards)
+}
+
+// ColdFlush mocks base method
+func (m *MocknamespaceIndex) ColdFlush(flush persist.IndexFlush, shards []databaseShard) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ColdFlush", flush, shards)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ColdFlush indicates an expected call of ColdFlush
+func (mr *MocknamespaceIndexMockRecorder) ColdFlush(flush, shards interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ColdFlush", reflect.TypeOf((*MocknamespaceIndex)(nil).ColdFlush), flush, shards)
 }
 
 // Close mocks base method

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -354,6 +354,11 @@ type databaseNamespace interface {
 		flush persist.FlushPreparer,
 	) error
 
+	// ColdFlushIndex flushes unflushed in-memory indexes of ColdWrites.
+	ColdFlushIndex(
+		flush persist.IndexFlush,
+	) error
+
 	// Snapshot snapshots unflushed in-memory WarmWrites.
 	Snapshot(blockStart, snapshotTime time.Time, flush persist.SnapshotPreparer) error
 
@@ -606,9 +611,16 @@ type namespaceIndex interface {
 	// data eviction, and so on.
 	Tick(c context.Cancellable, startTime time.Time) (namespaceIndexTickResult, error)
 
-	// Flush performs any flushes that the index has outstanding using
+	// WarmFlush performs any warm flushes that the index has outstanding using
 	// the owned shards of the database.
-	Flush(
+	WarmFlush(
+		flush persist.IndexFlush,
+		shards []databaseShard,
+	) error
+
+	// ColdFlush performs any cold flushes that the index has outstanding using
+	// the owned shards of the database.
+	ColdFlush(
 		flush persist.IndexFlush,
 		shards []databaseShard,
 	) error


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds the ability to write out indexed series written arbitrarily out of order in the past (cold writes). Based off of work done in this PR: https://github.com/m3db/m3/pull/1825. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
