### PR TITLE
[dbnode] Fix bootstrapping data for an unowned shard with commit log

### DIFF
--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -479,6 +479,8 @@ func (s *commitLogSource) Read(
 			continue
 		}
 		// If not bootstrapping shard for this series then also skip.
+		// NB(r): This can occur when a topology change happens then we
+		// bootstrap from the commit log data that the node no longer owns.
 		shard := seriesEntry.series.Shard
 		_, bootstrapping := seriesEntry.namespace.dataAndIndexShardRanges[shard]
 		if !bootstrapping {

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -220,10 +220,16 @@ func (b bootstrapProcess) Run(
 		for _, entry := range namespaces.Namespaces.Iter() {
 			namespace := entry.Value()
 			nsID := namespace.Metadata.ID()
-			result, ok := res.Results.Get(nsID)
-			if !ok {
-				return NamespaceResults{},
-					fmt.Errorf("result missing for namespace: %v", nsID.String())
+
+			var result NamespaceResult
+			if err == nil {
+				// Only can access the result if we didn't receive an error.
+				var ok bool
+				result, ok = res.Results.Get(nsID)
+				if !ok {
+					return NamespaceResults{},
+						fmt.Errorf("result missing for namespace: %v", nsID.String())
+				}
 			}
 
 			logFields := b.logFields(namespace.Metadata, namespace.Shards,

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -217,28 +217,26 @@ func (b bootstrapProcess) Run(
 		begin := b.nowFn()
 		res, err := b.bootstrapper.Bootstrap(namespaces)
 		took := b.nowFn().Sub(begin)
+		if err != nil {
+			b.log.Error("bootstrap process error",
+				zap.Duration("took", took),
+				zap.Error(err))
+			return NamespaceResults{}, err
+		}
+
 		for _, entry := range namespaces.Namespaces.Iter() {
 			namespace := entry.Value()
 			nsID := namespace.Metadata.ID()
 
-			var result NamespaceResult
-			if err == nil {
-				// Only can access the result if we didn't receive an error.
-				var ok bool
-				result, ok = res.Results.Get(nsID)
-				if !ok {
-					return NamespaceResults{},
-						fmt.Errorf("result missing for namespace: %v", nsID.String())
-				}
+			result, ok := res.Results.Get(nsID)
+			if !ok {
+				return NamespaceResults{},
+					fmt.Errorf("result missing for namespace: %v", nsID.String())
 			}
 
 			logFields := b.logFields(namespace.Metadata, namespace.Shards,
 				namespace.DataTargetRange.Range, namespace.IndexTargetRange.Range)
-			b.logBootstrapResult(result, logFields, err, took)
-		}
-
-		if err != nil {
-			return NamespaceResults{}, err
+			b.logBootstrapResult(result, logFields, took)
 		}
 
 		bootstrapResult = MergeNamespaceResults(bootstrapResult, res)
@@ -292,7 +290,6 @@ func (b bootstrapProcess) logBootstrapRun(
 func (b bootstrapProcess) logBootstrapResult(
 	result NamespaceResult,
 	logFields []zapcore.Field,
-	err error,
 	took time.Duration,
 ) {
 	logFields = append(logFields,
@@ -301,13 +298,8 @@ func (b bootstrapProcess) logBootstrapResult(
 		logFields = append(logFields,
 			zap.Int("numIndexBlocks", len(result.IndexResult.IndexResults())))
 	}
-	if err != nil {
-		logFields = append(logFields, zap.Error(err))
-		b.log.Info("bootstrap range completed with error", logFields...)
-		return
-	}
 
-	b.log.Info("bootstrap range completed successfully", logFields...)
+	b.log.Info("bootstrap range completed", logFields...)
 }
 
 func (b bootstrapProcess) targetRangesForData(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes issue #2051 on master with the latest bootstrapping changes, the commit log bootstrapper was attempting to bootstrap data from shards it no longer owned.

Followup change with an integration test to catch this case will follow.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
