### PR TITLE
Fix (almost) infinite loop in Fileset writer when previous fileset encountered an error writing out index files

### DIFF
--- a/src/dbnode/persist/fs/read_write_test.go
+++ b/src/dbnode/persist/fs/read_write_test.go
@@ -494,12 +494,6 @@ func TestWriterOnlyWritesNonNilBytes(t *testing.T) {
 	filePathPrefix := filepath.Join(dir, "")
 	defer os.RemoveAll(dir)
 
-	checkedBytes := func(b []byte) checked.Bytes {
-		r := checked.NewBytes(b, nil)
-		r.IncRef()
-		return r
-	}
-
 	w := newTestWriter(t, filePathPrefix)
 	writerOpts := DataWriterOpenOptions{
 		BlockSize: testBlockSize,
@@ -525,4 +519,10 @@ func TestWriterOnlyWritesNonNilBytes(t *testing.T) {
 	readTestData(t, r, 0, testWriterStart, []testEntry{
 		{"foo", nil, []byte{1, 2, 3, 4, 5, 6}},
 	})
+}
+
+func checkedBytes(b []byte) checked.Bytes {
+	r := checked.NewBytes(b, nil)
+	r.IncRef()
+	return r
 }

--- a/src/dbnode/persist/fs/write.go
+++ b/src/dbnode/persist/fs/write.go
@@ -152,20 +152,7 @@ func (w *writer) Open(opts DataWriterOpenOptions) error {
 		blockStart  = opts.Identifier.BlockStart
 		volumeIndex = opts.Identifier.VolumeIndex
 	)
-
-	w.blockSize = opts.BlockSize
-	w.start = blockStart
-	w.volumeIndex = volumeIndex
-	w.snapshotTime = opts.Snapshot.SnapshotTime
-	w.snapshotID = opts.Snapshot.SnapshotID
-	w.currIdx = 0
-	w.currOffset = 0
-	w.err = nil
-	// This happens after writing the previous set of files index files, however, do it
-	// again to ensure they get cleared even if there was a premature error writing out the
-	// previous set of files which would have prevented them from being cleared.
-	w.indexEntries.releaseRefs()
-	w.indexEntries = w.indexEntries[:0]
+	w.reset(opts)
 
 	var (
 		shardDir            string
@@ -232,6 +219,22 @@ func (w *writer) Open(opts DataWriterOpenOptions) error {
 	w.digestFdWithDigestContents.Reset(digestFd)
 
 	return nil
+}
+
+func (w *writer) reset(opts DataWriterOpenOptions) {
+	w.blockSize = opts.BlockSize
+	w.start = opts.Identifier.BlockStart
+	w.volumeIndex = opts.Identifier.VolumeIndex
+	w.snapshotTime = opts.Snapshot.SnapshotTime
+	w.snapshotID = opts.Snapshot.SnapshotID
+	w.currIdx = 0
+	w.currOffset = 0
+	w.err = nil
+	// This happens after writing the previous set of files index files, however, do it
+	// again to ensure they get cleared even if there was a premature error writing out the
+	// previous set of files which would have prevented them from being cleared.
+	w.indexEntries.releaseRefs()
+	w.indexEntries = w.indexEntries[:0]
 }
 
 func (w *writer) writeData(data []byte) error {

--- a/src/dbnode/persist/fs/write.go
+++ b/src/dbnode/persist/fs/write.go
@@ -161,6 +161,11 @@ func (w *writer) Open(opts DataWriterOpenOptions) error {
 	w.currIdx = 0
 	w.currOffset = 0
 	w.err = nil
+	// This happens after writing the previous set of files index files, however, do it
+	// again to ensure they get cleared even if there was a premature error writing out the
+	// previous set of files which would have prevented them from being cleared.
+	w.indexEntries.releaseRefs()
+	w.indexEntries = w.indexEntries[:0]
 
 	var (
 		shardDir            string

--- a/src/dbnode/persist/fs/write_test.go
+++ b/src/dbnode/persist/fs/write_test.go
@@ -1,0 +1,40 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/persist"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReuseAfterError(t *testing.T) {
+	dir := createTempDir(t)
+	filePathPrefix := filepath.Join(dir, "")
+	defer os.RemoveAll(dir)
+
+	seriesID := ident.StringID("series1")
+	w := newTestWriter(t, filePathPrefix)
+	writerOpts := DataWriterOpenOptions{
+		Identifier: FileSetFileIdentifier{
+			Namespace:   testNs1ID,
+			Shard:       0,
+			BlockStart:  time.Now().Truncate(time.Hour),
+			VolumeIndex: 0,
+		},
+		BlockSize:   time.Hour,
+		FileSetType: persist.FileSetFlushType,
+	}
+	data := checkedBytes([]byte{1, 2, 3})
+
+	require.NoError(t, w.Open(writerOpts))
+	require.NoError(t, w.Write(seriesID, ident.Tags{}, data, 0))
+	require.NoError(t, w.Write(seriesID, ident.Tags{}, data, 0))
+	require.Error(t, w.Close())
+
+	require.NoError(t, w.Open(writerOpts))
+	require.NoError(t, w.Close())
+}

--- a/src/dbnode/persist/fs/write_test.go
+++ b/src/dbnode/persist/fs/write_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestWriteReuseAfterError was added as a regression test after it was
+// discovered that reusing a fileset writer after a called to Close() had
+// returned an error could make the fileset writer end up in a near infinite
+// loop when it was reused to write out a completely indepedent set of files.
+//
+// This test verifies that the fix works as expected and prevents regressions
+// of the issue.
 func TestWriteReuseAfterError(t *testing.T) {
 	dir := createTempDir(t)
 	filePathPrefix := filepath.Join(dir, "")

--- a/src/dbnode/persist/fs/write_test.go
+++ b/src/dbnode/persist/fs/write_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package fs
 
 import (


### PR DESCRIPTION
This P.R fixes a bug in the fileset writer that would trigger a (near) infinite loop when the writer was reused after the previous set of files encountered an error trying to write out their index files. The P.R includes a regression test to ensure the issue doesn't crop up again and verify the included fix.

The bug was caused by the following sequence of events:

1. For some reason (root cause still pending on that) writing out a set of fileset files encountered an error during the call to `Close()`, likely that duplicate series IDs had been written into the fileset file which will cause the writer to error out when it tries to write its index-related files.

2. The writer is reused for writing out an entirely different set of fileset files. Normally this is fine since the call to `Open()` performs an implicit reset of the writers' state, however, the call to `Open()` has a bug where it does not reset the state of `w.indexEntries` which is a slice of all the time series that were written into the file. So now the state is that we're writing out filesets for files X but we're still holding on to `indexEntries` from files Y.

3. The fileset that we're writing just so happens to not have any time series for the current block start. This is a normal scenario that can happen when the M3DB nodes are not receiving any writes or briefly after topology changes where a flush may occur for a shard that was recently closed.

4. After writing 0 time series into the files, `Close` is called on the fileset writer which triggers the following block of code:

```golang
func (w *writer) writeIndexRelatedFiles() error {
	summariesApprox := float64(len(w.indexEntries)) * w.summariesPercent
	summaryEvery := 0
	if summariesApprox > 0 {
		summaryEvery = int(math.Floor(float64(len(w.indexEntries)) / summariesApprox))
	}

	// Write the index entries and calculate the bloom filter
	n, p := uint(w.currIdx), w.bloomFilterFalsePositivePercent
	m, k := bloom.EstimateFalsePositiveRate(n, p)
	bloomFilter := bloom.NewBloomFilter(m, k)

	err := w.writeIndexFileContents(bloomFilter, summaryEvery)
	if err != nil {
		return err
	}
```

Due to the implementation of `EstimateFalsePositiveRate`, passing a value of `0` for `n` will result in `9223372036854775808` being returned for the value of `k` (the number of hash functions the bloom filter will run for each value that is added to the bloom filter).

Normally this isn't a big deal because when the value of `n` is 0 there are no time series IDs to add to the bloom filter anyways and `bloomfilter.Add()` never gets called.

However, due to the aforementioned error writing out the previous set of files + the bug with `indexEntries` not properly being reset, the call to `writeIndexFileContents` will run the following function:

```golang
func (w *writer) writeIndexFileContents(
	bloomFilter *bloom.BloomFilter,
	summaryEvery int,
) error {
	// NB(r): Write the index file in order, in the future we could write
	// these in order to avoid this sort at the end however that does require
	// significant changes in the storage/databaseShard to store things in order
	// which would sacrifice O(1) insertion of new series we currently have.
	//
	// Probably do want to do this at the end still however so we don't stripe
	// writes to two different files during the write loop.
	sort.Sort(w.indexEntries)

	var (
		offset      int64
		prevID      []byte
		tagsIter    = ident.NewTagsIterator(ident.Tags{})
		tagsEncoder = w.tagEncoderPool.Get()
	)
	defer tagsEncoder.Finalize()
	for i := range w.indexEntries {
		id := w.indexEntries[i].id.Bytes()
		// Need to check if i > 0 or we can never write an empty string ID
		if i > 0 && bytes.Equal(id, prevID) {
			// Should never happen, Write() should only be called once per ID
			return fmt.Errorf("encountered duplicate ID: %s", id)
		}

		var encodedTags []byte
		if tags := w.indexEntries[i].tags; tags.Values() != nil {
			tagsIter.Reset(tags)
			tagsEncoder.Reset()
			if err := tagsEncoder.Encode(tagsIter); err != nil {
				return err
			}
			data, ok := tagsEncoder.Data()
			if !ok {
				return errWriterEncodeTagsDataNotAccessible
			}
			encodedTags = data.Bytes()
		}

		entry := schema.IndexEntry{
			Index:       w.indexEntries[i].index,
			ID:          id,
			Size:        int64(w.indexEntries[i].size),
			Offset:      w.indexEntries[i].dataFileOffset,
			Checksum:    int64(w.indexEntries[i].checksum),
			EncodedTags: encodedTags,
		}

		w.encoder.Reset()
		if err := w.encoder.EncodeIndexEntry(entry); err != nil {
			return err
		}

		data := w.encoder.Bytes()
		if _, err := w.indexFdWithDigest.Write(data); err != nil {
			return err
		}

		// Add to the bloom filter, note this must be zero alloc or else this will
		// cause heavy GC churn as we flush millions of series at end of each
		// time window
		bloomFilter.Add(id)

		if i%summaryEvery == 0 {
			// Capture the offset for when we write this summary back, only capture
			// for every summary we'll actually write to avoid a few memcopies
			w.indexEntries[i].indexFileOffset = offset
		}

		offset += int64(len(data))

		prevID = id
	}

	return nil
}
```

Since `w.indexEntries` was never properly reset, `bloomfilter.Add()` will be called and the goroutine will get stuck in a near infinite loop where it tries to run `9223372036854775808` hash functions.

This issue was extremely hard to debug because it manifested as the M3DB processes turning into "zombies" with 1 CPU core constantly pegged, but the nodes would not respond to any RPCs or networking in general so standard pprof tooling could not be used.

The reason this happened is because all of the function calls within `bloomfilter.Add()` are inlined making the entire function call unpre-emptible by the G.C until all of the `9223372036854775808` hash functions had been completed.

So when a stop the world G.C was started by the Go runtime it shut down all active goroutines that could have served any network requests and then hung forever waiting for the goroutine running the `bloomfilter.Add()` to complete so it could begin garbage collection.

This is clearly visible in the output from `sudo perf top` which shows the Go runtime stuck trying to start a stop the world G.C as well as demonstrates the `bloomfilter.Add` is clearly stuck in a very long loop based on how much time is being spent on the highlighted assembly instructions.

![debbug1](https://user-images.githubusercontent.com/9171254/70170114-13bab800-169a-11ea-94d3-95ca22878702.png)
![debug2](https://user-images.githubusercontent.com/9171254/70170115-14534e80-169a-11ea-827f-3dcdcc4f32c0.png)
![debug3](https://user-images.githubusercontent.com/9171254/70170116-14534e80-169a-11ea-8a2c-236a2454bf06.png)
![debug4](https://user-images.githubusercontent.com/9171254/70170117-14534e80-169a-11ea-939f-01de95d3a8ad.png)

This P.R likely requires several other followups:

1. Prevent `EstimateFalsePositiveRate` from returning absurdly large values of K when the value of `n` is zero.
2. Figure out under what combination of cold flushing / background repairs and their interactions causes fileset writes to fail immediately after topology changes.

However we will get this P.R merged ASAP to prevent the nodes from getting stuck into undebuggable states.