### PR TITLE
Instrument async replication worker pool utilization

### DIFF
--- a/src/dbnode/client/config.go
+++ b/src/dbnode/client/config.go
@@ -312,7 +312,7 @@ func (c Configuration) NewAdminClient(
 			size = *c.AsyncWriteWorkerPoolSize
 		}
 
-		workerPoolInstrumentOpts := iopts.SetMetricsScope(writeRequestScope)
+		workerPoolInstrumentOpts := iopts.SetMetricsScope(writeRequestScope.SubScope("workerpool"))
 		workerPoolOpts := xsync.NewPooledWorkerPoolOptions().
 			SetGrowOnDemand(true).
 			SetInstrumentOptions(workerPoolInstrumentOpts)

--- a/src/dbnode/client/config.go
+++ b/src/dbnode/client/config.go
@@ -312,8 +312,10 @@ func (c Configuration) NewAdminClient(
 			size = *c.AsyncWriteWorkerPoolSize
 		}
 
+		workerPoolInstrumentOpts := iopts.SetMetricsScope(writeRequestScope)
 		workerPoolOpts := xsync.NewPooledWorkerPoolOptions().
-			SetGrowOnDemand(true)
+			SetGrowOnDemand(true).
+			SetInstrumentOptions(workerPoolInstrumentOpts)
 		workerPool, err := xsync.NewPooledWorkerPool(size, workerPoolOpts)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create async worker pool: %v", err)


### PR DESCRIPTION
`PooledWorkerPool` is already instrumented so this PR just passes in instrument options during instantiation.