### PR TITLE
Use fmt.Fprintf(os.Stderr, ..) instead of stdlib log.Fatal(..) to ensure config errors always print

### DIFF
--- a/src/cmd/services/m3aggregator/main/main.go
+++ b/src/cmd/services/m3aggregator/main/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -55,13 +54,18 @@ func main() {
 
 	var cfg config.Configuration
 	if err := cfgOpts.MainLoad(&cfg, xconfig.Options{}); err != nil {
-		log.Fatal(err.Error())
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Create logger and metrics scope.
 	logger, err := cfg.Logging.BuildLogger()
 	if err != nil {
-		fmt.Printf("error creating logger: %v\n", err)
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "error creating logger: %v\n", err)
 		os.Exit(1)
 	}
 	defer logger.Sync()

--- a/src/cmd/services/m3collector/main/main.go
+++ b/src/cmd/services/m3collector/main/main.go
@@ -22,8 +22,9 @@ package main
 
 import (
 	"flag"
-	"log"
+	"fmt"
 	_ "net/http/pprof" // pprof: for debug listen server if configured
+	"os"
 
 	"github.com/m3db/m3/src/cmd/services/m3collector/config"
 	"github.com/m3db/m3/src/collector/server"
@@ -40,7 +41,10 @@ func main() {
 
 	var cfg config.Configuration
 	if err := configOpts.MainLoad(&cfg, xconfig.Options{}); err != nil {
-		log.Fatal(err.Error())
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Set globals for etcd related packages.

--- a/src/cmd/services/m3coordinator/main/main.go
+++ b/src/cmd/services/m3coordinator/main/main.go
@@ -22,8 +22,9 @@ package main
 
 import (
 	"flag"
-	"log"
+	"fmt"
 	_ "net/http/pprof" // pprof: for debug listen server if configured
+	"os"
 
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
 	"github.com/m3db/m3/src/query/server"
@@ -43,7 +44,10 @@ func main() {
 
 	var cfg config.Configuration
 	if err := cfgOpts.MainLoad(&cfg, xconfig.Options{}); err != nil {
-		log.Fatal(err.Error())
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
 	}
 
 	server.Run(server.RunOptions{

--- a/src/cmd/services/m3ctl/main/main.go
+++ b/src/cmd/services/m3ctl/main/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"strconv"
@@ -62,12 +61,17 @@ func main() {
 
 	var cfg config.Configuration
 	if err := configOpts.MainLoad(&cfg, xconfig.Options{}); err != nil {
-		log.Fatal(err.Error())
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
 	}
 
 	rawLogger, err := cfg.Logging.BuildLogger()
 	if err != nil {
-		fmt.Printf("error creating logger: %v\n", err)
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "error creating logger: %v\n", err)
 		os.Exit(1)
 	}
 	defer rawLogger.Sync()

--- a/src/cmd/services/m3dbnode/main/main.go
+++ b/src/cmd/services/m3dbnode/main/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	_ "net/http/pprof" // pprof: for debug listen server if configured
 	"os"
 	"os/signal"
@@ -51,11 +50,16 @@ func main() {
 
 	var cfg config.Configuration
 	if err := cfgOpts.MainLoad(&cfg, xconfig.Options{}); err != nil {
-		log.Fatal(err.Error())
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
 	}
 
 	if err := cfg.InitDefaultsAndValidate(); err != nil {
-		fmt.Fprintf(os.Stderr, "configuration validation failed %v\n", err)
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "erro validating config: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/src/cmd/services/m3query/main/main.go
+++ b/src/cmd/services/m3query/main/main.go
@@ -22,8 +22,9 @@ package main
 
 import (
 	"flag"
-	"log"
+	"fmt"
 	_ "net/http/pprof" // pprof: for debug listen server if configured
+	"os"
 
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
 	"github.com/m3db/m3/src/query/server"
@@ -43,8 +44,12 @@ func main() {
 
 	var cfg config.Configuration
 	if err := configOpts.MainLoad(&cfg, xconfig.Options{}); err != nil {
-		log.Fatal(err.Error())
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
 	}
+
 	server.Run(server.RunOptions{
 		Config: cfg,
 	})

--- a/src/collector/server/server.go
+++ b/src/collector/server/server.go
@@ -59,6 +59,8 @@ func Run(runOpts RunOptions) {
 	ctx := context.Background()
 	logger, err := cfg.Logging.Build()
 	if err != nil {
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
 		fmt.Fprintf(os.Stderr, "unable to create logger: %v", err)
 		os.Exit(1)
 	}

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -139,6 +139,8 @@ func Run(runOpts RunOptions) {
 	if runOpts.ConfigFile != "" {
 		var rootCfg config.Configuration
 		if err := xconfig.LoadFile(&rootCfg, runOpts.ConfigFile, xconfig.Options{}); err != nil {
+			// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+			// sending stdlib "log" to black hole. Don't remove unless with good reason.
 			fmt.Fprintf(os.Stderr, "unable to load %s: %v", runOpts.ConfigFile, err)
 			os.Exit(1)
 		}
@@ -150,12 +152,16 @@ func Run(runOpts RunOptions) {
 
 	err := cfg.InitDefaultsAndValidate()
 	if err != nil {
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
 		fmt.Fprintf(os.Stderr, "error initializing config defaults and validating config: %v", err)
 		os.Exit(1)
 	}
 
 	logger, err := cfg.Logging.BuildLogger()
 	if err != nil {
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
 		fmt.Fprintf(os.Stderr, "unable to create logger: %v", err)
 		os.Exit(1)
 	}

--- a/src/query/server/server.go
+++ b/src/query/server/server.go
@@ -129,6 +129,8 @@ func Run(runOpts RunOptions) {
 
 	logger, err := cfg.Logging.BuildLogger()
 	if err != nil {
+		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
+		// sending stdlib "log" to black hole. Don't remove unless with good reason.
 		fmt.Fprintf(os.Stderr, "unable to create logger: %v", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
`etcd.SetGlobals(...)` was mutating stdlib `log.Fatal(..)` from emitting config error loads being printed to stdout/stderr. 

Until a logger is built, always use `fmt.Fprintf(os.Stderr, ...)` so that no other packages can redirect output intended to be printed by the process for fatal errors.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
