### PR TITLE
[etcd] Upgrade etcd client library to 3.4.3 to fix data race in tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ common: &common
 
 steps:
   - name: "Codegen"
-    command: make clean install-vendor test-all-gen
+    command: make clean test-all-gen
     env:
       CGO_ENABLED: 0
       GIMME_GO_VERSION: 1.12.x
@@ -20,7 +20,7 @@ steps:
           import: github.com/m3db/m3
     <<: *common
   - name: "Unit %n"
-    command: make clean install-vendor test-ci-unit
+    command: make clean install-vendor-m3 test-ci-unit
     parallelism: 4
     plugins:
       docker-compose#v2.5.1:
@@ -28,7 +28,7 @@ steps:
         workdir: /go/src/github.com/m3db/m3
     <<: *common
   - name: "Big Unit %n"
-    command: make clean install-vendor test-ci-big-unit
+    command: make clean install-vendor-m3 test-ci-big-unit
     parallelism: 2
     plugins:
       docker-compose#v2.5.1:
@@ -36,14 +36,14 @@ steps:
         workdir: /go/src/github.com/m3db/m3
     <<: *common
   - name: "Services, Tools, Metalint"
-    command: make clean install-vendor services tools metalint
+    command: make clean install-vendor-m3 services tools metalint
     plugins:
       docker-compose#v2.5.1:
         run: app
         workdir: /go/src/github.com/m3db/m3
     <<: *common
   - name: "Integration (:docker:)"
-    command: make clean install-vendor docker-integration-test
+    command: make clean install-vendor-m3 docker-integration-test
     parallelism: 2
     env:
       CGO_ENABLED: 0
@@ -53,7 +53,7 @@ steps:
           import: github.com/m3db/m3
     <<: *common
   - name: "Prometheus compatibility (:docker:)"
-    command: make clean install-vendor docker-compatibility-test
+    command: make clean install-vendor-m3 docker-compatibility-test
     parallelism: 1
     env:
       CGO_ENABLED: 0
@@ -64,7 +64,7 @@ steps:
     <<: *common
   - name: "Integration (dbnode Recently Read) %n"
     parallelism: 2
-    command: make clean install-vendor test-ci-integration-dbnode cache_policy=recently_read
+    command: make clean install-vendor-m3 test-ci-integration-dbnode cache_policy=recently_read
     plugins:
       docker-compose#v2.5.1:
         run: app
@@ -72,7 +72,7 @@ steps:
     <<: *common
   - name: "Integration (dbnode LRU) %n"
     parallelism: 2
-    command: make clean install-vendor test-ci-integration-dbnode cache_policy=lru
+    command: make clean install-vendor-m3 test-ci-integration-dbnode cache_policy=lru
     plugins:
       docker-compose#v2.5.1:
         run: app
@@ -80,14 +80,14 @@ steps:
     <<: *common
   - label: "Integration (collector, aggregator, m3em, cluster, msg, metrics) %n"
     parallelism: 4
-    command: make clean install-vendor test-ci-integration-collector test-ci-integration-aggregator test-ci-integration-m3em test-ci-integration-cluster test-ci-integration-msg test-ci-integration-metrics
+    command: make clean install-vendor-m3 test-ci-integration-collector test-ci-integration-aggregator test-ci-integration-m3em test-ci-integration-cluster test-ci-integration-msg test-ci-integration-metrics
     plugins:
       docker-compose#v2.5.1:
         run: app
         workdir: /go/src/github.com/m3db/m3
     <<: *common
   - name: "Documentation tests"
-    command: make clean install-vendor docs-test
+    command: make clean install-vendor-m3 docs-test
     env:
       CGO_ENABLED: 0
       GIMME_GO_VERSION: 1.12.x
@@ -96,7 +96,7 @@ steps:
           import: github.com/m3db/m3
     <<: *common
   - label: "FOSSA license scan"
-    command: make clean install-vendor fossa
+    command: make clean install-vendor-m3 fossa
     plugins:
       docker-compose#v2.5.1:
         run: app

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ common: &common
 
 steps:
   - name: "Codegen"
-    command: make clean test-all-gen
+    command: make clean install-vendor-m3 test-all-gen
     env:
       CGO_ENABLED: 0
       GIMME_GO_VERSION: 1.12.x

--- a/.fossa.yml
+++ b/.fossa.yml
@@ -20,6 +20,8 @@ analyze:
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3aggregator/main
     path: src/cmd/services/m3aggregator/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/services/m3collector/main
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3collector/main

--- a/.fossa.yml
+++ b/.fossa.yml
@@ -12,10 +12,18 @@ analyze:
     type: go
     target: github.com/m3db/m3/scripts/lockfile
     path: scripts/lockfile
+    options:
+      # FOSSA finds Go dependencies by first finding all dependencies that a project uses and then comparing them to the lockfile to obtain version numbers.
+      # It appears that one of the dependencies is choosing to manually vendor a dependency, thereby omitting the version from its lockfile.
+      # This results in cryptic FOSSA failures.
+      # The solution for this is to allow this dependency to be discovered without a corresponding version.
+      allow-unresolved: true
   - name: github.com/m3db/m3/scripts/md5
     type: go
     target: github.com/m3db/m3/scripts/md5
     path: scripts/md5
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/services/m3aggregator/main
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3aggregator/main
@@ -26,20 +34,20 @@ analyze:
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3collector/main
     path: src/cmd/services/m3collector/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/services/m3coordinator/main
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3coordinator/main
     path: src/cmd/services/m3coordinator/main
     options:
-      # FOSSA finds Go dependencies by first finding all dependencies that a project uses and then comparing them to the lockfile to obtain version numbers.
-      # It appears that one of the dependencies is choosing to manually vendor a dependency, thereby omitting the version from its lockfile.
-      # This results in cryptic FOSSA failures.
-      # The solution for this is to allow this dependency to be discovered without a corresponding version.
       allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/services/m3ctl/main
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3ctl/main
     path: src/cmd/services/m3ctl/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/services/m3dbnode/main
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3dbnode/main
@@ -50,14 +58,20 @@ analyze:
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3em_agent/main
     path: src/cmd/services/m3em_agent/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/services/m3nsch_client/main
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3nsch_client/main
     path: src/cmd/services/m3nsch_client/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/services/m3nsch_server/main
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3nsch_server/main
     path: src/cmd/services/m3nsch_server/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/services/m3query/main
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3query/main
@@ -68,35 +82,53 @@ analyze:
     type: go
     target: github.com/m3db/m3/src/cmd/services/m3comparator/main
     path: src/cmd/services/m3comparator/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/tools/carbon_load/main
     type: go
     target: github.com/m3db/m3/src/cmd/tools/carbon_load/main
     path: src/cmd/tools/carbon_load/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/tools/clone_fileset/main
     type: go
     target: github.com/m3db/m3/src/cmd/tools/clone_fileset/main
     path: src/cmd/tools/clone_fileset/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/tools/read_data_files/main
     type: go
     target: github.com/m3db/m3/src/cmd/tools/read_data_files/main
     path: src/cmd/tools/read_data_files/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/tools/read_ids/main
     type: go
     target: github.com/m3db/m3/src/cmd/tools/read_ids/main
     path: src/cmd/tools/read_ids/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/tools/read_index_files/main
     type: go
     target: github.com/m3db/m3/src/cmd/tools/read_index_files/main
     path: src/cmd/tools/read_index_files/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/tools/read_index_ids/main
     type: go
     target: github.com/m3db/m3/src/cmd/tools/read_index_ids/main
     path: src/cmd/tools/read_index_ids/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/tools/verify_data_files/main
     type: go
     target: github.com/m3db/m3/src/cmd/tools/verify_data_files/main
     path: src/cmd/tools/verify_data_files/main
+    options:
+      allow-unresolved: true
   - name: github.com/m3db/m3/src/cmd/tools/verify_index_files/main
     type: go
     target: github.com/m3db/m3/src/cmd/tools/verify_index_files/main
     path: src/cmd/tools/verify_index_files/main
+    options:
+      allow-unresolved: true

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -35,7 +35,7 @@ Install dependencies:
 ```bash
 cd $working_dir/m3
 
-make install-vendor
+make install-vendor-m3
 ```
 
 If everything is setup correctly you should be able to build `m3dbnode`:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ assets_rules_dir     := generated/assets
 thrift_output_dir    := generated/thrift/rpc
 thrift_rules_dir     := generated/thrift
 vendor_prefix        := vendor
+bad_trace_dep        := go.etcd.io/etcd/vendor/golang.org/x/net/trace
 cache_policy         ?= recently_read
 genny_target         ?= genny-all
 
@@ -98,6 +99,24 @@ TOOLS :=               \
 setup:
 	mkdir -p $(BUILD)
 
+.PHONY: install-vendor-m3
+install-vendor-m3:
+	[ -d $(VENDOR) ] || make install-vendor
+
+	# Some deps were causing panics when using GRPC and etcd libraries were used.
+	# See issue: https://github.com/etcd-io/etcd/issues/9357
+	# $ go test -v
+	# panic: /debug/requests is already registered. You may have two independent 
+	# copies of golang.org/x/net/trace in your binary, trying to maintain separate 
+	# state. This may involve a vendored copy of golang.org/x/net/trace.
+	# 
+	# goroutine 1 [running]:
+	# github.com/m3db/m3/vendor/go.etcd.io/etcd/vendor/golang.org/x/net/trace.init.0()
+	#         /Users/r/go/src/github.com/m3db/m3/vendor/go.etcd.io/etcd/vendor/golang.org/x/net/trace/trace.go:123 +0x1cd
+	# exit status 2
+	# FAIL    github.com/m3db/m3/src/query/remote     0.024s
+	([ -d $(VENDOR)/$(bad_trace_dep) ] && rm -rf $(VENDOR)/$(bad_trace_dep)) || (echo "No bad trace dep" > /dev/null)
+
 define SERVICE_RULES
 
 .PHONY: $(SERVICE)
@@ -107,7 +126,7 @@ ifeq ($(SERVICE),m3ctl)
 	make build-ui-ctl-statik-gen
 endif
 	@echo Building $(SERVICE)
-	[ -d $(VENDOR) ] || make install-vendor
+	[ -d $(VENDOR) ] || make install-vendor-m3
 	$(GO_BUILD_COMMON_ENV) go build -ldflags '$(GO_BUILD_LDFLAGS)' -o $(BUILD)/$(SERVICE) ./src/cmd/services/$(SERVICE)/main/.
 
 .PHONY: $(SERVICE)-linux-amd64

--- a/docs/m3db/index.md
+++ b/docs/m3db/index.md
@@ -23,5 +23,5 @@ The project has also has optimized for the storage and retrieval of float64 valu
 
 [gorilla]: http://www.vldb.org/pvldb/vol8/p1816-teller.pdf
 [cassandra]: http://cassandra.apache.org/
-[etcd]: https://github.com/coreos/etcd
+[etcd]: https://github.com/etcd-io/etcd
 [ubeross]: http://uber.github.io

--- a/glide.lock
+++ b/glide.lock
@@ -23,8 +23,8 @@ imports:
   version: 112f0506e7743d64a6eb8fedbcff13d9979bbf92
 - name: github.com/coreos/bbolt
   version: 32c383e75ce054674c53b5a07e55de85332aee14
-- name: github.com/coreos/etcd
-  version: 2d861f39e9ec31dd9129a8070e8ff6492f859c07
+- name: go.etcd.io/etcd
+  version: 3cf2f69b5738fb702ba1a935590f36b52b18979b
   subpackages:
   - alarm
   - auth

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,8 +21,8 @@ import:
   - package: github.com/cespare/xxhash
     version: 48099fad606eafc26e3a569fad19ff510fff4df6
 
-  - package: github.com/coreos/etcd
-    version: 3.2.28
+  - package: go.etcd.io/etcd
+    version: 3.4.3
 
   - package: github.com/pkg/errors
     version: ^0.8

--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: quay.io/coreos/etcd:v3.3.3
+        image: quay.io/coreos/etcd:v3.4.3
         command:
         - "etcd"
         - "--name"

--- a/kube/etcd.yaml
+++ b/kube/etcd.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: quay.io/coreos/etcd:v3.3.3
+        image: quay.io/coreos/etcd:v3.4.3
         command:
         - "etcd"
         - "--name"

--- a/kube/terraform/main.tf
+++ b/kube/terraform/main.tf
@@ -73,7 +73,7 @@ resource "kubernetes_stateful_set" "etcd_stateful_set" {
       spec {
         container {
           name    = "etcd"
-          image   = "quay.io/coreos/etcd:v3.3.3"
+          image   = "quay.io/coreos/etcd:v3.4.3"
           command = ["etcd", "--name", "$(MY_POD_NAME)", "--listen-peer-urls", "http://$(MY_IP):2380", "--listen-client-urls", "http://$(MY_IP):2379,http://127.0.0.1:2379", "--advertise-client-urls", "http://$(MY_POD_NAME).etcd:2379", "--initial-cluster-token", "etcd-cluster-1", "--initial-advertise-peer-urls", "http://$(MY_POD_NAME).etcd:2380", "--initial-cluster", "etcd-0=http://etcd-0.etcd:2380,etcd-1=http://etcd-1.etcd:2380,etcd-2=http://etcd-2.etcd:2380", "--initial-cluster-state", "new", "--data-dir", "/var/lib/etcd"]
           port {
             name           = "client"

--- a/scripts/docker-integration-tests/dedicated_etcd_embedded_coordinator/docker-compose.yml
+++ b/scripts/docker-integration-tests/dedicated_etcd_embedded_coordinator/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "0.0.0.0:2379-2380:2379-2380"
     networks:
       - backend
-    image: quay.io/coreos/etcd:v3.3.10
+    image: quay.io/coreos/etcd:v3.4.3
     command:
       - "etcd"
       - "--name"

--- a/src/aggregator/integration/election.go
+++ b/src/aggregator/integration/election.go
@@ -26,8 +26,8 @@ import (
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/cluster/services/leader"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/integration"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/integration"
 	"github.com/stretchr/testify/require"
 )
 

--- a/src/cluster/client/etcd/client.go
+++ b/src/cluster/client/etcd/client.go
@@ -39,7 +39,7 @@ import (
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/retry"
 
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )

--- a/src/cluster/client/etcd/client_test.go
+++ b/src/cluster/client/etcd/client_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/m3db/m3/src/cluster/kv"
 	"github.com/m3db/m3/src/cluster/services"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/integration"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/integration"
 	"github.com/stretchr/testify/require"
 )
 

--- a/src/cluster/etcd/watchmanager/manager.go
+++ b/src/cluster/etcd/watchmanager/manager.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )

--- a/src/cluster/etcd/watchmanager/manager_test.go
+++ b/src/cluster/etcd/watchmanager/manager_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/m3db/m3/src/cluster/mocks"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/integration"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"

--- a/src/cluster/etcd/watchmanager/options.go
+++ b/src/cluster/etcd/watchmanager/options.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/m3db/m3/src/x/instrument"
 
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 )
 
 const (

--- a/src/cluster/etcd/watchmanager/types.go
+++ b/src/cluster/etcd/watchmanager/types.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/m3db/m3/src/x/instrument"
 
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 )
 
 // WatchManager manages etcd watch on a key

--- a/src/cluster/integration/etcd/etcd.go
+++ b/src/cluster/integration/etcd/etcd.go
@@ -35,7 +35,7 @@ import (
 	xclock "github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/errors"
 
-	"github.com/coreos/etcd/embed"
+	"go.etcd.io/etcd/embed"
 )
 
 type embeddedKV struct {

--- a/src/cluster/kv/etcd/store.go
+++ b/src/cluster/kv/etcd/store.go
@@ -33,7 +33,7 @@ import (
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/retry"
 
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"

--- a/src/cluster/kv/etcd/store_test.go
+++ b/src/cluster/kv/etcd/store_test.go
@@ -36,8 +36,8 @@ import (
 	"github.com/m3db/m3/src/cluster/mocks"
 	xclock "github.com/m3db/m3/src/x/clock"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/integration"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/integration"
 	"github.com/coreos/pkg/capnslog"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"

--- a/src/cluster/mocks/blackhole_watcher.go
+++ b/src/cluster/mocks/blackhole_watcher.go
@@ -23,7 +23,7 @@ package mocks
 import (
 	"sync"
 
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	"golang.org/x/net/context"
 )
 

--- a/src/cluster/mocks/blackhole_watcher.go
+++ b/src/cluster/mocks/blackhole_watcher.go
@@ -63,6 +63,11 @@ func (m *watcher) Watch(ctx context.Context, key string, opts ...clientv3.OpOpti
 	return m.c.Watch(ctx, key, opts...)
 }
 
+// RequestProgress is implementing etcd clientv3 Watcher interface
+func (m *watcher) RequestProgress(ctx context.Context) error {
+	return nil
+}
+
 // Close is implementing etcd clientv3 Watcher interface
 func (m *watcher) Close() error {
 	return m.c.Close()

--- a/src/cluster/services/heartbeat/etcd/store.go
+++ b/src/cluster/services/heartbeat/etcd/store.go
@@ -35,7 +35,7 @@ import (
 	"github.com/m3db/m3/src/x/retry"
 	"github.com/m3db/m3/src/x/watch"
 
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"

--- a/src/cluster/services/heartbeat/etcd/store_test.go
+++ b/src/cluster/services/heartbeat/etcd/store_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/m3db/m3/src/cluster/placement"
 	"github.com/m3db/m3/src/cluster/services"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/integration"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/integration"
 	"github.com/stretchr/testify/require"
 )
 

--- a/src/cluster/services/leader/client.go
+++ b/src/cluster/services/leader/client.go
@@ -29,8 +29,8 @@ import (
 	"github.com/m3db/m3/src/cluster/services/leader/campaign"
 	"github.com/m3db/m3/src/cluster/services/leader/election"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3/concurrency"
 	"golang.org/x/net/context"
 )
 

--- a/src/cluster/services/leader/client_test.go
+++ b/src/cluster/services/leader/client_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/m3db/m3/src/cluster/services/leader/campaign"
 	"github.com/m3db/m3/src/cluster/services/leader/election"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/integration"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"

--- a/src/cluster/services/leader/election/client.go
+++ b/src/cluster/services/leader/election/client.go
@@ -28,8 +28,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3/concurrency"
 	"golang.org/x/net/context"
 )
 

--- a/src/cluster/services/leader/election/client_test.go
+++ b/src/cluster/services/leader/election/client_test.go
@@ -25,9 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/clientv3/concurrency"
-	"github.com/coreos/etcd/integration"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/integration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/src/cluster/services/leader/election/options.go
+++ b/src/cluster/services/leader/election/options.go
@@ -20,7 +20,7 @@
 
 package election
 
-import "github.com/coreos/etcd/clientv3/concurrency"
+import "go.etcd.io/etcd/clientv3/concurrency"
 
 type clientOpts struct {
 	sessionOpts []concurrency.SessionOption

--- a/src/cluster/services/leader/service.go
+++ b/src/cluster/services/leader/service.go
@@ -28,7 +28,7 @@ import (
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/cluster/services/leader/campaign"
 
-	"github.com/coreos/etcd/clientv3"
+	"go.etcd.io/etcd/clientv3"
 )
 
 const (

--- a/src/cluster/services/leader/services_test.go
+++ b/src/cluster/services/leader/services_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/m3db/m3/src/cluster/services"
 
-	"github.com/coreos/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/clientv3/concurrency"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -38,9 +38,9 @@ import (
 	xlog "github.com/m3db/m3/src/x/log"
 	"github.com/m3db/m3/src/x/opentracing"
 
-	"github.com/coreos/etcd/embed"
-	"github.com/coreos/etcd/pkg/transport"
-	"github.com/coreos/etcd/pkg/types"
+	"go.etcd.io/etcd/embed"
+	"go.etcd.io/etcd/pkg/transport"
+	"go.etcd.io/etcd/pkg/types"
 )
 
 const (

--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -475,7 +475,7 @@ func NewEtcdEmbedConfig(cfg DBConfiguration) (*embed.Config, error) {
 	newKVCfg.InitialCluster = initialClusterString(kvCfg.InitialCluster)
 
 	copySecurityDetails := func(tls *transport.TLSInfo, ysc *environment.SeedNodeSecurityConfig) {
-		tls.CAFile = ysc.CAFile
+		tls.TrustedCAFile = ysc.CAFile
 		tls.CertFile = ysc.CertFile
 		tls.KeyFile = ysc.KeyFile
 		tls.ClientCertAuth = ysc.CertAuth

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -86,7 +86,7 @@ import (
 	xsync "github.com/m3db/m3/src/x/sync"
 
 	apachethrift "github.com/apache/thrift/lib/go/thrift"
-	"github.com/coreos/etcd/embed"
+	"go.etcd.io/etcd/embed"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes the data races we were seeing in unit tests. The earliest release that includes the fix is on the 3.4 release so we are upgrading to 3.4.3.

Our "TestClient" unit test was experiencing data race in package `src/cluster/client/etcd`.
```
=== RUN   TestClient                                                                                                                                                                                                                                                                                                                                               [142/880]
2020-01-12 08:23:42.066828 I | integration: launching 4035819850191458261 (unix://localhost:40358198501914582610)
2020-01-12 08:23:42.075830 I | etcdserver: name = 4035819850191458261
2020-01-12 08:23:42.075883 I | etcdserver: data dir = /var/folders/_g/hmzqg1j12hb08_d3jn26tnsm0000gn/T/etcd849792472
2020-01-12 08:23:42.075927 I | etcdserver: member dir = /var/folders/_g/hmzqg1j12hb08_d3jn26tnsm0000gn/T/etcd849792472/member
2020-01-12 08:23:42.075959 I | etcdserver: heartbeat = 10ms
2020-01-12 08:23:42.075988 I | etcdserver: election = 100ms
2020-01-12 08:23:42.076012 I | etcdserver: snapshot count = 0
2020-01-12 08:23:42.076057 I | etcdserver: advertise client URLs = unix://127.0.0.1:2100230805
2020-01-12 08:23:42.076091 I | etcdserver: initial advertise peer URLs = unix://127.0.0.1:2100130805
2020-01-12 08:23:42.076131 I | etcdserver: initial cluster = 4035819850191458261=unix://127.0.0.1:2100130805
2020-01-12 08:23:42.157559 I | etcdserver: starting member 5c2b4ba308bb1e8c in cluster c82e8fb8629e9da3
2020-01-12 08:23:42.157650 I | raft: 5c2b4ba308bb1e8c became follower at term 0
2020-01-12 08:23:42.157708 I | raft: newRaft 5c2b4ba308bb1e8c [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastterm: 0]
2020-01-12 08:23:42.157742 I | raft: 5c2b4ba308bb1e8c became follower at term 1
2020-01-12 08:23:42.192919 W | auth: simple token is not cryptographically signed
2020-01-12 08:23:42.220864 I | etcdserver: set snapshot count to default 100000
2020-01-12 08:23:42.220919 I | etcdserver: starting server... [version: 3.2.28, cluster version: to_be_decided]
2020-01-12 08:23:42.221446 I | etcdserver: 5c2b4ba308bb1e8c as single-node; fast-forwarding 9 ticks (election ticks 10)
2020-01-12 08:23:42.221720 E | etcdserver: cannot monitor file descriptor usage (cannot get FDUsage on darwin)
2020-01-12 08:23:42.222390 I | etcdserver/membership: added member 5c2b4ba308bb1e8c [unix://127.0.0.1:2100130805] to cluster c82e8fb8629e9da3
==================
WARNING: DATA RACE
Write at 0x000002b54290 by goroutine 121:
  github.com/m3db/m3/vendor/github.com/coreos/etcd/etcdserver/api/v3rpc.Server.func1()
      /Users/r/go/src/github.com/m3db/m3/vendor/google.golang.org/grpc/grpclog/loggerv2.go:68 +0x264
  sync.(*Once).doSlow()
      /usr/local/Cellar/go/1.13.4/libexec/src/sync/once.go:66 +0x100
  sync.(*Once).Do()
      /usr/local/Cellar/go/1.13.4/libexec/src/sync/once.go:57 +0x68
  github.com/m3db/m3/vendor/github.com/coreos/etcd/etcdserver/api/v3rpc.Server()
      /Users/r/go/src/github.com/m3db/m3/vendor/github.com/coreos/etcd/etcdserver/api/v3rpc/grpc.go:62 +0xaaf
  github.com/m3db/m3/vendor/github.com/coreos/etcd/integration.(*member).Launch()
      /Users/r/go/src/github.com/m3db/m3/vendor/github.com/coreos/etcd/integration/cluster.go:775 +0xe8c
  github.com/m3db/m3/vendor/github.com/coreos/etcd/integration.(*cluster).Launch.func1()
      /Users/r/go/src/github.com/m3db/m3/vendor/github.com/coreos/etcd/integration/cluster.go:178 +0x38

Previous read at 0x000002b54290 by goroutine 117:
  github.com/m3db/m3/vendor/google.golang.org/grpc.(*ccBalancerWrapper).UpdateBalancerState()
      /Users/r/go/src/github.com/m3db/m3/vendor/google.golang.org/grpc/grpclog/grpclog.go:45 +0xe2
  github.com/m3db/m3/vendor/google.golang.org/grpc.(*balancerWrapper).HandleSubConnStateChange()
      /Users/r/go/src/github.com/m3db/m3/vendor/google.golang.org/grpc/balancer_v1_wrapper.go:247 +0x3dd
  github.com/m3db/m3/vendor/google.golang.org/grpc.(*ccBalancerWrapper).watcher()
      /Users/r/go/src/github.com/m3db/m3/vendor/google.golang.org/grpc/balancer_conn_wrappers.go:120 +0x43c

Goroutine 121 (running) created at:
  github.com/m3db/m3/vendor/github.com/coreos/etcd/integration.(*cluster).Launch()
      /Users/r/go/src/github.com/m3db/m3/vendor/github.com/coreos/etcd/integration/cluster.go:177 +0xe3
  github.com/m3db/m3/vendor/github.com/coreos/etcd/integration.NewClusterV3()
      /Users/r/go/src/github.com/m3db/m3/vendor/github.com/coreos/etcd/integration/cluster.go:982 +0x11c
  github.com/m3db/m3/src/cluster/client/etcd.testNewETCDFn()
      /Users/r/go/src/github.com/m3db/m3/src/cluster/client/etcd/client_test.go:366 +0xb6
  github.com/m3db/m3/src/cluster/client/etcd.TestClient()
      /Users/r/go/src/github.com/m3db/m3/src/cluster/client/etcd/client_test.go:121 +0x1df
  testing.tRunner()
      /usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0x199

Goroutine 117 (running) created at:
  github.com/m3db/m3/vendor/google.golang.org/grpc.newCCBalancerWrapper()
      /Users/r/go/src/github.com/m3db/m3/vendor/google.golang.org/grpc/balancer_conn_wrappers.go:108 +0x23d
  github.com/m3db/m3/vendor/google.golang.org/grpc.DialContext()
      /Users/r/go/src/github.com/m3db/m3/vendor/google.golang.org/grpc/clientconn.go:449 +0x9aa
  github.com/m3db/m3/vendor/github.com/coreos/etcd/clientv3.(*Client).dial()
      /Users/r/go/src/github.com/m3db/m3/vendor/github.com/coreos/etcd/clientv3/client.go:352 +0x285
  github.com/m3db/m3/vendor/github.com/coreos/etcd/clientv3.newClient()
      /Users/r/go/src/github.com/m3db/m3/vendor/github.com/coreos/etcd/clientv3/client.go:421 +0x6d3
  github.com/m3db/m3/src/cluster/client/etcd.newClient()
      /Users/r/go/src/github.com/m3db/m3/vendor/github.com/coreos/etcd/clientv3/client.go:80 +0x244
  github.com/m3db/m3/src/cluster/client/etcd.(*csclient).etcdClientGen.func1()
      /Users/r/go/src/github.com/m3db/m3/src/cluster/client/etcd/client.go:268 +0x8c
  github.com/m3db/m3/src/x/retry.(*retrier).attempt()
      /Users/r/go/src/github.com/m3db/m3/src/x/retry/retry.go:113 +0x95
  github.com/m3db/m3/src/x/retry.(*retrier).Attempt()
      /Users/r/go/src/github.com/m3db/m3/src/x/retry/retry.go:98 +0x4b
  github.com/m3db/m3/src/cluster/client/etcd.(*csclient).etcdClientGen()
      /Users/r/go/src/github.com/m3db/m3/src/cluster/client/etcd/client.go:266 +0x313
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
