### PR TITLE
[query] Fix bug in graphite find result

### DIFF
--- a/scripts/docker-integration-tests/carbon/expected/a.b.json
+++ b/scripts/docker-integration-tests/carbon/expected/a.b.json
@@ -2,9 +2,23 @@
   {
     "id": "a.bar",
     "text": "bar",
+    "leaf": 1,
+    "expandable": 0,
+    "allowChildren": 0
+  },
+  {
+    "id": "a.bar",
+    "text": "bar",
     "leaf": 0,
     "expandable": 1,
     "allowChildren": 1
+  },
+  {
+    "id": "a.biz",
+    "text": "biz",
+    "leaf": 1,
+    "expandable": 0,
+    "allowChildren": 0
   },
   {
     "id": "a.biz",

--- a/scripts/docker-integration-tests/carbon/expected/a.ba.json
+++ b/scripts/docker-integration-tests/carbon/expected/a.ba.json
@@ -12,5 +12,12 @@
     "leaf": 0,
     "expandable": 1,
     "allowChildren": 1
+  },
+  {
+    "id": "a.bar",
+    "text": "bar",
+    "leaf": 1,
+    "expandable": 0,
+    "allowChildren": 0
   }
 ]

--- a/scripts/docker-integration-tests/carbon/expected/a.json
+++ b/scripts/docker-integration-tests/carbon/expected/a.json
@@ -2,6 +2,13 @@
   {
     "id": "a",
     "text": "a",
+    "leaf": 1,
+    "expandable": 0,
+    "allowChildren": 0
+  },
+  {
+    "id": "a",
+    "text": "a",
     "leaf": 0,
     "expandable": 1,
     "allowChildren": 1

--- a/src/query/api/v1/handler/graphite/find.go
+++ b/src/query/api/v1/handler/graphite/find.go
@@ -69,18 +69,6 @@ type nodeDescriptor struct {
 	hasChildren bool
 }
 
-func (d nodeDescriptor) leafAndChildrenValues() (int, int) {
-	if d.isLeaf {
-		if d.hasChildren {
-			return 1, 1
-		}
-
-		return 1, 0
-	}
-
-	return 0, 1
-}
-
 func mergeTags(
 	terminatedResult *storage.CompleteTagsResult,
 	childResult *storage.CompleteTagsResult,

--- a/src/query/api/v1/handler/graphite/find_parser.go
+++ b/src/query/api/v1/handler/graphite/find_parser.go
@@ -32,7 +32,7 @@ import (
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/util/json"
-	"github.com/m3db/m3/src/x/net/http"
+	xhttp "github.com/m3db/m3/src/x/net/http"
 )
 
 // parseFindParamsToQueries parses an incoming request to two find queries,
@@ -142,36 +142,61 @@ func parseFindParamsToQueries(r *http.Request) (
 func findResultsJSON(
 	w io.Writer,
 	prefix string,
-	tags map[string]bool,
+	tags map[string]nodeDescriptor,
 ) error {
 	jw := json.NewWriter(w)
 	jw.BeginArray()
 
-	for value, hasChildren := range tags {
-		leaf := 1
-		if hasChildren {
-			leaf = 0
-		}
-		jw.BeginObject()
-
-		jw.BeginObjectField("id")
-		jw.WriteString(fmt.Sprintf("%s%s", prefix, value))
-
-		jw.BeginObjectField("text")
-		jw.WriteString(value)
-
-		jw.BeginObjectField("leaf")
-		jw.WriteInt(leaf)
-
-		jw.BeginObjectField("expandable")
-		jw.WriteInt(1 - leaf)
-
-		jw.BeginObjectField("allowChildren")
-		jw.WriteInt(1 - leaf)
-
-		jw.EndObject()
+	for value, descriptor := range tags {
+		writeFindNodeResultJSON(jw, prefix, value, descriptor)
 	}
 
 	jw.EndArray()
 	return jw.Close()
+}
+
+func writeFindNodeResultJSON(
+	jw *json.Writer,
+	prefix string,
+	value string,
+	descriptor nodeDescriptor,
+) {
+	id := fmt.Sprintf("%s%s", prefix, value)
+	if descriptor.isLeaf {
+		writeFindResultJSON(jw, id, value, false)
+	}
+
+	if descriptor.hasChildren {
+		writeFindResultJSON(jw, id, value, true)
+	}
+}
+
+func writeFindResultJSON(
+	jw *json.Writer,
+	id string,
+	value string,
+	hasChildren bool,
+) {
+	var leaf = 1
+	if hasChildren {
+		leaf = 0
+	}
+	jw.BeginObject()
+
+	jw.BeginObjectField("id")
+	jw.WriteString(id)
+
+	jw.BeginObjectField("text")
+	jw.WriteString(value)
+
+	jw.BeginObjectField("leaf")
+	jw.WriteInt(leaf)
+
+	jw.BeginObjectField("expandable")
+	jw.WriteInt(1 - leaf)
+
+	jw.BeginObjectField("allowChildren")
+	jw.WriteInt(1 - leaf)
+
+	jw.EndObject()
 }

--- a/src/query/api/v1/handler/graphite/find_test.go
+++ b/src/query/api/v1/handler/graphite/find_test.go
@@ -261,8 +261,10 @@ func testFind(t *testing.T, ex bool, ex2 bool, header string) {
 
 	expected := results{
 		makeNoChildrenResult("bar"),
+		makeNoChildrenResult("baz"),
 		makeWithChildrenResult("baz"),
 		makeWithChildrenResult("bix"),
+		makeNoChildrenResult("bug"),
 		makeWithChildrenResult("bug"),
 	}
 


### PR DESCRIPTION
Fixes issue where graphite find result for a node that is both a leaf and has children would not display the leaf case.