### PR TITLE
[dbnode] Allow returning empty term values from aggregate index values RPC

### DIFF
--- a/src/dbnode/storage/index/aggregate_results.go
+++ b/src/dbnode/storage/index/aggregate_results.go
@@ -238,10 +238,6 @@ func (r *aggregatedResults) addFieldWithLock(
 		return fmt.Errorf(missingDocumentFields, "term")
 	}
 
-	if len(value) == 0 {
-		return fmt.Errorf(missingDocumentFields, "value")
-	}
-
 	// if a term filter is provided, ensure this field matches the filter,
 	// otherwise ignore it.
 	filter := r.aggregateOpts.FieldFilter

--- a/src/dbnode/storage/index/aggregate_results_test.go
+++ b/src/dbnode/storage/index/aggregate_results_test.go
@@ -59,21 +59,11 @@ func TestAggResultsInsertInvalid(t *testing.T) {
 	size, err = res.AddDocuments([]doc.Document{dInvalid})
 	require.Error(t, err)
 	require.Equal(t, 0, size)
-
-	dInvalid = genDoc("foo", "")
-	size, err = res.AddDocuments([]doc.Document{dInvalid})
-	require.Error(t, err)
-	require.Equal(t, 0, size)
 }
 
 func TestAggResultsInsertEmptyTermValue(t *testing.T) {
 	res := NewAggregateResults(nil, AggregateResultsOptions{}, testOpts)
-	dValidEmptyTerm := doc.Document{
-		ID: []byte("foo_id"),
-		Fields: []doc.Field{
-			{Name: []byte("foo"), Value: nil},
-		},
-	}
+	dValidEmptyTerm := genDoc("foo", "")
 	size, err := res.AddDocuments([]doc.Document{dValidEmptyTerm})
 	require.NoError(t, err)
 	require.Equal(t, 1, size)

--- a/src/dbnode/storage/index/aggregate_results_test.go
+++ b/src/dbnode/storage/index/aggregate_results_test.go
@@ -66,6 +66,19 @@ func TestAggResultsInsertInvalid(t *testing.T) {
 	require.Equal(t, 0, size)
 }
 
+func TestAggResultsInsertEmptyTermValue(t *testing.T) {
+	res := NewAggregateResults(nil, AggregateResultsOptions{}, testOpts)
+	dValidEmptyTerm := doc.Document{
+		ID: []byte("foo_id"),
+		Fields: []doc.Field{
+			{Name: []byte("foo"), Value: nil},
+		},
+	}
+	size, err := res.AddDocuments([]doc.Document{dValidEmptyTerm})
+	require.NoError(t, err)
+	require.Equal(t, 1, size)
+}
+
 func TestAggResultsTermOnlyInsert(t *testing.T) {
 	res := NewAggregateResults(nil, AggregateResultsOptions{
 		Type: AggregateTagNames,

--- a/src/dbnode/storage/index/aggregate_values.go
+++ b/src/dbnode/storage/index/aggregate_values.go
@@ -21,14 +21,8 @@
 package index
 
 import (
-	"errors"
-
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
-)
-
-var (
-	errUnableToAddValueMissingID = errors.New("no id for value")
 )
 
 // AggregateValues is a collection of unique identity values backed by a pool.
@@ -83,10 +77,9 @@ func (v *AggregateValues) finalize() {
 }
 
 func (v *AggregateValues) addValue(value ident.ID) error {
+	// NB(r): Allow for empty values to be set, an empty string
+	// is still different from not having the field at all.
 	bytesID := ident.BytesID(value.Bytes())
-	if len(bytesID) == 0 {
-		return errUnableToAddValueMissingID
-	}
 
 	// NB: fine to overwrite the values here.
 	v.valuesMap.Set(bytesID, struct{}{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This allows empty term values to be returned for aggregate index values requests. This helps when using M3DB as a generic metric store and generic TSDB since differentiating a field that exists with empty string and a field that doesn't exist at all can be helpful for some use cases. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
