### PR TITLE
[coordinator] Delete related etcd keys when aggregator placement deleted

### DIFF
--- a/src/query/api/v1/handler/placement/common.go
+++ b/src/query/api/v1/handler/placement/common.go
@@ -482,11 +482,11 @@ func isStateless(serviceName string) bool {
 	return false
 }
 
-func deleteAggregatorInstanceKeys(
+func deleteAggregatorShardSetIDRelatedKeys(
 	svc handleroptions.ServiceNameAndDefaults,
 	svcOpts handleroptions.ServiceOptions,
 	clusterClient clusterclient.Client,
-	instances []placement.Instance,
+	shardSetIDs []uint32,
 ) error {
 	if svc.ServiceName != handleroptions.M3AggregatorServiceName {
 		return fmt.Errorf("error deleting aggregator instance keys, bad service: %s",
@@ -504,9 +504,7 @@ func deleteAggregatorInstanceKeys(
 		return fmt.Errorf("cannot get KV store to delete aggregator keys: %v", err)
 	}
 
-	for _, instance := range instances {
-		shardSetID := instance.ShardSetID()
-
+	for _, shardSetID := range shardSetIDs {
 		// Check if flush times key exists, if so delete.
 		flushTimesKey := fmt.Sprintf(flushTimesMgrOpts.FlushTimesKeyFmt(),
 			shardSetID)

--- a/src/query/api/v1/handler/placement/delete.go
+++ b/src/query/api/v1/handler/placement/delete.go
@@ -162,18 +162,19 @@ func (h *DeleteHandler) ServeHTTP(
 	// Now need to delete aggregator related keys (e.g. for shardsets) if required.
 	if svc.ServiceName == handleroptions.M3AggregatorServiceName {
 		shardSetID := instance.ShardSetID()
-		existingShardSetIDs := 0
+		anyExistingShardSetIDs := false
 		for _, elem := range curPlacement.Instances() {
 			if elem.ID() == instance.ID() {
 				continue
 			}
 			if elem.ShardSetID() == shardSetID {
-				existingShardSetIDs++
+				anyExistingShardSetIDs = true
+				break
 			}
 		}
 
 		// Only delete the related shardset keys if no other shardsets left.
-		if existingShardSetIDs == 0 {
+		if !anyExistingShardSetIDs {
 			err := deleteAggregatorShardSetIDRelatedKeys(svc, opts,
 				h.clusterClient, []uint32{shardSetID})
 			if err != nil {

--- a/src/query/api/v1/handler/placement/delete_all.go
+++ b/src/query/api/v1/handler/placement/delete_all.go
@@ -117,10 +117,9 @@ func (h *DeleteAllHandler) ServeHTTP(
 					break
 				}
 			}
-			if found {
-				continue
+			if !found {
+				shardSetIDs = append(shardSetIDs, value)
 			}
-			shardSetIDs = append(shardSetIDs, value)
 		}
 
 		err := deleteAggregatorShardSetIDRelatedKeys(svc, opts,

--- a/src/query/api/v1/handler/placement/delete_all_test.go
+++ b/src/query/api/v1/handler/placement/delete_all_test.go
@@ -66,7 +66,19 @@ func TestPlacementDeleteAllHandler(t *testing.T) {
 			inst0 = inst0.SetShardSetID(0)
 		}
 
-		instances := []placement.Instance{inst0}
+		inst1 := placement.NewInstance().
+			SetID("bar").
+			SetEndpoint("bar:123").
+			SetHostname("bar").
+			SetPort(123).
+			SetIsolationGroup("bar-group").
+			SetWeight(1).
+			SetZone("default")
+		if serviceName == handleroptions.M3AggregatorServiceName {
+			inst1 = inst1.SetShardSetID(0)
+		}
+
+		instances := []placement.Instance{inst0, inst1}
 
 		existing := placement.NewPlacement().
 			SetInstances(instances)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Keys related to the aggregator were not being cleaned up after placement deletion and as such there's no way to really cleanly reset an environment after aggregator has been setup (i.e. coordinator placement deleted, aggregator placement deleted and aggregator topic deleted).

Here were the remaining keys that should be removed if they still exist after placement deletion:
```
$ ETCDCTL_API=3 etcdctl get --prefix '' --keys-only| grep shard
_kv/default_env/shardset/1/flush
_kv/default_env/shardset/2/flush
_kv/default_env/shardset/3/flush
_kv/default_env/shardset/4/flush
_kv/default_env/shardset/5/flush
_kv/default_env/shardset/6/flush
_kv/default_env/shardset/7/flush
_kv/default_env/shardset/8/flush
_kv/default_env/shardset/9/flush
```
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
