### PR TITLE
Add support for general etcd configuration

### DIFF
--- a/src/cluster/client/etcd/client.go
+++ b/src/cluster/client/etcd/client.go
@@ -277,6 +277,14 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 }
 
 func newClient(cluster Cluster) (*clientv3.Client, error) {
+	cfg, err := newConfigFromCluster(cluster)
+	if err != nil {
+		return nil, err
+	}
+	return clientv3.New(*cfg)
+}
+
+func newConfigFromCluster(cluster Cluster) (*clientv3.Config, error) {
 	tls, err := cluster.TLSOptions().Config()
 	if err != nil {
 		return nil, err
@@ -298,7 +306,13 @@ func newClient(cluster Cluster) (*clientv3.Client, error) {
 		cfg.DialKeepAliveTimeout = opts.KeepAliveTimeout()
 	}
 
-	return clientv3.New(cfg)
+	// apply the catch all options
+	for _, opt := range cluster.EtcdOptions() {
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
+	}
+	return &cfg, nil
 }
 
 func (c *csclient) cacheFileFn(extraFields ...string) cacheFileForZoneFn {

--- a/src/cluster/client/etcd/client_test.go
+++ b/src/cluster/client/etcd/client_test.go
@@ -21,11 +21,13 @@
 package etcd
 
 import (
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/m3db/m3/src/cluster/kv"
 	"github.com/m3db/m3/src/cluster/services"
+	"github.com/stretchr/testify/assert"
 
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/integration"
@@ -342,6 +344,28 @@ func TestValidateNamespace(t *testing.T) {
 			require.Error(t, err)
 		}
 	}
+}
+
+func TestNewConfigFromCluster_EtcdOptions(t *testing.T) {
+	t.Run("applies EtcdOptions", func(t *testing.T) {
+		testPassword := "supersecret"
+		cluster := NewCluster().SetEtcdOptions(func(cfg *clientv3.Config) error {
+			cfg.Password = testPassword
+			return nil
+		})
+		cfg, err := newConfigFromCluster(cluster)
+		require.NoError(t, err)
+		assert.Equal(t, testPassword, cfg.Password)
+	})
+
+	t.Run("errors on option err", func(t *testing.T) {
+		testErr := errors.New("some err")
+		cluster := NewCluster().SetEtcdOptions(func(cfg *clientv3.Config) error {
+			return testErr
+		})
+		_, err := newConfigFromCluster(cluster)
+		require.EqualError(t, err, testErr.Error())
+	})
 }
 
 func testOptions() Options {

--- a/src/cluster/client/etcd/options.go
+++ b/src/cluster/client/etcd/options.go
@@ -327,6 +327,7 @@ type cluster struct {
 	keepAliveOpts    KeepAliveOptions
 	tlsOpts          TLSOptions
 	autoSyncInterval time.Duration
+	etcdOptions      []EtcdOption
 }
 
 func (c cluster) Zone() string {
@@ -372,4 +373,13 @@ func (c cluster) AutoSyncInterval() time.Duration {
 func (c cluster) SetAutoSyncInterval(autoSyncInterval time.Duration) Cluster {
 	c.autoSyncInterval = autoSyncInterval
 	return c
+}
+
+func (c cluster) SetEtcdOptions(opts ...EtcdOption) Cluster {
+	c.etcdOptions = opts
+	return c
+}
+
+func (c cluster) EtcdOptions() []EtcdOption {
+	return c.etcdOptions
 }

--- a/src/cluster/client/etcd/types.go
+++ b/src/cluster/client/etcd/types.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/retry"
+	"go.etcd.io/etcd/clientv3"
 )
 
 // Options is the Options to create a config service client.
@@ -131,4 +132,16 @@ type Cluster interface {
 
 	SetAutoSyncInterval(value time.Duration) Cluster
 	AutoSyncInterval() time.Duration
+
+	// SetEtcdOptions allows the user to apply a set of transformations to the etcd config 
+	// just before it is used. The configs provided to the options will be populated with values 
+	// from other fields on Cluster.
+	SetEtcdOptions(opts ...EtcdOption) Cluster
+	
+	// EtcdOptions -- see SetEtcdOptions.
+	EtcdOptions() []EtcdOption
 }
+
+// EtcdOption applies a modification to the provided etcd config. An option can error if the config 
+// provided doesn't work with it.
+type EtcdOption func(config *clientv3.Config) error


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, our ability to configure our etcd clients is exceedingly limited. We pass through some options, but others are left unexposed. I see no in principle reason to do this. The ideal here would probably be to switch to a more dependency injection style (i.e. pass in the client directly), but I think that might be a difficult change to make.

To inject a bit more flexibility while maintaining the current structure, I added:

```
        // SetEtcdOptions allows the user to apply a set of transformations to the etcd config 
	// just before it is used. The configs provided to the options will be populated with values 
	// from other fields on Cluster.
	SetEtcdOptions(opts ...EtcdOption) Cluster
```

Not too wedded to this; if it feels wonky, I can just plumb the specific option I need. 

**Does this PR introduce a user-facing and/or backwards incompatible change?**:

```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--

```documentation-note
NONE
```
