### PR TITLE
[dbnode] Prevent repairs from getting stuck on a bad block

### DIFF
--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -606,8 +606,9 @@ func (r *dbRepairer) Repair() error {
 
 			if err := r.repairNamespaceBlockstart(n, blockStart); err != nil {
 				multiErr = multiErr.Add(err)
+			} else {
+				hasRepairedABlockStart = true
 			}
-			hasRepairedABlockStart = true
 
 			return true
 		})


### PR DESCRIPTION
Currently we only make one attempt to repair a block per call to `Repair()`. Because we iterate backward through blocks until we find the first one which is unrepaired, if for whatever reason this block is persistently unable to be repaired (e.g.: somehow corrupted), even on subsequent attempts, repairs will never proceed past this block.

This PR changes the logic so that repairs on multiple blocks may be attempted, but execution will end upon the first successful repair.

The variable names and comments seem to indicate this was the intended behavior (e.g.: `hasRepairedABlockStart` vs `hasAttemptedABlockStart`) so this is marked as a bug.