### PR TITLE
[kv] Include key name in watch errors

### DIFF
--- a/src/cluster/kv/util/runtime/value.go
+++ b/src/cluster/kv/util/runtime/value.go
@@ -81,7 +81,8 @@ func (v *value) initValue() {
 		SetInitWatchTimeout(v.opts.InitWatchTimeout()).
 		SetNewUpdatableFn(v.newUpdatableFn).
 		SetGetUpdateFn(v.getUpdateFn).
-		SetProcessFn(v.updateFn)
+		SetProcessFn(v.updateFn).
+		SetKey(v.key)
 	v.Value = watch.NewValue(valueOpts)
 }
 

--- a/src/x/watch/options.go
+++ b/src/x/watch/options.go
@@ -61,6 +61,12 @@ type Options interface {
 
 	// ProcessFn returns the process function.
 	ProcessFn() ProcessFn
+
+	// Key returns the key for the watch.
+	Key() string
+
+	// SetKey sets the key for the watch.
+	SetKey(key string) Options
 }
 
 type options struct {
@@ -69,6 +75,7 @@ type options struct {
 	newUpdatableFn   NewUpdatableFn
 	getUpdateFn      GetUpdateFn
 	processFn        ProcessFn
+	key              string
 }
 
 // NewOptions creates a new set of options.
@@ -127,4 +134,14 @@ func (o *options) SetProcessFn(value ProcessFn) Options {
 
 func (o *options) ProcessFn() ProcessFn {
 	return o.processFn
+}
+
+func (o *options) Key() string {
+	return o.key
+}
+
+func (o *options) SetKey(key string) Options {
+	opts := *o
+	opts.key = key
+	return &opts
 }

--- a/src/x/watch/value.go
+++ b/src/x/watch/value.go
@@ -172,7 +172,7 @@ func (v *value) watchUpdates(updatable Updatable) {
 			continue
 		}
 		if err = v.processWithLockFn(update); err != nil {
-			v.log.Error("error updating update",
+			v.log.Error("error applying update",
 				zap.String("key", v.opts.Key()),
 				zap.Error(err))
 		}

--- a/src/x/watch/value.go
+++ b/src/x/watch/value.go
@@ -71,6 +71,7 @@ type value struct {
 	getUpdateFn       GetUpdateFn
 	processFn         ProcessFn
 	processWithLockFn processWithLockFn
+	key               string
 
 	updatable Updatable
 	status    valueStatus
@@ -100,7 +101,10 @@ func (v *value) Watch() error {
 	}
 	updatable, err := v.newUpdatableFn()
 	if err != nil {
-		return CreateWatchError{innerError: err}
+		return CreateWatchError{
+			innerError: err,
+			key:        v.opts.Key(),
+		}
 	}
 	v.status = valueWatching
 	v.updatable = updatable
@@ -113,16 +117,25 @@ func (v *value) Watch() error {
 	select {
 	case <-v.updatable.C():
 	case <-time.After(v.opts.InitWatchTimeout()):
-		return InitValueError{innerError: errInitWatchTimeout}
+		return InitValueError{
+			innerError: errInitWatchTimeout,
+			key:        v.opts.Key(),
+		}
 	}
 
 	update, err := v.getUpdateFn(v.updatable)
 	if err != nil {
-		return InitValueError{innerError: err}
+		return InitValueError{
+			innerError: err,
+			key:        v.opts.Key(),
+		}
 	}
 
 	if err = v.processWithLockFn(update); err != nil {
-		return InitValueError{innerError: err}
+		return InitValueError{
+			innerError: err,
+			key:        v.opts.Key(),
+		}
 	}
 	return nil
 }
@@ -152,12 +165,16 @@ func (v *value) watchUpdates(updatable Updatable) {
 		}
 		update, err := v.getUpdateFn(updatable)
 		if err != nil {
-			v.log.Error("error getting update", zap.Error(err))
+			v.log.Error("error getting update",
+				zap.String("key", v.opts.Key()),
+				zap.Error(err))
 			v.Unlock()
 			continue
 		}
 		if err = v.processWithLockFn(update); err != nil {
-			v.log.Error("error updating update", zap.Error(err))
+			v.log.Error("error updating update",
+				zap.String("key", v.opts.Key()),
+				zap.Error(err))
 		}
 		v.Unlock()
 	}
@@ -173,17 +190,19 @@ func (v *value) processWithLock(update interface{}) error {
 // CreateWatchError is returned when encountering an error creating a watch.
 type CreateWatchError struct {
 	innerError error
+	key        string
 }
 
 func (e CreateWatchError) Error() string {
-	return fmt.Sprintf("create watch error:%v", e.innerError)
+	return fmt.Sprintf("create watch error (key='%s'): %v", e.key, e.innerError)
 }
 
 // InitValueError is returned when encountering an error when initializing a value.
 type InitValueError struct {
 	innerError error
+	key        string
 }
 
 func (e InitValueError) Error() string {
-	return fmt.Sprintf("initializing value error:%v", e.innerError)
+	return fmt.Sprintf("initializing value error (key='%s'): %v", e.key, e.innerError)
 }

--- a/src/x/watch/value_test.go
+++ b/src/x/watch/value_test.go
@@ -42,10 +42,14 @@ func TestValueWatchCreateWatchError(t *testing.T) {
 	updatableFn := func() (Updatable, error) {
 		return nil, errWatch
 	}
-	rv := NewValue(testValueOptions().SetNewUpdatableFn(updatableFn)).(*value)
+	rv := NewValue(
+		testValueOptions().
+			SetNewUpdatableFn(updatableFn).
+			SetKey("foobar"),
+	).(*value)
 
 	err := rv.Watch()
-	require.Equal(t, CreateWatchError{innerError: errWatch}, err)
+	require.Equal(t, CreateWatchError{innerError: errWatch, key: "foobar"}, err)
 	require.Equal(t, valueNotWatching, rv.status)
 
 	rv.Unwatch()
@@ -55,7 +59,7 @@ func TestValueWatchCreateWatchError(t *testing.T) {
 func TestValueWatchWatchTimeout(t *testing.T) {
 	_, rv := testWatchableAndValue()
 	err := rv.Watch()
-	require.Equal(t, InitValueError{innerError: errInitWatchTimeout}, err)
+	require.Equal(t, InitValueError{innerError: errInitWatchTimeout, key: "foobar"}, err)
 	require.Equal(t, valueWatching, rv.status)
 
 	rv.Unwatch()
@@ -68,7 +72,7 @@ func TestValueWatchUpdateError(t *testing.T) {
 	require.NoError(t, wa.Update(1))
 	rv.processWithLockFn = func(interface{}) error { return errUpdate }
 
-	require.Equal(t, InitValueError{innerError: errUpdate}, rv.Watch())
+	require.Equal(t, InitValueError{innerError: errUpdate, key: "foobar"}, rv.Watch())
 	require.Equal(t, valueWatching, rv.status)
 
 	rv.Unwatch()
@@ -231,7 +235,9 @@ func testWatchableAndValue() (Watchable, *value) {
 		SetNewUpdatableFn(testUpdatableFn(wa)).
 		SetGetUpdateFn(func(updatable Updatable) (interface{}, error) {
 			return updatable.(Watch).Get(), nil
-		})
+		}).
+		SetKey("foobar")
+
 	return wa, NewValue(opts).(*value)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**: Ensures that all watch errors will include the key they're watching. Sometimes loggers have enough context to include this error, but not always. Should make watch errors less ambiguous.

This doesn't fully fix the problem as we don't have access to the raw etcd key, but should make some cases less difficult to debug.

Before:
```json
{"level":"fatal","ts":1581361983.0189734,"msg":"error creating aggregator options","error":"initializing value error:init watch timeout"}
```

After:
```json
{"level":"fatal","ts":1581362476.4911253,"msg":"error creating aggregator options","error":"initializing value error (key='m3aggregator'): init watch timeout"}
```
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improve dynamic config errors
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
