### PR TITLE
Update kind & kube/prom operators

### DIFF
--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -35,7 +35,7 @@ function test_prometheus_remote_read {
   # Ensure Prometheus can proxy a Prometheus query
   echo "Wait until the remote write endpoint generates and allows for data to be queried"
   ATTEMPTS=50 TIMEOUT=2 MAX_TIMEOUT=4 retry_with_backoff  \
-    '[[ $(curl -sSf 0.0.0.0:9090/api/v1/query?query=prometheus_remote_storage_succeeded_samples_total | jq -r .data.result[].value[1]) -gt 100 ]]'
+    '[[ $(curl -sSf 0.0.0.0:9090/api/v1/query?query=prometheus_remote_storage_succeeded_samples_total | jq -r .data.result[0].value[1]) -gt 100 ]]'
 }
 
 function test_prometheus_remote_write_multi_namespaces {

--- a/scripts/docker-integration-tests/simple_v2_batch_apis/test.sh
+++ b/scripts/docker-integration-tests/simple_v2_batch_apis/test.sh
@@ -34,7 +34,7 @@ function test_prometheus_remote_read {
   # Ensure Prometheus can proxy a Prometheus query
   echo "Wait until the remote write endpoint generates and allows for data to be queried"
   ATTEMPTS=50 TIMEOUT=2 MAX_TIMEOUT=4 retry_with_backoff  \
-    '[[ $(curl -sSf 0.0.0.0:9090/api/v1/query?query=prometheus_remote_storage_succeeded_samples_total | jq -r .data.result[].value[1]) -gt 100 ]]'
+    '[[ $(curl -sSf 0.0.0.0:9090/api/v1/query?query=prometheus_remote_storage_succeeded_samples_total | jq -r .data.result[0].value[1]) -gt 100 ]]'
 }
 
 function test_prometheus_remote_write_multi_namespaces {

--- a/scripts/vagrant/provision/manifests/kube-prometheus/0prometheus-operator-clusterRole.yaml
+++ b/scripts/vagrant/provision/manifests/kube-prometheus/0prometheus-operator-clusterRole.yaml
@@ -18,6 +18,8 @@ rules:
   - alertmanagers/finalizers
   - servicemonitors
   - prometheusrules
+  - podmonitors
+  - thanosrulers
   verbs:
   - '*'
 - apiGroups:

--- a/scripts/vagrant/provision/manifests/kube-prometheus/0prometheus-operator-deployment.yaml
+++ b/scripts/vagrant/provision/manifests/kube-prometheus/0prometheus-operator-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/scripts/vagrant/provision/manifests/kube-prometheus/0prometheus-operator-deployment.yaml
+++ b/scripts/vagrant/provision/manifests/kube-prometheus/0prometheus-operator-deployment.yaml
@@ -20,8 +20,8 @@ spec:
         - --kubelet-service=kube-system/kubelet
         - --logtostderr=true
         - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
-        image: quay.io/coreos/prometheus-operator:v0.29.0
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.36.0
+        image: quay.io/coreos/prometheus-operator:v0.36.0
         name: prometheus-operator
         ports:
         - containerPort: 8080

--- a/scripts/vagrant/provision/manifests/kube-prometheus/grafana-deployment.yaml
+++ b/scripts/vagrant/provision/manifests/kube-prometheus/grafana-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/scripts/vagrant/provision/manifests/kube-prometheus/kube-state-metrics-deployment.yaml
+++ b/scripts/vagrant/provision/manifests/kube-prometheus/kube-state-metrics-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/scripts/vagrant/provision/manifests/kube-prometheus/node-exporter-daemonset.yaml
+++ b/scripts/vagrant/provision/manifests/kube-prometheus/node-exporter-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/scripts/vagrant/provision/manifests/kube-prometheus/prometheus-adapter-deployment.yaml
+++ b/scripts/vagrant/provision/manifests/kube-prometheus/prometheus-adapter-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-adapter

--- a/scripts/vagrant/provision/manifests/kube-prometheus/prometheus-roleSpecificNamespaces.yaml
+++ b/scripts/vagrant/provision/manifests/kube-prometheus/prometheus-roleSpecificNamespaces.yaml
@@ -12,6 +12,7 @@ items:
     - services
     - endpoints
     - pods
+    - podmonitors
     verbs:
     - get
     - list
@@ -28,6 +29,7 @@ items:
     - services
     - endpoints
     - pods
+    - podmonitors
     verbs:
     - get
     - list
@@ -44,6 +46,7 @@ items:
     - services
     - endpoints
     - pods
+    - podmonitors
     verbs:
     - get
     - list

--- a/scripts/vagrant/provision/manifests/m3db-primary.yaml
+++ b/scripts/vagrant/provision/manifests/m3db-primary.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName: 
+      storageClassName:
       resources:
         requests:
-          storage: 1000Gi
+          storage: 2000Gi

--- a/scripts/vagrant/provision/manifests/m3db-primary.yaml
+++ b/scripts/vagrant/provision/manifests/m3db-primary.yaml
@@ -28,7 +28,6 @@ spec:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName:
       resources:
         requests:
           storage: 2000Gi

--- a/scripts/vagrant/provision/manifests/m3db-secondary.yaml
+++ b/scripts/vagrant/provision/manifests/m3db-secondary.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName: 
+      storageClassName:
       resources:
         requests:
-          storage: 1000Gi
+          storage: 2000Gi

--- a/scripts/vagrant/provision/manifests/m3db-secondary.yaml
+++ b/scripts/vagrant/provision/manifests/m3db-secondary.yaml
@@ -28,7 +28,6 @@ spec:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName:
       resources:
         requests:
           storage: 2000Gi

--- a/scripts/vagrant/provision/manifests/operator.yaml
+++ b/scripts/vagrant/provision/manifests/operator.yaml
@@ -31,7 +31,7 @@ rules:
   verbs: ["create", "get", "deletecollection", "delete"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["list", "get", "watch", "update"]
+  verbs: ["list", "get", "watch", "patch", "update"]
 - apiGroups: ["apps"]
   resources: ["statefulsets", "deployments"]
   verbs: ["*"]
@@ -84,7 +84,7 @@ spec:
         runAsGroup: 65534
       containers:
         - name: m3db-operator
-          image: quay.io/m3db/m3db-operator:v0.3.0
+          image: quay.io/m3db/m3db-operator:v0.4.0
           command:
           - m3db-operator
           imagePullPolicy: Always

--- a/scripts/vagrant/provision/setup_kube.sh
+++ b/scripts/vagrant/provision/setup_kube.sh
@@ -12,9 +12,6 @@ set -xe
 # Create cluster
 kind create cluster --config ./manifests/kind-kube-cluster.yaml
 
-# Use correct kubeconfig
-export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-
 # Apply common kube manifests
 kubectl apply -f ./kube/sysctl-daemonset.yaml
 

--- a/scripts/vagrant/provision/setup_unprivileged.sh
+++ b/scripts/vagrant/provision/setup_unprivileged.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 # Use with Ubuntu 16.x+
 set -xe
@@ -15,7 +15,7 @@ echo '# GOPATH bin' >> ${HOME}/.bashrc
 echo 'export PATH=$PATH:${HOME}/go/bin' >> ${HOME}/.bashrc
 
 # Install Kind
-GO111MODULE="on" go get sigs.k8s.io/kind@v0.4.0
+GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
 
 # Link Kind (so GOPATH does not have to be set, not guaranteed always)
 mkdir -p ${HOME}/bin


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Updates `kind` version so it creates a `default` `StorageClass` that uses `local-path-provisioner` to create persistent volumes.
Also upgrades prom/kube operators since kind/kube APIs changed as well.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
None
```
