### PR TITLE
[dbnode] Add aggregator client maxBatchSize config for bigger buffer for data sent to aggregator

### DIFF
--- a/src/aggregator/client/config.go
+++ b/src/aggregator/client/config.go
@@ -45,6 +45,7 @@ type Configuration struct {
 	ShardCutoffLingerDuration  *time.Duration                 `yaml:"shardCutoffLingerDuration"`
 	Encoder                    EncoderConfiguration           `yaml:"encoder"`
 	FlushSize                  int                            `yaml:"flushSize"`
+	MaxBatchSize               int                            `yaml:"maxBatchSize"`
 	MaxTimerBatchSize          int                            `yaml:"maxTimerBatchSize"`
 	QueueSize                  int                            `yaml:"queueSize"`
 	QueueDropType              *DropType                      `yaml:"queueDropType"`
@@ -126,6 +127,9 @@ func (c *Configuration) newClientOptions(
 	}
 	if c.FlushSize != 0 {
 		opts = opts.SetFlushSize(c.FlushSize)
+	}
+	if c.MaxBatchSize != 0 {
+		opts = opts.SetMaxBatchSize(c.MaxBatchSize)
 	}
 	if c.MaxTimerBatchSize != 0 {
 		opts = opts.SetMaxTimerBatchSize(c.MaxTimerBatchSize)

--- a/src/aggregator/client/options.go
+++ b/src/aggregator/client/options.go
@@ -37,6 +37,8 @@ const (
 	// By default there is no limit on the timer batch size.
 	defaultMaxTimerBatchSize = 0
 
+	// defaultInstanceQueueSize determines how many metrics can be buffered
+	// before it must wait for an existing batch to be flushed to an instance.
 	defaultInstanceQueueSize = 4096
 
 	// By default traffic is cut over to shards 10 minutes before the designated
@@ -51,10 +53,10 @@ const (
 	// By default the oldest metrics in the queue are dropped when it is full.
 	defaultDropType = DropOldest
 
-	// By default set maximum batch size to 32k
-	defaultMaxBatchSize = 2 << 14
+	// By default set maximum batch size to 16mb.
+	defaultMaxBatchSize = 2 << 23
 
-	// By default write at least every 100ms
+	// By default write at least every 100ms.
 	defaultBatchFlushDeadline = 100 * time.Millisecond
 )
 

--- a/src/aggregator/client/options.go
+++ b/src/aggregator/client/options.go
@@ -39,7 +39,7 @@ const (
 
 	// defaultInstanceQueueSize determines how many metrics can be buffered
 	// before it must wait for an existing batch to be flushed to an instance.
-	defaultInstanceQueueSize = 4096
+	defaultInstanceQueueSize = 2 << 15 // ~65k
 
 	// By default traffic is cut over to shards 10 minutes before the designated
 	// cutover time in case there are issues with the instances owning the shards.

--- a/src/aggregator/client/options.go
+++ b/src/aggregator/client/options.go
@@ -53,8 +53,8 @@ const (
 	// By default the oldest metrics in the queue are dropped when it is full.
 	defaultDropType = DropOldest
 
-	// By default set maximum batch size to 16mb.
-	defaultMaxBatchSize = 2 << 23
+	// By default set maximum batch size to 8mb.
+	defaultMaxBatchSize = 2 << 22
 
 	// By default write at least every 100ms.
 	defaultBatchFlushDeadline = 100 * time.Millisecond


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The default was also vastly too small for workloads with a lot of metrics being sent to a single aggregator instance. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
