### PR TITLE
Align index block metric labels.

### DIFF
--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -158,10 +158,12 @@ func newBlockMetrics(s tally.Scope) blockMetrics {
 		backgroundCompactionPlanRunLatency: backgroundScope.Timer("compaction-plan-run-latency"),
 		backgroundCompactionTaskRunLatency: backgroundScope.Timer("compaction-task-run-latency"),
 		segmentFreeMmapSuccess: s.Tagged(map[string]string{
-			"result": "success",
+			"result":    "success",
+			"skip_type": "none",
 		}).Counter(segmentFreeMmap),
 		segmentFreeMmapError: s.Tagged(map[string]string{
-			"result": "error",
+			"result":    "error",
+			"skip_type": "none",
 		}).Counter(segmentFreeMmap),
 		segmentFreeMmapSkipNotImmutable: s.Tagged(map[string]string{
 			"result":    "skip",


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Prom client doesn't allow registering of keys w/ differing label names. See error:
```
a previously registered descriptor with the same fully-qualified name as Desc{fqName: \"index_block_segment_free_mmap\", help: \"index_block_segment_free_mmap counter\", constLabels: {}, variableLabels: [result skip_type]} has different label names or a different help string
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
