### PR TITLE
Don't return error on missing writable bucket during cold flush

### DIFF
--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -691,6 +691,12 @@ func (b *dbBuffer) FetchBlocksForColdFlush(
 		return nil, fmt.Errorf("buckets do not exist with block start %s", start)
 	}
 	if bucket, exists := buckets.writableBucket(ColdWrite); exists {
+		// Update the version of the writable bucket (effectively making it not
+		// writable). This marks this bucket as attempted to be flushed,
+		// although it is only actually written to disk successfully at the
+		// shard level after every series has completed the flush process.
+		// The tick following a successful flush to disk will remove this bucket
+		// from memory.
 		bucket.version = version
 	}
 	// No-op if the writable bucket doesn't exist.

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -692,9 +692,12 @@ func (b *dbBuffer) FetchBlocksForColdFlush(
 	}
 	if bucket, exists := buckets.writableBucket(ColdWrite); exists {
 		bucket.version = version
-	} else {
-		return nil, fmt.Errorf("writable bucket does not exist with block start %s", start)
 	}
+	// No-op if the writable bucket doesn't exist.
+	// This function should only get called for blocks that we know need to be
+	// cold flushed. However, buckets that get attempted to be cold flushed and
+	// fail need to get cold flushed as well. These kinds of buckets will have
+	// a non-writable version.
 
 	return blocks, nil
 }

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -1647,10 +1647,11 @@ func TestFetchBlocksForColdFlush(t *testing.T) {
 	requireReaderValuesEqual(t, expected[blockStartNano1], [][]xio.BlockReader{reader}, opts, nsCtx)
 	assert.Equal(t, 4, buffer.bucketsMap[blockStartNano1].buckets[0].version)
 
-	// Try to fetch from block1 again, which should result in error since we
-	// just fetched, which would mark those buckets as not dirty.
-	_, err = buffer.FetchBlocksForColdFlush(ctx, blockStart1, 9, nsCtx)
-	assert.Error(t, err)
+	// Try to fetch from block1 again, this should not be an error because we
+	// would want to fetch blocks with buckets that failed to flush fully a
+	// previous time.
+	reader, err = buffer.FetchBlocksForColdFlush(ctx, blockStart1, 9, nsCtx)
+	assert.NoError(t, err)
 
 	reader, err = buffer.FetchBlocksForColdFlush(ctx, blockStart3, 1, nsCtx)
 	assert.NoError(t, err)


### PR DESCRIPTION

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
During a cold flush, we first collect all the block starts that require cold flushing. This includes two cases:
1. Any block that has a cold bucket with new un-flushed writes (a "writable bucket")
2. Any block that has a cold bucket with writes that have failed to flush completely

After getting all these blocks, we go through each one to fetch data and compact.

Therefore when fetching data for a ColdFlush, encountering a block that has no writable bucket is not an error, since that means we're hitting case (2).

Please see the section explaining bucket versions [here](https://m3db.github.io/m3/m3db/architecture/engine/#buffer) for more context if needed.

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
