### PR TITLE
[query] api: Fix agg+coord set+replace routes

### DIFF
--- a/src/query/api/v1/handler/placement/replace.go
+++ b/src/query/api/v1/handler/placement/replace.go
@@ -51,12 +51,12 @@ var (
 	// M3AggReplaceURL is the url for the m3aggregator replace handler (method
 	// POST).
 	M3AggReplaceURL = path.Join(handler.RoutePrefixV1,
-		handleroptions.M3AggregatorServiceName, replacePathName)
+		M3AggServicePlacementPathName, replacePathName)
 
 	// M3CoordinatorReplaceURL is the url for the m3coordinator replace handler
 	// (method POST).
 	M3CoordinatorReplaceURL = path.Join(handler.RoutePrefixV1,
-		handleroptions.M3CoordinatorServiceName, replacePathName)
+		M3CoordinatorServicePlacementPathName, replacePathName)
 )
 
 // ReplaceHandler is the type for placement replaces.

--- a/src/query/api/v1/handler/placement/set.go
+++ b/src/query/api/v1/handler/placement/set.go
@@ -52,12 +52,12 @@ var (
 	// M3AggSetURL is the url for the m3aggregator replace handler (method
 	// POST).
 	M3AggSetURL = path.Join(handler.RoutePrefixV1,
-		handleroptions.M3AggregatorServiceName, setPathName)
+		M3AggServicePlacementPathName, setPathName)
 
 	// M3CoordinatorSetURL is the url for the m3coordinator replace handler
 	// (method POST).
 	M3CoordinatorSetURL = path.Join(handler.RoutePrefixV1,
-		handleroptions.M3CoordinatorServiceName, setPathName)
+		M3CoordinatorServicePlacementPathName, setPathName)
 )
 
 // SetHandler is the type for placement replaces.


### PR DESCRIPTION
We had been serving on `/api/v1/${SVC}/set` rather than
`/api/v1/services/${SVC}/set`.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**: **YES**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix routes that m3coordinator + m3aggregator `/replace` and `/set` routes are served on. WARNING: this is a breaking change to fix a bug in route naming. We are not aware of any users leveraging these APIs, but if you are you will have to update `/api/v1/${SVC}/set` to `/api/v1/services/${SVC}/set`.
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
