### PR TITLE
[dbnode] Expose SchemaDescr on MultiReaderIterator

### DIFF
--- a/src/dbnode/encoding/encoding_mock.go
+++ b/src/dbnode/encoding/encoding_mock.go
@@ -1060,11 +1060,12 @@ func (m *MockSeriesIteratorConsolidator) EXPECT() *MockSeriesIteratorConsolidato
 }
 
 // ConsolidateReplicas mocks base method
-func (m *MockSeriesIteratorConsolidator) ConsolidateReplicas(arg0 []MultiReaderIterator) []MultiReaderIterator {
+func (m *MockSeriesIteratorConsolidator) ConsolidateReplicas(arg0 []MultiReaderIterator) ([]MultiReaderIterator, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConsolidateReplicas", arg0)
 	ret0, _ := ret[0].([]MultiReaderIterator)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ConsolidateReplicas indicates an expected call of ConsolidateReplicas

--- a/src/dbnode/encoding/encoding_mock.go
+++ b/src/dbnode/encoding/encoding_mock.go
@@ -820,6 +820,20 @@ func (mr *MockMultiReaderIteratorMockRecorder) Readers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readers", reflect.TypeOf((*MockMultiReaderIterator)(nil).Readers))
 }
 
+// Schema mocks base method
+func (m *MockMultiReaderIterator) Schema() namespace.SchemaDescr {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Schema")
+	ret0, _ := ret[0].(namespace.SchemaDescr)
+	return ret0
+}
+
+// Schema indicates an expected call of Schema
+func (mr *MockMultiReaderIteratorMockRecorder) Schema() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Schema", reflect.TypeOf((*MockMultiReaderIterator)(nil).Schema))
+}
+
 // MockSeriesIterator is a mock of SeriesIterator interface
 type MockSeriesIterator struct {
 	ctrl     *gomock.Controller

--- a/src/dbnode/encoding/iterator_test.go
+++ b/src/dbnode/encoding/iterator_test.go
@@ -154,6 +154,10 @@ func (it *testMultiIterator) ResetSliceOfSlices(readers xio.ReaderSliceOfSlicesI
 	}
 }
 
+func (it *testMultiIterator) Schema() namespace.SchemaDescr {
+	return nil
+}
+
 func (it *testMultiIterator) Readers() xio.ReaderSliceOfSlicesIterator {
 	return nil
 }

--- a/src/dbnode/encoding/multi_reader_iterator.go
+++ b/src/dbnode/encoding/multi_reader_iterator.go
@@ -181,6 +181,10 @@ func (it *multiReaderIterator) ResetSliceOfSlices(slicesIter xio.ReaderSliceOfSl
 	it.moveToNext()
 }
 
+func (it *multiReaderIterator) Schema() namespace.SchemaDescr {
+	return it.schemaDesc
+}
+
 func (it *multiReaderIterator) Close() {
 	if it.isClosed() {
 		return

--- a/src/dbnode/encoding/series_iterator.go
+++ b/src/dbnode/encoding/series_iterator.go
@@ -143,10 +143,14 @@ func (it *seriesIterator) Reset(opts SeriesIteratorOptions) {
 		it.iters.setFilter(it.start, it.end)
 	}
 	it.SetIterateEqualTimestampStrategy(opts.IterateEqualTimestampStrategy)
-
 	replicas := opts.Replicas
+	var err error
 	if consolidator := opts.SeriesIteratorConsolidator; consolidator != nil {
-		replicas = consolidator.ConsolidateReplicas(replicas)
+		replicas, err = consolidator.ConsolidateReplicas(replicas)
+		if err != nil {
+			it.err = err
+			return
+		}
 	}
 
 	for _, replica := range replicas {

--- a/src/dbnode/encoding/series_iterator_test.go
+++ b/src/dbnode/encoding/series_iterator_test.go
@@ -231,8 +231,8 @@ type testConsolidator struct {
 }
 
 func (c *testConsolidator) ConsolidateReplicas(
-	_ []MultiReaderIterator) []MultiReaderIterator {
-	return c.iters
+	_ []MultiReaderIterator) ([]MultiReaderIterator, error) {
+	return c.iters, nil
 }
 
 func TestSeriesIteratorSetSeriesIteratorConsolidator(t *testing.T) {

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -210,6 +210,9 @@ type MultiReaderIterator interface {
 	// Readers exposes the underlying ReaderSliceOfSlicesIterator
 	// for this MultiReaderIterator.
 	Readers() xio.ReaderSliceOfSlicesIterator
+
+	// Schema exposes the underlying SchemaDescr for this MutliReaderIterator.
+	Schema() namespace.SchemaDescr
 }
 
 // SeriesIterator is an iterator that iterates over a set of iterators from

--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -270,7 +270,7 @@ type SeriesIteratorStats struct {
 // reset series iterators.
 type SeriesIteratorConsolidator interface {
 	// ConsolidateReplicas consolidates MultiReaderIterator slices.
-	ConsolidateReplicas([]MultiReaderIterator) []MultiReaderIterator
+	ConsolidateReplicas([]MultiReaderIterator) ([]MultiReaderIterator, error)
 }
 
 // SeriesIteratorOptions is a set of options for using a series iterator.


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes SchemaDescr on the MultiReaderIterator interface