### PR TITLE
[aggregator] Add ability to jitter by shard instead of by aggregator server

### DIFF
--- a/src/aggregator/integration/custom_aggregations_test.go
+++ b/src/aggregator/integration/custom_aggregations_test.go
@@ -241,6 +241,6 @@ func testCustomAggregations(t *testing.T, metadataFns [4]metadataFn) {
 		expected = append(expected, mustComputeExpectedResults(t, finalTime, input, testServer.aggregatorOpts)...)
 	}
 	sort.Sort(byTimeIDPolicyAscending(expected))
-	actual := testServer.sortedResults()
+	actual := testServer.snapshotSortedResults()
 	require.Equal(t, expected, actual)
 }

--- a/src/aggregator/integration/flush_jitter_by_shard_test.go
+++ b/src/aggregator/integration/flush_jitter_by_shard_test.go
@@ -1,0 +1,212 @@
+// +build integration
+
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/aggregator/aggregator"
+	"github.com/m3db/m3/src/cluster/placement"
+	maggregation "github.com/m3db/m3/src/metrics/aggregation"
+	"github.com/m3db/m3/src/metrics/metadata"
+	"github.com/m3db/m3/src/metrics/metric/aggregated"
+	"github.com/m3db/m3/src/metrics/policy"
+	"github.com/m3db/m3/src/x/clock"
+	xtest "github.com/m3db/m3/src/x/test"
+	xtime "github.com/m3db/m3/src/x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlushJitterByShard(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	// Create server opts with jitter enabled at 50%.
+	jitterFactor := 0.8
+	serverOpts := newTestServerOptions().
+		SetJitterEnabled(true).
+		SetFlushJitterType(aggregator.FlushJitterByShard).
+		SetMaxJitterFn(
+			aggregator.FlushJitterFn(func(interval time.Duration) time.Duration {
+				return time.Duration(float64(interval) * jitterFactor)
+			})).
+		SetBufferForPastTimedMetricFn(
+			aggregator.BufferForPastTimedMetricFn(func(resolution time.Duration) time.Duration {
+				// Allow an extra second for data to arrive.
+				return resolution + time.Second
+			}))
+
+	// Clock setup.
+	var (
+		lock  sync.RWMutex
+		nowFn func() time.Time
+	)
+	now := time.Now()
+	getNowFn := func() time.Time {
+		lock.RLock()
+		t := now
+		if nowFn != nil {
+			t = nowFn()
+		}
+		lock.RUnlock()
+		return t
+	}
+	setNowFn := func(fn func() time.Time) {
+		lock.Lock()
+		nowFn = fn
+		lock.Unlock()
+	}
+	setNow := func(t time.Time) {
+		lock.Lock()
+		now = t
+		lock.Unlock()
+	}
+	clockOpts := clock.NewOptions().SetNowFn(getNowFn)
+	serverOpts = serverOpts.SetClockOptions(clockOpts)
+
+	// Placement setup.
+	numShards := 1024
+	cfg := placementInstanceConfig{
+		instanceID:          serverOpts.InstanceID(),
+		shardSetID:          serverOpts.ShardSetID(),
+		shardStartInclusive: 0,
+		shardEndExclusive:   uint32(numShards),
+	}
+	instance := cfg.newPlacementInstance()
+	placement := newPlacement(numShards, []placement.Instance{instance})
+	placementKey := serverOpts.PlacementKVKey()
+	placementStore := serverOpts.KVStore()
+	require.NoError(t, setPlacement(placementKey, placementStore, placement))
+
+	// Create server.
+	testServer := newTestServerSetup(t, serverOpts)
+	defer testServer.close()
+
+	// Start the server.
+	log := testServer.aggregatorOpts.InstrumentOptions().Logger()
+	log.Info("test one client sending multiple types of timed metrics")
+	require.NoError(t, testServer.startServer())
+	log.Info("server is now up")
+	require.NoError(t, testServer.waitUntilLeader())
+	log.Info("server is now the leader")
+
+	var (
+		idPrefix   = "full.id"
+		numIDs     = 100
+		resolution = 10 * time.Second
+		precision  = xtime.Second
+		start      = getNowFn().Truncate(resolution).Add(resolution)
+		stop       = start.Add(resolution)
+	)
+	client := testServer.newClient()
+	require.NoError(t, client.connect())
+	defer client.close()
+
+	ids := generateTestIDs(idPrefix, numIDs)
+	testTimedMetadataTemplate := metadata.TimedMetadata{
+		AggregationID: maggregation.MustCompressTypes(maggregation.Sum),
+		StoragePolicy: policy.NewStoragePolicy(resolution, precision, time.Hour),
+	}
+	metadataFn := func(idx int) metadataUnion {
+		timedMetadata := testTimedMetadataTemplate
+		return metadataUnion{
+			mType:         timedMetadataType,
+			timedMetadata: timedMetadata,
+		}
+	}
+	dataset := mustGenerateTestDataset(t, datasetGenOpts{
+		start:        start,
+		stop:         stop,
+		interval:     resolution,
+		ids:          ids,
+		category:     timedMetric,
+		typeFn:       roundRobinMetricTypeFn,
+		valueGenOpts: defaultValueGenOpts,
+		metadataFn:   metadataFn,
+	})
+	for _, data := range dataset {
+		setNow(data.timestamp)
+		for _, mm := range data.metricWithMetadatas {
+			require.NoError(t, client.writeTimedMetricWithMetadata(mm.metric.timed, mm.metadata.timedMetadata))
+		}
+		require.NoError(t, client.flush())
+	}
+
+	var (
+		sampleExpectedAt = start.Add(time.Hour)
+		expected         = mustComputeExpectedResults(t, sampleExpectedAt,
+			dataset, testServer.aggregatorOpts)
+		actual      []aggregated.MetricWithStoragePolicy
+		verifyStart = time.Now()
+		verifyFor   = 60 * time.Second
+		verifyPause = 100 * time.Millisecond
+	)
+	// Make sure we're expecting results.
+	require.True(t, len(expected) == numIDs)
+
+	// Resume time and wait for flushing to happen.
+	setNowFn(time.Now)
+
+	for time.Since(verifyStart) <= verifyFor {
+		// Validate results.
+		actual = testServer.snapshotSortedResults()
+		if reflect.DeepEqual(expected, actual) {
+			break
+		}
+		time.Sleep(verifyPause)
+	}
+	require.Equal(t, expected, actual,
+		xtest.Diff(xtest.MustPrettyJSONValue(t, newAggregatedMetrics(expected)),
+			xtest.MustPrettyJSONValue(t, newAggregatedMetrics(actual))))
+
+	var minRecv, maxRecv time.Time
+	for _, m := range testServer.snapshotReceived() {
+		if minRecv.IsZero() || m.receivedAt.Before(minRecv) {
+			minRecv = m.receivedAt
+		}
+		if maxRecv.IsZero() || m.receivedAt.After(maxRecv) {
+			maxRecv = m.receivedAt
+		}
+	}
+
+	skew := maxRecv.Sub(minRecv)
+
+	// Require at least 90% skew between received values, we have
+	// 1024 shards so it should be very likely that with a good
+	// random function that we get very close to our desired skew
+	// across shards.
+	minRequiredSkew := time.Duration(float64(resolution) * (0.9 * jitterFactor))
+	require.True(t, skew >= minRequiredSkew,
+		fmt.Sprintf("wanted min skew of at least %s, instead skew is %s\n",
+			minRequiredSkew, skew))
+
+	// Stop the server.
+	require.NoError(t, testServer.stopServer())
+	log.Info("server is now down")
+}

--- a/src/aggregator/integration/integration.go
+++ b/src/aggregator/integration/integration.go
@@ -22,6 +22,8 @@ package integration
 
 import (
 	"time"
+
+	"github.com/m3db/m3/src/metrics/metric/aggregated"
 )
 
 type conditionFn func() bool
@@ -35,4 +37,35 @@ func waitUntil(fn conditionFn, timeout time.Duration) bool {
 		time.Sleep(time.Second)
 	}
 	return false
+}
+
+// aggregatedMetric is useful for JSON comparison of expected metrics.
+type aggregatedMetric struct {
+	ID            string
+	Type          string
+	Time          time.Time
+	Value         float64
+	StoragePolicy string
+}
+
+func newAggregatedMetric(
+	m aggregated.MetricWithStoragePolicy,
+) aggregatedMetric {
+	return aggregatedMetric{
+		ID:            m.Metric.ID.String(),
+		Type:          m.Metric.Type.String(),
+		Time:          time.Unix(0, m.Metric.TimeNanos),
+		Value:         m.Metric.Value,
+		StoragePolicy: m.StoragePolicy.String(),
+	}
+}
+
+func newAggregatedMetrics(
+	m []aggregated.MetricWithStoragePolicy,
+) []aggregatedMetric {
+	results := make([]aggregatedMetric, 0, len(m))
+	for _, m := range m {
+		results = append(results, newAggregatedMetric(m))
+	}
+	return results
 }

--- a/src/aggregator/integration/metadata_change_test.go
+++ b/src/aggregator/integration/metadata_change_test.go
@@ -185,6 +185,6 @@ func testMetadataChange(t *testing.T, oldMetadataFn, newMetadataFn metadataFn) {
 		expected = append(expected, mustComputeExpectedResults(t, finalTime, input, testServer.aggregatorOpts)...)
 	}
 	sort.Sort(byTimeIDPolicyAscending(expected))
-	actual := testServer.sortedResults()
+	actual := testServer.snapshotSortedResults()
 	require.Equal(t, expected, actual)
 }

--- a/src/aggregator/integration/multi_client_one_type_test.go
+++ b/src/aggregator/integration/multi_client_one_type_test.go
@@ -163,6 +163,6 @@ func testMultiClientOneType(t *testing.T, metadataFn metadataFn) {
 
 	// Validate results.
 	expected := mustComputeExpectedResults(t, finalTime, dataset, testServer.aggregatorOpts)
-	actual := testServer.sortedResults()
+	actual := testServer.snapshotSortedResults()
 	require.Equal(t, expected, actual)
 }

--- a/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
+++ b/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
@@ -426,5 +426,5 @@ func testMultiServerForwardingPipeline(t *testing.T, discardNaNAggregatedValues 
 		expectedResultsFlattened = append(expectedResultsFlattened, expectedResults...)
 	}
 	sort.Sort(byTimeIDPolicyAscending(expectedResultsFlattened))
-	require.True(t, cmp.Equal(expectedResultsFlattened, destinationServer.sortedResults(), testCmpOpts...))
+	require.True(t, cmp.Equal(expectedResultsFlattened, destinationServer.snapshotSortedResults(), testCmpOpts...))
 }

--- a/src/aggregator/integration/one_client_multi_type_forwarded_test.go
+++ b/src/aggregator/integration/one_client_multi_type_forwarded_test.go
@@ -144,6 +144,6 @@ func TestOneClientMultiTypeForwardedMetrics(t *testing.T) {
 
 	// Validate results.
 	expected := mustComputeExpectedResults(t, finalTime, dataset, testServer.aggregatorOpts)
-	actual := testServer.sortedResults()
+	actual := testServer.snapshotSortedResults()
 	require.Equal(t, expected, actual)
 }

--- a/src/aggregator/integration/one_client_multi_type_timed_test.go
+++ b/src/aggregator/integration/one_client_multi_type_timed_test.go
@@ -142,6 +142,6 @@ func TestOneClientMultiTypeTimedMetrics(t *testing.T) {
 
 	// Validate results.
 	expected := mustComputeExpectedResults(t, finalTime, dataset, testServer.aggregatorOpts)
-	actual := testServer.sortedResults()
+	actual := testServer.snapshotSortedResults()
 	require.Equal(t, expected, actual)
 }

--- a/src/aggregator/integration/one_client_multi_type_untimed_test.go
+++ b/src/aggregator/integration/one_client_multi_type_untimed_test.go
@@ -151,6 +151,6 @@ func testOneClientMultiType(t *testing.T, metadataFn metadataFn) {
 
 	// Validate results.
 	expected := mustComputeExpectedResults(t, finalTime, dataset, testServer.aggregatorOpts)
-	actual := testServer.sortedResults()
+	actual := testServer.snapshotSortedResults()
 	require.Equal(t, expected, actual)
 }

--- a/src/aggregator/integration/options.go
+++ b/src/aggregator/integration/options.go
@@ -171,6 +171,12 @@ type testServerOptions interface {
 	// JitterEnabled returns whether jittering is enabled.
 	JitterEnabled() bool
 
+	// SetFlushJitterType sets which type of jittering is to be used.
+	SetFlushJitterType(value aggregator.FlushJitterType) testServerOptions
+
+	// FlushJitterType returns which type of jittering is to be used.
+	FlushJitterType() aggregator.FlushJitterType
+
 	// SetMaxJitterFn sets the max flush jittering function.
 	SetMaxJitterFn(value aggregator.FlushJitterFn) testServerOptions
 
@@ -188,6 +194,12 @@ type testServerOptions interface {
 
 	// DiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
 	DiscardNaNAggregatedValues() bool
+
+	// SetBufferForPastTimedMetricFn sets the size of the buffer for timed metrics in the past.
+	SetBufferForPastTimedMetricFn(value aggregator.BufferForPastTimedMetricFn) testServerOptions
+
+	// BufferForPastTimedMetricFn returns the size of the buffer for timed metrics in the past.
+	BufferForPastTimedMetricFn() aggregator.BufferForPastTimedMetricFn
 }
 
 // nolint: maligned
@@ -212,9 +224,11 @@ type serverOptions struct {
 	electionStateChangeTimeout  time.Duration
 	entryCheckInterval          time.Duration
 	jitterEnabled               bool
+	jitterType                  aggregator.FlushJitterType
 	maxJitterFn                 aggregator.FlushJitterFn
 	maxAllowedForwardingDelayFn aggregator.MaxAllowedForwardingDelayFn
 	discardNaNAggregatedValues  bool
+	bufferForPastTimedMetricFn  aggregator.BufferForPastTimedMetricFn
 }
 
 func newTestServerOptions() testServerOptions {
@@ -241,6 +255,7 @@ func newTestServerOptions() testServerOptions {
 		clientConnectionOpts:        aggclient.NewConnectionOptions(),
 		electionStateChangeTimeout:  defaultElectionStateChangeTimeout,
 		jitterEnabled:               defaultJitterEnabled,
+		jitterType:                  aggregator.FlushJitterTypeDefault,
 		entryCheckInterval:          defaultEntryCheckInterval,
 		maxJitterFn:                 defaultMaxJitterFn,
 		maxAllowedForwardingDelayFn: defaultMaxAllowedForwardingDelayFn,
@@ -448,6 +463,16 @@ func (o *serverOptions) JitterEnabled() bool {
 	return o.jitterEnabled
 }
 
+func (o *serverOptions) SetFlushJitterType(value aggregator.FlushJitterType) testServerOptions {
+	opts := *o
+	opts.jitterType = value
+	return &opts
+}
+
+func (o *serverOptions) FlushJitterType() aggregator.FlushJitterType {
+	return o.jitterType
+}
+
 func (o *serverOptions) SetMaxJitterFn(value aggregator.FlushJitterFn) testServerOptions {
 	opts := *o
 	opts.maxJitterFn = value
@@ -476,6 +501,16 @@ func (o *serverOptions) SetDiscardNaNAggregatedValues(value bool) testServerOpti
 
 func (o *serverOptions) DiscardNaNAggregatedValues() bool {
 	return o.discardNaNAggregatedValues
+}
+
+func (o *serverOptions) SetBufferForPastTimedMetricFn(value aggregator.BufferForPastTimedMetricFn) testServerOptions {
+	opts := *o
+	opts.bufferForPastTimedMetricFn = value
+	return &opts
+}
+
+func (o *serverOptions) BufferForPastTimedMetricFn() aggregator.BufferForPastTimedMetricFn {
+	return o.bufferForPastTimedMetricFn
 }
 
 func defaultMaxJitterFn(interval time.Duration) time.Duration {

--- a/src/aggregator/integration/same_id_multi_type_test.go
+++ b/src/aggregator/integration/same_id_multi_type_test.go
@@ -175,6 +175,6 @@ func testSameIDMultiType(t *testing.T, metadataFn metadataFn) {
 
 	// Validate results.
 	expected := mustComputeExpectedResults(t, finalTime, dataset, testServer.aggregatorOpts)
-	actual := testServer.sortedResults()
+	actual := testServer.snapshotSortedResults()
 	require.Equal(t, expected, actual)
 }

--- a/src/x/test/diff.go
+++ b/src/x/test/diff.go
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const jsonPrettyIndent = "  "
+
 // Diff is a helper method to print a terminal pretty diff of two strings
 // for test output purposes.
 func Diff(expected, actual string) string {
@@ -41,7 +43,14 @@ func MustPrettyJSON(t *testing.T, str string) string {
 	var unmarshalled map[string]interface{}
 	err := json.Unmarshal([]byte(str), &unmarshalled)
 	require.NoError(t, err)
-	pretty, err := json.MarshalIndent(unmarshalled, "", "  ")
+	pretty, err := json.MarshalIndent(unmarshalled, "", jsonPrettyIndent)
+	require.NoError(t, err)
+	return string(pretty)
+}
+
+// MustPrettyJSONValue returns an indented version of the JSON.
+func MustPrettyJSONValue(t *testing.T, v interface{}) string {
+	pretty, err := json.MarshalIndent(v, "", jsonPrettyIndent)
 	require.NoError(t, err)
 	return string(pretty)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This allows an operator to jitter flushing by shard rather than by aggregator server. This is running very few vertically scaled aggregators (since they will attempt to send a lot of network data very quickly and overwhelm queues).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
