### PR TITLE
[aggregator] Take last value by value timestamp not arrival time

### DIFF
--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -21,7 +21,14 @@ echo "Run m3dbnode and m3coordinator containers"
 docker-compose -f ${COMPOSE_FILE} up -d dbnode01
 docker-compose -f ${COMPOSE_FILE} up -d coordinator01
 
+TEST_SUCCESS=false
+
 function defer {
+  if [[ "$TEST_SUCCESS" != "true" ]]; then
+    echo "Test failure, printing docker-compose logs"
+    docker-compose logs
+  fi
+
   docker-compose -f ${COMPOSE_FILE} down || echo "unable to shutdown containers" # CI fails to stop all containers sometimes
 }
 trap defer EXIT
@@ -191,3 +198,5 @@ test_query_restrict_metrics_type
 
 echo "Running function correctness tests"
 test_correctness
+
+TEST_SUCCESS=true

--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -26,7 +26,7 @@ TEST_SUCCESS=false
 function defer {
   if [[ "$TEST_SUCCESS" != "true" ]]; then
     echo "Test failure, printing docker-compose logs"
-    docker-compose logs
+    docker-compose -f ${COMPOSE_FILE} logs
   fi
 
   docker-compose -f ${COMPOSE_FILE} down || echo "unable to shutdown containers" # CI fails to stop all containers sometimes

--- a/src/aggregator/aggregation/counter.go
+++ b/src/aggregator/aggregation/counter.go
@@ -22,6 +22,7 @@ package aggregation
 
 import (
 	"math"
+	"time"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
 )
@@ -47,7 +48,7 @@ func NewCounter(opts Options) Counter {
 }
 
 // Update updates the counter value.
-func (c *Counter) Update(value int64) {
+func (c *Counter) Update(timestamp time.Time, value int64) {
 	c.sum += value
 
 	c.count++

--- a/src/aggregator/aggregation/counter_test.go
+++ b/src/aggregator/aggregation/counter_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/m3db/m3/src/metrics/aggregation"
 
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 func TestCounterDefaultAggregationType(t *testing.T) {
-	c := NewCounter(NewOptions())
+	c := NewCounter(NewOptions(tally.NoopScope))
 	require.False(t, c.HasExpensiveAggregations)
 	for i := 1; i <= 100; i++ {
 		c.Update(int64(i))
@@ -41,7 +42,7 @@ func TestCounterDefaultAggregationType(t *testing.T) {
 }
 
 func TestCounterCustomAggregationType(t *testing.T) {
-	opts := NewOptions()
+	opts := NewOptions(tally.NoopScope)
 	opts.HasExpensiveAggregations = true
 
 	c := NewCounter(opts)

--- a/src/aggregator/aggregation/counter_test.go
+++ b/src/aggregator/aggregation/counter_test.go
@@ -24,13 +24,13 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
+	"github.com/m3db/m3/src/x/instrument"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 )
 
 func TestCounterDefaultAggregationType(t *testing.T) {
-	c := NewCounter(NewOptions(tally.NoopScope))
+	c := NewCounter(NewOptions(instrument.NewOptions()))
 	require.False(t, c.HasExpensiveAggregations)
 	for i := 1; i <= 100; i++ {
 		c.Update(int64(i))
@@ -42,7 +42,7 @@ func TestCounterDefaultAggregationType(t *testing.T) {
 }
 
 func TestCounterCustomAggregationType(t *testing.T) {
-	opts := NewOptions(tally.NoopScope)
+	opts := NewOptions(instrument.NewOptions())
 	opts.HasExpensiveAggregations = true
 
 	c := NewCounter(opts)

--- a/src/aggregator/aggregation/counter_test.go
+++ b/src/aggregator/aggregation/counter_test.go
@@ -22,6 +22,7 @@ package aggregation
 
 import (
 	"testing"
+	"time"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/x/instrument"
@@ -33,7 +34,7 @@ func TestCounterDefaultAggregationType(t *testing.T) {
 	c := NewCounter(NewOptions(instrument.NewOptions()))
 	require.False(t, c.HasExpensiveAggregations)
 	for i := 1; i <= 100; i++ {
-		c.Update(int64(i))
+		c.Update(time.Now(), int64(i))
 	}
 	require.Equal(t, int64(5050), c.Sum())
 	require.Equal(t, 5050.0, c.ValueOf(aggregation.Sum))
@@ -49,7 +50,7 @@ func TestCounterCustomAggregationType(t *testing.T) {
 	require.True(t, c.HasExpensiveAggregations)
 
 	for i := 1; i <= 100; i++ {
-		c.Update(int64(i))
+		c.Update(time.Now(), int64(i))
 	}
 	require.Equal(t, int64(5050), c.Sum())
 	for aggType := range aggregation.ValidTypes {

--- a/src/aggregator/aggregation/gauge.go
+++ b/src/aggregator/aggregation/gauge.go
@@ -62,7 +62,7 @@ func (g *Gauge) Update(timestamp time.Time, value float64) {
 		g.last = value
 		g.lastAt = timestamp
 	} else {
-		g.Options.Metrics.IncGaugeValuesOutOfOrder()
+		g.Options.Metrics.Gauge.IncValuesOutOfOrder()
 	}
 
 	g.sum += value

--- a/src/aggregator/aggregation/gauge_test.go
+++ b/src/aggregator/aggregation/gauge_test.go
@@ -97,8 +97,9 @@ func TestGaugeLastOutOfOrderValues(t *testing.T) {
 	g.Update(timePrePre, 40)
 
 	require.Equal(t, 43.0, g.Last())
-	snap := scope.Snapshot().Counters()
-	counter, ok := snap["aggregation.gauges.values-out-of-order+"]
+	snap := scope.Snapshot()
+	counters := snap.Counters()
+	counter, ok := counters["aggregation.gauges.values-out-of-order+"]
 	require.True(t, ok)
 	require.Equal(t, int64(2), counter.Value())
 }

--- a/src/aggregator/aggregation/gauge_test.go
+++ b/src/aggregator/aggregation/gauge_test.go
@@ -25,13 +25,14 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
+	"github.com/m3db/m3/src/x/instrument"
 
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 )
 
 func TestGaugeDefaultAggregationType(t *testing.T) {
-	g := NewGauge(NewOptions(tally.NoopScope))
+	g := NewGauge(NewOptions(instrument.NewOptions()))
 	require.False(t, g.HasExpensiveAggregations)
 	for i := 1.0; i <= 100.0; i++ {
 		g.Update(time.Now(), i)
@@ -44,7 +45,7 @@ func TestGaugeDefaultAggregationType(t *testing.T) {
 }
 
 func TestGaugeCustomAggregationType(t *testing.T) {
-	opts := NewOptions(tally.NoopScope)
+	opts := NewOptions(instrument.NewOptions())
 	opts.HasExpensiveAggregations = true
 
 	g := NewGauge(opts)
@@ -83,7 +84,7 @@ func TestGaugeCustomAggregationType(t *testing.T) {
 
 func TestGaugeLastOutOfOrderValues(t *testing.T) {
 	scope := tally.NewTestScope("", nil)
-	g := NewGauge(NewOptions(scope))
+	g := NewGauge(NewOptions(instrument.NewOptions().SetMetricsScope(scope)))
 
 	timeMid := time.Now().Add(time.Minute)
 	timePre := timeMid.Add(-1 * time.Second)

--- a/src/aggregator/aggregation/options_test.go
+++ b/src/aggregator/aggregation/options_test.go
@@ -24,13 +24,13 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
+	"github.com/m3db/m3/src/x/instrument"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 )
 
 func TestOptions(t *testing.T) {
-	o := NewOptions(tally.NoopScope)
+	o := NewOptions(instrument.NewOptions())
 	require.False(t, o.HasExpensiveAggregations)
 
 	o.ResetSetData(nil)

--- a/src/aggregator/aggregation/options_test.go
+++ b/src/aggregator/aggregation/options_test.go
@@ -26,10 +26,11 @@ import (
 	"github.com/m3db/m3/src/metrics/aggregation"
 
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 func TestOptions(t *testing.T) {
-	o := NewOptions()
+	o := NewOptions(tally.NoopScope)
 	require.False(t, o.HasExpensiveAggregations)
 
 	o.ResetSetData(nil)

--- a/src/aggregator/aggregation/timer_benchmark_test.go
+++ b/src/aggregator/aggregation/timer_benchmark_test.go
@@ -24,12 +24,11 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/aggregator/aggregation/quantile/cm"
-
-	"github.com/uber-go/tally"
+	"github.com/m3db/m3/src/x/instrument"
 )
 
 func getTimer() Timer {
-	opts := NewOptions(tally.NoopScope)
+	opts := NewOptions(instrument.NewOptions())
 	opts.ResetSetData(testAggTypes)
 
 	timer := NewTimer(testQuantiles, cm.NewOptions(), opts)

--- a/src/aggregator/aggregation/timer_benchmark_test.go
+++ b/src/aggregator/aggregation/timer_benchmark_test.go
@@ -24,10 +24,12 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/aggregator/aggregation/quantile/cm"
+
+	"github.com/uber-go/tally"
 )
 
 func getTimer() Timer {
-	opts := NewOptions()
+	opts := NewOptions(tally.NoopScope)
 	opts.ResetSetData(testAggTypes)
 
 	timer := NewTimer(testQuantiles, cm.NewOptions(), opts)

--- a/src/aggregator/aggregation/timer_test.go
+++ b/src/aggregator/aggregation/timer_test.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/m3db/m3/src/aggregator/aggregation/quantile/cm"
 	"github.com/m3db/m3/src/metrics/aggregation"
+	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/pool"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 )
 
 var (
@@ -57,13 +57,13 @@ func TestCreateTimerResetStream(t *testing.T) {
 
 	// Add a value to the timer and close the timer, which returns the
 	// underlying stream to the pool.
-	timer := NewTimer(testQuantiles, streamOpts, NewOptions(tally.NoopScope))
+	timer := NewTimer(testQuantiles, streamOpts, NewOptions(instrument.NewOptions()))
 	timer.Add(1.0)
 	require.Equal(t, 1.0, timer.Min())
 	timer.Close()
 
 	// Create a new timer and assert the underlying stream has been closed.
-	timer = NewTimer(testQuantiles, streamOpts, NewOptions(tally.NoopScope))
+	timer = NewTimer(testQuantiles, streamOpts, NewOptions(instrument.NewOptions()))
 	timer.Add(1.0)
 	require.Equal(t, 1.0, timer.Min())
 	timer.Close()
@@ -71,7 +71,7 @@ func TestCreateTimerResetStream(t *testing.T) {
 }
 
 func TestTimerAggregations(t *testing.T) {
-	opts := NewOptions(tally.NoopScope)
+	opts := NewOptions(instrument.NewOptions())
 	opts.ResetSetData(testAggTypes)
 
 	timer := NewTimer(testQuantiles, cm.NewOptions(), opts)
@@ -144,7 +144,7 @@ func TestTimerAggregations(t *testing.T) {
 }
 
 func TestTimerAggregationsNotExpensive(t *testing.T) {
-	opts := NewOptions(tally.NoopScope)
+	opts := NewOptions(instrument.NewOptions())
 	opts.ResetSetData(aggregation.Types{aggregation.Sum})
 
 	timer := NewTimer(testQuantiles, cm.NewOptions(), opts)

--- a/src/aggregator/aggregation/timer_test.go
+++ b/src/aggregator/aggregation/timer_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3/src/x/pool"
 
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 var (
@@ -56,13 +57,13 @@ func TestCreateTimerResetStream(t *testing.T) {
 
 	// Add a value to the timer and close the timer, which returns the
 	// underlying stream to the pool.
-	timer := NewTimer(testQuantiles, streamOpts, NewOptions())
+	timer := NewTimer(testQuantiles, streamOpts, NewOptions(tally.NoopScope))
 	timer.Add(1.0)
 	require.Equal(t, 1.0, timer.Min())
 	timer.Close()
 
 	// Create a new timer and assert the underlying stream has been closed.
-	timer = NewTimer(testQuantiles, streamOpts, NewOptions())
+	timer = NewTimer(testQuantiles, streamOpts, NewOptions(tally.NoopScope))
 	timer.Add(1.0)
 	require.Equal(t, 1.0, timer.Min())
 	timer.Close()
@@ -70,7 +71,7 @@ func TestCreateTimerResetStream(t *testing.T) {
 }
 
 func TestTimerAggregations(t *testing.T) {
-	opts := NewOptions()
+	opts := NewOptions(tally.NoopScope)
 	opts.ResetSetData(testAggTypes)
 
 	timer := NewTimer(testQuantiles, cm.NewOptions(), opts)
@@ -143,7 +144,7 @@ func TestTimerAggregations(t *testing.T) {
 }
 
 func TestTimerAggregationsNotExpensive(t *testing.T) {
-	opts := NewOptions()
+	opts := NewOptions(tally.NoopScope)
 	opts.ResetSetData(aggregation.Types{aggregation.Sum})
 
 	timer := NewTimer(testQuantiles, cm.NewOptions(), opts)

--- a/src/aggregator/aggregator/aggregation.go
+++ b/src/aggregator/aggregator/aggregation.go
@@ -36,12 +36,12 @@ func newCounterAggregation(c aggregation.Counter) counterAggregation {
 	return counterAggregation{Counter: c}
 }
 
-func (c *counterAggregation) Add(value float64) {
-	c.Counter.Update(int64(value))
+func (c *counterAggregation) Add(t time.Time, value float64) {
+	c.Counter.Update(t, int64(value))
 }
 
-func (c *counterAggregation) AddUnion(mu unaggregated.MetricUnion) {
-	c.Counter.Update(mu.CounterVal)
+func (c *counterAggregation) AddUnion(t time.Time, mu unaggregated.MetricUnion) {
+	c.Counter.Update(t, mu.CounterVal)
 }
 
 // timerAggregation is a timer aggregation.

--- a/src/aggregator/aggregator/aggregation.go
+++ b/src/aggregator/aggregator/aggregation.go
@@ -21,6 +21,8 @@
 package aggregator
 
 import (
+	"time"
+
 	"github.com/m3db/m3/src/aggregator/aggregation"
 	"github.com/m3db/m3/src/metrics/metric/unaggregated"
 )
@@ -34,23 +36,44 @@ func newCounterAggregation(c aggregation.Counter) counterAggregation {
 	return counterAggregation{Counter: c}
 }
 
-func (c *counterAggregation) Add(value float64)                    { c.Counter.Update(int64(value)) }
-func (c *counterAggregation) AddUnion(mu unaggregated.MetricUnion) { c.Counter.Update(mu.CounterVal) }
+func (c *counterAggregation) Add(value float64) {
+	c.Counter.Update(int64(value))
+}
+
+func (c *counterAggregation) AddUnion(mu unaggregated.MetricUnion) {
+	c.Counter.Update(mu.CounterVal)
+}
 
 // timerAggregation is a timer aggregation.
 type timerAggregation struct {
 	aggregation.Timer
 }
 
-func newTimerAggregation(t aggregation.Timer) timerAggregation   { return timerAggregation{Timer: t} }
-func (t *timerAggregation) Add(value float64)                    { t.Timer.Add(value) }
-func (t *timerAggregation) AddUnion(mu unaggregated.MetricUnion) { t.Timer.AddBatch(mu.BatchTimerVal) }
+func newTimerAggregation(t aggregation.Timer) timerAggregation {
+	return timerAggregation{Timer: t}
+}
+
+func (t *timerAggregation) Add(value float64) {
+	t.Timer.Add(value)
+}
+
+func (t *timerAggregation) AddUnion(mu unaggregated.MetricUnion) {
+	t.Timer.AddBatch(mu.BatchTimerVal)
+}
 
 // gaugeAggregation is a gauge aggregation.
 type gaugeAggregation struct {
 	aggregation.Gauge
 }
 
-func newGaugeAggregation(g aggregation.Gauge) gaugeAggregation   { return gaugeAggregation{Gauge: g} }
-func (g *gaugeAggregation) Add(value float64)                    { g.Gauge.Update(value) }
-func (g *gaugeAggregation) AddUnion(mu unaggregated.MetricUnion) { g.Gauge.Update(mu.GaugeVal) }
+func newGaugeAggregation(g aggregation.Gauge) gaugeAggregation {
+	return gaugeAggregation{Gauge: g}
+}
+
+func (g *gaugeAggregation) Add(t time.Time, value float64) {
+	g.Gauge.Update(t, value)
+}
+
+func (g *gaugeAggregation) AddUnion(t time.Time, mu unaggregated.MetricUnion) {
+	g.Gauge.Update(t, mu.GaugeVal)
+}

--- a/src/aggregator/aggregator/aggregation.go
+++ b/src/aggregator/aggregator/aggregation.go
@@ -36,12 +36,12 @@ func newCounterAggregation(c aggregation.Counter) counterAggregation {
 	return counterAggregation{Counter: c}
 }
 
-func (c *counterAggregation) Add(t time.Time, value float64) {
-	c.Counter.Update(t, int64(value))
+func (a *counterAggregation) Add(t time.Time, value float64) {
+	a.Counter.Update(t, int64(value))
 }
 
-func (c *counterAggregation) AddUnion(t time.Time, mu unaggregated.MetricUnion) {
-	c.Counter.Update(t, mu.CounterVal)
+func (a *counterAggregation) AddUnion(t time.Time, mu unaggregated.MetricUnion) {
+	a.Counter.Update(t, mu.CounterVal)
 }
 
 // timerAggregation is a timer aggregation.
@@ -53,12 +53,12 @@ func newTimerAggregation(t aggregation.Timer) timerAggregation {
 	return timerAggregation{Timer: t}
 }
 
-func (t *timerAggregation) Add(value float64) {
-	t.Timer.Add(value)
+func (a *timerAggregation) Add(_ time.Time, value float64) {
+	a.Timer.Add(value)
 }
 
-func (t *timerAggregation) AddUnion(mu unaggregated.MetricUnion) {
-	t.Timer.AddBatch(mu.BatchTimerVal)
+func (a *timerAggregation) AddUnion(_ time.Time, mu unaggregated.MetricUnion) {
+	a.Timer.AddBatch(mu.BatchTimerVal)
 }
 
 // gaugeAggregation is a gauge aggregation.
@@ -70,10 +70,10 @@ func newGaugeAggregation(g aggregation.Gauge) gaugeAggregation {
 	return gaugeAggregation{Gauge: g}
 }
 
-func (g *gaugeAggregation) Add(t time.Time, value float64) {
-	g.Gauge.Update(t, value)
+func (a *gaugeAggregation) Add(t time.Time, value float64) {
+	a.Gauge.Update(t, value)
 }
 
-func (g *gaugeAggregation) AddUnion(t time.Time, mu unaggregated.MetricUnion) {
-	g.Gauge.Update(t, mu.GaugeVal)
+func (a *gaugeAggregation) AddUnion(t time.Time, mu unaggregated.MetricUnion) {
+	a.Gauge.Update(t, mu.GaugeVal)
 }

--- a/src/aggregator/aggregator/aggregation_test.go
+++ b/src/aggregator/aggregator/aggregation_test.go
@@ -75,7 +75,7 @@ func TestCounterAggregationAddUnion(t *testing.T) {
 func TestTimerAggregationAdd(t *testing.T) {
 	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationValues {
-		tm.Add(v)
+		tm.Add(time.Now(), v)
 	}
 	require.Equal(t, int64(4), tm.Count())
 	require.Equal(t, 799.2, tm.Sum())
@@ -84,7 +84,7 @@ func TestTimerAggregationAdd(t *testing.T) {
 func TestTimerAggregationAddUnion(t *testing.T) {
 	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationUnions {
-		tm.AddUnion(v)
+		tm.AddUnion(time.Now(), v)
 	}
 	require.Equal(t, int64(5), tm.Count())
 	require.Equal(t, 18.0, tm.Sum())

--- a/src/aggregator/aggregator/aggregation_test.go
+++ b/src/aggregator/aggregator/aggregation_test.go
@@ -57,7 +57,7 @@ var (
 func TestCounterAggregationAdd(t *testing.T) {
 	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationValues {
-		c.Add(v)
+		c.Add(time.Now(), v)
 	}
 	require.Equal(t, int64(4), c.Count())
 	require.Equal(t, int64(799), c.Sum())
@@ -66,7 +66,7 @@ func TestCounterAggregationAdd(t *testing.T) {
 func TestCounterAggregationAddUnion(t *testing.T) {
 	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationUnions {
-		c.AddUnion(v)
+		c.AddUnion(time.Now(), v)
 	}
 	require.Equal(t, int64(3), c.Count())
 	require.Equal(t, int64(1234), c.Sum())

--- a/src/aggregator/aggregator/aggregation_test.go
+++ b/src/aggregator/aggregator/aggregation_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/m3db/m3/src/aggregator/aggregation/quantile/cm"
 	"github.com/m3db/m3/src/metrics/metric"
 	"github.com/m3db/m3/src/metrics/metric/unaggregated"
+	"github.com/m3db/m3/src/x/instrument"
 
 	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 )
 
 var (
@@ -55,7 +55,7 @@ var (
 )
 
 func TestCounterAggregationAdd(t *testing.T) {
-	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions(tally.NoopScope)))
+	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationValues {
 		c.Add(v)
 	}
@@ -64,7 +64,7 @@ func TestCounterAggregationAdd(t *testing.T) {
 }
 
 func TestCounterAggregationAddUnion(t *testing.T) {
-	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions(tally.NoopScope)))
+	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationUnions {
 		c.AddUnion(v)
 	}
@@ -73,7 +73,7 @@ func TestCounterAggregationAddUnion(t *testing.T) {
 }
 
 func TestTimerAggregationAdd(t *testing.T) {
-	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions(tally.NoopScope)))
+	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationValues {
 		tm.Add(v)
 	}
@@ -82,7 +82,7 @@ func TestTimerAggregationAdd(t *testing.T) {
 }
 
 func TestTimerAggregationAddUnion(t *testing.T) {
-	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions(tally.NoopScope)))
+	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationUnions {
 		tm.AddUnion(v)
 	}
@@ -91,7 +91,7 @@ func TestTimerAggregationAddUnion(t *testing.T) {
 }
 
 func TestGaugeAggregationAdd(t *testing.T) {
-	g := newGaugeAggregation(aggregation.NewGauge(aggregation.NewOptions(tally.NoopScope)))
+	g := newGaugeAggregation(aggregation.NewGauge(aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationValues {
 		g.Add(time.Now(), v)
 	}
@@ -100,7 +100,7 @@ func TestGaugeAggregationAdd(t *testing.T) {
 }
 
 func TestGaugeAggregationAddUnion(t *testing.T) {
-	g := newGaugeAggregation(aggregation.NewGauge(aggregation.NewOptions(tally.NoopScope)))
+	g := newGaugeAggregation(aggregation.NewGauge(aggregation.NewOptions(instrument.NewOptions())))
 	for _, v := range testAggregationUnions {
 		g.AddUnion(time.Now(), v)
 	}

--- a/src/aggregator/aggregator/aggregation_test.go
+++ b/src/aggregator/aggregator/aggregation_test.go
@@ -22,6 +22,7 @@ package aggregator
 
 import (
 	"testing"
+	"time"
 
 	"github.com/m3db/m3/src/aggregator/aggregation"
 	"github.com/m3db/m3/src/aggregator/aggregation/quantile/cm"
@@ -29,6 +30,7 @@ import (
 	"github.com/m3db/m3/src/metrics/metric/unaggregated"
 
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 var (
@@ -53,7 +55,7 @@ var (
 )
 
 func TestCounterAggregationAdd(t *testing.T) {
-	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions()))
+	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions(tally.NoopScope)))
 	for _, v := range testAggregationValues {
 		c.Add(v)
 	}
@@ -62,7 +64,7 @@ func TestCounterAggregationAdd(t *testing.T) {
 }
 
 func TestCounterAggregationAddUnion(t *testing.T) {
-	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions()))
+	c := newCounterAggregation(aggregation.NewCounter(aggregation.NewOptions(tally.NoopScope)))
 	for _, v := range testAggregationUnions {
 		c.AddUnion(v)
 	}
@@ -71,7 +73,7 @@ func TestCounterAggregationAddUnion(t *testing.T) {
 }
 
 func TestTimerAggregationAdd(t *testing.T) {
-	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions()))
+	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions(tally.NoopScope)))
 	for _, v := range testAggregationValues {
 		tm.Add(v)
 	}
@@ -80,7 +82,7 @@ func TestTimerAggregationAdd(t *testing.T) {
 }
 
 func TestTimerAggregationAddUnion(t *testing.T) {
-	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions()))
+	tm := newTimerAggregation(aggregation.NewTimer([]float64{0.5}, cm.NewOptions(), aggregation.NewOptions(tally.NoopScope)))
 	for _, v := range testAggregationUnions {
 		tm.AddUnion(v)
 	}
@@ -89,18 +91,18 @@ func TestTimerAggregationAddUnion(t *testing.T) {
 }
 
 func TestGaugeAggregationAdd(t *testing.T) {
-	g := newGaugeAggregation(aggregation.NewGauge(aggregation.NewOptions()))
+	g := newGaugeAggregation(aggregation.NewGauge(aggregation.NewOptions(tally.NoopScope)))
 	for _, v := range testAggregationValues {
-		g.Add(v)
+		g.Add(time.Now(), v)
 	}
 	require.Equal(t, int64(4), g.Count())
 	require.Equal(t, 799.2, g.Sum())
 }
 
 func TestGaugeAggregationAddUnion(t *testing.T) {
-	g := newGaugeAggregation(aggregation.NewGauge(aggregation.NewOptions()))
+	g := newGaugeAggregation(aggregation.NewGauge(aggregation.NewOptions(tally.NoopScope)))
 	for _, v := range testAggregationUnions {
-		g.AddUnion(v)
+		g.AddUnion(time.Now(), v)
 	}
 	require.Equal(t, int64(3), g.Count())
 	require.Equal(t, 123.456, g.Sum())

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -153,7 +153,7 @@ func (e *CounterElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion)
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	lockedAgg.aggregation.AddUnion(mu)
+	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.Unlock()
 	return nil
 }
@@ -170,7 +170,7 @@ func (e *CounterElem) AddValue(timestamp time.Time, value float64) error {
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	lockedAgg.aggregation.Add(value)
+	lockedAgg.aggregation.Add(timestamp, value)
 	lockedAgg.Unlock()
 	return nil
 }
@@ -196,7 +196,7 @@ func (e *CounterElem) AddUnique(timestamp time.Time, values []float64, sourceID 
 	}
 	lockedAgg.sourcesSeen.Set(source)
 	for _, v := range values {
-		lockedAgg.aggregation.Add(v)
+		lockedAgg.aggregation.Add(timestamp, v)
 	}
 	lockedAgg.Unlock()
 	return nil

--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -173,11 +173,10 @@ type elemBase struct {
 }
 
 func newElemBase(opts Options) elemBase {
-	scope := opts.InstrumentOptions().MetricsScope()
 	return elemBase{
 		opts:         opts,
 		aggTypesOpts: opts.AggregationTypesOptions(),
-		aggOpts:      raggregation.NewOptions(scope),
+		aggOpts:      raggregation.NewOptions(opts.InstrumentOptions()),
 	}
 }
 

--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -173,10 +173,11 @@ type elemBase struct {
 }
 
 func newElemBase(opts Options) elemBase {
+	scope := opts.InstrumentOptions().MetricsScope()
 	return elemBase{
 		opts:         opts,
 		aggTypesOpts: opts.AggregationTypesOptions(),
-		aggOpts:      raggregation.NewOptions(),
+		aggOpts:      raggregation.NewOptions(scope),
 	}
 }
 

--- a/src/aggregator/aggregator/elem_base_test.go
+++ b/src/aggregator/aggregator/elem_base_test.go
@@ -168,11 +168,11 @@ func TestCounterElemBase(t *testing.T) {
 func TestCounterElemBaseNewAggregation(t *testing.T) {
 	e := counterElemBase{}
 	la := e.NewAggregation(nil, raggregation.Options{})
-	la.AddUnion(unaggregated.MetricUnion{
+	la.AddUnion(time.Now(), unaggregated.MetricUnion{
 		Type:       metric.CounterType,
 		CounterVal: 100,
 	})
-	la.AddUnion(unaggregated.MetricUnion{
+	la.AddUnion(time.Now(), unaggregated.MetricUnion{
 		Type:       metric.CounterType,
 		CounterVal: 200,
 	})

--- a/src/aggregator/aggregator/elem_base_test.go
+++ b/src/aggregator/aggregator/elem_base_test.go
@@ -218,11 +218,11 @@ func TestTimerElemBase(t *testing.T) {
 func TestTimerElemBaseNewAggregation(t *testing.T) {
 	e := timerElemBase{}
 	la := e.NewAggregation(NewOptions(), raggregation.Options{})
-	la.AddUnion(unaggregated.MetricUnion{
+	la.AddUnion(time.Now(), unaggregated.MetricUnion{
 		Type:          metric.TimerType,
 		BatchTimerVal: []float64{100.0, 200.0},
 	})
-	la.AddUnion(unaggregated.MetricUnion{
+	la.AddUnion(time.Now(), unaggregated.MetricUnion{
 		Type:          metric.TimerType,
 		BatchTimerVal: []float64{300.0, 400.0, 500.0},
 	})

--- a/src/aggregator/aggregator/elem_base_test.go
+++ b/src/aggregator/aggregator/elem_base_test.go
@@ -23,6 +23,7 @@ package aggregator
 import (
 	"strings"
 	"testing"
+	"time"
 
 	raggregation "github.com/m3db/m3/src/aggregator/aggregation"
 	maggregation "github.com/m3db/m3/src/metrics/aggregation"
@@ -276,11 +277,11 @@ func TestGaugeElemBase(t *testing.T) {
 func TestGaugeElemBaseNewLockedAggregation(t *testing.T) {
 	e := gaugeElemBase{}
 	la := e.NewAggregation(nil, raggregation.Options{})
-	la.AddUnion(unaggregated.MetricUnion{
+	la.AddUnion(time.Now(), unaggregated.MetricUnion{
 		Type:     metric.GaugeType,
 		GaugeVal: 100.0,
 	})
-	la.AddUnion(unaggregated.MetricUnion{
+	la.AddUnion(time.Now(), unaggregated.MetricUnion{
 		Type:     metric.GaugeType,
 		GaugeVal: 200.0,
 	})

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -1843,7 +1843,7 @@ func testGaugeElem(
 	e := MustNewGaugeElem(testGaugeID, testStoragePolicy, aggTypes, pipeline, testNumForwardedTimes, WithPrefixWithSuffix, opts)
 	for i, aligned := range alignedstartAtNanos {
 		gauge := &lockedGaugeAggregation{aggregation: newGaugeAggregation(raggregation.NewGauge(e.aggOpts))}
-		gauge.aggregation.Update(gaugeVals[i])
+		gauge.aggregation.Update(time.Now(), gaugeVals[i])
 		e.values = append(e.values, timedGauge{
 			startAtNanos: aligned,
 			lockedAgg:    gauge,

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -1804,7 +1804,7 @@ func testCounterElem(
 	e := MustNewCounterElem(testCounterID, testStoragePolicy, aggTypes, pipeline, testNumForwardedTimes, WithPrefixWithSuffix, opts)
 	for i, aligned := range alignedstartAtNanos {
 		counter := &lockedCounterAggregation{aggregation: newCounterAggregation(raggregation.NewCounter(e.aggOpts))}
-		counter.aggregation.Update(counterVals[i])
+		counter.aggregation.Update(time.Unix(0, aligned), counterVals[i])
 		e.values = append(e.values, timedCounter{
 			startAtNanos: aligned,
 			lockedAgg:    counter,

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -153,7 +153,7 @@ func (e *GaugeElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) e
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	lockedAgg.aggregation.AddUnion(mu)
+	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.Unlock()
 	return nil
 }
@@ -170,7 +170,7 @@ func (e *GaugeElem) AddValue(timestamp time.Time, value float64) error {
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	lockedAgg.aggregation.Add(value)
+	lockedAgg.aggregation.Add(timestamp, value)
 	lockedAgg.Unlock()
 	return nil
 }
@@ -196,7 +196,7 @@ func (e *GaugeElem) AddUnique(timestamp time.Time, values []float64, sourceID ui
 	}
 	lockedAgg.sourcesSeen.Set(source)
 	for _, v := range values {
-		lockedAgg.aggregation.Add(v)
+		lockedAgg.aggregation.Add(timestamp, v)
 	}
 	lockedAgg.Unlock()
 	return nil

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -43,10 +43,10 @@ type typeSpecificAggregation interface {
 	generic.Type
 
 	// Add adds a new metric value.
-	Add(value float64)
+	Add(t time.Time, value float64)
 
 	// AddUnion adds a new metric value union.
-	AddUnion(mu unaggregated.MetricUnion)
+	AddUnion(t time.Time, mu unaggregated.MetricUnion)
 
 	// ValueOf returns the value for the given aggregation type.
 	ValueOf(aggType maggregation.Type) float64
@@ -207,7 +207,7 @@ func (e *GenericElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion)
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	lockedAgg.aggregation.AddUnion(mu)
+	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.Unlock()
 	return nil
 }
@@ -224,7 +224,7 @@ func (e *GenericElem) AddValue(timestamp time.Time, value float64) error {
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	lockedAgg.aggregation.Add(value)
+	lockedAgg.aggregation.Add(timestamp, value)
 	lockedAgg.Unlock()
 	return nil
 }
@@ -250,7 +250,7 @@ func (e *GenericElem) AddUnique(timestamp time.Time, values []float64, sourceID 
 	}
 	lockedAgg.sourcesSeen.Set(source)
 	for _, v := range values {
-		lockedAgg.aggregation.Add(v)
+		lockedAgg.aggregation.Add(timestamp, v)
 	}
 	lockedAgg.Unlock()
 	return nil

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -153,7 +153,7 @@ func (e *TimerElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion) e
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	lockedAgg.aggregation.AddUnion(mu)
+	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.Unlock()
 	return nil
 }
@@ -170,7 +170,7 @@ func (e *TimerElem) AddValue(timestamp time.Time, value float64) error {
 		lockedAgg.Unlock()
 		return errAggregationClosed
 	}
-	lockedAgg.aggregation.Add(value)
+	lockedAgg.aggregation.Add(timestamp, value)
 	lockedAgg.Unlock()
 	return nil
 }
@@ -196,7 +196,7 @@ func (e *TimerElem) AddUnique(timestamp time.Time, values []float64, sourceID ui
 	}
 	lockedAgg.sourcesSeen.Set(source)
 	for _, v := range values {
-		lockedAgg.aggregation.Add(v)
+		lockedAgg.aggregation.Add(timestamp, v)
 	}
 	lockedAgg.Unlock()
 	return nil

--- a/src/aggregator/integration/integration_data.go
+++ b/src/aggregator/integration/integration_data.go
@@ -423,7 +423,7 @@ func addUntimedMetricToAggregation(
 	switch mu.Type {
 	case metric.CounterType:
 		v := values.(aggregation.Counter)
-		v.Update(mu.CounterVal)
+		v.Update(time.Now(), mu.CounterVal)
 		return v, nil
 	case metric.TimerType:
 		v := values.(aggregation.Timer)
@@ -445,7 +445,7 @@ func addTimedMetricToAggregation(
 	switch mu.Type {
 	case metric.CounterType:
 		v := values.(aggregation.Counter)
-		v.Update(int64(mu.Value))
+		v.Update(time.Now(), int64(mu.Value))
 		return v, nil
 	case metric.TimerType:
 		v := values.(aggregation.Timer)
@@ -468,7 +468,7 @@ func addForwardedMetricToAggregation(
 	case metric.CounterType:
 		v := values.(aggregation.Counter)
 		for _, val := range mu.Values {
-			v.Update(int64(val))
+			v.Update(time.Now(), int64(val))
 		}
 		return v, nil
 	case metric.TimerType:

--- a/src/aggregator/integration/integration_data.go
+++ b/src/aggregator/integration/integration_data.go
@@ -367,7 +367,7 @@ func computeExpectedAggregationBuckets(
 					var (
 						aggTypeOpts     = opts.AggregationTypesOptions()
 						aggTypes        = maggregation.NewIDDecompressor().MustDecompress(bucket.key.aggregationID)
-						aggregationOpts = aggregation.NewOptions()
+						aggregationOpts = aggregation.NewOptions(opts.InstrumentOptions().MetricsScope())
 					)
 					switch mu.Type() {
 					case metric.CounterType:
@@ -431,7 +431,7 @@ func addUntimedMetricToAggregation(
 		return v, nil
 	case metric.GaugeType:
 		v := values.(aggregation.Gauge)
-		v.Update(mu.GaugeVal)
+		v.Update(time.Now(), mu.GaugeVal)
 		return v, nil
 	default:
 		return nil, fmt.Errorf("unrecognized untimed metric type %v", mu.Type)
@@ -453,7 +453,7 @@ func addTimedMetricToAggregation(
 		return v, nil
 	case metric.GaugeType:
 		v := values.(aggregation.Gauge)
-		v.Update(mu.Value)
+		v.Update(time.Now(), mu.Value)
 		return v, nil
 	default:
 		return nil, fmt.Errorf("unrecognized timed metric type %v", mu.Type)
@@ -478,7 +478,7 @@ func addForwardedMetricToAggregation(
 	case metric.GaugeType:
 		v := values.(aggregation.Gauge)
 		for _, val := range mu.Values {
-			v.Update(val)
+			v.Update(time.Now(), val)
 		}
 		return v, nil
 	default:

--- a/src/aggregator/integration/integration_data.go
+++ b/src/aggregator/integration/integration_data.go
@@ -367,7 +367,7 @@ func computeExpectedAggregationBuckets(
 					var (
 						aggTypeOpts     = opts.AggregationTypesOptions()
 						aggTypes        = maggregation.NewIDDecompressor().MustDecompress(bucket.key.aggregationID)
-						aggregationOpts = aggregation.NewOptions(opts.InstrumentOptions().MetricsScope())
+						aggregationOpts = aggregation.NewOptions(opts.InstrumentOptions())
 					)
 					switch mu.Type() {
 					case metric.CounterType:

--- a/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
+++ b/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
@@ -397,8 +397,9 @@ func testMultiServerForwardingPipeline(t *testing.T, discardNaNAggregatedValues 
 				continue
 			}
 			currTime := start.Add(time.Duration(i+1) * storagePolicy.Resolution().Window)
-			agg := aggregation.NewGauge(aggregation.NewOptions())
-			agg.Update(expectedValuesList[spIdx][i])
+			scope := aggregatorOpts.InstrumentOptions().MetricsScope()
+			agg := aggregation.NewGauge(aggregation.NewOptions(scope))
+			agg.Update(time.Now(), expectedValuesList[spIdx][i])
 			expectedValuesByTimeList[spIdx][currTime.UnixNano()] = agg
 		}
 	}

--- a/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
+++ b/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
@@ -397,8 +397,8 @@ func testMultiServerForwardingPipeline(t *testing.T, discardNaNAggregatedValues 
 				continue
 			}
 			currTime := start.Add(time.Duration(i+1) * storagePolicy.Resolution().Window)
-			scope := aggregatorOpts.InstrumentOptions().MetricsScope()
-			agg := aggregation.NewGauge(aggregation.NewOptions(scope))
+			instrumentOpts := aggregatorOpts.InstrumentOptions()
+			agg := aggregation.NewGauge(aggregation.NewOptions(instrumentOpts))
 			agg.Update(time.Now(), expectedValuesList[spIdx][i])
 			expectedValuesByTimeList[spIdx][currTime.UnixNano()] = agg
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
We've noticed that at times a bunch of values for the same gauge can arrive at the same time to the aggregator with a varying set of timestamps, gauge last value aggregation should take the last value by timestamp not by arrival time to account for this. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
