### PR TITLE
[coordinator] Only honor default aggregation policies if not matched by mapping rule

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -125,8 +125,8 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 	} else {
 		// NB(r): First apply mapping rules to see which storage policies
 		// have been applied, any that have been applied as part of
-		// mapping rules that exact match a default storage policy will
-		// skipped when applying default rules so to avoid storing
+		// mapping rules that exact match a default storage policy will be
+		// skipped when applying default rules, so as to avoid storing
 		// the same metrics in the same namespace with the same metric
 		// name and tags (i.e. overwriting each other).
 		a.mappingRuleStoragePolicies = a.mappingRuleStoragePolicies[:0]
@@ -162,7 +162,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			a.debugLogMatch("downsampler applying default mapping rule",
 				debugLogMatchOptions{Meta: stagedMetadatas})
 
-			stagedMetadatsBeforeFilter := stagedMetadatas[:]
+			stagedMetadataBeforeFilter := stagedMetadatas[:]
 			if len(a.mappingRuleStoragePolicies) != 0 {
 				// If mapping rules have applied aggregations for
 				// storage policies then de-dupe so we don't have two
@@ -180,7 +180,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 								if sp.Equivalent(existing) {
 									matchedByMappingRule = true
 									a.debugLogMatch("downsampler skipping default mapping rule storage policy",
-										debugLogMatchOptions{Meta: stagedMetadatsBeforeFilter})
+										debugLogMatchOptions{Meta: stagedMetadataBeforeFilter})
 									break
 								}
 							}
@@ -219,7 +219,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			// after any filtering that's applied.
 			if len(stagedMetadatas) == 0 {
 				a.debugLogMatch("downsampler skipping default mapping rule completely",
-					debugLogMatchOptions{Meta: stagedMetadatsBeforeFilter})
+					debugLogMatchOptions{Meta: stagedMetadataBeforeFilter})
 				continue
 			}
 

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3/src/metrics/generated/proto/metricpb"
 	"github.com/m3db/m3/src/metrics/matcher"
 	"github.com/m3db/m3/src/metrics/metadata"
+	"github.com/m3db/m3/src/metrics/policy"
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/serialize"
 
@@ -56,6 +57,8 @@ type metricsAppenderOptions struct {
 	tagEncoder             serialize.TagEncoder
 	matcher                matcher.Matcher
 	metricTagsIteratorPool serialize.MetricTagsIteratorPool
+
+	mappingRuleStoragePolicies []policy.StoragePolicy
 
 	clockOpts    clock.Options
 	debugLogging bool
@@ -120,11 +123,30 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			})
 		}
 	} else {
-		// Always aggregate any default staged metadats
-		for _, stagedMetadatas := range a.defaultStagedMetadatas {
-			a.debugLogMatch("downsampler applying default mapping rule",
+		// NB(r): First apply mapping rules to see which storage policies
+		// have been applied, any that have been applied as part of
+		// mapping rules that exact match a default storage policy will
+		// skip be skipped when applying default rules so to avoid
+		// storing the same metrics in the same namespace with the same
+		// metric name and tags (i.e. overwriting each other).
+		a.mappingRuleStoragePolicies = a.mappingRuleStoragePolicies[:0]
+
+		stagedMetadatas := matchResult.ForExistingIDAt(nowNanos)
+		if !stagedMetadatas.IsDefault() && len(stagedMetadatas) != 0 {
+			a.debugLogMatch("downsampler applying matched mapping rule",
 				debugLogMatchOptions{Meta: stagedMetadatas})
 
+			// Collect all the current active mapping rules
+			for _, stagedMetadata := range stagedMetadatas {
+				for _, pipe := range stagedMetadata.Pipelines {
+					for _, sp := range pipe.StoragePolicies {
+						a.mappingRuleStoragePolicies =
+							append(a.mappingRuleStoragePolicies, sp)
+					}
+				}
+			}
+
+			// Only sample if going to actually aggregate
 			a.multiSamplesAppender.addSamplesAppender(samplesAppender{
 				agg:             a.agg,
 				clientRemote:    a.clientRemote,
@@ -133,12 +155,74 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			})
 		}
 
-		stagedMetadatas := matchResult.ForExistingIDAt(nowNanos)
-		if !stagedMetadatas.IsDefault() && len(stagedMetadatas) != 0 {
-			a.debugLogMatch("downsampler applying matched mapping rule",
+		// Always aggregate any default staged metadatas (unless
+		// mapping rule has provided an override for a storage policy,
+		// if so then skip aggregating for that storage policy).
+		for _, stagedMetadatas := range a.defaultStagedMetadatas {
+			a.debugLogMatch("downsampler applying default mapping rule",
 				debugLogMatchOptions{Meta: stagedMetadatas})
 
-			// Only sample if going to actually aggregate
+			stagedMetadatsBeforeFilter := stagedMetadatas[:]
+			if len(a.mappingRuleStoragePolicies) != 0 {
+				// If mapping rules have applied aggregatinons for
+				// storage policies then de-dupe so we don't have two
+				// active aggregations for the same storage policy.
+				stagedMetadatasAfterFilter := stagedMetadatas[:0]
+				for _, stagedMetadata := range stagedMetadatas {
+					pipesAfterFilter := stagedMetadata.Pipelines[:0]
+					for _, pipe := range stagedMetadata.Pipelines {
+						storagePoliciesAfterFilter := pipe.StoragePolicies[:0]
+						for _, sp := range pipe.StoragePolicies {
+							// Check aggregation for storage policy not already
+							// set by a mapping rule.
+							matchedByMappingRule := false
+							for _, existing := range a.mappingRuleStoragePolicies {
+								if sp.Equivalent(existing) {
+									matchedByMappingRule = true
+									a.debugLogMatch("downsampler skipping default mapping rule storage policy",
+										debugLogMatchOptions{Meta: stagedMetadatsBeforeFilter})
+									break
+								}
+							}
+							if !matchedByMappingRule {
+								// Keep storage policy if not matched by mapping rule.
+								storagePoliciesAfterFilter =
+									append(storagePoliciesAfterFilter, sp)
+							}
+						}
+
+						// Update storage policies slice after filtering.
+						pipe.StoragePolicies = storagePoliciesAfterFilter
+
+						if len(pipe.StoragePolicies) != 0 {
+							// Keep storage policy if still has some storage policies.
+							pipesAfterFilter = append(pipesAfterFilter, pipe)
+						}
+					}
+
+					// Update pipelnes after filtering.
+					stagedMetadata.Pipelines = pipesAfterFilter
+
+					if len(stagedMetadata.Pipelines) != 0 {
+						// Keep staged metadata if still has some pipelines.
+						stagedMetadatasAfterFilter =
+							append(stagedMetadatasAfterFilter, stagedMetadata)
+					}
+				}
+
+				// Finally set the staged metadatas we're keeping
+				// as those that were kept after filtering.
+				stagedMetadatas = stagedMetadatasAfterFilter
+			}
+
+			// Now skip appending if after filtering there's no staged metadatas
+			// after any filtering that's applied.
+			if len(stagedMetadatas) == 0 {
+				a.debugLogMatch("downsampler skipping default mapping rule completely",
+					debugLogMatchOptions{Meta: stagedMetadatsBeforeFilter})
+				continue
+			}
+
 			a.multiSamplesAppender.addSamplesAppender(samplesAppender{
 				agg:             a.agg,
 				clientRemote:    a.clientRemote,
@@ -167,8 +251,9 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 }
 
 type debugLogMatchOptions struct {
-	Meta     metadata.StagedMetadatas
-	RollupID []byte
+	Meta          metadata.StagedMetadatas
+	StoragePolicy policy.StoragePolicy
+	RollupID      []byte
 }
 
 func (a *metricsAppender) debugLogMatch(str string, opts debugLogMatchOptions) {
@@ -183,6 +268,9 @@ func (a *metricsAppender) debugLogMatch(str string, opts debugLogMatchOptions) {
 	}
 	if v := opts.Meta; v != nil {
 		fields = append(fields, stagedMetadatasLogField(v))
+	}
+	if v := opts.StoragePolicy; v != policy.EmptyStoragePolicy {
+		fields = append(fields, zap.Stringer("storagePolicy", v))
 	}
 	a.logger.Debug(str, fields...)
 }

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -126,9 +126,9 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 		// NB(r): First apply mapping rules to see which storage policies
 		// have been applied, any that have been applied as part of
 		// mapping rules that exact match a default storage policy will
-		// skip be skipped when applying default rules so to avoid
-		// storing the same metrics in the same namespace with the same
-		// metric name and tags (i.e. overwriting each other).
+		// skipped when applying default rules so to avoid storing
+		// the same metrics in the same namespace with the same metric
+		// name and tags (i.e. overwriting each other).
 		a.mappingRuleStoragePolicies = a.mappingRuleStoragePolicies[:0]
 
 		stagedMetadatas := matchResult.ForExistingIDAt(nowNanos)
@@ -164,7 +164,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 
 			stagedMetadatsBeforeFilter := stagedMetadatas[:]
 			if len(a.mappingRuleStoragePolicies) != 0 {
-				// If mapping rules have applied aggregatinons for
+				// If mapping rules have applied aggregations for
 				// storage policies then de-dupe so we don't have two
 				// active aggregations for the same storage policy.
 				stagedMetadatasAfterFilter := stagedMetadatas[:0]

--- a/src/metrics/policy/storage_policy.go
+++ b/src/metrics/policy/storage_policy.go
@@ -73,6 +73,14 @@ func NewStoragePolicyFromProto(pb *policypb.StoragePolicy) (StoragePolicy, error
 	return sp, nil
 }
 
+// Equivalent returns whether two storage policies are equal by their
+// retention width and resolution. The resolution precision is ignored
+// for equivalency (hence why the method is not named Equal).
+func (p StoragePolicy) Equivalent(other StoragePolicy) bool {
+	return p.resolution.Window == other.resolution.Window &&
+		p.retention == other.retention
+}
+
 // String is the string representation of a storage policy.
 func (p StoragePolicy) String() string {
 	return fmt.Sprintf("%s%s%s", p.resolution.String(), resolutionRetentionSeparator, p.retention.String())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
After seeing mapping rules in use, it's become obvious that default aggregations should not honored if a matching mapping rule already specifies an aggregation for the same storage policy (retention + resolution). Letting both apply will cause race conditions on which aggregated value makes it to storage with the same metric name and tags.

This keeps the current behavior as is however will remove any applicable default aggregations for aggregated namespaces defined if a mapping rule has already been applied for the given storage policy (retention + resolution).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
