### PR TITLE
[aggregator] [coordinator] Allow configuring last value aggregations to use last timestamp

### DIFF
--- a/src/aggregator/aggregation/common.go
+++ b/src/aggregator/aggregation/common.go
@@ -22,9 +22,18 @@ package aggregation
 
 import (
 	"math"
+	"time"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
 )
+
+// Value is an aggregation value, with the ability to override the
+// aggregation value timestamp.
+type Value struct {
+	Value               float64
+	AdjustTimestamp     bool
+	AdjustTimestampTime time.Time
+}
 
 func stdev(count int64, sumSq, sum float64) float64 {
 	div := count * (count - 1)

--- a/src/aggregator/aggregation/counter.go
+++ b/src/aggregator/aggregation/counter.go
@@ -59,7 +59,7 @@ func (c *Counter) Update(timestamp time.Time, value int64) {
 		c.min = value
 	}
 
-	if c.HasExpensiveAggregations {
+	if c.EnableExpensiveAggregations {
 		c.sumSq += value * value
 	}
 }
@@ -93,24 +93,24 @@ func (c *Counter) Min() int64 { return c.min }
 func (c *Counter) Max() int64 { return c.max }
 
 // ValueOf returns the value for the aggregation type.
-func (c *Counter) ValueOf(aggType aggregation.Type) float64 {
+func (c *Counter) ValueOf(aggType aggregation.Type) Value {
 	switch aggType {
 	case aggregation.Min:
-		return float64(c.Min())
+		return Value{Value: float64(c.Min())}
 	case aggregation.Max:
-		return float64(c.Max())
+		return Value{Value: float64(c.Max())}
 	case aggregation.Mean:
-		return c.Mean()
+		return Value{Value: c.Mean()}
 	case aggregation.Count:
-		return float64(c.Count())
+		return Value{Value: float64(c.Count())}
 	case aggregation.Sum:
-		return float64(c.Sum())
+		return Value{Value: float64(c.Sum())}
 	case aggregation.SumSq:
-		return float64(c.SumSq())
+		return Value{Value: float64(c.SumSq())}
 	case aggregation.Stdev:
-		return c.Stdev()
+		return Value{Value: c.Stdev()}
 	default:
-		return 0
+		return Value{}
 	}
 }
 

--- a/src/aggregator/aggregation/gauge.go
+++ b/src/aggregator/aggregation/gauge.go
@@ -74,13 +74,16 @@ func (g *Gauge) Update(timestamp time.Time, value float64) {
 		g.min = value
 	}
 
-	if g.HasExpensiveAggregations {
+	if g.EnableExpensiveAggregations {
 		g.sumSq += value * value
 	}
 }
 
 // Last returns the last value received.
 func (g *Gauge) Last() float64 { return g.last }
+
+// LastAt returns the last value received time.
+func (g *Gauge) LastAt() time.Time { return g.lastAt }
 
 // Count returns the number of values received.
 func (g *Gauge) Count() int64 { return g.count }
@@ -111,26 +114,33 @@ func (g *Gauge) Min() float64 { return g.min }
 func (g *Gauge) Max() float64 { return g.max }
 
 // ValueOf returns the value for the aggregation type.
-func (g *Gauge) ValueOf(aggType aggregation.Type) float64 {
+func (g *Gauge) ValueOf(aggType aggregation.Type) Value {
 	switch aggType {
 	case aggregation.Last:
-		return g.Last()
+		if g.Options.EnableAggregationLastValueAdjustTimestamp {
+			return Value{
+				Value:               g.Last(),
+				AdjustTimestamp:     true,
+				AdjustTimestampTime: g.LastAt(),
+			}
+		}
+		return Value{Value: g.Last()}
 	case aggregation.Min:
-		return g.Min()
+		return Value{Value: g.Min()}
 	case aggregation.Max:
-		return g.Max()
+		return Value{Value: g.Max()}
 	case aggregation.Mean:
-		return g.Mean()
+		return Value{Value: g.Mean()}
 	case aggregation.Count:
-		return float64(g.Count())
+		return Value{Value: float64(g.Count())}
 	case aggregation.Sum:
-		return g.Sum()
+		return Value{Value: g.Sum()}
 	case aggregation.SumSq:
-		return g.SumSq()
+		return Value{Value: g.SumSq()}
 	case aggregation.Stdev:
-		return g.Stdev()
+		return Value{Value: g.Stdev()}
 	default:
-		return 0
+		return Value{}
 	}
 }
 

--- a/src/aggregator/aggregation/options.go
+++ b/src/aggregator/aggregation/options.go
@@ -28,14 +28,19 @@ import (
 )
 
 var (
-	defaultHasExpensiveAggregations = false
+	defaultEnableExpensiveAggregations               = false
+	defaultEnableAggregationLastValueAdjustTimestamp = false
 )
 
 // Options is the options for aggregations.
 type Options struct {
-	// HasExpensiveAggregations means expensive (multiplication／division)
+	// EnableExpensiveAggregations means expensive (multiplication／division)
 	// aggregation types are enabled.
-	HasExpensiveAggregations bool
+	EnableExpensiveAggregations bool
+	// EnableAggregationLastValueAdjustTimestamp will enable last value
+	// aggregations to adjust the timestamp of the resulting last value
+	// aggregation.
+	EnableAggregationLastValueAdjustTimestamp bool
 	// Metrics is as set of aggregation metrics.
 	Metrics Metrics
 }
@@ -74,12 +79,13 @@ func (m GaugeMetrics) IncValuesOutOfOrder() {
 // NewOptions creates a new aggregation options.
 func NewOptions(instrumentOpts instrument.Options) Options {
 	return Options{
-		HasExpensiveAggregations: defaultHasExpensiveAggregations,
-		Metrics:                  NewMetrics(instrumentOpts.MetricsScope()),
+		EnableExpensiveAggregations:               defaultEnableExpensiveAggregations,
+		EnableAggregationLastValueAdjustTimestamp: defaultEnableAggregationLastValueAdjustTimestamp,
+		Metrics: NewMetrics(instrumentOpts.MetricsScope()),
 	}
 }
 
 // ResetSetData resets the aggregation options.
 func (o *Options) ResetSetData(aggTypes aggregation.Types) {
-	o.HasExpensiveAggregations = isExpensive(aggTypes)
+	o.EnableExpensiveAggregations = isExpensive(aggTypes)
 }

--- a/src/aggregator/aggregation/timer.go
+++ b/src/aggregator/aggregation/timer.go
@@ -51,7 +51,7 @@ func (t *Timer) Add(value float64) {
 	t.sum += value
 	t.stream.Add(value)
 
-	if t.HasExpensiveAggregations {
+	if t.EnableExpensiveAggregations {
 		t.sumSq += value * value
 	}
 }
@@ -104,28 +104,28 @@ func (t *Timer) Stdev() float64 {
 }
 
 // ValueOf returns the value for the aggregation type.
-func (t *Timer) ValueOf(aggType aggregation.Type) float64 {
+func (t *Timer) ValueOf(aggType aggregation.Type) Value {
 	if q, ok := aggType.Quantile(); ok {
-		return t.Quantile(q)
+		return Value{Value: t.Quantile(q)}
 	}
 
 	switch aggType {
 	case aggregation.Min:
-		return t.Min()
+		return Value{Value: t.Min()}
 	case aggregation.Max:
-		return t.Max()
+		return Value{Value: t.Max()}
 	case aggregation.Mean:
-		return t.Mean()
+		return Value{Value: t.Mean()}
 	case aggregation.Count:
-		return float64(t.Count())
+		return Value{Value: float64(t.Count())}
 	case aggregation.Sum:
-		return t.Sum()
+		return Value{Value: t.Sum()}
 	case aggregation.SumSq:
-		return t.SumSq()
+		return Value{Value: t.SumSq()}
 	case aggregation.Stdev:
-		return t.Stdev()
+		return Value{Value: t.Stdev()}
 	}
-	return 0
+	return Value{}
 }
 
 // Close closes the timer.

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -401,17 +401,25 @@ func (e *CounterElem) indexOfWithLock(alignedStart int64) (int, bool) {
 }
 
 func (e *CounterElem) processValueWithAggregationLock(
-	timeNanos int64,
+	aggregationTimeNanos int64,
 	lockedAgg *lockedCounterAggregation,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 ) {
 	var (
 		transformations  = e.parsedPipeline.Transformations
-		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
+		discardNaNValues = e.opts.EnableDiscardNaNAggregatedValues()
 	)
 	for aggTypeIdx, aggType := range e.aggTypes {
-		value := lockedAgg.aggregation.ValueOf(aggType)
+		aggValue := lockedAgg.aggregation.ValueOf(aggType)
+
+		timeNanos := aggregationTimeNanos
+		if aggValue.AdjustTimestamp {
+			timeNanos = aggValue.AdjustTimestampTime.UnixNano()
+		}
+
+		value := aggValue.Value
+
 		for i := 0; i < transformations.Len(); i++ {
 			transformType := transformations.At(i).Transformation.Type
 			if transformType.IsUnaryTransform() {
@@ -431,20 +439,27 @@ func (e *CounterElem) processValueWithAggregationLock(
 				value = res.Value
 			}
 		}
+
 		if discardNaNValues && math.IsNaN(value) {
 			continue
 		}
+
 		if !e.parsedPipeline.HasRollup {
+			// Process non-rollup.
 			switch e.idPrefixSuffixType {
 			case NoPrefixNoSuffix:
 				flushLocalFn(nil, e.id, nil, timeNanos, value, e.sp)
 			case WithPrefixWithSuffix:
 				flushLocalFn(e.FullPrefix(e.opts), e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 			}
-		} else {
-			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey, timeNanos, value)
+			continue
 		}
+
+		// Process rollup.
+		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+		flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey, timeNanos, value)
 	}
-	e.lastConsumedAtNanos = timeNanos
+
+	// Track when last consumed relative to the aggregation time window.
+	e.lastConsumedAtNanos = aggregationTimeNanos
 }

--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -173,10 +173,13 @@ type elemBase struct {
 }
 
 func newElemBase(opts Options) elemBase {
+	aggOpts := raggregation.NewOptions(opts.InstrumentOptions())
+	aggOpts.EnableAggregationLastValueAdjustTimestamp =
+		opts.EnableAggregationLastValueAdjustTimestamp()
 	return elemBase{
 		opts:         opts,
 		aggTypesOpts: opts.AggregationTypesOptions(),
-		aggOpts:      raggregation.NewOptions(opts.InstrumentOptions()),
+		aggOpts:      aggOpts,
 	}
 }
 

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -485,7 +485,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Sum}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
+	opts := NewOptions().SetEnableDiscardNaNAggregatedValues(false)
 	e := testCounterElem(alignedstartAtNanos[:3], counterVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{
@@ -983,7 +983,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Min}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
+	opts := NewOptions().SetEnableDiscardNaNAggregatedValues(false)
 	e := testTimerElem(alignedstartAtNanos[:3], timerVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{
@@ -1526,7 +1526,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Last}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
+	opts := NewOptions().SetEnableDiscardNaNAggregatedValues(false)
 	e := testGaugeElem(alignedstartAtNanos[:3], gaugeVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{

--- a/src/aggregator/aggregator/options_test.go
+++ b/src/aggregator/aggregator/options_test.go
@@ -202,10 +202,16 @@ func TestSetMaxNumCachedSourceSets(t *testing.T) {
 	require.Equal(t, value, o.MaxNumCachedSourceSets())
 }
 
-func TestSetDiscardNaNAggregatedValues(t *testing.T) {
+func TestSetEnableDiscardNaNAggregatedValues(t *testing.T) {
 	value := false
-	o := NewOptions().SetDiscardNaNAggregatedValues(value)
-	require.Equal(t, value, o.DiscardNaNAggregatedValues())
+	o := NewOptions().SetEnableDiscardNaNAggregatedValues(value)
+	require.Equal(t, value, o.EnableDiscardNaNAggregatedValues())
+}
+
+func TestSetEnableAggregationLastValueAdjustTimestamp(t *testing.T) {
+	value := true
+	o := NewOptions().SetEnableAggregationLastValueAdjustTimestamp(value)
+	require.Equal(t, value, o.EnableAggregationLastValueAdjustTimestamp())
 }
 
 func TestSetCounterElemPool(t *testing.T) {

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -401,17 +401,25 @@ func (e *TimerElem) indexOfWithLock(alignedStart int64) (int, bool) {
 }
 
 func (e *TimerElem) processValueWithAggregationLock(
-	timeNanos int64,
+	aggregationTimeNanos int64,
 	lockedAgg *lockedTimerAggregation,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 ) {
 	var (
 		transformations  = e.parsedPipeline.Transformations
-		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
+		discardNaNValues = e.opts.EnableDiscardNaNAggregatedValues()
 	)
 	for aggTypeIdx, aggType := range e.aggTypes {
-		value := lockedAgg.aggregation.ValueOf(aggType)
+		aggValue := lockedAgg.aggregation.ValueOf(aggType)
+
+		timeNanos := aggregationTimeNanos
+		if aggValue.AdjustTimestamp {
+			timeNanos = aggValue.AdjustTimestampTime.UnixNano()
+		}
+
+		value := aggValue.Value
+
 		for i := 0; i < transformations.Len(); i++ {
 			transformType := transformations.At(i).Transformation.Type
 			if transformType.IsUnaryTransform() {
@@ -431,20 +439,27 @@ func (e *TimerElem) processValueWithAggregationLock(
 				value = res.Value
 			}
 		}
+
 		if discardNaNValues && math.IsNaN(value) {
 			continue
 		}
+
 		if !e.parsedPipeline.HasRollup {
+			// Process non-rollup.
 			switch e.idPrefixSuffixType {
 			case NoPrefixNoSuffix:
 				flushLocalFn(nil, e.id, nil, timeNanos, value, e.sp)
 			case WithPrefixWithSuffix:
 				flushLocalFn(e.FullPrefix(e.opts), e.id, e.TypeStringFor(e.aggTypesOpts, aggType), timeNanos, value, e.sp)
 			}
-		} else {
-			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey, timeNanos, value)
+			continue
 		}
+
+		// Process rollup.
+		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
+		flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey, timeNanos, value)
 	}
-	e.lastConsumedAtNanos = timeNanos
+
+	// Track when last consumed relative to the aggregation time window.
+	e.lastConsumedAtNanos = aggregationTimeNanos
 }

--- a/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
+++ b/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
@@ -179,7 +179,7 @@ func testMultiServerForwardingPipeline(t *testing.T, discardNaNAggregatedValues 
 			SetShardFn(shardFn).
 			SetShardSetID(mss.instanceConfig.shardSetID).
 			SetClientConnectionOptions(connectionOpts).
-			SetDiscardNaNAggregatedValues(discardNaNAggregatedValues)
+			SetEnableDiscardNaNAggregatedValues(discardNaNAggregatedValues)
 		server := newTestServerSetup(t, serverOpts)
 		servers = append(servers, server)
 	}

--- a/src/aggregator/integration/options.go
+++ b/src/aggregator/integration/options.go
@@ -34,20 +34,20 @@ import (
 )
 
 const (
-	defaultRawTCPAddr                 = "localhost:6000"
-	defaultHTTPAddr                   = "localhost:6001"
-	defaultServerStateChangeTimeout   = 5 * time.Second
-	defaultClientBatchSize            = 1440
-	defaultWorkerPoolSize             = 4
-	defaultInstanceID                 = "localhost"
-	defaultPlacementKVKey             = "/placement"
-	defaultElectionKeyFmt             = "/shardset/%d/lock"
-	defaultFlushTimesKeyFmt           = "/shardset/%d/flush"
-	defaultShardSetID                 = 0
-	defaultElectionStateChangeTimeout = 10 * time.Second
-	defaultEntryCheckInterval         = time.Second
-	defaultJitterEnabled              = true
-	defaultDiscardNaNAggregatedValues = true
+	defaultRawTCPAddr                       = "localhost:6000"
+	defaultHTTPAddr                         = "localhost:6001"
+	defaultServerStateChangeTimeout         = 5 * time.Second
+	defaultClientBatchSize                  = 1440
+	defaultWorkerPoolSize                   = 4
+	defaultInstanceID                       = "localhost"
+	defaultPlacementKVKey                   = "/placement"
+	defaultElectionKeyFmt                   = "/shardset/%d/lock"
+	defaultFlushTimesKeyFmt                 = "/shardset/%d/flush"
+	defaultShardSetID                       = 0
+	defaultElectionStateChangeTimeout       = 10 * time.Second
+	defaultEntryCheckInterval               = time.Second
+	defaultJitterEnabled                    = true
+	defaultEnableDiscardNaNAggregatedValues = true
 )
 
 type testServerOptions interface {
@@ -183,38 +183,38 @@ type testServerOptions interface {
 	// MaxAllowedForwardingDelayFn returns the maximum allowed forwarding delay function.
 	MaxAllowedForwardingDelayFn() aggregator.MaxAllowedForwardingDelayFn
 
-	// SetDiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
-	SetDiscardNaNAggregatedValues(value bool) testServerOptions
+	// SetEnableDiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
+	SetEnableDiscardNaNAggregatedValues(value bool) testServerOptions
 
-	// DiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
-	DiscardNaNAggregatedValues() bool
+	// EnableDiscardNaNAggregatedValues determines whether NaN aggregated values are discarded.
+	EnableDiscardNaNAggregatedValues() bool
 }
 
 // nolint: maligned
 type serverOptions struct {
-	clockOpts                   clock.Options
-	instrumentOpts              instrument.Options
-	aggTypesOpts                aggregation.TypesOptions
-	rawTCPAddr                  string
-	httpAddr                    string
-	instanceID                  string
-	electionKeyFmt              string
-	electionCluster             *testCluster
-	shardSetID                  uint32
-	shardFn                     sharding.ShardFn
-	placementKVKey              string
-	flushTimesKeyFmt            string
-	kvStore                     kv.Store
-	serverStateChangeTimeout    time.Duration
-	workerPoolSize              int
-	clientBatchSize             int
-	clientConnectionOpts        aggclient.ConnectionOptions
-	electionStateChangeTimeout  time.Duration
-	entryCheckInterval          time.Duration
-	jitterEnabled               bool
-	maxJitterFn                 aggregator.FlushJitterFn
-	maxAllowedForwardingDelayFn aggregator.MaxAllowedForwardingDelayFn
-	discardNaNAggregatedValues  bool
+	clockOpts                        clock.Options
+	instrumentOpts                   instrument.Options
+	aggTypesOpts                     aggregation.TypesOptions
+	rawTCPAddr                       string
+	httpAddr                         string
+	instanceID                       string
+	electionKeyFmt                   string
+	electionCluster                  *testCluster
+	shardSetID                       uint32
+	shardFn                          sharding.ShardFn
+	placementKVKey                   string
+	flushTimesKeyFmt                 string
+	kvStore                          kv.Store
+	serverStateChangeTimeout         time.Duration
+	workerPoolSize                   int
+	clientBatchSize                  int
+	clientConnectionOpts             aggclient.ConnectionOptions
+	electionStateChangeTimeout       time.Duration
+	entryCheckInterval               time.Duration
+	jitterEnabled                    bool
+	maxJitterFn                      aggregator.FlushJitterFn
+	maxAllowedForwardingDelayFn      aggregator.MaxAllowedForwardingDelayFn
+	enableDiscardNaNAggregatedValues bool
 }
 
 func newTestServerOptions() testServerOptions {
@@ -223,28 +223,28 @@ func newTestServerOptions() testServerOptions {
 		SetTimerTypeStringTransformFn(aggregation.SuffixTransform).
 		SetGaugeTypeStringTransformFn(aggregation.EmptyTransform)
 	return &serverOptions{
-		rawTCPAddr:                  defaultRawTCPAddr,
-		httpAddr:                    defaultHTTPAddr,
-		clockOpts:                   clock.NewOptions(),
-		instrumentOpts:              instrument.NewOptions(),
-		aggTypesOpts:                aggTypesOpts,
-		instanceID:                  defaultInstanceID,
-		electionKeyFmt:              defaultElectionKeyFmt,
-		shardSetID:                  defaultShardSetID,
-		shardFn:                     sharding.Murmur32Hash.MustShardFn(),
-		placementKVKey:              defaultPlacementKVKey,
-		flushTimesKeyFmt:            defaultFlushTimesKeyFmt,
-		kvStore:                     mem.NewStore(),
-		serverStateChangeTimeout:    defaultServerStateChangeTimeout,
-		workerPoolSize:              defaultWorkerPoolSize,
-		clientBatchSize:             defaultClientBatchSize,
-		clientConnectionOpts:        aggclient.NewConnectionOptions(),
-		electionStateChangeTimeout:  defaultElectionStateChangeTimeout,
-		jitterEnabled:               defaultJitterEnabled,
-		entryCheckInterval:          defaultEntryCheckInterval,
-		maxJitterFn:                 defaultMaxJitterFn,
-		maxAllowedForwardingDelayFn: defaultMaxAllowedForwardingDelayFn,
-		discardNaNAggregatedValues:  defaultDiscardNaNAggregatedValues,
+		rawTCPAddr:                       defaultRawTCPAddr,
+		httpAddr:                         defaultHTTPAddr,
+		clockOpts:                        clock.NewOptions(),
+		instrumentOpts:                   instrument.NewOptions(),
+		aggTypesOpts:                     aggTypesOpts,
+		instanceID:                       defaultInstanceID,
+		electionKeyFmt:                   defaultElectionKeyFmt,
+		shardSetID:                       defaultShardSetID,
+		shardFn:                          sharding.Murmur32Hash.MustShardFn(),
+		placementKVKey:                   defaultPlacementKVKey,
+		flushTimesKeyFmt:                 defaultFlushTimesKeyFmt,
+		kvStore:                          mem.NewStore(),
+		serverStateChangeTimeout:         defaultServerStateChangeTimeout,
+		workerPoolSize:                   defaultWorkerPoolSize,
+		clientBatchSize:                  defaultClientBatchSize,
+		clientConnectionOpts:             aggclient.NewConnectionOptions(),
+		electionStateChangeTimeout:       defaultElectionStateChangeTimeout,
+		jitterEnabled:                    defaultJitterEnabled,
+		entryCheckInterval:               defaultEntryCheckInterval,
+		maxJitterFn:                      defaultMaxJitterFn,
+		maxAllowedForwardingDelayFn:      defaultMaxAllowedForwardingDelayFn,
+		enableDiscardNaNAggregatedValues: defaultEnableDiscardNaNAggregatedValues,
 	}
 }
 
@@ -468,14 +468,14 @@ func (o *serverOptions) MaxAllowedForwardingDelayFn() aggregator.MaxAllowedForwa
 	return o.maxAllowedForwardingDelayFn
 }
 
-func (o *serverOptions) SetDiscardNaNAggregatedValues(value bool) testServerOptions {
+func (o *serverOptions) SetEnableDiscardNaNAggregatedValues(value bool) testServerOptions {
 	opts := *o
-	opts.discardNaNAggregatedValues = value
+	opts.enableDiscardNaNAggregatedValues = value
 	return &opts
 }
 
-func (o *serverOptions) DiscardNaNAggregatedValues() bool {
-	return o.discardNaNAggregatedValues
+func (o *serverOptions) EnableDiscardNaNAggregatedValues() bool {
+	return o.enableDiscardNaNAggregatedValues
 }
 
 func defaultMaxJitterFn(interval time.Duration) time.Duration {

--- a/src/aggregator/integration/setup.go
+++ b/src/aggregator/integration/setup.go
@@ -97,7 +97,7 @@ func newTestServerSetup(t *testing.T, opts testServerOptions) *testServerSetup {
 		SetAggregationTypesOptions(opts.AggregationTypesOptions()).
 		SetEntryCheckInterval(opts.EntryCheckInterval()).
 		SetMaxAllowedForwardingDelayFn(opts.MaxAllowedForwardingDelayFn()).
-		SetDiscardNaNAggregatedValues(opts.DiscardNaNAggregatedValues())
+		SetEnableDiscardNaNAggregatedValues(opts.DiscardNaNAggregatedValues())
 
 	// Set up placement manager.
 	placementWatcherOpts := placement.NewStagedPlacementWatcherOptions().

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -143,6 +143,9 @@ type AggregatorConfiguration struct {
 	// Whether to discard NaN aggregated values.
 	DiscardNaNAggregatedValues *bool `yaml:"discardNaNAggregatedValues"`
 
+	// Whether to use last timestamp of a last value aggregation rather than the window time.
+	AggregationLastValueAdjustTimestamp *bool `yaml:"aggregationLastValueAdjustTimestamp"`
+
 	// Pool of counter elements.
 	CounterElemPool pool.ObjectPoolConfiguration `yaml:"counterElemPool"`
 
@@ -389,13 +392,19 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	opts = opts.SetDefaultStoragePolicies(storagePolicies)
 
 	// Set cached source sets options.
-	if c.MaxNumCachedSourceSets != nil {
-		opts = opts.SetMaxNumCachedSourceSets(*c.MaxNumCachedSourceSets)
+	if v := c.MaxNumCachedSourceSets; v != nil {
+		opts = opts.SetMaxNumCachedSourceSets(*v)
 	}
 
 	// Set whether to discard NaN aggregated values.
-	if c.DiscardNaNAggregatedValues != nil {
-		opts = opts.SetDiscardNaNAggregatedValues(*c.DiscardNaNAggregatedValues)
+	if v := c.DiscardNaNAggregatedValues; v != nil {
+		opts = opts.SetEnableDiscardNaNAggregatedValues(*v)
+	}
+
+	// Set whether to adjust the aggregation last value timestamp taken
+	// to the time at which it was received instead of the last window timestamp.
+	if v := c.AggregationLastValueAdjustTimestamp; v != nil {
+		opts = opts.SetEnableAggregationLastValueAdjustTimestamp(*v)
 	}
 
 	// Set counter elem pool.

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/serialize"
+	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -57,8 +58,9 @@ import (
 
 var (
 	testAggregationType            = aggregation.Sum
+	testAggregationResolution      = 2 * time.Second
 	testAggregationStoragePolicies = []policy.StoragePolicy{
-		policy.MustParseStoragePolicy("2s:1d"),
+		policy.MustParseStoragePolicy(testAggregationResolution.String() + ":1d"),
 	}
 )
 
@@ -326,6 +328,53 @@ func TestDownsamplerAggregationWithOverrideRules(t *testing.T) {
 	testDownsamplerAggregation(t, testDownsampler)
 }
 
+func TestDownsamplerAggregationLastValueAdjustTimestamp(t *testing.T) {
+	alignedStart := time.Now().
+		Truncate(testAggregationResolution).
+		Add(testAggregationResolution)
+
+	subStep := time.Duration(float64(testAggregationResolution) * 0.25)
+
+	metric := testGaugeMetric{
+		tags: map[string]string{nameTag: "gauge0", "app": "testapp", "qux": "qaz"},
+		timedSamples: []testGaugeMetricTimedSample{
+			{value: 4, time: alignedStart},
+			{value: 6, time: alignedStart.Add(subStep)},
+			{value: 5, time: alignedStart.Add(2 * subStep)},
+		},
+	}
+
+	lastSample := metric.timedSamples[len(metric.timedSamples)-1]
+
+	expectedTimestamp := xtime.UnixNano(lastSample.time.UnixNano())
+
+	expectedWrite := testExpectedWrite{
+		tags:      metric.tags,
+		value:     5,
+		timestamp: &expectedTimestamp,
+	}
+
+	aggregationLastValueAdjustment := true
+	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
+		aggregationLastValueAdjustment: &aggregationLastValueAdjustment,
+		autoMappingRules: []AutoMappingRule{
+			{
+				Aggregations: []aggregation.Type{aggregation.Last},
+				Policies:     testAggregationStoragePolicies,
+			},
+		},
+		ingest: &testDownsamplerOptionsIngest{
+			gaugeMetrics: []testGaugeMetric{metric},
+		},
+		expect: &testDownsamplerOptionsExpect{
+			writes: []testExpectedWrite{expectedWrite},
+		},
+	})
+
+	// Test expected output
+	testDownsamplerAggregation(t, testDownsampler)
+}
+
 func TestDownsamplerAggregationWithRemoteAggregatorClient(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -351,6 +400,7 @@ func TestDownsamplerAggregationWithRemoteAggregatorClient(t *testing.T) {
 type testExpectedWrite struct {
 	tags       map[string]string
 	value      float64
+	timestamp  *xtime.UnixNano
 	attributes *storage.Attributes
 }
 
@@ -499,13 +549,28 @@ CheckAllWritesArrivedLoop:
 
 		write, found := findWrite(t, writes, name)
 		require.True(t, found)
+
 		assert.Equal(t, expectedWrite.tags, tagsToStringMap(write.Tags))
+
 		require.Equal(t, 1, len(write.Datapoints))
+
 		assert.Equal(t, float64(value), write.Datapoints[0].Value)
+
+		if ts := expectedWrite.timestamp; ts != nil {
+			timestamp := *ts
+			offBy := write.Datapoints[0].Timestamp.Sub(timestamp.ToTime())
+			if offBy < 0 {
+				offBy = -1 * offBy
+			}
+			assert.Equal(t,
+				int64(timestamp), write.Datapoints[0].Timestamp.UnixNano(),
+				"write timestamp off by "+offBy.String())
+		}
 
 		if attrs := expectedWrite.attributes; attrs != nil {
 			assert.Equal(t, *attrs, write.Attributes)
 		}
+
 	}
 }
 
@@ -696,10 +761,11 @@ type testDownsamplerOptions struct {
 	instrumentOpts instrument.Options
 
 	// Options for the test
-	autoMappingRules   []AutoMappingRule
-	sampleAppenderOpts *SampleAppenderOptions
-	remoteClientMock   *client.MockClient
-	rulesConfig        *RulesConfiguration
+	autoMappingRules               []AutoMappingRule
+	sampleAppenderOpts             *SampleAppenderOptions
+	remoteClientMock               *client.MockClient
+	rulesConfig                    *RulesConfiguration
+	aggregationLastValueAdjustment *bool
 
 	// Test ingest and expectations overrides
 	ingest *testDownsamplerOptionsIngest
@@ -761,6 +827,9 @@ func newTestDownsampler(t *testing.T, opts testDownsamplerOptions) testDownsampl
 	}
 	if opts.rulesConfig != nil {
 		cfg.Rules = opts.rulesConfig
+	}
+	if opts.aggregationLastValueAdjustment != nil {
+		cfg.AggregationLastValueAdjustTimestamp = opts.aggregationLastValueAdjustment
 	}
 
 	instance, err := cfg.NewDownsampler(DownsamplerOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This allows for last value aggregations in the aggregator and coordinator to use the last timestamp instead of the window timestamp for the aggregation if desired.

As m3coordinator's downsampler is primarily used as a sidecar for Prometheus metrics, it has this behavior turned on by default.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
