### PR TITLE
Add metric for BootstrappedAndDurable

### DIFF
--- a/src/dbnode/storage/bootstrap.go
+++ b/src/dbnode/storage/bootstrap.go
@@ -83,6 +83,7 @@ type bootstrapManager struct {
 	hasPending                  bool
 	status                      tally.Gauge
 	bootstrapDuration           tally.Timer
+	durableStatus               tally.Gauge
 	lastBootstrapCompletionTime time.Time
 }
 
@@ -102,6 +103,7 @@ func newBootstrapManager(
 		processProvider:   opts.BootstrapProcessProvider(),
 		status:            scope.Gauge("bootstrapped"),
 		bootstrapDuration: scope.Timer("bootstrap-duration"),
+		durableStatus:     scope.Gauge("bootstrapped-durable"),
 	}
 	m.bootstrapFn = m.bootstrap
 	return m
@@ -198,6 +200,12 @@ func (m *bootstrapManager) Report() {
 		m.status.Update(1)
 	} else {
 		m.status.Update(0)
+	}
+
+	if m.database.IsBootstrappedAndDurable() {
+		m.durableStatus.Update(1)
+	} else {
+		m.durableStatus.Update(0)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
BootstrappedAndDurable is what is reported as "bootstrapped" by `/health` endpoint. Adding this metric gives us visibility in this database status without hitting the endpoint for that information.

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
