### PR TITLE
[dbnode] Account for Neg/Pos Offsets when building per field roaring bitmap posting lists

### DIFF
--- a/src/m3ninx/index/segment/builder/multi_segments_field_postings_list_iter.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_field_postings_list_iter.go
@@ -46,8 +46,35 @@ func newFieldPostingsListIterFromSegments(
 			continue
 		}
 
-		multiIter.add(iter, seg.segment)
+		multiIter.add(&fieldsKeyIter{
+			iter:    iter,
+			segment: seg,
+		})
 	}
 
 	return multiIter, nil
+}
+
+// fieldsKeyIter needs to be a keyIterator and contains a terms iterator
+var _ keyIterator = &fieldsKeyIter{}
+
+type fieldsKeyIter struct {
+	iter    segment.FieldsIterator
+	segment segmentMetadata
+}
+
+func (i *fieldsKeyIter) Next() bool {
+	return i.iter.Next()
+}
+
+func (i *fieldsKeyIter) Current() []byte {
+	return i.iter.Current()
+}
+
+func (i *fieldsKeyIter) Err() error {
+	return i.iter.Err()
+}
+
+func (i *fieldsKeyIter) Close() error {
+	return i.iter.Close()
 }

--- a/src/m3ninx/index/segment/builder/multi_segments_field_postings_list_iter_test.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_field_postings_list_iter_test.go
@@ -1,0 +1,118 @@
+package builder
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/m3db/m3/src/m3ninx/doc"
+	"github.com/m3db/m3/src/m3ninx/index/segment"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldPostingsListIterFromSegments(t *testing.T) {
+	segments := []segment.Segment{
+		newTestSegmentWithDocs(t, []doc.Document{
+			{
+				ID: []byte("bux_0"),
+				Fields: []doc.Field{
+					{Name: []byte("fruit"), Value: []byte("apple")},
+					{Name: []byte("vegetable"), Value: []byte("carrot")},
+					{Name: []byte("infrequent"), Value: []byte("val0")},
+				},
+			},
+			{
+				ID: []byte("bar_0"),
+				Fields: []doc.Field{
+					{Name: []byte("cat"), Value: []byte("rhymes")},
+					{Name: []byte("hat"), Value: []byte("with")},
+					{Name: []byte("bat"), Value: []byte("pat")},
+				},
+			},
+		}),
+		newTestSegmentWithDocs(t, []doc.Document{
+			{
+				ID: []byte("foo_0"),
+				Fields: []doc.Field{
+					{Name: []byte("fruit"), Value: []byte("apple")},
+					{Name: []byte("vegetable"), Value: []byte("carrot")},
+					{Name: []byte("infrequent"), Value: []byte("val0")},
+				},
+			},
+			{
+				ID: []byte("bux_1"),
+				Fields: []doc.Field{
+					{Name: []byte("delta"), Value: []byte("22")},
+					{Name: []byte("gamma"), Value: []byte("33")},
+					{Name: []byte("theta"), Value: []byte("44")},
+				},
+			},
+		}),
+		newTestSegmentWithDocs(t, []doc.Document{
+			{
+				ID: []byte("bar_1"),
+				Fields: []doc.Field{
+					{Name: []byte("cat"), Value: []byte("rhymes")},
+					{Name: []byte("hat"), Value: []byte("with")},
+					{Name: []byte("bat"), Value: []byte("pat")},
+				},
+			},
+			{
+				ID: []byte("foo_1"),
+				Fields: []doc.Field{
+					{Name: []byte("fruit"), Value: []byte("apple")},
+					{Name: []byte("vegetable"), Value: []byte("carrot")},
+					{Name: []byte("infrequent"), Value: []byte("val1")},
+				},
+			},
+			{
+				ID: []byte("baz_0"),
+				Fields: []doc.Field{
+					{Name: []byte("fruit"), Value: []byte("watermelon")},
+					{Name: []byte("color"), Value: []byte("green")},
+					{Name: []byte("alpha"), Value: []byte("0.5")},
+				},
+			},
+			{
+				ID: []byte("bux_2"),
+				Fields: []doc.Field{
+					{Name: []byte("delta"), Value: []byte("22")},
+					{Name: []byte("gamma"), Value: []byte("33")},
+					{Name: []byte("theta"), Value: []byte("44")},
+				},
+			},
+		}),
+	}
+	builder := NewBuilderFromSegments(testOptions)
+	builder.Reset(0)
+
+	b, ok := builder.(*builderFromSegments)
+	require.True(t, ok)
+	require.NoError(t, builder.AddSegments(segments))
+	iter, err := b.FieldsPostingsList()
+	require.NoError(t, err)
+	for iter.Next() {
+		field, pl := iter.Current()
+		plIter := pl.Iterator()
+		for plIter.Next() {
+			pID := plIter.Current()
+			doc, err := b.Doc(pID)
+			require.NoError(t, err)
+			found := checkValidPostingsListsForField(field, doc)
+			require.True(t, found)
+		}
+	}
+}
+
+func checkValidPostingsListsForField(
+	field []byte,
+	doc doc.Document,
+) bool {
+	found := false
+	for _, f := range doc.Fields {
+		if bytes.Equal(field, f.Name) {
+			found = true
+		}
+	}
+	return found
+}

--- a/src/m3ninx/index/segment/builder/multi_segments_field_postings_list_iter_test.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_field_postings_list_iter_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package builder
 
 import (
@@ -91,20 +111,21 @@ func TestFieldPostingsListIterFromSegments(t *testing.T) {
 	require.NoError(t, builder.AddSegments(segments))
 	iter, err := b.FieldsPostingsList()
 	require.NoError(t, err)
+	// Perform both present/not present checks per field/field postings list.
 	for iter.Next() {
 		field, pl := iter.Current()
-		plIter := pl.Iterator()
-		for plIter.Next() {
-			pID := plIter.Current()
-			doc, err := b.Doc(pID)
-			require.NoError(t, err)
-			found := checkValidPostingsListsForField(field, doc)
-			require.True(t, found)
+		docIter, err := b.AllDocs()
+		require.NoError(t, err)
+		for docIter.Next() {
+			doc := docIter.Current()
+			pID := docIter.PostingsID()
+			found := checkIfFieldExistsInDoc(field, doc)
+			require.Equal(t, found, pl.Contains(pID))
 		}
 	}
 }
 
-func checkValidPostingsListsForField(
+func checkIfFieldExistsInDoc(
 	field []byte,
 	doc doc.Document,
 ) bool {

--- a/src/m3ninx/index/segment/builder/multi_segments_multi_key_postings_list_iter.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_multi_key_postings_list_iter.go
@@ -122,13 +122,10 @@ func (i *multiKeyPostingsListIterator) Next() bool {
 
 	// NB(bodu): Build the postings list for this field if the field has changed.
 	defer func() {
-		for _, reader := range i.currReaders {
+		for idx, reader := range i.currReaders {
 			if err := reader.Close(); err != nil {
 				i.err = err
 			}
-		}
-
-		for idx := range i.currReaders {
 			i.currReaders[idx] = nil
 		}
 		i.currReaders = i.currReaders[:0]

--- a/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go
@@ -174,7 +174,10 @@ func (i *termsIterFromSegments) Next() bool {
 				continue
 			}
 			value := curr + termsKeyIter.segment.offset - negativeOffset
-			_ = i.currPostingsList.Insert(value)
+			if err := i.currPostingsList.Insert(value); err != nil {
+				i.err = err
+				return false
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Need to account for negative/positive offsets when building per field postings lists from multiple segments.

Also adds a test to verify that per field postings lists built from multiple segments is correct.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
