### PR TITLE
[query] Fix query limit metrics reporting not starting at startup

### DIFF
--- a/scripts/development/m3_stack/docker-compose.yml
+++ b/scripts/development/m3_stack/docker-compose.yml
@@ -90,8 +90,9 @@ services:
       dockerfile: ./docker/m3coordinator/development.Dockerfile
     image: m3coordinator:dev
     volumes:
-      # Use a path in the bin directory (gitignored) to easily change configs
-      - "../../../bin/m3coordinator.yml:/etc/m3coordinator/m3coordinator.yml"
+      # Use a git ignored path to easily change pre-set configs.
+      # Note: Use ".tmp" suffix is git ignored.
+      - "./m3coordinator.yml.tmp:/etc/m3coordinator/m3coordinator.yml"
       - "./schema.proto:/etc/m3coordinator/schema.proto"
   m3collector01:
     expose:

--- a/scripts/development/m3_stack/start_m3.sh
+++ b/scripts/development/m3_stack/start_m3.sh
@@ -52,7 +52,8 @@ else
 fi
 
 # Use standard coordinator config when bringing up coordinator first time
-cp ./m3coordinator-standard.yml ${RELATIVE}/bin/m3coordinator.yml
+# Note: Use ".tmp" suffix to be git ignored.
+cp ./m3coordinator-standard.yml ./m3coordinator.yml.tmp
 
 if [[ "$M3COORDINATOR_DEV_IMG" == "0" ]] || [[ "$FORCE_BUILD" == true ]] || [[ "$BUILD_M3COORDINATOR" == true ]]; then
     prepare_build_cmd "make m3coordinator-linux-amd64"
@@ -298,7 +299,9 @@ if [[ "$USE_AGGREGATOR" = true ]]; then
 
     # Restart with aggregator coordinator config
     docker-compose -f docker-compose.yml stop m3coordinator01
-    cp ./m3coordinator-aggregator.yml ${RELATIVE}/bin/m3coordinator.yml
+
+    # Note: Use ".tmp" suffix to be git ignored.
+    cp ./m3coordinator-aggregator.yml ./m3coordinator.yml.tmp
     docker-compose -f docker-compose.yml up $DOCKER_ARGS m3coordinator01
 
     # May not necessarily flush

--- a/src/query/server/cost_reporters_test.go
+++ b/src/query/server/cost_reporters_test.go
@@ -103,7 +103,7 @@ func TestNewConfiguredChainedEnforcer(t *testing.T) {
 		assertHasGauge(t,
 			tctx.Scope.Snapshot(),
 			tally.KeyForPrefixedStringMap(
-				fmt.Sprintf("cost.global.%s", datapointsMetric), nil),
+				fmt.Sprintf("cost.reporter.%s", datapointsMetric), map[string]string{"limiter": "global"}),
 			7,
 		)
 
@@ -113,7 +113,7 @@ func TestNewConfiguredChainedEnforcer(t *testing.T) {
 		assertHasHistogram(t,
 			tctx.Scope.Snapshot(),
 			tally.KeyForPrefixedStringMap(
-				fmt.Sprintf("cost.per_query.%s", maxDatapointsHistMetric), nil),
+				fmt.Sprintf("cost.reporter.%s", maxDatapointsHistMetric), map[string]string{"limiter": "query"}),
 			map[float64]int64{10: 1},
 		)
 	})
@@ -135,7 +135,7 @@ func TestNewConfiguredChainedEnforcer(t *testing.T) {
 		test.AssertLimitErrorWithMsg(
 			t,
 			r.Error,
-			"exceeded query limit: limits.perQuery.maxFetchedDatapoints exceeded",
+			"exceeded query limit: exceeded limits.perQuery.maxFetchedDatapoints",
 			6,
 			6)
 
@@ -146,7 +146,7 @@ func TestNewConfiguredChainedEnforcer(t *testing.T) {
 		test.AssertLimitErrorWithMsg(
 			t,
 			r.Error,
-			"exceeded global limit: limits.global.maxFetchedDatapoints exceeded",
+			"exceeded global limit: exceeded limits.global.maxFetchedDatapoints",
 			11,
 			10)
 

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -31,7 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	clusterclient "github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/kv"
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
@@ -47,16 +46,19 @@ import (
 	rpc "github.com/m3db/m3/src/query/generated/proto/rpcpb"
 	"github.com/m3db/m3/src/query/storage/m3"
 	xclock "github.com/m3db/m3/src/x/clock"
+	"github.com/m3db/m3/src/x/close"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/serialize"
 	xtest "github.com/m3db/m3/src/x/test"
-	"go.uber.org/atomic"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/atomic"
 	"google.golang.org/grpc"
 )
 
@@ -510,7 +512,12 @@ func TestNewPerQueryEnforcer(t *testing.T) {
 		Global cost.ChainedEnforcer
 		Query  cost.ChainedEnforcer
 		Block  cost.ChainedEnforcer
+		Closer close.SimpleCloser
 	}
+
+	scope := tally.NewTestScope("", nil)
+	instrumentOpts := instrument.NewTestOptions(t).
+		SetMetricsScope(scope)
 
 	setup := func(t *testing.T, globalLimit, queryLimit int) testContext {
 		cfg := &config.Configuration{
@@ -524,7 +531,7 @@ func TestNewPerQueryEnforcer(t *testing.T) {
 			},
 		}
 
-		global, err := newConfiguredChainedEnforcer(cfg, instrument.NewOptions())
+		global, closer, err := newConfiguredChainedEnforcer(cfg, instrumentOpts)
 		require.NoError(t, err)
 
 		queryLvl := global.Child(cost.QueryLevel)
@@ -534,13 +541,15 @@ func TestNewPerQueryEnforcer(t *testing.T) {
 			Global: global,
 			Query:  queryLvl,
 			Block:  blockLvl,
+			Closer: closer,
 		}
 	}
 
 	tctx := setup(t, 100, 10)
+	defer tctx.Closer.Close()
 
-	// spot check that limits are setup properly for each level
-	r := tctx.Block.Add(11)
+	// Spot check that limits are setup properly for each level.
+	r := tctx.Query.Add(11)
 	require.Error(t, r.Error)
 
 	floatsEqual := func(f1, f2 float64) {
@@ -555,6 +564,59 @@ func TestNewPerQueryEnforcer(t *testing.T) {
 	r, _ = tctx.Global.State()
 	floatsEqual(float64(r.Cost), 11)
 	require.NoError(t, r.Error)
+
+	// Check stats.
+	expectCounterValues := map[string]int64{
+		"cost.reporter.over_datapoints_limit+enabled=false,limiter=global": 0,
+		"cost.reporter.over_datapoints_limit+enabled=true,limiter=global":  0,
+		"cost.reporter.datapoints_counter+limiter=global":                  11,
+		"cost.reporter.over_datapoints_limit+enabled=false,limiter=query":  0,
+		"cost.reporter.over_datapoints_limit+enabled=true,limiter=query":   1,
+	}
+	expectGaugeValues := map[string]float64{
+		"cost.limits.threshold+limiter=global":    0,
+		"cost.limits.enabled+limiter=global":      0,
+		"cost.reporter.datapoints+limiter=global": 11,
+		"cost.limits.threshold+limiter=query":     0,
+		"cost.limits.enabled+limiter=query":       0,
+	}
+
+	snapshot := scope.Snapshot()
+	actualCounterValues := make(map[string]int64)
+	for k, v := range snapshot.Counters() {
+		actualCounterValues[k] = v.Value()
+
+		expected, ok := expectCounterValues[k]
+		if !ok {
+			continue
+		}
+
+		// Check match.
+		assert.Equal(t, expected, v.Value(),
+			fmt.Sprintf("stat mismatch: stat=%s", k))
+
+		delete(expectCounterValues, k)
+	}
+	assert.Equal(t, 0, len(expectCounterValues),
+		fmt.Sprintf("missing stats: %+v", expectCounterValues))
+
+	actualGaugeValues := make(map[string]float64)
+	for k, v := range snapshot.Gauges() {
+		actualGaugeValues[k] = v.Value()
+
+		expected, ok := expectGaugeValues[k]
+		if !ok {
+			continue
+		}
+
+		// Check match.
+		assert.Equal(t, expected, v.Value(),
+			fmt.Sprintf("stat mismatch: stat=%s", k))
+
+		delete(expectGaugeValues, k)
+	}
+	assert.Equal(t, 0, len(expectGaugeValues),
+		fmt.Sprintf("missing stats: %+v", expectGaugeValues))
 }
 
 var _ rpc.QueryServer = &queryServer{}

--- a/src/x/close/close.go
+++ b/src/x/close/close.go
@@ -37,9 +37,25 @@ type Closer interface {
 	io.Closer
 }
 
+// CloserFn implements the SimpleCloser interface.
+type CloserFn func() error
+
+// Close implements the SimplerCloser interface.
+func (fn CloserFn) Close() error {
+	return fn()
+}
+
 // SimpleCloser is a resource that can be closed without returning a result.
 type SimpleCloser interface {
 	Close()
+}
+
+// SimpleCloserFn implements the SimpleCloser interface.
+type SimpleCloserFn func()
+
+// Close implements the SimplerCloser interface.
+func (fn SimpleCloserFn) Close() {
+	fn()
 }
 
 // TryClose attempts to close a resource, the resource is expected to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
We had correctly registered the limit metrics (the global limit metrics at least, not per query limit metrics) but had not kicked off reporting after creating the limiters. This adds the kick off required to report metrics.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
