### PR TITLE
[ci] Temporarily disable kubeval validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,13 +107,13 @@ install-vendor-m3:
 
 # Some deps were causing panics when using GRPC and etcd libraries were used.
 # See issue: https://github.com/etcd-io/etcd/issues/9357
-# TODO: Move M3 to go mod to avoid the issue entirely instead of this hack 
+# TODO: Move M3 to go mod to avoid the issue entirely instead of this hack
 # (which is bad and we should feel bad).
 # $ go test -v
-# panic: /debug/requests is already registered. You may have two independent 
-# copies of golang.org/x/net/trace in your binary, trying to maintain separate 
+# panic: /debug/requests is already registered. You may have two independent
+# copies of golang.org/x/net/trace in your binary, trying to maintain separate
 # state. This may involve a vendored copy of golang.org/x/net/trace.
-# 
+#
 # goroutine 1 [running]:
 # github.com/m3db/m3/vendor/go.etcd.io/etcd/vendor/golang.org/x/net/trace.init.0()
 #         /Users/r/go/src/github.com/m3db/m3/vendor/go.etcd.io/etcd/vendor/golang.org/x/net/trace/trace.go:123 +0x1cd
@@ -323,15 +323,17 @@ test-ci-integration:
 
 define SUBDIR_RULES
 
+# Temporarily remove kube validation until we fix a dependency issue with
+# kubeval (one of its depenencies depends on go1.13).
+#
 # We override the rules for `*-gen-kube` to just generate the kube manifest
-# bundle.
-ifeq ($(SUBDIR), kube)
+# bundle. ifeq ($(SUBDIR), kube)
 
 # Builds the single kube bundle from individual manifest files.
-all-gen-kube: install-tools
-	@echo "--- Generating kube bundle"
-	@./kube/scripts/build_bundle.sh
-	find kube -name '*.yaml' -print0 | PATH=$(combined_bin_paths):$(PATH) xargs -0 kubeval -v=1.12.0
+# all-gen-kube: install-tools
+# 	@echo "--- Generating kube bundle"
+# 	@./kube/scripts/build_bundle.sh
+# 	find kube -name '*.yaml' -print0 | PATH=$(combined_bin_paths):$(PATH) xargs -0 kubeval -v=1.12.0
 
 else
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ SUBDIRS :=    \
 	m3ninx      \
 	aggregator  \
 	ctl         \
-	# Disabled during kubeval dependency issue
+	# Disabled during kubeval dependency issue https://github.com/m3db/m3/issues/2220
 	# kube        \
 
 TOOLS :=               \
@@ -326,9 +326,11 @@ define SUBDIR_RULES
 
 # Temporarily remove kube validation until we fix a dependency issue with
 # kubeval (one of its depenencies depends on go1.13).
+# https://github.com/m3db/m3/issues/2220
 #
 # We override the rules for `*-gen-kube` to just generate the kube manifest
-# bundle. ifeq ($(SUBDIR), kube)
+# bundle.
+# ifeq ($(SUBDIR), kube)
 
 # Builds the single kube bundle from individual manifest files.
 # all-gen-kube: install-tools

--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ define SUBDIR_RULES
 # 	@./kube/scripts/build_bundle.sh
 # 	find kube -name '*.yaml' -print0 | PATH=$(combined_bin_paths):$(PATH) xargs -0 kubeval -v=1.12.0
 
-else
+# else
 
 .PHONY: mock-gen-$(SUBDIR)
 mock-gen-$(SUBDIR): install-tools

--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,8 @@ metalint-$(SUBDIR): install-gometalinter install-linter-badtime install-linter-i
 	@(PATH=$(combined_bin_paths):$(PATH) $(metalint_check) \
 		$(metalint_config) $(metalint_exclude) src/$(SUBDIR))
 
-endif
+# endif kubeval
+# endif
 
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,8 @@ SUBDIRS :=    \
 	m3ninx      \
 	aggregator  \
 	ctl         \
-	kube        \
+	# Disabled during kubeval dependency issue
+	# kube        \
 
 TOOLS :=               \
 	read_ids             \

--- a/tools.json
+++ b/tools.json
@@ -37,10 +37,6 @@
       "Commit": "19b88da8fc15428620782ba18f68423130e7ac7d"
     },
     {
-      "Repository": "github.com/garethr/kubeval",
-      "Commit": "c44f5193dc944abc00e60a1b041ce48b0ae03dfb"
-    },
-    {
       "Repository": "github.com/google/go-jsonnet/cmd/jsonnet",
       "Commit": "71a3e169581ece942e77bfc47840a806eb868ca8"
     }


### PR DESCRIPTION
Kubeval depends on `hashicorp/go-multierror`, which now depends on
go1.13 error methods.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
