### PR TITLE
ShardTimeRanges AddRanges Clone if Not Exists

### DIFF
--- a/src/dbnode/storage/bootstrap/result/shard_ranges.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges.go
@@ -138,9 +138,8 @@ func (r shardTimeRanges) AddRanges(other ShardTimeRanges) {
 		}
 		if existing, ok := r[shard]; ok {
 			existing.AddRanges(ranges)
-			r[shard] = existing
 		} else {
-			r[shard] = ranges
+			r[shard] = ranges.Clone()
 		}
 	}
 }

--- a/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
@@ -1,0 +1,29 @@
+package result
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardTimeRangesAdd(t *testing.T) {
+	start := time.Now().Truncate(testBlockSize)
+	times := []time.Time{start, start.Add(testBlockSize), start.Add(2 * testBlockSize), start.Add(3 * testBlockSize)}
+
+	sr := []ShardTimeRanges{
+		NewShardTimeRangesFromRange(times[0], times[1], 1, 2, 3),
+		NewShardTimeRangesFromRange(times[1], times[2], 1, 2, 3),
+		NewShardTimeRangesFromRange(times[2], times[3], 1, 2, 3),
+	}
+	ranges := NewShardTimeRanges()
+	for _, r := range sr {
+		ranges.AddRanges(r)
+	}
+	for i, r := range sr {
+		min, max, r := r.MinMaxRange()
+		require.Equal(t, r, testBlockSize)
+		require.Equal(t, min, times[i])
+		require.Equal(t, max, times[i+1])
+	}
+}

--- a/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package result
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
ShardTimeRanges `AddRanges` must clone the shard ranges if it does not exist before setting the ranges for the shard.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
