### PR TITLE
[query] Fix offset fetching too much data

### DIFF
--- a/src/query/plan/physical.go
+++ b/src/query/plan/physical.go
@@ -97,8 +97,8 @@ func (p PhysicalPlan) shiftTime() PhysicalPlan {
 		}
 
 		spec := boundOp.Bounds()
-		if spec.Offset+p.LookbackDuration > maxOffset {
-			maxOffset = spec.Offset + p.LookbackDuration
+		if p.LookbackDuration > maxOffset {
+			maxOffset = p.LookbackDuration
 		}
 
 		if spec.Range > maxRange {

--- a/src/query/plan/physical_test.go
+++ b/src/query/plan/physical_test.go
@@ -98,6 +98,6 @@ func TestShiftTime(t *testing.T) {
 	p, err = NewPhysicalPlan(lp, params)
 	require.NoError(t, err)
 	assert.Equal(t, params.Start.
-		Add(-1*(time.Minute+time.Hour+defaultLookbackDuration)), p.TimeSpec.Start,
+		Add(-1*(time.Hour+defaultLookbackDuration)), p.TimeSpec.Start,
 		"start time offset by fetch")
 }


### PR DESCRIPTION
The offset was applied to series start twice; once in physical plan (removed here), then again on query execution. What this did was fetch the range [ `start-offset*2`-`end-offset` ] rather than [ `start-offset`-`end-offset` ]

The data would then be removed before values are returned, but this may cause a lot of additional data with large offsets