### PR TITLE
[dbnode] Cleanup duplicate index segments from disk

### DIFF
--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -830,9 +830,10 @@ func ReadInfoFiles(
 
 // ReadIndexInfoFileResult is the result of reading an info file
 type ReadIndexInfoFileResult struct {
-	ID   FileSetFileIdentifier
-	Info index.IndexVolumeInfo
-	Err  ReadInfoFileResultError
+	ID         FileSetFileIdentifier
+	Info       index.IndexVolumeInfo
+	PathPrefix string // fs path prefix for all files in this fileset.
+	Err        ReadInfoFileResultError
 }
 
 // ReadIndexInfoFiles reads all the valid index info entries. Even if ReadIndexInfoFiles returns an error,
@@ -855,8 +856,9 @@ func ReadIndexInfoFiles(
 			var info index.IndexVolumeInfo
 			err := info.Unmarshal(data)
 			infoFileResults = append(infoFileResults, ReadIndexInfoFileResult{
-				ID:   id,
-				Info: info,
+				ID:         id,
+				Info:       info,
+				PathPrefix: fmt.Sprintf("%s*", pathPrefixFromIndexInfoFilePath(filepath)),
 				Err: readInfoFileResultError{
 					err:      err,
 					filepath: filepath,
@@ -1714,4 +1716,8 @@ func snapshotMetadataIdentifierFromFilePath(filePath string) (SnapshotMetadataId
 		Index: index,
 		UUID:  id,
 	}, nil
+}
+
+func pathPrefixFromIndexInfoFilePath(path string) string {
+	return strings.Split(path, fmt.Sprintf("%s%s", infoFileSuffix, fileSuffix))[0]
 }

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -1720,7 +1720,3 @@ func snapshotMetadataIdentifierFromFilePath(filePath string) (SnapshotMetadataId
 		UUID:  id,
 	}, nil
 }
-
-func pathPrefixFromIndexInfoFilePath(path string) string {
-	return strings.Split(path, fmt.Sprintf("%s%s", infoFileSuffix, fileSuffix))[0]
-}

--- a/src/dbnode/persist/fs/files_test.go
+++ b/src/dbnode/persist/fs/files_test.go
@@ -203,7 +203,8 @@ func TestForEachInfoFile(t *testing.T) {
 			shard:          shard,
 		},
 		testReaderBufferSize,
-		func(fname string, _ FileSetFileIdentifier, data []byte) {
+		func(file FileSetFile, data []byte) {
+			fname := file.AbsoluteFilepaths[0]
 			fnames = append(fnames, fname)
 			res = append(res, data...)
 		})

--- a/src/dbnode/persist/fs/on_disk_segments.go
+++ b/src/dbnode/persist/fs/on_disk_segments.go
@@ -21,7 +21,6 @@
 package fs
 
 import (
-	"path/filepath"
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/generated/proto/index"
@@ -31,7 +30,7 @@ import (
 )
 
 type onDiskSegments struct {
-	pathPrefixPattern string
+	absoluteFilepaths []string
 	shardRanges       result.ShardTimeRanges
 	volumeType        idxpersist.IndexVolumeType
 }
@@ -39,7 +38,7 @@ type onDiskSegments struct {
 // NewOnDiskSegments returns an on disk segments for an index info file.
 func NewOnDiskSegments(
 	info index.IndexVolumeInfo,
-	pathPrefixPattern string,
+	absoluteFilepaths []string,
 ) OnDiskSegments {
 	sr := result.NewShardTimeRanges()
 	indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
@@ -62,7 +61,7 @@ func NewOnDiskSegments(
 	return &onDiskSegments{
 		shardRanges:       sr,
 		volumeType:        volumeType,
-		pathPrefixPattern: pathPrefixPattern,
+		absoluteFilepaths: absoluteFilepaths,
 	}
 }
 
@@ -74,10 +73,6 @@ func (o *onDiskSegments) VolumeType() idxpersist.IndexVolumeType {
 	return o.volumeType
 }
 
-func (o *onDiskSegments) AbsolutePaths() ([]string, error) {
-	files, err := filepath.Glob(o.pathPrefixPattern)
-	if err != nil {
-		return nil, err
-	}
-	return files, nil
+func (o *onDiskSegments) AbsoluteFilepaths() []string {
+	return o.absoluteFilepaths
 }

--- a/src/dbnode/persist/fs/on_disk_segments.go
+++ b/src/dbnode/persist/fs/on_disk_segments.go
@@ -33,11 +33,13 @@ type onDiskSegments struct {
 	absoluteFilepaths []string
 	shardRanges       result.ShardTimeRanges
 	volumeType        idxpersist.IndexVolumeType
+	volumeIndex       int
 }
 
 // NewOnDiskSegments returns an on disk segments for an index info file.
 func NewOnDiskSegments(
 	info index.IndexVolumeInfo,
+	volumeIndex int,
 	absoluteFilepaths []string,
 ) OnDiskSegments {
 	sr := result.NewShardTimeRanges()
@@ -61,6 +63,7 @@ func NewOnDiskSegments(
 	return &onDiskSegments{
 		shardRanges:       sr,
 		volumeType:        volumeType,
+		volumeIndex:       volumeIndex,
 		absoluteFilepaths: absoluteFilepaths,
 	}
 }
@@ -75,4 +78,8 @@ func (o *onDiskSegments) VolumeType() idxpersist.IndexVolumeType {
 
 func (o *onDiskSegments) AbsoluteFilepaths() []string {
 	return o.absoluteFilepaths
+}
+
+func (o *onDiskSegments) VolumeIndex() int {
+	return o.volumeIndex
 }

--- a/src/dbnode/persist/fs/on_disk_segments.go
+++ b/src/dbnode/persist/fs/on_disk_segments.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2020 Uber Technologies, Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE
+
+package fs
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/generated/proto/index"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	idxpersist "github.com/m3db/m3/src/m3ninx/persist"
+	xtime "github.com/m3db/m3/src/x/time"
+)
+
+type onDiskSegments struct {
+	pathPrefixPattern string
+	shardRanges       result.ShardTimeRanges
+	volumeType        idxpersist.IndexVolumeType
+}
+
+// NewOnDiskSegments returns an on disk segments for an index info file.
+func NewOnDiskSegments(
+	info index.IndexVolumeInfo,
+	pathPrefixPattern string,
+) OnDiskSegments {
+	sr := result.NewShardTimeRanges()
+	indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
+	indexBlockRange := xtime.Range{
+		Start: indexBlockStart,
+		End:   indexBlockStart.Add(time.Duration(info.BlockSize)),
+	}
+	for _, shard := range info.Shards {
+		ranges, ok := sr.Get(shard)
+		if !ok {
+			ranges = xtime.NewRanges()
+			sr.Set(shard, ranges)
+		}
+		ranges.AddRange(indexBlockRange)
+	}
+	volumeType := idxpersist.DefaultIndexVolumeType
+	if info.IndexVolumeType != nil {
+		volumeType = idxpersist.IndexVolumeType(info.IndexVolumeType.Value)
+	}
+	return &onDiskSegments{
+		shardRanges:       sr,
+		volumeType:        volumeType,
+		pathPrefixPattern: pathPrefixPattern,
+	}
+}
+
+func (o *onDiskSegments) ShardTimeRanges() result.ShardTimeRanges {
+	return o.shardRanges
+}
+
+func (o *onDiskSegments) VolumeType() idxpersist.IndexVolumeType {
+	return o.volumeType
+}
+
+func (o *onDiskSegments) AbsolutePaths() ([]string, error) {
+	files, err := filepath.Glob(o.pathPrefixPattern)
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}

--- a/src/dbnode/persist/fs/segments.go
+++ b/src/dbnode/persist/fs/segments.go
@@ -29,19 +29,19 @@ import (
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
-type onDiskSegments struct {
+type segments struct {
 	absoluteFilepaths []string
 	shardRanges       result.ShardTimeRanges
 	volumeType        idxpersist.IndexVolumeType
 	volumeIndex       int
 }
 
-// NewOnDiskSegments returns an on disk segments for an index info file.
-func NewOnDiskSegments(
+// NewSegments returns an on disk segments for an index info file.
+func NewSegments(
 	info index.IndexVolumeInfo,
 	volumeIndex int,
 	absoluteFilepaths []string,
-) OnDiskSegments {
+) Segments {
 	sr := result.NewShardTimeRanges()
 	indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
 	indexBlockRange := xtime.Range{
@@ -60,7 +60,7 @@ func NewOnDiskSegments(
 	if info.IndexVolumeType != nil {
 		volumeType = idxpersist.IndexVolumeType(info.IndexVolumeType.Value)
 	}
-	return &onDiskSegments{
+	return &segments{
 		shardRanges:       sr,
 		volumeType:        volumeType,
 		volumeIndex:       volumeIndex,
@@ -68,18 +68,18 @@ func NewOnDiskSegments(
 	}
 }
 
-func (o *onDiskSegments) ShardTimeRanges() result.ShardTimeRanges {
+func (o *segments) ShardTimeRanges() result.ShardTimeRanges {
 	return o.shardRanges
 }
 
-func (o *onDiskSegments) VolumeType() idxpersist.IndexVolumeType {
+func (o *segments) VolumeType() idxpersist.IndexVolumeType {
 	return o.volumeType
 }
 
-func (o *onDiskSegments) AbsoluteFilepaths() []string {
+func (o *segments) AbsoluteFilepaths() []string {
 	return o.absoluteFilepaths
 }
 
-func (o *onDiskSegments) VolumeIndex() int {
+func (o *segments) VolumeIndex() int {
 	return o.volumeIndex
 }

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -562,8 +562,8 @@ type NewMergerFn func(
 	nsOpts namespace.Options,
 ) Merger
 
-// OnDiskSegments represents on index segments on disk for an index volume.
-type OnDiskSegments interface {
+// Segments represents on index segments on disk for an index volume.
+type Segments interface {
 	ShardTimeRanges() result.ShardTimeRanges
 	VolumeType() idxpersist.IndexVolumeType
 	VolumeIndex() int

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -566,5 +566,6 @@ type NewMergerFn func(
 type OnDiskSegments interface {
 	ShardTimeRanges() result.ShardTimeRanges
 	VolumeType() idxpersist.IndexVolumeType
+	VolumeIndex() int
 	AbsoluteFilepaths() []string
 }

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/msgpack"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/block"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	"github.com/m3db/m3/src/m3ninx/index/segment/fst"
 	idxpersist "github.com/m3db/m3/src/m3ninx/persist"
@@ -560,3 +561,10 @@ type NewMergerFn func(
 	contextPool context.Pool,
 	nsOpts namespace.Options,
 ) Merger
+
+// OnDiskSegments represents on index segments on disk for an index volume.
+type OnDiskSegments interface {
+	ShardTimeRanges() result.ShardTimeRanges
+	VolumeType() idxpersist.IndexVolumeType
+	AbsolutePaths() ([]string, error)
+}

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -566,5 +566,5 @@ type NewMergerFn func(
 type OnDiskSegments interface {
 	ShardTimeRanges() result.ShardTimeRanges
 	VolumeType() idxpersist.IndexVolumeType
-	AbsolutePaths() ([]string, error)
+	AbsoluteFilepaths() []string
 }

--- a/src/dbnode/persist/schema/types.go
+++ b/src/dbnode/persist/schema/types.go
@@ -22,7 +22,6 @@ package schema
 
 import (
 	"github.com/m3db/m3/src/dbnode/persist"
-	idxpersist "github.com/m3db/m3/src/m3ninx/persist"
 )
 
 // MajorVersion is the major schema version for a set of fileset files,
@@ -32,17 +31,16 @@ const MajorVersion = 1
 
 // IndexInfo stores metadata information about block filesets
 type IndexInfo struct {
-	MajorVersion    int64
-	BlockStart      int64
-	BlockSize       int64
-	Entries         int64
-	Summaries       IndexSummariesInfo
-	BloomFilter     IndexBloomFilterInfo
-	SnapshotTime    int64
-	FileType        persist.FileSetType
-	SnapshotID      []byte
-	VolumeIndex     int
-	IndexVolumeType idxpersist.IndexVolumeType
+	MajorVersion int64
+	BlockStart   int64
+	BlockSize    int64
+	Entries      int64
+	Summaries    IndexSummariesInfo
+	BloomFilter  IndexBloomFilterInfo
+	SnapshotTime int64
+	FileType     persist.FileSetType
+	SnapshotID   []byte
+	VolumeIndex  int
 }
 
 // IndexSummariesInfo stores metadata about the summaries

--- a/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
@@ -47,3 +47,31 @@ func TestShardTimeRangesAdd(t *testing.T) {
 		require.Equal(t, max, times[i+1])
 	}
 }
+
+func TestShardTimeRangesIsSuperset(t *testing.T) {
+	start := time.Now().Truncate(testBlockSize)
+	times := []time.Time{start, start.Add(testBlockSize), start.Add(2 * testBlockSize), start.Add(3 * testBlockSize)}
+
+	sr1 := []ShardTimeRanges{
+		NewShardTimeRangesFromRange(times[0], times[1], 1, 2, 3),
+		NewShardTimeRangesFromRange(times[1], times[2], 1, 2, 3),
+		NewShardTimeRangesFromRange(times[2], times[3], 1, 2, 3),
+	}
+	ranges1 := NewShardTimeRanges()
+	for _, r := range sr1 {
+		ranges1.AddRanges(r)
+	}
+	sr2 := []ShardTimeRanges{
+		NewShardTimeRangesFromRange(times[0], times[1], 2),
+		NewShardTimeRangesFromRange(times[1], times[2], 1, 2),
+		NewShardTimeRangesFromRange(times[2], times[3], 1),
+	}
+	ranges2 := NewShardTimeRanges()
+	for _, r := range sr2 {
+		ranges2.AddRanges(r)
+	}
+
+	require.True(t, ranges1.IsSuperset(ranges2))
+	require.False(t, ranges2.IsSuperset(ranges1))
+	require.True(t, ranges1.IsSuperset(ranges1))
+}

--- a/src/dbnode/storage/bootstrap/result/types.go
+++ b/src/dbnode/storage/bootstrap/result/types.go
@@ -147,6 +147,10 @@ type ShardTimeRanges interface {
 
 	Copy() ShardTimeRanges
 
+	// IsSuperset returns whether the current shard time ranges are a
+	// superset of the other shard time ranges.
+	IsSuperset(other ShardTimeRanges) bool
+
 	// Equal returns whether two shard time ranges are equal.
 	Equal(other ShardTimeRanges) bool
 

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -122,7 +122,7 @@ func newCleanupManager(
 	}
 }
 
-func (m *cleanupManager) Cleanup(t time.Time) error {
+func (m *cleanupManager) Cleanup(t time.Time, isBootstrapped bool) error {
 	m.Lock()
 	m.cleanupInProgress = true
 	m.Unlock()
@@ -149,7 +149,7 @@ func (m *cleanupManager) Cleanup(t time.Time) error {
 			"encountered errors when cleaning up index files for %v: %v", t, err))
 	}
 
-	if err := m.cleanupDuplicateIndexFiles(namespaces); err != nil {
+	if err := m.cleanupDuplicateIndexFiles(namespaces, isBootstrapped); err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
 			"encountered errors when cleaning up index files for %v: %v", t, err))
 	}
@@ -259,7 +259,12 @@ func (m *cleanupManager) cleanupExpiredIndexFiles(t time.Time, namespaces []data
 	return multiErr.FinalError()
 }
 
-func (m *cleanupManager) cleanupDuplicateIndexFiles(namespaces []databaseNamespace) error {
+func (m *cleanupManager) cleanupDuplicateIndexFiles(namespaces []databaseNamespace, isBootstrapped bool) error {
+	// NB(bodu): Do not cleanup duplicate index files while we are bootstrapping since bootrapping and removing
+	// files from disk is racy if performed concurrently.
+	if !isBootstrapped {
+		return nil
+	}
 	multiErr := xerrors.NewMultiError()
 	for _, n := range namespaces {
 		if !n.Options().CleanupEnabled() || !n.Options().IndexOptions().Enabled() {

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -270,7 +270,7 @@ func (m *cleanupManager) cleanupDuplicateIndexFiles(namespaces []databaseNamespa
 		if !n.Options().CleanupEnabled() || !n.Options().IndexOptions().Enabled() {
 			continue
 		}
-		idx, err := n.GetIndex()
+		idx, err := n.Index()
 		if err != nil {
 			multiErr = multiErr.Add(err)
 			continue

--- a/src/dbnode/storage/cleanup_test.go
+++ b/src/dbnode/storage/cleanup_test.go
@@ -351,7 +351,7 @@ func TestCleanupManagerNamespaceCleanupBootstrapped(t *testing.T) {
 	ns.EXPECT().OwnedShards().Return(nil).AnyTimes()
 
 	idx := NewMockNamespaceIndex(ctrl)
-	ns.EXPECT().Index().Return(idx, nil)
+	ns.EXPECT().Index().Times(2).Return(idx, nil)
 
 	nses := []databaseNamespace{ns}
 	db := newMockdatabase(ctrl, ns)

--- a/src/dbnode/storage/cleanup_test.go
+++ b/src/dbnode/storage/cleanup_test.go
@@ -329,7 +329,7 @@ func TestCleanupManagerCleanupCommitlogsAndSnapshots(t *testing.T) {
 	}
 }
 
-func TestCleanupManagerNamespaceCleanup(t *testing.T) {
+func TestCleanupManagerNamespaceCleanupBootstrapped(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
@@ -359,7 +359,41 @@ func TestCleanupManagerNamespaceCleanup(t *testing.T) {
 
 	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 	idx.EXPECT().CleanupExpiredFileSets(ts).Return(nil)
+	idx.EXPECT().CleanupDuplicateFileSets().Return(nil)
 	require.NoError(t, mgr.Cleanup(ts, true))
+}
+
+func TestCleanupManagerNamespaceCleanupNotBootstrapped(t *testing.T) {
+	ctrl := gomock.NewController(xtest.Reporter{T: t})
+	defer ctrl.Finish()
+
+	ts := timeFor(36000)
+	rOpts := retentionOptions.
+		SetRetentionPeriod(21600 * time.Second).
+		SetBlockSize(3600 * time.Second)
+	nsOpts := namespaceOptions.
+		SetRetentionOptions(rOpts).
+		SetCleanupEnabled(true).
+		SetIndexOptions(namespace.NewIndexOptions().
+			SetEnabled(true).
+			SetBlockSize(7200 * time.Second))
+
+	ns := NewMockdatabaseNamespace(ctrl)
+	ns.EXPECT().ID().Return(ident.StringID("ns")).AnyTimes()
+	ns.EXPECT().Options().Return(nsOpts).AnyTimes()
+	ns.EXPECT().NeedsFlush(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
+	ns.EXPECT().OwnedShards().Return(nil).AnyTimes()
+
+	idx := NewMockNamespaceIndex(ctrl)
+	ns.EXPECT().Index().Return(idx, nil)
+
+	nses := []databaseNamespace{ns}
+	db := newMockdatabase(ctrl, ns)
+	db.EXPECT().OwnedNamespaces().Return(nses, nil).AnyTimes()
+
+	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
+	idx.EXPECT().CleanupExpiredFileSets(ts).Return(nil)
+	require.NoError(t, mgr.Cleanup(ts, false))
 }
 
 // Test NS doesn't cleanup when flag is present

--- a/src/dbnode/storage/cleanup_test.go
+++ b/src/dbnode/storage/cleanup_test.go
@@ -317,7 +317,7 @@ func TestCleanupManagerCleanupCommitlogsAndSnapshots(t *testing.T) {
 				return nil
 			}
 
-			err := mgr.Cleanup(ts)
+			err := mgr.Cleanup(ts, true)
 			if tc.expectErr {
 				require.Error(t, err)
 			} else {
@@ -359,7 +359,7 @@ func TestCleanupManagerNamespaceCleanup(t *testing.T) {
 
 	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 	idx.EXPECT().CleanupExpiredFileSets(ts).Return(nil)
-	require.NoError(t, mgr.Cleanup(ts))
+	require.NoError(t, mgr.Cleanup(ts, true))
 }
 
 // Test NS doesn't cleanup when flag is present
@@ -392,7 +392,7 @@ func TestCleanupManagerDoesntNeedCleanup(t *testing.T) {
 		return nil
 	}
 
-	require.NoError(t, mgr.Cleanup(ts))
+	require.NoError(t, mgr.Cleanup(ts, true))
 }
 
 func TestCleanupDataAndSnapshotFileSetFiles(t *testing.T) {
@@ -418,7 +418,7 @@ func TestCleanupDataAndSnapshotFileSetFiles(t *testing.T) {
 	db.EXPECT().OwnedNamespaces().Return(namespaces, nil).AnyTimes()
 	mgr := newCleanupManager(db, newNoopFakeActiveLogs(), tally.NoopScope).(*cleanupManager)
 
-	require.NoError(t, mgr.Cleanup(ts))
+	require.NoError(t, mgr.Cleanup(ts, true))
 }
 
 type deleteInactiveDirectoriesCall struct {
@@ -457,7 +457,7 @@ func TestDeleteInactiveDataAndSnapshotFileSetFiles(t *testing.T) {
 	}
 	mgr.deleteInactiveDirectoriesFn = deleteInactiveDirectoriesFn
 
-	require.NoError(t, mgr.Cleanup(ts))
+	require.NoError(t, mgr.Cleanup(ts, true))
 
 	expectedCalls := []deleteInactiveDirectoriesCall{
 		deleteInactiveDirectoriesCall{
@@ -502,7 +502,7 @@ func TestCleanupManagerPropagatesOwnedNamespacesError(t *testing.T) {
 	require.NoError(t, db.Open())
 	require.NoError(t, db.Terminate())
 
-	require.Error(t, mgr.Cleanup(ts))
+	require.Error(t, mgr.Cleanup(ts, true))
 }
 
 func timeFor(s int64) time.Time {

--- a/src/dbnode/storage/fs.go
+++ b/src/dbnode/storage/fs.go
@@ -158,7 +158,7 @@ func (m *fileSystemManager) Run(
 		// and not caught in CI or integration tests.
 		// When an invariant occurs in CI tests it panics so as to fail
 		// the build.
-		if err := m.Cleanup(t); err != nil {
+		if err := m.Cleanup(t, m.database.IsBootstrapped()); err != nil {
 			instrument.EmitAndLogInvariantViolation(m.opts.InstrumentOptions(),
 				func(l *zap.Logger) {
 					l.Error("error when cleaning up data", zap.Time("time", t), zap.Error(err))

--- a/src/dbnode/storage/fs_test.go
+++ b/src/dbnode/storage/fs_test.go
@@ -85,7 +85,7 @@ func TestFileSystemManagerRun(t *testing.T) {
 
 	ts := time.Now()
 	gomock.InOrder(
-		cm.EXPECT().Cleanup(ts).Return(errors.New("foo")),
+		cm.EXPECT().Cleanup(ts, true).Return(errors.New("foo")),
 		fm.EXPECT().Flush(ts).Return(errors.New("bar")),
 	)
 

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1537,7 +1537,7 @@ func (i *nsIndex) CleanupDuplicateFileSets() error {
 	)
 	onDiskSegmentsOrderByVolumeIndexByVolumeType := make(map[idxpersist.IndexVolumeType][]fs.OnDiskSegments)
 	for _, file := range infoFiles {
-		seg := fs.NewOnDiskSegments(file.Info, file.PathPrefix)
+		seg := fs.NewOnDiskSegments(file.Info, file.AbsoluteFilepaths)
 		volumeType := seg.VolumeType()
 		if _, ok := onDiskSegmentsOrderByVolumeIndexByVolumeType[volumeType]; !ok {
 			onDiskSegmentsOrderByVolumeIndexByVolumeType[volumeType] = make([]fs.OnDiskSegments, 0)
@@ -1554,11 +1554,7 @@ func (i *nsIndex) CleanupDuplicateFileSets() error {
 			if seg.ShardTimeRanges().IsSuperset(shardTimeRangesCovered) {
 				// Mark dupe segments for deletion.
 				for _, currSeg := range currOnDiskSegments {
-					files, err := currSeg.AbsolutePaths()
-					if err != nil {
-						multiErr = multiErr.Add(err)
-					}
-					filesToDelete = append(filesToDelete, files...)
+					filesToDelete = append(filesToDelete, currSeg.AbsoluteFilepaths()...)
 				}
 				currOnDiskSegments = []fs.OnDiskSegments{seg}
 				shardTimeRangesCovered = seg.ShardTimeRanges()

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1535,15 +1535,24 @@ func (i *nsIndex) CleanupDuplicateFileSets() error {
 		i.nsMetadata.ID(),
 		fsOpts.InfoReaderBufferSize(),
 	)
+
 	onDiskSegmentsOrderByVolumeIndexByVolumeType := make(map[idxpersist.IndexVolumeType][]fs.OnDiskSegments)
 	for _, file := range infoFiles {
-		seg := fs.NewOnDiskSegments(file.Info, file.AbsoluteFilepaths)
+		seg := fs.NewOnDiskSegments(file.Info, file.ID.VolumeIndex, file.AbsoluteFilepaths)
 		volumeType := seg.VolumeType()
 		if _, ok := onDiskSegmentsOrderByVolumeIndexByVolumeType[volumeType]; !ok {
 			onDiskSegmentsOrderByVolumeIndexByVolumeType[volumeType] = make([]fs.OnDiskSegments, 0)
 		}
 		onDiskSegmentsOrderByVolumeIndexByVolumeType[volumeType] = append(onDiskSegmentsOrderByVolumeIndexByVolumeType[volumeType], seg)
 	}
+
+	// Ensure that segments are soroted by volume index.
+	for _, segs := range onDiskSegmentsOrderByVolumeIndexByVolumeType {
+		sort.SliceStable(segs, func(i, j int) bool {
+			return segs[i].VolumeIndex() < segs[j].VolumeIndex()
+		})
+	}
+
 	multiErr := xerrors.NewMultiError()
 	// Check for dupes and remove.
 	filesToDelete := make([]string, 0)
@@ -1557,7 +1566,7 @@ func (i *nsIndex) CleanupDuplicateFileSets() error {
 					filesToDelete = append(filesToDelete, currSeg.AbsoluteFilepaths()...)
 				}
 				currOnDiskSegments = []fs.OnDiskSegments{seg}
-				shardTimeRangesCovered = seg.ShardTimeRanges()
+				shardTimeRangesCovered = seg.ShardTimeRanges().Copy()
 				continue
 			}
 			currOnDiskSegments = append(currOnDiskSegments, seg)

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -22,11 +22,15 @@ package storage
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
+	indexpb "github.com/m3db/m3/src/dbnode/generated/proto/index"
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/index"
@@ -34,10 +38,12 @@ import (
 	"github.com/m3db/m3/src/m3ninx/index/segment"
 	idxpersist "github.com/m3db/m3/src/m3ninx/persist"
 	"github.com/m3db/m3/src/x/context"
+	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
 	xtest "github.com/m3db/m3/src/x/test"
 	xtime "github.com/m3db/m3/src/x/time"
 
+	protobuftypes "github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,6 +69,133 @@ func TestNamespaceIndexCleanupExpiredFilesets(t *testing.T) {
 		return nil
 	}
 	require.NoError(t, idx.CleanupExpiredFileSets(now))
+}
+
+func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
+	md := testNamespaceMetadata(time.Hour, time.Hour*8)
+	nsIdx, err := newNamespaceIndex(md, testShardSet, DefaultTestOptions())
+	require.NoError(t, err)
+
+	idx := nsIdx.(*nsIndex)
+	now := time.Now().Truncate(time.Hour)
+	indexBlockSize := 2 * time.Hour
+	blockTime := now.Add(-2 * indexBlockSize)
+
+	fset1, err := ioutil.TempFile("", "fileset-9000-0-")
+	require.NoError(t, err)
+	fset2, err := ioutil.TempFile("", "fileset-9000-1-")
+	require.NoError(t, err)
+	fset3, err := ioutil.TempFile("", "fileset-9000-2-")
+	require.NoError(t, err)
+
+	volumeType := "extra"
+	infoFiles := []fs.ReadIndexInfoFileResult{
+		{
+			Info: indexpb.IndexVolumeInfo{
+				BlockStart: blockTime.UnixNano(),
+				BlockSize:  int64(indexBlockSize),
+				Shards:     []uint32{0, 1, 2},
+				IndexVolumeType: &protobuftypes.StringValue{
+					Value: volumeType,
+				},
+			},
+			PathPrefix: fmt.Sprintf("%s*", fset1.Name()),
+		},
+		{
+			Info: indexpb.IndexVolumeInfo{
+				BlockStart: blockTime.UnixNano(),
+				BlockSize:  int64(indexBlockSize),
+				Shards:     []uint32{0, 1, 2},
+				IndexVolumeType: &protobuftypes.StringValue{
+					Value: volumeType,
+				},
+			},
+			PathPrefix: fmt.Sprintf("%s*", fset2.Name()),
+		},
+		{
+			Info: indexpb.IndexVolumeInfo{
+				BlockStart: blockTime.UnixNano(),
+				BlockSize:  int64(indexBlockSize),
+				Shards:     []uint32{0, 1, 2, 3},
+				IndexVolumeType: &protobuftypes.StringValue{
+					Value: volumeType,
+				},
+			},
+			PathPrefix: fmt.Sprintf("%s*", fset3.Name()),
+		},
+	}
+
+	idx.readIndexInfoFilesFn = func(
+		filePathPrefix string,
+		namespace ident.ID,
+		readerBufferSize int,
+	) []fs.ReadIndexInfoFileResult {
+		return infoFiles
+	}
+	idx.deleteFilesFn = func(s []string) error {
+		require.Equal(t, []string{fset1.Name(), fset2.Name()}, s)
+		multiErr := xerrors.NewMultiError()
+		for _, file := range s {
+			multiErr = multiErr.Add(os.Remove(file))
+		}
+		return multiErr.FinalError()
+	}
+	require.NoError(t, idx.CleanupDuplicateFileSets())
+}
+
+func TestNamespaceIndexCleanupDuplicateFilesetsNoop(t *testing.T) {
+	md := testNamespaceMetadata(time.Hour, time.Hour*8)
+	nsIdx, err := newNamespaceIndex(md, testShardSet, DefaultTestOptions())
+	require.NoError(t, err)
+
+	idx := nsIdx.(*nsIndex)
+	now := time.Now().Truncate(time.Hour)
+	indexBlockSize := 2 * time.Hour
+	blockTime := now.Add(-2 * indexBlockSize)
+
+	fset1, err := ioutil.TempFile("", "fileset-9000-0-")
+	require.NoError(t, err)
+	fset2, err := ioutil.TempFile("", "fileset-9000-1-")
+	require.NoError(t, err)
+
+	volumeType := string(idxpersist.DefaultIndexVolumeType)
+	infoFiles := []fs.ReadIndexInfoFileResult{
+		{
+			Info: indexpb.IndexVolumeInfo{
+				BlockStart: blockTime.UnixNano(),
+				BlockSize:  int64(indexBlockSize),
+				Shards:     []uint32{0, 1, 2},
+				IndexVolumeType: &protobuftypes.StringValue{
+					Value: volumeType,
+				},
+			},
+			PathPrefix: fmt.Sprintf("%s*", fset1.Name()),
+		},
+		{
+			Info: indexpb.IndexVolumeInfo{
+				BlockStart: blockTime.UnixNano(),
+				BlockSize:  int64(indexBlockSize),
+				Shards:     []uint32{4},
+				IndexVolumeType: &protobuftypes.StringValue{
+					Value: volumeType,
+				},
+			},
+			PathPrefix: fmt.Sprintf("%s*", fset2.Name()),
+		},
+	}
+
+	idx.readIndexInfoFilesFn = func(
+		filePathPrefix string,
+		namespace ident.ID,
+		readerBufferSize int,
+	) []fs.ReadIndexInfoFileResult {
+		return infoFiles
+	}
+	idx.deleteFilesFn = func(s []string) error {
+		require.Equal(t, []string{}, s)
+		return nil
+	}
+	require.NoError(t, idx.CleanupDuplicateFileSets())
 }
 
 func TestNamespaceIndexCleanupExpiredFilesetsWithBlocks(t *testing.T) {

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -81,11 +81,16 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 	indexBlockSize := 2 * time.Hour
 	blockTime := now.Add(-2 * indexBlockSize)
 
-	fset1, err := ioutil.TempFile("", "fileset-9000-0-")
+	dir, err := ioutil.TempDir("", t.Name())
 	require.NoError(t, err)
-	fset2, err := ioutil.TempFile("", "fileset-9000-1-")
+
+	defer os.RemoveAll(dir)
+
+	fset1, err := ioutil.TempFile(dir, "fileset-9000-0-")
 	require.NoError(t, err)
-	fset3, err := ioutil.TempFile("", "fileset-9000-2-")
+	fset2, err := ioutil.TempFile(dir, "fileset-9000-1-")
+	require.NoError(t, err)
+	fset3, err := ioutil.TempFile(dir, "fileset-9000-2-")
 	require.NoError(t, err)
 
 	volumeType := "extra"
@@ -153,9 +158,14 @@ func TestNamespaceIndexCleanupDuplicateFilesetsNoop(t *testing.T) {
 	indexBlockSize := 2 * time.Hour
 	blockTime := now.Add(-2 * indexBlockSize)
 
-	fset1, err := ioutil.TempFile("", "fileset-9000-0-")
+	dir, err := ioutil.TempDir("", t.Name())
 	require.NoError(t, err)
-	fset2, err := ioutil.TempFile("", "fileset-9000-1-")
+
+	defer os.RemoveAll(dir)
+
+	fset1, err := ioutil.TempFile(dir, "fileset-9000-0-")
+	require.NoError(t, err)
+	fset2, err := ioutil.TempFile(dir, "fileset-9000-1-")
 	require.NoError(t, err)
 
 	volumeType := string(idxpersist.DefaultIndexVolumeType)

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -99,7 +99,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			PathPrefix: fmt.Sprintf("%s*", fset1.Name()),
+			AbsoluteFilepaths: []string{fset1.Name()},
 		},
 		{
 			Info: indexpb.IndexVolumeInfo{
@@ -110,7 +110,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			PathPrefix: fmt.Sprintf("%s*", fset2.Name()),
+			AbsoluteFilepaths: []string{fset2.Name()},
 		},
 		{
 			Info: indexpb.IndexVolumeInfo{
@@ -121,7 +121,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			PathPrefix: fmt.Sprintf("%s*", fset3.Name()),
+			AbsoluteFilepaths: []string{fset3.Name()},
 		},
 	}
 
@@ -169,7 +169,7 @@ func TestNamespaceIndexCleanupDuplicateFilesetsNoop(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			PathPrefix: fmt.Sprintf("%s*", fset1.Name()),
+			AbsoluteFilepaths: []string{fset1.Name()},
 		},
 		{
 			Info: indexpb.IndexVolumeInfo{
@@ -180,7 +180,7 @@ func TestNamespaceIndexCleanupDuplicateFilesetsNoop(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			PathPrefix: fmt.Sprintf("%s*", fset2.Name()),
+			AbsoluteFilepaths: []string{fset2.Name()},
 		},
 	}
 

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2146,6 +2146,20 @@ func (mr *MockNamespaceIndexMockRecorder) CleanupExpiredFileSets(t interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupExpiredFileSets", reflect.TypeOf((*MockNamespaceIndex)(nil).CleanupExpiredFileSets), t)
 }
 
+// CleanupDuplicateFileSets mocks base method
+func (m *MocknamespaceIndex) CleanupDuplicateFileSets() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupDuplicateFileSets")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupDuplicateFileSets indicates an expected call of CleanupDuplicateFileSets
+func (mr *MocknamespaceIndexMockRecorder) CleanupDuplicateFileSets() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupDuplicateFileSets", reflect.TypeOf((*MocknamespaceIndex)(nil).CleanupDuplicateFileSets))
+}
+
 // Tick mocks base method
 func (m *MockNamespaceIndex) Tick(c context.Cancellable, startTime time.Time) (namespaceIndexTickResult, error) {
 	m.ctrl.T.Helper()

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2147,7 +2147,7 @@ func (mr *MockNamespaceIndexMockRecorder) CleanupExpiredFileSets(t interface{}) 
 }
 
 // CleanupDuplicateFileSets mocks base method
-func (m *MocknamespaceIndex) CleanupDuplicateFileSets() error {
+func (m *MockNamespaceIndex) CleanupDuplicateFileSets() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupDuplicateFileSets")
 	ret0, _ := ret[0].(error)
@@ -2155,9 +2155,9 @@ func (m *MocknamespaceIndex) CleanupDuplicateFileSets() error {
 }
 
 // CleanupDuplicateFileSets indicates an expected call of CleanupDuplicateFileSets
-func (mr *MocknamespaceIndexMockRecorder) CleanupDuplicateFileSets() *gomock.Call {
+func (mr *MockNamespaceIndexMockRecorder) CleanupDuplicateFileSets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupDuplicateFileSets", reflect.TypeOf((*MocknamespaceIndex)(nil).CleanupDuplicateFileSets))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupDuplicateFileSets", reflect.TypeOf((*MockNamespaceIndex)(nil).CleanupDuplicateFileSets))
 }
 
 // Tick mocks base method

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2436,17 +2436,17 @@ func (m *MockdatabaseCleanupManager) EXPECT() *MockdatabaseCleanupManagerMockRec
 }
 
 // Cleanup mocks base method
-func (m *MockdatabaseCleanupManager) Cleanup(t time.Time) error {
+func (m *MockdatabaseCleanupManager) Cleanup(t time.Time, isBootstrapped bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cleanup", t)
+	ret := m.ctrl.Call(m, "Cleanup", t, isBootstrapped)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Cleanup indicates an expected call of Cleanup
-func (mr *MockdatabaseCleanupManagerMockRecorder) Cleanup(t interface{}) *gomock.Call {
+func (mr *MockdatabaseCleanupManagerMockRecorder) Cleanup(t, isBootstrapped interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockdatabaseCleanupManager)(nil).Cleanup), t)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockdatabaseCleanupManager)(nil).Cleanup), t, isBootstrapped)
 }
 
 // Report mocks base method
@@ -2485,17 +2485,17 @@ func (m *MockdatabaseFileSystemManager) EXPECT() *MockdatabaseFileSystemManagerM
 }
 
 // Cleanup mocks base method
-func (m *MockdatabaseFileSystemManager) Cleanup(t time.Time) error {
+func (m *MockdatabaseFileSystemManager) Cleanup(t time.Time, isBootstrapped bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cleanup", t)
+	ret := m.ctrl.Call(m, "Cleanup", t, isBootstrapped)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Cleanup indicates an expected call of Cleanup
-func (mr *MockdatabaseFileSystemManagerMockRecorder) Cleanup(t interface{}) *gomock.Call {
+func (mr *MockdatabaseFileSystemManagerMockRecorder) Cleanup(t, isBootstrapped interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockdatabaseFileSystemManager)(nil).Cleanup), t)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockdatabaseFileSystemManager)(nil).Cleanup), t, isBootstrapped)
 }
 
 // Flush mocks base method

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -625,6 +625,9 @@ type NamespaceIndex interface {
 	// using the provided `t` as the frame of reference.
 	CleanupExpiredFileSets(t time.Time) error
 
+	// CleanupDuplicateFileSets removes duplicate fileset files.
+	CleanupDuplicateFileSets() error
+
 	// Tick performs internal house keeping in the index, including block rotation,
 	// data eviction, and so on.
 	Tick(c context.Cancellable, startTime time.Time) (namespaceIndexTickResult, error)

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -707,7 +707,7 @@ type databaseFlushManager interface {
 // databaseCleanupManager manages cleaning up persistent storage space.
 type databaseCleanupManager interface {
 	// Cleanup cleans up data not needed in the persistent storage.
-	Cleanup(t time.Time) error
+	Cleanup(t time.Time, isBootstrapped bool) error
 
 	// Report reports runtime information.
 	Report()
@@ -716,7 +716,7 @@ type databaseCleanupManager interface {
 // databaseFileSystemManager manages the database related filesystem activities.
 type databaseFileSystemManager interface {
 	// Cleanup cleans up data not needed in the persistent storage.
-	Cleanup(t time.Time) error
+	Cleanup(t time.Time, isBootstrapped bool) error
 
 	// Flush flushes in-memory data to persistent storage.
 	Flush(t time.Time) error


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Clean up dupe index segments from disk.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
