### PR TITLE
[docs] fix refId for Persitence graph

### DIFF
--- a/integrations/grafana/m3db_dashboard.json
+++ b/integrations/grafana/m3db_dashboard.json
@@ -4384,7 +4384,7 @@
               "format": "time_series",
               "intervalFactor": 1,
               "key": 0.2814048282536148,
-              "refId": "A"
+              "refId": "B"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
**What this PR does / why we need it**:
Having 2 refIds that are identical in the same panel causes grafana to be unable to load the panel. This sets the 2nd query to be a different refId

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
