### PR TITLE
[dbnode] Fix dedupe/superset logic

### DIFF
--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -664,7 +664,7 @@ func forEachInfoFile(
 		filePathPrefix: args.filePathPrefix,
 		namespace:      args.namespace,
 		shard:          args.shard,
-		pattern:        infoFilePattern,
+		pattern:        filesetFilePattern,
 	})
 	if err != nil {
 		return
@@ -758,9 +758,11 @@ func forEachInfoFile(
 		if err != nil {
 			continue
 		}
-		if len(matched[i].AbsoluteFilepaths) != 1 {
-			continue
-		}
+		// Sort the matched fileset files so info file comes first.
+		suffix := infoFileSuffix + fileSuffix
+		sort.SliceStable(matched[i].AbsoluteFilepaths, func(j, k int) bool {
+			return strings.HasSuffix(matched[i].AbsoluteFilepaths[j], suffix)
+		})
 
 		fn(matched[i], infoData)
 	}

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -50,6 +50,7 @@ var (
 	timeZero time.Time
 
 	errSnapshotTimeAndIDZero = errors.New("tried to read snapshot time and ID of zero value")
+	errNonSnapshotFileset    = errors.New("tried to determine snapshot time and id of non-snapshot")
 )
 
 const (
@@ -103,7 +104,7 @@ const (
 // FileSetFile represents a set of FileSet files for a given block start
 type FileSetFile struct {
 	ID                FileSetFileIdentifier
-	AbsoluteFilepaths []string
+	AbsoluteFilePaths []string
 
 	CachedSnapshotTime              time.Time
 	CachedSnapshotID                uuid.UUID
@@ -117,11 +118,8 @@ func (f *FileSetFile) SnapshotTimeAndID() (time.Time, uuid.UUID, error) {
 	if f.IsZero() {
 		return time.Time{}, nil, errSnapshotTimeAndIDZero
 	}
-	if len(f.AbsoluteFilepaths) > 0 &&
-		!strings.Contains(f.AbsoluteFilepaths[0], snapshotDirName) {
-		return time.Time{}, nil, fmt.Errorf(
-			"tried to determine snapshot time and id of non-snapshot: %s",
-			f.AbsoluteFilepaths[0])
+	if _, ok := f.SnapshotFilepath(); !ok {
+		return time.Time{}, nil, errNonSnapshotFileset
 	}
 
 	if !f.CachedSnapshotTime.IsZero() || f.CachedSnapshotID != nil {
@@ -140,9 +138,36 @@ func (f *FileSetFile) SnapshotTimeAndID() (time.Time, uuid.UUID, error) {
 	return f.CachedSnapshotTime, f.CachedSnapshotID, nil
 }
 
+// InfoFilePath returns the info file path of a filesetfile (if found).
+func (f *FileSetFile) InfoFilePath() (string, bool) {
+	return f.filepath(infoFileSuffix)
+}
+
+// SnapshotFilepath returns the info file path of a filesetfile (if found).
+func (f *FileSetFile) SnapshotFilepath() (string, bool) {
+	return f.filepath(snapshotDirName)
+}
+
 // IsZero returns whether the FileSetFile is a zero value.
 func (f FileSetFile) IsZero() bool {
-	return len(f.AbsoluteFilepaths) == 0
+	return len(f.AbsoluteFilePaths) == 0
+}
+
+func (f *FileSetFile) filepath(pathContains string) (string, bool) {
+	var (
+		found    bool
+		foundIdx int
+	)
+	for idx, path := range f.AbsoluteFilePaths {
+		if strings.Contains(path, pathContains) {
+			found = true
+			foundIdx = idx
+		}
+	}
+	if found {
+		return f.AbsoluteFilePaths[foundIdx], true
+	}
+	return "", false
 }
 
 // HasCompleteCheckpointFile returns a bool indicating whether the given set of
@@ -159,7 +184,7 @@ func (f *FileSetFile) HasCompleteCheckpointFile() bool {
 }
 
 func (f *FileSetFile) evalHasCompleteCheckpointFile() LazyEvalBool {
-	for _, fileName := range f.AbsoluteFilepaths {
+	for _, fileName := range f.AbsoluteFilePaths {
 		if strings.Contains(fileName, checkpointFileSuffix) {
 			exists, err := CompleteCheckpointFileExists(fileName)
 			if err != nil {
@@ -182,7 +207,7 @@ type FileSetFilesSlice []FileSetFile
 func (f FileSetFilesSlice) Filepaths() []string {
 	flattened := []string{}
 	for _, fileset := range f {
-		flattened = append(flattened, fileset.AbsoluteFilepaths...)
+		flattened = append(flattened, fileset.AbsoluteFilePaths...)
 	}
 
 	return flattened
@@ -262,9 +287,9 @@ type SnapshotMetadata struct {
 	CheckpointFilePath  string
 }
 
-// AbsoluteFilepaths returns a slice of all the absolute filepaths associated
+// AbsoluteFilePaths returns a slice of all the absolute filepaths associated
 // with a snapshot metadata.
-func (s SnapshotMetadata) AbsoluteFilepaths() []string {
+func (s SnapshotMetadata) AbsoluteFilePaths() []string {
 	return []string{s.MetadataFilePath, s.CheckpointFilePath}
 }
 
@@ -289,7 +314,7 @@ type SnapshotMetadataIdentifier struct {
 func NewFileSetFile(id FileSetFileIdentifier, filePathPrefix string) FileSetFile {
 	return FileSetFile{
 		ID:                id,
-		AbsoluteFilepaths: []string{},
+		AbsoluteFilePaths: []string{},
 		filePathPrefix:    filePathPrefix,
 	}
 }
@@ -758,11 +783,10 @@ func forEachInfoFile(
 		if err != nil {
 			continue
 		}
-		// Sort the matched fileset files so info file comes first.
-		suffix := infoFileSuffix + fileSuffix
-		sort.SliceStable(matched[i].AbsoluteFilepaths, func(j, k int) bool {
-			return strings.HasSuffix(matched[i].AbsoluteFilepaths[j], suffix)
-		})
+		// Guarantee that every matched fileset has an info file.
+		if _, ok := matched[i].InfoFilePath(); !ok {
+			continue
+		}
 
 		fn(matched[i], infoData)
 	}
@@ -817,14 +841,14 @@ func ReadInfoFiles(
 		},
 		readerBufferSize,
 		func(file FileSetFile, data []byte) {
-			filepath := file.AbsoluteFilepaths[0]
+			filePath, _ := file.InfoFilePath()
 			decoder.Reset(msgpack.NewByteDecoderStream(data))
 			info, err := decoder.DecodeIndexInfo()
 			infoFileResults = append(infoFileResults, ReadInfoFileResult{
 				Info: info,
 				Err: readInfoFileResultError{
 					err:      err,
-					filepath: filepath,
+					filepath: filePath,
 				},
 			})
 		})
@@ -835,7 +859,7 @@ func ReadInfoFiles(
 type ReadIndexInfoFileResult struct {
 	ID                FileSetFileIdentifier
 	Info              index.IndexVolumeInfo
-	AbsoluteFilepaths []string
+	AbsoluteFilePaths []string
 	Err               ReadInfoFileResultError
 }
 
@@ -856,14 +880,14 @@ func ReadIndexInfoFiles(
 		},
 		readerBufferSize,
 		func(file FileSetFile, data []byte) {
-			filepath := file.AbsoluteFilepaths[0]
+			filepath, _ := file.InfoFilePath()
 			id := file.ID
 			var info index.IndexVolumeInfo
 			err := info.Unmarshal(data)
 			infoFileResults = append(infoFileResults, ReadIndexInfoFileResult{
 				ID:                id,
 				Info:              info,
-				AbsoluteFilepaths: file.AbsoluteFilepaths,
+				AbsoluteFilePaths: file.AbsoluteFilePaths,
 				Err: readInfoFileResultError{
 					err:      err,
 					filepath: filepath,
@@ -1060,7 +1084,7 @@ func DeleteFileSetAt(filePathPrefix string, namespace ident.ID, shard uint32, bl
 		return fmt.Errorf("fileset for blockStart: %d does not exist", blockStart.Unix())
 	}
 
-	return DeleteFiles(fileset.AbsoluteFilepaths)
+	return DeleteFiles(fileset.AbsoluteFilePaths)
 }
 
 // DataFileSetsBefore returns all the flush data fileset paths whose timestamps are earlier than a given time.
@@ -1262,7 +1286,7 @@ func filesetFiles(args filesetFilesSelector) (FileSetFilesSlice, error) {
 		latestBlockStart = currentFileBlockStart
 		latestVolumeIndex = volumeIndex
 
-		latestFileSetFile.AbsoluteFilepaths = append(latestFileSetFile.AbsoluteFilepaths, file)
+		latestFileSetFile.AbsoluteFilePaths = append(latestFileSetFile.AbsoluteFilePaths, file)
 	}
 	filesetFiles = append(filesetFiles, latestFileSetFile)
 

--- a/src/dbnode/persist/fs/files_test.go
+++ b/src/dbnode/persist/fs/files_test.go
@@ -204,7 +204,8 @@ func TestForEachInfoFile(t *testing.T) {
 		},
 		testReaderBufferSize,
 		func(file FileSetFile, data []byte) {
-			fname := file.AbsoluteFilepaths[0]
+			fname, ok := file.InfoFilePath()
+			require.True(t, ok)
 			fnames = append(fnames, fname)
 			res = append(res, data...)
 		})
@@ -841,7 +842,7 @@ func TestSnapshotFileHasCompleteCheckpointFile(t *testing.T) {
 
 	// Check validates a valid checkpoint file
 	f := FileSetFile{
-		AbsoluteFilepaths: []string{checkpointFilePath},
+		AbsoluteFilePaths: []string{checkpointFilePath},
 	}
 	require.Equal(t, true, f.HasCompleteCheckpointFile())
 
@@ -849,14 +850,14 @@ func TestSnapshotFileHasCompleteCheckpointFile(t *testing.T) {
 	err = ioutil.WriteFile(checkpointFilePath, []byte{42}, defaultNewFileMode)
 	require.NoError(t, err)
 	f = FileSetFile{
-		AbsoluteFilepaths: []string{checkpointFilePath},
+		AbsoluteFilePaths: []string{checkpointFilePath},
 	}
 	require.Equal(t, false, f.HasCompleteCheckpointFile())
 
 	// Check ignores index file path
 	indexFilePath := path.Join(dir, "123-index-0.db")
 	f = FileSetFile{
-		AbsoluteFilepaths: []string{indexFilePath},
+		AbsoluteFilePaths: []string{indexFilePath},
 	}
 	require.Equal(t, false, f.HasCompleteCheckpointFile())
 }
@@ -1114,7 +1115,7 @@ func TestSnapshotFileSnapshotTimeAndIDZeroValue(t *testing.T) {
 
 func TestSnapshotFileSnapshotTimeAndIDNotSnapshot(t *testing.T) {
 	f := FileSetFile{}
-	f.AbsoluteFilepaths = []string{"/var/lib/m3db/data/fileset-data.db"}
+	f.AbsoluteFilePaths = []string{"/var/lib/m3db/data/fileset-data.db"}
 	_, _, err := f.SnapshotTimeAndID()
 	require.Error(t, err)
 }

--- a/src/dbnode/persist/fs/segments.go
+++ b/src/dbnode/persist/fs/segments.go
@@ -78,7 +78,7 @@ func (o *segments) VolumeType() idxpersist.IndexVolumeType {
 	return o.volumeType
 }
 
-func (o *segments) AbsoluteFilepaths() []string {
+func (o *segments) AbsoluteFilePaths() []string {
 	return o.absoluteFilepaths
 }
 

--- a/src/dbnode/persist/fs/segments.go
+++ b/src/dbnode/persist/fs/segments.go
@@ -34,6 +34,7 @@ type segments struct {
 	shardRanges       result.ShardTimeRanges
 	volumeType        idxpersist.IndexVolumeType
 	volumeIndex       int
+	blockStart        time.Time
 }
 
 // NewSegments returns an on disk segments for an index info file.
@@ -65,6 +66,7 @@ func NewSegments(
 		volumeType:        volumeType,
 		volumeIndex:       volumeIndex,
 		absoluteFilepaths: absoluteFilepaths,
+		blockStart:        indexBlockStart,
 	}
 }
 
@@ -82,4 +84,8 @@ func (o *segments) AbsoluteFilepaths() []string {
 
 func (o *segments) VolumeIndex() int {
 	return o.volumeIndex
+}
+
+func (o *segments) BlockStart() time.Time {
+	return o.blockStart
 }

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -568,4 +568,5 @@ type Segments interface {
 	VolumeType() idxpersist.IndexVolumeType
 	VolumeIndex() int
 	AbsoluteFilepaths() []string
+	BlockStart() time.Time
 }

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -567,6 +567,6 @@ type Segments interface {
 	ShardTimeRanges() result.ShardTimeRanges
 	VolumeType() idxpersist.IndexVolumeType
 	VolumeIndex() int
-	AbsoluteFilepaths() []string
+	AbsoluteFilePaths() []string
 	BlockStart() time.Time
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -656,7 +656,7 @@ func (s *commitLogSource) mostRecentCompleteSnapshotByBlockShard(
 							zap.Time("blockStart", mostRecentSnapshot.ID.BlockStart),
 							zap.Uint32("shard", mostRecentSnapshot.ID.Shard),
 							zap.Int("index", mostRecentSnapshot.ID.VolumeIndex),
-							zap.Strings("filepaths", mostRecentSnapshot.AbsoluteFilepaths),
+							zap.Strings("filepaths", mostRecentSnapshot.AbsoluteFilePaths),
 							zap.Error(err),
 						).
 						Error("error resolving snapshot time for snapshot file")

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -328,7 +328,7 @@ func testItMergesSnapshotsAndCommitLogs(t *testing.T, opts Options,
 					VolumeIndex: 0,
 				},
 				// Make sure path passes the "is snapshot" check in SnapshotTimeAndID method.
-				AbsoluteFilepaths:               []string{"snapshots/checkpoint"},
+				AbsoluteFilePaths:               []string{"snapshots/checkpoint"},
 				CachedHasCompleteCheckpointFile: fs.EvalTrue,
 				CachedSnapshotTime:              start.Add(time.Minute),
 			},

--- a/src/dbnode/storage/bootstrap/result/shard_ranges.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges.go
@@ -119,15 +119,11 @@ func (r shardTimeRanges) Equal(other ShardTimeRanges) bool {
 // IsSuperset returns whether the current shard time ranges is a superset of the
 // other shard time ranges.
 func (r shardTimeRanges) IsSuperset(other ShardTimeRanges) bool {
-	if len(r) < other.Len() {
+	if len(r) < other.Len() || other.Len() == 0 {
 		return false
 	}
 	for shard, ranges := range r {
 		otherRanges := other.GetOrAdd(shard)
-		// Can still be a superset if other ranges does not exist for a shard.
-		if otherRanges == nil {
-			continue
-		}
 		if ranges.Len() < otherRanges.Len() {
 			return false
 		}
@@ -140,9 +136,8 @@ func (r shardTimeRanges) IsSuperset(other ShardTimeRanges) bool {
 		// the current ranges are a superset of the other ranges.
 		for otherIt.Next() {
 			otherValue := otherIt.Value()
-			itHasNext := false
-			for it.Next() {
-				itHasNext = true
+			itHasNext := it.Next()
+			for ; itHasNext; itHasNext = it.Next() {
 				value := it.Value()
 				if value.Equal(otherValue) {
 					break

--- a/src/dbnode/storage/bootstrap/result/shard_ranges.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges.go
@@ -136,16 +136,20 @@ func (r shardTimeRanges) IsSuperset(other ShardTimeRanges) bool {
 		// the current ranges are a superset of the other ranges.
 	otherIteratorNext:
 		for otherIt.Next() {
-			for it.Next() {
+			var itHasNext bool
+			for itHasNext = it.Next(); itHasNext; itHasNext = it.Next() {
 				if otherIt.Value().Equal(it.Value()) {
 					continue otherIteratorNext
 				}
+			}
+			if !itHasNext {
+				break otherIteratorNext
 			}
 		}
 
 		// If there is an unmatched range (not empty) left in `otherIt` then the current shard ranges
 		// are NOT a superset of the other shard ranges.
-		if otherIt.Next() {
+		if !otherIt.Value().IsEmpty() {
 			return false
 		}
 	}

--- a/src/dbnode/storage/bootstrap/result/shard_ranges.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges.go
@@ -119,7 +119,7 @@ func (r shardTimeRanges) Equal(other ShardTimeRanges) bool {
 // IsSuperset returns whether the current shard time ranges is a superset of the
 // other shard time ranges.
 func (r shardTimeRanges) IsSuperset(other ShardTimeRanges) bool {
-	if len(r) < other.Len() || other.Len() == 0 {
+	if len(r) < other.Len() {
 		return false
 	}
 	for shard, ranges := range r {

--- a/src/dbnode/storage/bootstrap/result/shard_ranges.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges.go
@@ -134,24 +134,18 @@ func (r shardTimeRanges) IsSuperset(other ShardTimeRanges) bool {
 		// and the block sizes are expected to line up.
 		// The logic is that if we finish iterating through otherIt then
 		// the current ranges are a superset of the other ranges.
+	otherIteratorNext:
 		for otherIt.Next() {
-			otherValue := otherIt.Value()
-			itHasNext := it.Next()
-			for ; itHasNext; itHasNext = it.Next() {
-				value := it.Value()
-				if value.Equal(otherValue) {
-					break
+			for it.Next() {
+				if otherIt.Value().Equal(it.Value()) {
+					continue otherIteratorNext
 				}
-			}
-			// We've reached the end of the current iterator so we should stop going.
-			if !itHasNext {
-				break
 			}
 		}
 
 		// If there is an unmatched range (not empty) left in `otherIt` then the current shard ranges
 		// are NOT a superset of the other shard ranges.
-		if !otherIt.Value().IsEmpty() {
+		if otherIt.Next() {
 			return false
 		}
 	}

--- a/src/dbnode/storage/bootstrap/result/shard_ranges.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges.go
@@ -134,22 +134,22 @@ func (r shardTimeRanges) IsSuperset(other ShardTimeRanges) bool {
 		// and the block sizes are expected to line up.
 		// The logic is that if we finish iterating through otherIt then
 		// the current ranges are a superset of the other ranges.
+		missedRange := false
 	otherIteratorNext:
 		for otherIt.Next() {
-			var itHasNext bool
-			for itHasNext = it.Next(); itHasNext; itHasNext = it.Next() {
+			for it.Next() {
 				if otherIt.Value().Equal(it.Value()) {
 					continue otherIteratorNext
 				}
 			}
-			if !itHasNext {
-				break otherIteratorNext
-			}
+
+			missedRange = true
+			break
 		}
 
 		// If there is an unmatched range (not empty) left in `otherIt` then the current shard ranges
 		// are NOT a superset of the other shard ranges.
-		if !otherIt.Value().IsEmpty() {
+		if missedRange {
 			return false
 		}
 	}

--- a/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
@@ -105,7 +105,7 @@ func TestShardTimeRangesIsSuperset(t *testing.T) {
 
 	require.False(t, ranges2.IsSuperset(ranges1))
 	require.False(t, ranges1.IsSuperset(ranges2))
-	require.False(t, ranges2.IsSuperset(ranges3))
+	require.True(t, ranges2.IsSuperset(ranges3))
 	require.False(t, ranges3.IsSuperset(ranges1))
 	require.False(t, ranges3.IsSuperset(ranges2))
 }

--- a/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges_test.go
@@ -70,8 +70,42 @@ func TestShardTimeRangesIsSuperset(t *testing.T) {
 	for _, r := range sr2 {
 		ranges2.AddRanges(r)
 	}
+	sr3 := []ShardTimeRanges{
+		NewShardTimeRangesFromRange(times[1], times[2], 1, 2, 3),
+	}
+	ranges3 := NewShardTimeRanges()
+	for _, r := range sr3 {
+		ranges3.AddRanges(r)
+	}
 
 	require.True(t, ranges1.IsSuperset(ranges2))
-	require.False(t, ranges2.IsSuperset(ranges1))
 	require.True(t, ranges1.IsSuperset(ranges1))
+	require.True(t, ranges1.IsSuperset(ranges3))
+
+	// Reverse sanity checks.
+	require.False(t, ranges2.IsSuperset(ranges1))
+	require.False(t, ranges3.IsSuperset(ranges1))
+
+	// Added some more false checks for non overlapping time ranges and no time ranges.
+	sr1 = []ShardTimeRanges{
+		NewShardTimeRangesFromRange(times[0], times[1], 1, 2, 3),
+	}
+	ranges1 = NewShardTimeRanges()
+	for _, r := range sr1 {
+		ranges1.AddRanges(r)
+	}
+	sr2 = []ShardTimeRanges{
+		NewShardTimeRangesFromRange(times[1], times[2], 1, 2, 3),
+	}
+	ranges2 = NewShardTimeRanges()
+	for _, r := range sr2 {
+		ranges2.AddRanges(r)
+	}
+	ranges3 = NewShardTimeRanges()
+
+	require.False(t, ranges2.IsSuperset(ranges1))
+	require.False(t, ranges1.IsSuperset(ranges2))
+	require.False(t, ranges2.IsSuperset(ranges3))
+	require.False(t, ranges3.IsSuperset(ranges1))
+	require.False(t, ranges3.IsSuperset(ranges2))
 }

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -403,9 +403,9 @@ func (m *cleanupManager) cleanupSnapshotsAndCommitlogs(namespaces []databaseName
 					m.metrics.corruptSnapshotFile.Inc(1)
 					logger.With(
 						zap.Error(err),
-						zap.Strings("files", snapshot.AbsoluteFilepaths),
+						zap.Strings("files", snapshot.AbsoluteFilePaths),
 					).Warn("corrupt snapshot file during cleanup, marking files for deletion")
-					filesToDelete = append(filesToDelete, snapshot.AbsoluteFilepaths...)
+					filesToDelete = append(filesToDelete, snapshot.AbsoluteFilePaths...)
 					continue
 				}
 
@@ -413,7 +413,7 @@ func (m *cleanupManager) cleanupSnapshotsAndCommitlogs(namespaces []databaseName
 					// If the UUID of the snapshot files doesn't match the most recent snapshot
 					// then its safe to delete because it means we have a more recently complete set.
 					m.metrics.deletedSnapshotFile.Inc(1)
-					filesToDelete = append(filesToDelete, snapshot.AbsoluteFilepaths...)
+					filesToDelete = append(filesToDelete, snapshot.AbsoluteFilePaths...)
 				}
 			}
 		}
@@ -422,7 +422,7 @@ func (m *cleanupManager) cleanupSnapshotsAndCommitlogs(namespaces []databaseName
 	// Delete all snapshot metadatas prior to the most recent one.
 	for _, snapshot := range sortedSnapshotMetadatas[:len(sortedSnapshotMetadatas)-1] {
 		m.metrics.deletedSnapshotMetadataFile.Inc(1)
-		filesToDelete = append(filesToDelete, snapshot.AbsoluteFilepaths()...)
+		filesToDelete = append(filesToDelete, snapshot.AbsoluteFilePaths()...)
 	}
 
 	// Delete corrupt snapshot metadata files.

--- a/src/dbnode/storage/cleanup_test.go
+++ b/src/dbnode/storage/cleanup_test.go
@@ -110,7 +110,7 @@ func TestCleanupManagerCleanupCommitlogsAndSnapshots(t *testing.T) {
 							Shard:       shard,
 							VolumeIndex: 0,
 						},
-						AbsoluteFilepaths:  []string{fmt.Sprintf("/snapshots/%s/snapshot-filepath-%d", namespace, shard)},
+						AbsoluteFilePaths:  []string{fmt.Sprintf("/snapshots/%s/snapshot-filepath-%d", namespace, shard)},
 						CachedSnapshotTime: testBlockStart,
 						CachedSnapshotID:   testSnapshotUUID0,
 					},
@@ -134,7 +134,7 @@ func TestCleanupManagerCleanupCommitlogsAndSnapshots(t *testing.T) {
 							Shard:       shard,
 							VolumeIndex: 0,
 						},
-						AbsoluteFilepaths:  []string{fmt.Sprintf("/snapshots/%s/snapshot-filepath-%d", namespace, shard)},
+						AbsoluteFilePaths:  []string{fmt.Sprintf("/snapshots/%s/snapshot-filepath-%d", namespace, shard)},
 						CachedSnapshotTime: testBlockStart,
 						CachedSnapshotID:   testSnapshotUUID0,
 					},
@@ -193,7 +193,7 @@ func TestCleanupManagerCleanupCommitlogsAndSnapshots(t *testing.T) {
 							Shard:       shard,
 							VolumeIndex: 0,
 						},
-						AbsoluteFilepaths: []string{fmt.Sprintf("/snapshots/%s/snapshot-filepath-%d", namespace, shard)},
+						AbsoluteFilePaths: []string{fmt.Sprintf("/snapshots/%s/snapshot-filepath-%d", namespace, shard)},
 						// Zero these out so it will try to look them up and return an error, indicating the files
 						// are corrupt.
 						CachedSnapshotTime: time.Time{},

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1538,7 +1538,7 @@ func (i *nsIndex) CleanupDuplicateFileSets() error {
 
 	segmentsOrderByVolumeIndexByVolumeTypeAndBlockStart := make(map[time.Time]map[idxpersist.IndexVolumeType][]fs.Segments)
 	for _, file := range infoFiles {
-		seg := fs.NewSegments(file.Info, file.ID.VolumeIndex, file.AbsoluteFilepaths)
+		seg := fs.NewSegments(file.Info, file.ID.VolumeIndex, file.AbsoluteFilePaths)
 		blockStart := seg.BlockStart()
 		segmentsOrderByVolumeIndexByVolumeType, ok := segmentsOrderByVolumeIndexByVolumeTypeAndBlockStart[blockStart]
 		if !ok {
@@ -1573,7 +1573,7 @@ func (i *nsIndex) CleanupDuplicateFileSets() error {
 				if seg.ShardTimeRanges().IsSuperset(shardTimeRangesCovered) {
 					// Mark dupe segments for deletion.
 					for _, currSeg := range currSegments {
-						filesToDelete = append(filesToDelete, currSeg.AbsoluteFilepaths()...)
+						filesToDelete = append(filesToDelete, currSeg.AbsoluteFilePaths()...)
 					}
 					currSegments = []fs.Segments{seg}
 					shardTimeRangesCovered = seg.ShardTimeRanges().Copy()

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -104,7 +104,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			AbsoluteFilepaths: []string{fset1.Name()},
+			AbsoluteFilePaths: []string{fset1.Name()},
 		},
 		{
 			Info: indexpb.IndexVolumeInfo{
@@ -115,7 +115,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			AbsoluteFilepaths: []string{fset2.Name()},
+			AbsoluteFilePaths: []string{fset2.Name()},
 		},
 		{
 			Info: indexpb.IndexVolumeInfo{
@@ -126,7 +126,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			AbsoluteFilepaths: []string{fset3.Name()},
+			AbsoluteFilePaths: []string{fset3.Name()},
 		},
 	}
 
@@ -179,7 +179,7 @@ func TestNamespaceIndexCleanupDuplicateFilesetsNoop(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			AbsoluteFilepaths: []string{fset1.Name()},
+			AbsoluteFilePaths: []string{fset1.Name()},
 		},
 		{
 			Info: indexpb.IndexVolumeInfo{
@@ -190,7 +190,7 @@ func TestNamespaceIndexCleanupDuplicateFilesetsNoop(t *testing.T) {
 					Value: volumeType,
 				},
 			},
-			AbsoluteFilepaths: []string{fset2.Name()},
+			AbsoluteFilePaths: []string{fset2.Name()},
 		},
 	}
 

--- a/src/x/time/range_iter.go
+++ b/src/x/time/range_iter.go
@@ -26,6 +26,7 @@ import "container/list"
 type RangeIter struct {
 	ranges *list.List
 	cur    *list.Element
+	eof    bool
 }
 
 func newRangeIter(ranges *list.List) *RangeIter {
@@ -37,12 +38,16 @@ func (it *RangeIter) Next() bool {
 	if it.ranges == nil {
 		return false
 	}
+	if it.eof {
+		return false
+	}
 	if it.cur == nil {
 		it.cur = it.ranges.Front()
 	} else {
 		it.cur = it.cur.Next()
 	}
-	return it.cur != nil
+	it.eof = it.cur == nil
+	return !it.eof
 }
 
 // Value returns the current time range.

--- a/src/x/time/range_iter_test.go
+++ b/src/x/time/range_iter_test.go
@@ -56,3 +56,17 @@ func TestRangeIter(t *testing.T) {
 	require.False(t, it.Next())
 
 }
+
+func TestRangeIterEOF(t *testing.T) {
+	it := newRangeIter(nil)
+	require.False(t, it.Next())
+
+	it = newRangeIter(getTestList())
+	var i int
+	for it.Next() {
+		require.Equal(t, testTimeRanges[i], it.Value())
+		i++
+	}
+	// Next() always returns falsy after hitting eof.
+	require.False(t, it.Next())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes on disk index dedupe and is superset logic for shard time ranges. Deduping should be done w/in a block. 
Also grabs all fileset files paths when reading index info files.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
