### PR TITLE
[dbnode] Persist manager close resources

### DIFF
--- a/src/dbnode/persist/fs/persist_manager.go
+++ b/src/dbnode/persist/fs/persist_manager.go
@@ -35,6 +35,7 @@ import (
 	m3ninxfs "github.com/m3db/m3/src/m3ninx/index/segment/fst"
 	m3ninxpersist "github.com/m3db/m3/src/m3ninx/persist"
 	"github.com/m3db/m3/src/x/checked"
+	xclose "github.com/m3db/m3/src/x/close"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 
@@ -92,6 +93,8 @@ type persistManager struct {
 	slept        time.Duration
 
 	metrics persistManagerMetrics
+
+	runtimeOptsListener xclose.SimpleCloser
 }
 
 type dataPersistManager struct {
@@ -190,7 +193,8 @@ func NewPersistManager(opts Options) (persist.Manager, error) {
 	}
 	pm.indexPM.newReaderFn = NewIndexReader
 	pm.indexPM.newPersistentSegmentFn = m3ninxpersist.NewSegment
-	opts.RuntimeOptionsManager().RegisterListener(pm)
+	pm.runtimeOptsListener = opts.RuntimeOptionsManager().RegisterListener(pm)
+
 	return pm, nil
 }
 
@@ -591,6 +595,11 @@ func (pm *persistManager) DoneSnapshot(
 	}
 
 	return pm.doneShared()
+}
+
+// Close all resources.
+func (pm *persistManager) Close() {
+	pm.runtimeOptsListener.Close()
 }
 
 func (pm *persistManager) doneShared() error {

--- a/src/dbnode/persist/persist_mock.go
+++ b/src/dbnode/persist/persist_mock.go
@@ -102,6 +102,18 @@ func (mr *MockManagerMockRecorder) StartIndexPersist() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartIndexPersist", reflect.TypeOf((*MockManager)(nil).StartIndexPersist))
 }
 
+// Close mocks base method
+func (m *MockManager) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close
+func (mr *MockManagerMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockManager)(nil).Close))
+}
+
 // MockPreparer is a mock of Preparer interface
 type MockPreparer struct {
 	ctrl     *gomock.Controller

--- a/src/dbnode/persist/types.go
+++ b/src/dbnode/persist/types.go
@@ -90,6 +90,8 @@ type Manager interface {
 
 	// StartIndexPersist begins a flush for index data.
 	StartIndexPersist() (IndexFlush, error)
+
+	Close()
 }
 
 // Preparer can generate a PreparedDataPersist object for writing data for


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Allows closing of persist manager resources.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
