### PR TITLE
WIP [dbnode] Fix flush state not in sync after topology change

### DIFF
--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -347,11 +347,11 @@ func (s *peersSource) handlePersistenceFlush(
 	bootstrapResult result.DataBootstrapResult,
 	lock *sync.Mutex,
 ) {
+	// We added an additional wait per flush.
 	defer flush.wg.Done()
 	err := s.flush(opts, persistFlush, flush.nsMetadata, flush.shard,
 		flush.shardRetrieverMgr, flush.shardResult, flush.timeRange)
 	if err == nil {
-		// NB(bodu): We only considered the peers bootstrapper's work to be done AFTER it flushes everything to disk.
 		return
 	}
 
@@ -416,6 +416,8 @@ func (s *peersSource) fetchBootstrapBlocksFromPeers(
 
 			if shouldPersist {
 				// NB(bodu): Add an additional wait on any flush work that needs to be done.
+				// We only consider the peers bootstrapper's work to be done AFTER it
+				// flushes everything to disk.
 				wg.Add(1)
 				persistenceQueue <- persistenceFlush{
 					wg:                wg,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Ensures flush state does not drift during/after a topology change.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
