### PR TITLE
[dbnode] Closes seekers on shard close

### DIFF
--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -119,6 +119,85 @@ func (mr *MockDataFileSetWriterMockRecorder) WriteAll(arg0, arg1, arg2, arg3 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAll", reflect.TypeOf((*MockDataFileSetWriter)(nil).WriteAll), arg0, arg1, arg2, arg3)
 }
 
+// MockManagedBloomFilter is a mock of ManagedBloomFilter interface
+type MockManagedBloomFilter struct {
+	ctrl     *gomock.Controller
+	recorder *MockManagedBloomFilterMockRecorder
+}
+
+// MockManagedBloomFilterMockRecorder is the mock recorder for MockManagedBloomFilter
+type MockManagedBloomFilterMockRecorder struct {
+	mock *MockManagedBloomFilter
+}
+
+// NewMockManagedBloomFilter creates a new mock instance
+func NewMockManagedBloomFilter(ctrl *gomock.Controller) *MockManagedBloomFilter {
+	mock := &MockManagedBloomFilter{ctrl: ctrl}
+	mock.recorder = &MockManagedBloomFilterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockManagedBloomFilter) EXPECT() *MockManagedBloomFilterMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method
+func (m *MockManagedBloomFilter) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close
+func (mr *MockManagedBloomFilterMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockManagedBloomFilter)(nil).Close))
+}
+
+// K mocks base method
+func (m *MockManagedBloomFilter) K() uint {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "K")
+	ret0, _ := ret[0].(uint)
+	return ret0
+}
+
+// K indicates an expected call of K
+func (mr *MockManagedBloomFilterMockRecorder) K() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "K", reflect.TypeOf((*MockManagedBloomFilter)(nil).K))
+}
+
+// M mocks base method
+func (m *MockManagedBloomFilter) M() uint {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "M")
+	ret0, _ := ret[0].(uint)
+	return ret0
+}
+
+// M indicates an expected call of M
+func (mr *MockManagedBloomFilterMockRecorder) M() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "M", reflect.TypeOf((*MockManagedBloomFilter)(nil).M))
+}
+
+// Test mocks base method
+func (m *MockManagedBloomFilter) Test(arg0 []byte) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Test", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Test indicates an expected call of Test
+func (mr *MockManagedBloomFilterMockRecorder) Test(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Test", reflect.TypeOf((*MockManagedBloomFilter)(nil).Test), arg0)
+}
+
 // MockDataFileSetReader is a mock of DataFileSetReader interface
 type MockDataFileSetReader struct {
 	ctrl     *gomock.Controller
@@ -386,10 +465,10 @@ func (mr *MockDataFileSetSeekerMockRecorder) ConcurrentClone() *gomock.Call {
 }
 
 // ConcurrentIDBloomFilter mocks base method
-func (m *MockDataFileSetSeeker) ConcurrentIDBloomFilter() *ManagedConcurrentBloomFilter {
+func (m *MockDataFileSetSeeker) ConcurrentIDBloomFilter() ManagedBloomFilter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConcurrentIDBloomFilter")
-	ret0, _ := ret[0].(*ManagedConcurrentBloomFilter)
+	ret0, _ := ret[0].(ManagedBloomFilter)
 	return ret0
 }
 
@@ -1123,10 +1202,10 @@ func (mr *MockConcurrentDataFileSetSeekerMockRecorder) Close() *gomock.Call {
 }
 
 // ConcurrentIDBloomFilter mocks base method
-func (m *MockConcurrentDataFileSetSeeker) ConcurrentIDBloomFilter() *ManagedConcurrentBloomFilter {
+func (m *MockConcurrentDataFileSetSeeker) ConcurrentIDBloomFilter() ManagedBloomFilter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConcurrentIDBloomFilter")
-	ret0, _ := ret[0].(*ManagedConcurrentBloomFilter)
+	ret0, _ := ret[0].(ManagedBloomFilter)
 	return ret0
 }
 

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -151,6 +151,19 @@ func (r *blockRetriever) Open(ns namespace.Metadata) error {
 	return nil
 }
 
+func (r *blockRetriever) CloseShardIndices(shards []uint32) error {
+	r.RLock()
+	if r.status != blockRetrieverOpen {
+		r.RUnlock()
+		return errBlockRetrieverNotOpen
+	}
+	seekerMgr := r.seekerMgr
+	r.RUnlock()
+
+	seekerMgr.CloseShardIndices(shards)
+	return nil
+}
+
 func (r *blockRetriever) CacheShardIndices(shards []uint32) error {
 	r.RLock()
 	if r.status != blockRetrieverOpen {

--- a/src/dbnode/persist/fs/seek.go
+++ b/src/dbnode/persist/fs/seek.go
@@ -76,7 +76,7 @@ type seeker struct {
 
 	// Bloom filter associated with the shard / block the seeker is responsible
 	// for. Needs to be closed when done.
-	bloomFilter *ManagedConcurrentBloomFilter
+	bloomFilter ManagedBloomFilter
 	indexLookup *nearestIndexOffsetLookup
 
 	isClone bool
@@ -138,7 +138,7 @@ func newSeeker(opts seekerOpts) fileSetSeeker {
 	}
 }
 
-func (s *seeker) ConcurrentIDBloomFilter() *ManagedConcurrentBloomFilter {
+func (s *seeker) ConcurrentIDBloomFilter() ManagedBloomFilter {
 	return s.bloomFilter
 }
 

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -119,7 +119,7 @@ type seekerUnreadBuf struct {
 type seekersAndBloom struct {
 	wg          *sync.WaitGroup
 	seekers     []borrowableSeeker
-	bloomFilter *ManagedConcurrentBloomFilter
+	bloomFilter ManagedBloomFilter
 	volume      int
 }
 

--- a/src/dbnode/persist/fs/seek_manager.go
+++ b/src/dbnode/persist/fs/seek_manager.go
@@ -73,6 +73,14 @@ const (
 	seekerManagerClosed
 )
 
+type byTimeSeekersState int
+
+const (
+	byTimeSeekersInit byTimeSeekersState = iota
+	byTimeSeekersAccessed
+	byTimeSeekersClosed
+)
+
 // seekerManager provides functionality around borrowableSeekers such as
 // opening and closing them, as well as lending them out to a Retriever.
 // There is a single seekerManager per namespace which contains all
@@ -134,9 +142,15 @@ type borrowableSeeker struct {
 // blockStart. The accessed field allows for pre-caching those seekers.
 type seekersByTime struct {
 	sync.RWMutex
-	shard    uint32
-	accessed bool
-	seekers  map[xtime.UnixNano]rotatableSeekers
+	shard uint32
+	// Seekers for a shard can be marked closed. Seek manager will periodically close
+	// file descriptors for closed seekers in open/close loop. Seekers for blocks which
+	// fall outside the rentention period are automatically closed by open/close loop
+	// periodically but sekeers for a shard might need to be closed pro-actively by marking
+	// them closed. For eg. when a shard leaves a node.
+	// Seekers can also be marked accessed to be prefetched in open/close loop.
+	state   byTimeSeekersState
+	seekers map[xtime.UnixNano]rotatableSeekers
 }
 
 // rotatableSeekers is a wrapper around seekersAndBloom that allows for rotating
@@ -229,7 +243,7 @@ func (m *seekerManager) CacheShardIndices(shards []uint32) error {
 
 		byTime.Lock()
 		// Track accessed to precache in open/close loop
-		byTime.accessed = true
+		byTime.state = byTimeSeekersAccessed
 		byTime.Unlock()
 
 		wg.Add(1)
@@ -245,6 +259,17 @@ func (m *seekerManager) CacheShardIndices(shards []uint32) error {
 
 	wg.Wait()
 	return multiErr.FinalError()
+}
+
+func (m *seekerManager) CloseShardIndices(shards []uint32) {
+	for _, shard := range shards {
+		byTime := m.seekersByTime(shard)
+
+		byTime.Lock()
+		// Track state to close FDs in open/close loop
+		byTime.state = byTimeSeekersClosed
+		byTime.Unlock()
+	}
 }
 
 func (m *seekerManager) Test(id ident.ID, shard uint32, start time.Time) (bool, error) {
@@ -264,6 +289,11 @@ func (m *seekerManager) Test(id ident.ID, shard uint32, start time.Time) (bool, 
 
 	byTime.Lock()
 	defer byTime.Unlock()
+
+	// Mark byTime seekers accessed so that open/close loop does not
+	// try to close byTime seekers if this function was called after
+	// these seekers were marked closed using CloseShardIndices()
+	byTime.state = byTimeSeekersAccessed
 
 	// Check if raced with another call to this method
 	if seekers, ok := byTime.seekers[startNano]; ok && seekers.active.wg == nil {
@@ -286,7 +316,7 @@ func (m *seekerManager) Borrow(shard uint32, start time.Time) (ConcurrentDataFil
 	byTime.Lock()
 	defer byTime.Unlock()
 	// Track accessed to precache in open/close loop
-	byTime.accessed = true
+	byTime.state = byTimeSeekersAccessed
 
 	startNano := xtime.ToUnixNano(start)
 	seekersAndBloom, err := m.getOrOpenSeekersWithLock(startNano, byTime)
@@ -912,14 +942,30 @@ func (m *seekerManager) openCloseLoop() {
 			break
 		}
 
-		for _, byTime := range m.seekersByShardIdx {
+		// Record seekers for all shard/block combinations to open and close
+		for shardIdx, byTime := range m.seekersByShardIdx {
 			byTime.RLock()
-			accessed := byTime.accessed
-			byTime.RUnlock()
-			if !accessed {
-				continue
+			byTimeSeekersState := byTime.state
+			// Record seekers for a shard which need to be opened
+			if byTimeSeekersState == byTimeSeekersAccessed {
+				shouldTryOpen = append(shouldTryOpen, byTime)
 			}
-			shouldTryOpen = append(shouldTryOpen, byTime)
+			// Record seekers for a shard which need to be closed. A seeker for a block might need to be closed either
+			// because a block falls out of retention window or because a shard leaves a node.
+			// We caputure seekers to open and seekers to close under the same byTime.rLock to avoid a race condition
+			// wherein a seeker is opened and closed quickly in succession which results in one iteration of this loop
+			// opening and closing the same seeker resulting in wasted work.
+			for blockStartNano := range byTime.seekers {
+				blockStart := blockStartNano.ToTime()
+				if byTime.state == byTimeSeekersClosed || blockStart.Before(earliestSeekableBlockStart) {
+					shouldClose = append(shouldClose, seekerManagerPendingClose{
+						shard:      uint32(shardIdx),
+						blockStart: blockStart,
+					})
+				}
+			}
+
+			byTime.RUnlock()
 		}
 		m.RUnlock()
 
@@ -929,20 +975,6 @@ func (m *seekerManager) openCloseLoop() {
 		}
 
 		m.RLock()
-		for shard, byTime := range m.seekersByShardIdx {
-			byTime.RLock()
-			for blockStartNano := range byTime.seekers {
-				blockStart := blockStartNano.ToTime()
-				if blockStart.Before(earliestSeekableBlockStart) {
-					shouldClose = append(shouldClose, seekerManagerPendingClose{
-						shard:      uint32(shard),
-						blockStart: blockStart,
-					})
-				}
-			}
-			byTime.RUnlock()
-		}
-
 		if len(shouldClose) > 0 {
 			for _, elem := range shouldClose {
 				byTime := m.seekersByShardIdx[elem.shard]

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -261,6 +261,19 @@ type DataFileSetSeekerManager interface {
 	// to improve times when seeking to a block.
 	CacheShardIndices(shards []uint32) error
 
+	// Closes seekers for shards. This functionality is needed when shards move out of
+	// a node on topology change and file descriptors backing shards need to be closed 
+	// so that the shards' fileset files can be deleted from disk.
+	// This operation is best effort and the actual file descriptors are closed asynchronous
+	// to this this method. 
+	// Seekers are not closed until all the borrowed seekers are returned. If a seeker is 
+	// borrowed (Borrow()) or tested (Test()) after closing shard indices, then the seeker 
+	// will be reopened. 
+	// Seeker manager is not responsible to track the lifecycle of a shard. Its the reponsibility 
+	// of the caller to not borrow or test a seeker after closing the seeker if they want seeker 
+	// to finally be closed.
+	CloseShardIndices(shards []uint32)
+
 	// Borrow returns an open seeker for a given shard, block start time, and
 	// volume.
 	Borrow(shard uint32, start time.Time) (ConcurrentDataFileSetSeeker, error)

--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -868,6 +868,20 @@ func (mr *MockDatabaseBlockRetrieverMockRecorder) CacheShardIndices(shards inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheShardIndices", reflect.TypeOf((*MockDatabaseBlockRetriever)(nil).CacheShardIndices), shards)
 }
 
+// CloseShardIndices mocks base method
+func (m *MockDatabaseBlockRetriever) CloseShardIndices(shards []uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseShardIndices", shards)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseShardIndices indicates an expected call of CloseShardIndices
+func (mr *MockDatabaseBlockRetrieverMockRecorder) CloseShardIndices(shards interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseShardIndices", reflect.TypeOf((*MockDatabaseBlockRetriever)(nil).CacheShardIndices), shards)
+}
+
 // Stream mocks base method
 func (m *MockDatabaseBlockRetriever) Stream(ctx context.Context, shard uint32, id ident.ID, blockStart time.Time, onRetrieve OnRetrieveBlock, nsCtx namespace.Context) (xio.BlockReader, error) {
 	m.ctrl.T.Helper()

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -271,6 +271,12 @@ type DatabaseBlockRetriever interface {
 	// to improve times when streaming a block.
 	CacheShardIndices(shards []uint32) error
 
+	// CloseShardIndices purge pre-parsed indexes for the given shards and 
+	// close file descriptors to the fileset files for the given shards. 
+	// Shard indices are closed on a best effort basis and may fail without 
+	// returning an error.
+	CloseShardIndices(shards []uint32) error
+
 	// Stream will stream a block for a given shard, id and start.
 	Stream(
 		ctx context.Context,

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -332,8 +332,9 @@ func TestShardBootstrapWithCacheShardIndices(t *testing.T) {
 	s := testDatabaseShard(t, opts)
 	defer s.Close()
 
+	mockRetrieverMgr.EXPECT().Retriever(s.namespace).Return(mockRetriever, nil).Times(2)
 	mockRetriever.EXPECT().CacheShardIndices([]uint32{s.ID()}).Return(nil)
-	mockRetrieverMgr.EXPECT().Retriever(s.namespace).Return(mockRetriever, nil)
+	mockRetriever.EXPECT().CloseShardIndices([]uint32{s.ID()}).Return(nil)
 
 	ctx := context.NewContext()
 	defer ctx.Close()


### PR DESCRIPTION
- Resolves github issue - https://github.com/m3db/m3/issues/2294

- Shards are closed and fileset files deleted when a shard leaves a node
on topologu change. Ideally the fileset files should be deleted from
disk but because file descriptor to these files stays open, underlying
OS is unable to delete them from disk.

- This commit resolve this issue by explicitly closing the seekers for a
shard on shard close. A seeker is a wrapper on top of index and data db
files.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2294 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
