### PR TITLE
[logging] Update types on some log fields

### DIFF
--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -309,7 +309,7 @@ func (s *commitLogSource) Read(
 			datapointsRead += worker.datapointsRead
 		}
 		s.log.Info("read commit logs done",
-			zap.Stringer("took", s.nowFn().Sub(startCommitLogsRead)),
+			zap.Duration("took", s.nowFn().Sub(startCommitLogsRead)),
 			zap.Int("datapointsRead", datapointsRead),
 			zap.Int("datapointsSkippedNotBootstrappingNamespace", datapointsSkippedNotBootstrappingNamespace),
 			zap.Int("datapointsSkippedNotBootstrappingShard", datapointsSkippedNotBootstrappingShard),

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -798,8 +798,8 @@ func (s *peersSource) processReaders(
 					xtime.NewRanges(timeRange),
 				))
 			} else {
-				s.log.Error(err.Error(),
-					zap.String("timeRange.start", fmt.Sprintf("%v", start)))
+				s.log.Error("error processing readers", zap.Error(err),
+					zap.Time("timeRange.start", start))
 				timesWithErrors = append(timesWithErrors, timeRange.Start)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes some zap field types to display e.g. `"took":"6m42.895234s"` vs `"took":404.830821181` 