### PR TITLE
Closes seekers on shard close

### DIFF
--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -386,10 +386,10 @@ func (mr *MockDataFileSetSeekerMockRecorder) ConcurrentClone() *gomock.Call {
 }
 
 // ConcurrentIDBloomFilter mocks base method
-func (m *MockDataFileSetSeeker) ConcurrentIDBloomFilter() *ManagedConcurrentBloomFilter {
+func (m *MockDataFileSetSeeker) ConcurrentIDBloomFilter() ManagedBloomFilter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConcurrentIDBloomFilter")
-	ret0, _ := ret[0].(*ManagedConcurrentBloomFilter)
+	ret0, _ := ret[0].(ManagedBloomFilter)
 	return ret0
 }
 

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -151,6 +151,19 @@ func (r *blockRetriever) Open(ns namespace.Metadata) error {
 	return nil
 }
 
+func (r *blockRetriever) CleanupShardIndices(shards []uint32) error {
+	r.RLock()
+	if r.status != blockRetrieverOpen {
+		r.RUnlock()
+		return errBlockRetrieverNotOpen
+	}
+	seekerMgr := r.seekerMgr
+	r.RUnlock()
+
+	seekerMgr.CleanupShardIndices(shards)
+	return nil
+}
+
 func (r *blockRetriever) CacheShardIndices(shards []uint32) error {
 	r.RLock()
 	if r.status != blockRetrieverOpen {

--- a/src/dbnode/persist/fs/seek.go
+++ b/src/dbnode/persist/fs/seek.go
@@ -76,7 +76,7 @@ type seeker struct {
 
 	// Bloom filter associated with the shard / block the seeker is responsible
 	// for. Needs to be closed when done.
-	bloomFilter *ManagedConcurrentBloomFilter
+	bloomFilter ManagedBloomFilter
 	indexLookup *nearestIndexOffsetLookup
 
 	isClone bool
@@ -138,7 +138,7 @@ func newSeeker(opts seekerOpts) fileSetSeeker {
 	}
 }
 
-func (s *seeker) ConcurrentIDBloomFilter() *ManagedConcurrentBloomFilter {
+func (s *seeker) ConcurrentIDBloomFilter() ManagedBloomFilter {
 	return s.bloomFilter
 }
 

--- a/src/dbnode/persist/fs/test_bloom_filter.go
+++ b/src/dbnode/persist/fs/test_bloom_filter.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fs
+
+import (
+	"github.com/m3db/bloom"
+)
+
+// TestManagedBloomFilter is a container object that implements a no-op lifecycle
+// management on-top of a BloomFilter. I.E it wraps a bloom filter such that
+// all resources are released when the Close() method is called. It's also safe
+// for concurrent access
+type TestManagedBloomFilter struct {
+	*bloom.ConcurrentReadOnlyBloomFilter
+}
+
+// Close closes the bloom filter, Releasing any held resources
+func (bf *TestManagedBloomFilter) Close() error {
+	return nil
+}
+
+// NewTestManagedBloomFilter returns a test implementation of ManagedBloomFilter.
+// This test implementation is backed by an in-memory implementation of bloom filter
+func NewTestManagedBloomFilter(m uint, k uint, data []byte) ManagedBloomFilter {
+	return &TestManagedBloomFilter{bloom.NewConcurrentReadOnlyBloomFilter(m, k, data)}
+}

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -119,6 +119,22 @@ type DataReaderOpenOptions struct {
 	FileSetType persist.FileSetType
 }
 
+// ManagedBloomFilter is a container object that implements lifecycle
+// management on-top of a BloomFilter. I.E it wraps a bloom filter such that
+// all resources are released when the Close() method is called.
+type ManagedBloomFilter interface {
+	io.Closer
+
+	// Test tests whether a value is in the bloom filter
+	Test(value []byte) bool
+
+	// M returns the number of elements in the bloom filter
+	M() uint
+
+	// K returns the number of hash functions in the bloom filter
+	K() uint
+}
+
 // DataFileSetReader provides an unsynchronized reader for a TSDB file set
 type DataFileSetReader interface {
 	io.Closer
@@ -202,7 +218,7 @@ type DataFileSetSeeker interface {
 	// be used to quickly disqualify ID's that definitely do not exist. I.E if the
 	// Test() method returns true, the ID may exist on disk, but if it returns
 	// false, it definitely does not.
-	ConcurrentIDBloomFilter() *ManagedConcurrentBloomFilter
+	ConcurrentIDBloomFilter() ManagedBloomFilter
 
 	// ConcurrentClone clones a seeker, creating a copy that uses the same underlying resources
 	// (mmaps), but that is capable of seeking independently. The original can continue
@@ -231,7 +247,7 @@ type ConcurrentDataFileSetSeeker interface {
 	SeekIndexEntry(id ident.ID, resources ReusableSeekerResources) (IndexEntry, error)
 
 	// ConcurrentIDBloomFilter is the same as in DataFileSetSeeker
-	ConcurrentIDBloomFilter() *ManagedConcurrentBloomFilter
+	ConcurrentIDBloomFilter() ManagedBloomFilter
 }
 
 // DataFileSetSeekerManager provides management of seekers for a TSDB namespace.
@@ -244,6 +260,19 @@ type DataFileSetSeekerManager interface {
 	// CacheShardIndices will pre-parse the indexes for given shards
 	// to improve times when seeking to a block.
 	CacheShardIndices(shards []uint32) error
+
+	// Closes seekers for shards. This functionality is needed when shards move out of
+	// a node on topology change and file descriptors backing shards need to be closed
+	// so that the shards' fileset files can be deleted from disk.
+	// This operation is best effort and the actual file descriptors are closed asynchronous
+	// to this this method.
+	// Seekers are not closed until all the borrowed seekers are returned. If a seeker is
+	// borrowed (Borrow()) or tested (Test()) after closing shard indices, then the seeker
+	// will be reopened.
+	// Seeker manager is not responsible to track the lifecycle of a shard. Its the reponsibility
+	// of the caller to not borrow or test a seeker after closing the seeker if they want seeker
+	// to finally be closed.
+	CleanupShardIndices(shards []uint32)
 
 	// Borrow returns an open seeker for a given shard, block start time, and
 	// volume.

--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -868,6 +868,20 @@ func (mr *MockDatabaseBlockRetrieverMockRecorder) CacheShardIndices(shards inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheShardIndices", reflect.TypeOf((*MockDatabaseBlockRetriever)(nil).CacheShardIndices), shards)
 }
 
+// CleanupShardIndices mocks base method
+func (m *MockDatabaseBlockRetriever) CleanupShardIndices(shards []uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CleanupShardIndices", shards)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CleanupShardIndices indicates an expected call of CleanupShardIndices
+func (mr *MockDatabaseBlockRetrieverMockRecorder) CleanupShardIndices(shards interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupShardIndices", reflect.TypeOf((*MockDatabaseBlockRetriever)(nil).CacheShardIndices), shards)
+}
+
 // Stream mocks base method
 func (m *MockDatabaseBlockRetriever) Stream(ctx context.Context, shard uint32, id ident.ID, blockStart time.Time, onRetrieve OnRetrieveBlock, nsCtx namespace.Context) (xio.BlockReader, error) {
 	m.ctrl.T.Helper()

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -271,6 +271,12 @@ type DatabaseBlockRetriever interface {
 	// to improve times when streaming a block.
 	CacheShardIndices(shards []uint32) error
 
+	// CleanupShardIndices purge pre-parsed indexes for the given shards and
+	// close file descriptors to the fileset files for the given shards.
+	// Shard indices are closed on a best effort basis and may fail without
+	// returning an error.
+	CleanupShardIndices(shards []uint32) error
+
 	// Stream will stream a block for a given shard, id and start.
 	Stream(
 		ctx context.Context,

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -332,8 +332,9 @@ func TestShardBootstrapWithCacheShardIndices(t *testing.T) {
 	s := testDatabaseShard(t, opts)
 	defer s.Close()
 
+	mockRetrieverMgr.EXPECT().Retriever(s.namespace).Return(mockRetriever, nil).Times(2)
 	mockRetriever.EXPECT().CacheShardIndices([]uint32{s.ID()}).Return(nil)
-	mockRetrieverMgr.EXPECT().Retriever(s.namespace).Return(mockRetriever, nil)
+	mockRetriever.EXPECT().CleanupShardIndices([]uint32{s.ID()}).Return(nil)
 
 	ctx := context.NewContext()
 	defer ctx.Close()


### PR DESCRIPTION
- Resolves github issue - https://github.com/m3db/m3/issues/2294

- Shards are closed and fileset files deleted when a shard leaves a node
on topologu change. Ideally the fileset files should be deleted from
disk but because file descriptor to these files stays open, underlying
OS is unable to delete them from disk.

- This commit resolve this issue by explicitly closing the seekers for a
shard on shard close. A seeker is a wrapper on top of index and data db
files.

- Introduces unit tests to test CloseShardIndices() behavior

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2294 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
