### PR TITLE
Emits oldest repair time for successfully repaired time range per ns

### DIFF
--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -395,9 +395,9 @@ const (
 )
 
 type repairState struct {
-	LastSuccessfullAttempt time.Time
-	LastAttempt            time.Time
-	Status                 repairStatus
+	LastSuccessfulAttempt time.Time
+	LastAttempt           time.Time
+	Status                repairStatus
 }
 
 type namespaceRepairStateByTime map[xtime.UnixNano]repairState
@@ -596,8 +596,8 @@ func (r *dbRepairer) Repair() error {
 				leastRecentlyRepairedBlockStartLastRepairTime = repairState.LastAttempt
 			}
 
-			if repairState.LastSuccessfullAttempt.Before(leastRecentlySuccessfullyRepairedBlockStartLastRepairTime) {
-				leastRecentlySuccessfullyRepairedBlockStartLastRepairTime = repairState.LastSuccessfullAttempt
+			if repairState.LastSuccessfulAttempt.Before(leastRecentlySuccessfullyRepairedBlockStartLastRepairTime) {
+				leastRecentlySuccessfullyRepairedBlockStartLastRepairTime = repairState.LastSuccessfulAttempt
 			}
 			return true
 		})
@@ -703,7 +703,7 @@ func (r *dbRepairer) markRepairAttempt(
 	repairState.Status = repairStatus
 	repairState.LastAttempt = repairTime
 	if repairStatus == repairSuccess {
-		repairState.LastSuccessfullAttempt = repairTime
+		repairState.LastSuccessfulAttempt = repairTime
 	}
 	r.repairStatesByNs.setRepairState(namespace, blockStart, repairState)
 }

--- a/src/dbnode/storage/repair.go
+++ b/src/dbnode/storage/repair.go
@@ -395,8 +395,9 @@ const (
 )
 
 type repairState struct {
-	LastAttempt time.Time
-	Status      repairStatus
+	LastSuccessfullAttempt time.Time
+	LastAttempt            time.Time
+	Status                 repairStatus
 }
 
 type namespaceRepairStateByTime map[xtime.UnixNano]repairState
@@ -577,18 +578,32 @@ func (r *dbRepairer) Repair() error {
 		repairRange.Start = repairRange.Start.Add(-blockSize)
 
 		var (
-			numUnrepairedBlocks                           = 0
-			hasRepairedABlockStart                        = false
-			leastRecentlyRepairedBlockStart               time.Time
-			leastRecentlyRepairedBlockStartLastRepairTime time.Time
+			numUnrepairedBlocks                                       = 0
+			hasRepairedABlockStart                                    = false
+			leastRecentlyRepairedBlockStart                           time.Time
+			leastRecentlyRepairedBlockStartLastRepairTime             time.Time
+			leastRecentlySuccessfullyRepairedBlockStartLastRepairTime = r.nowFn()
 		)
+
+		// Record the earliest repaired time range and the earliet successfully repaired time range across all the
+		// time ranges for a namespace.
 		repairRange.IterateBackward(blockSize, func(blockStart time.Time) bool {
 			repairState, ok := r.repairStatesByNs.repairStates(n.ID(), blockStart)
+
 			if ok && (leastRecentlyRepairedBlockStart.IsZero() ||
 				repairState.LastAttempt.Before(leastRecentlyRepairedBlockStartLastRepairTime)) {
 				leastRecentlyRepairedBlockStart = blockStart
 				leastRecentlyRepairedBlockStartLastRepairTime = repairState.LastAttempt
 			}
+
+			if repairState.LastSuccessfullAttempt.Before(leastRecentlySuccessfullyRepairedBlockStartLastRepairTime) {
+				leastRecentlySuccessfullyRepairedBlockStartLastRepairTime = repairState.LastSuccessfullAttempt
+			}
+			return true
+		})
+
+		repairRange.IterateBackward(blockSize, func(blockStart time.Time) bool {
+			repairState, ok := r.repairStatesByNs.repairStates(n.ID(), blockStart)
 
 			if ok && repairState.Status == repairSuccess {
 				return true
@@ -622,6 +637,12 @@ func (r *dbRepairer) Repair() error {
 		r.scope.Tagged(map[string]string{
 			"namespace": n.ID().String(),
 		}).Gauge("max-seconds-since-last-block-repair").Update(secondsSinceLastRepair)
+
+		secondsSinceLastSuccessfullRepair :=
+			r.nowFn().Sub(leastRecentlySuccessfullyRepairedBlockStartLastRepairTime).Seconds()
+		r.scope.Tagged(map[string]string{
+			"namespace": n.ID().String(),
+		}).Gauge("max-seconds-since-oldest-successful-block-repair").Update(secondsSinceLastSuccessfullRepair)
 
 		if hasRepairedABlockStart {
 			// Previous loop performed a repair which means we've hit our limit of repairing
@@ -681,6 +702,9 @@ func (r *dbRepairer) markRepairAttempt(
 	repairState, _ := r.repairStatesByNs.repairStates(namespace, blockStart)
 	repairState.Status = repairStatus
 	repairState.LastAttempt = repairTime
+	if repairStatus == repairSuccess {
+		repairState.LastSuccessfullAttempt = repairTime
+	}
 	r.repairStatesByNs.setRepairState(namespace, blockStart, repairState)
 }
 

--- a/src/dbnode/storage/repair_test.go
+++ b/src/dbnode/storage/repair_test.go
@@ -718,8 +718,8 @@ func TestDatabaseRepairSkipsPoisonShard(t *testing.T) {
 		flushTimeStart = retention.FlushTimeStart(rOpts, now)
 		flushTimeEnd   = retention.FlushTimeEnd(rOpts, now)
 
-		//flushTimeStartNano = xtime.ToUnixNano(flushTimeStart)
-		flushTimeEndNano = xtime.ToUnixNano(flushTimeEnd)
+		flushTimeStartNano = xtime.ToUnixNano(flushTimeStart)
+		flushTimeEndNano   = xtime.ToUnixNano(flushTimeEnd)
 	)
 	require.NoError(t, nsOpts.Validate())
 	// Ensure only two flushable blocks in retention to make test logic simpler.
@@ -740,8 +740,14 @@ func TestDatabaseRepairSkipsPoisonShard(t *testing.T) {
 			repairState: repairStatesByNs{
 				"ns2": namespaceRepairStateByTime{
 					flushTimeEndNano: repairState{
-						Status:      repairSuccess,
-						LastAttempt: time.Time{},
+						Status:                 repairSuccess,
+						LastAttempt:            time.Unix(1557745001, 0),
+						LastSuccessfullAttempt: time.Unix(1557745001, 0),
+					},
+					flushTimeStartNano: repairState{
+						Status:                 repairFailed,
+						LastAttempt:            time.Unix(1557745002, 0),
+						LastSuccessfullAttempt: time.Unix(1557745000, 0),
 					},
 				},
 			},
@@ -771,6 +777,9 @@ func TestDatabaseRepairSkipsPoisonShard(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
 			opts := DefaultTestOptions().SetRepairOptions(testRepairOptions(ctrl))
+			iopts := opts.InstrumentOptions()
+			scope := tally.NewTestScope("", nil)
+			opts = opts.SetInstrumentOptions(iopts.SetMetricsScope(scope))
 			mockDatabase := NewMockdatabase(ctrl)
 
 			databaseRepairer, err := newDatabaseRepairer(mockDatabase, opts)
@@ -818,6 +827,12 @@ func TestDatabaseRepairSkipsPoisonShard(t *testing.T) {
 			mockDatabase.EXPECT().OwnedNamespaces().Return(namespaces, nil)
 
 			require.NotNil(t, repairer.Repair())
+
+			gaugesSnapshot := scope.Snapshot().Gauges()
+			require.Equal(t, now.Sub(time.Time{}).Seconds(),
+				gaugesSnapshot[tally.KeyForPrefixedStringMap("repair.max-seconds-since-oldest-successful-block-repair", map[string]string{"namespace": "ns1"})].Value())
+			require.Equal(t, now.Sub(time.Unix(1557745000, 0)).Seconds(),
+				gaugesSnapshot[tally.KeyForPrefixedStringMap("repair.max-seconds-since-oldest-successful-block-repair", map[string]string{"namespace": "ns2"})].Value())
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Emits a metric to monitor the last successfully repaired time range for a namespace. This will help monitor how long it has been since a time range was successfully repaired.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
