### PR TITLE
[dbnode] Fix first write logic

### DIFF
--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -981,10 +981,8 @@ func (b *BufferBucketVersions) firstWrite(opts streamsOptions) time.Time {
 			continue
 		}
 		// Get the earliest valid first write time.
-		if res.IsZero() {
-			res = bucket.firstWrite
-		}
-		if bucket.firstWrite.Before(res) {
+		if res.IsZero() ||
+			(bucket.firstWrite.Before(res) && !bucket.firstWrite.IsZero()) {
 			res = bucket.firstWrite
 		}
 	}
@@ -1206,8 +1204,9 @@ func (b *BufferBucket) write(
 
 	var err error
 	defer func() {
+		nowFn := b.opts.ClockOptions().NowFn()
 		if err == nil && b.firstWrite.IsZero() {
-			b.firstWrite = timestamp
+			b.firstWrite = nowFn()
 		}
 	}()
 

--- a/src/dbnode/storage/series/buffer_test.go
+++ b/src/dbnode/storage/series/buffer_test.go
@@ -1572,6 +1572,19 @@ func TestColdFlushBlockStarts(t *testing.T) {
 			},
 		},
 		blockData{
+			start:     blockStart2,
+			writeType: ColdWrite,
+			data: [][]DecodedTestValue{
+				{
+					{blockStart2.Add(secs(2)), 4, xtime.Second, nil},
+					{blockStart2.Add(secs(5)), 5, xtime.Second, nil},
+					{blockStart2.Add(secs(11)), 6, xtime.Second, nil},
+					{blockStart2.Add(secs(15)), 7, xtime.Second, nil},
+					{blockStart2.Add(secs(40)), 8, xtime.Second, nil},
+				},
+			},
+		},
+		blockData{
 			start:     blockStart3,
 			writeType: ColdWrite,
 			data: [][]DecodedTestValue{
@@ -1733,7 +1746,7 @@ func TestFetchBlocksForColdFlush(t *testing.T) {
 	assert.True(t, wasWritten)
 	result, err = buffer.FetchBlocksForColdFlush(ctx, blockStart2, 1, nsCtx)
 	assert.NoError(t, err)
-	assert.Equal(t, now, result.FirstWritet)
+	assert.Equal(t, now, result.FirstWrite)
 
 	result, err = buffer.FetchBlocksForColdFlush(ctx, blockStart3, 1, nsCtx)
 	assert.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
--> 
Record buffer first writes as now. Also don't set if the bucket write value is zero. 

Adds tests for first write.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
