### PR TITLE
[dbnode] Add cold mutable segs and expose APIs to rotate/evict

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -651,13 +651,11 @@ func (i *nsIndex) writeBatches(
 				return
 			}
 
-			if ts.Before(pastLimit) {
+			if ts.Before(pastLimit) && !i.coldWritesEnabled {
 				// NB(bodu): We only mark entries as too far in the past if
 				// cold writes are not enabled.
-				if !i.coldWritesEnabled {
-					batch.MarkUnmarkedEntryError(m3dberrors.ErrTooPast, idx)
-					return
-				}
+				batch.MarkUnmarkedEntryError(m3dberrors.ErrTooPast, idx)
+				return
 			}
 
 			if forwardIndexEnabled {
@@ -956,7 +954,7 @@ func (i *nsIndex) canFlushBlock(
 			return false, nil
 		}
 	case series.ColdWrite:
-		if !block.IsSealed() || !block.NeedsColdMutableSegmentsEvicted() {
+		if !block.NeedsColdMutableSegmentsEvicted() {
 			return false, nil
 		}
 	}

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -1007,7 +1007,7 @@ func (b *block) NeedsColdMutableSegmentsEvicted() bool {
 	for _, coldSeg := range b.coldMutableSegments {
 		anyColdMutableSegmentNeedsEviction = anyColdMutableSegmentNeedsEviction || coldSeg.NeedsEviction()
 	}
-	return anyColdMutableSegmentNeedsEviction
+	return b.state == blockStateSealed && anyColdMutableSegmentNeedsEviction
 }
 
 func (b *block) EvictColdMutableSegments() error {

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -128,6 +128,7 @@ type block struct {
 	state blockState
 
 	mutableSegments                 *mutableSegments
+	coldMutableSegments             []*mutableSegments
 	shardRangesSegmentsByVolumeType shardRangesSegmentsByVolumeType
 	newFieldsAndTermsIteratorFn     newFieldsAndTermsIteratorFn
 	newExecutorFn                   newExecutorFn
@@ -136,6 +137,7 @@ type block struct {
 	blockSize                       time.Duration
 	opts                            Options
 	iopts                           instrument.Options
+	blockOpts                       BlockOptions
 	nsMD                            namespace.Metadata
 	queryStats                      stats.QueryStats
 
@@ -200,18 +202,29 @@ func NewBlock(
 	iopts := opts.InstrumentOptions()
 	scope := iopts.MetricsScope().SubScope("index").SubScope("block")
 	iopts = iopts.SetMetricsScope(scope)
-	mutableSegments := newMutableSegments(
+	segs := newMutableSegments(
 		blockStart,
 		opts,
 		blockOpts,
 		iopts,
 	)
+	// NB(bodu): The length of coldMutableSegments is always at least 1.
+	coldSegs := []*mutableSegments{
+		newMutableSegments(
+			blockStart,
+			opts,
+			blockOpts,
+			iopts,
+		),
+	}
 	b := &block{
 		state:                           blockStateOpen,
 		blockStart:                      blockStart,
 		blockEnd:                        blockStart.Add(blockSize),
 		blockSize:                       blockSize,
-		mutableSegments:                 mutableSegments,
+		blockOpts:                       blockOpts,
+		mutableSegments:                 segs,
+		coldMutableSegments:             coldSegs,
 		shardRangesSegmentsByVolumeType: make(shardRangesSegmentsByVolumeType),
 		opts:                            opts,
 		iopts:                           iopts,
@@ -236,12 +249,16 @@ func (b *block) EndTime() time.Time {
 
 func (b *block) WriteBatch(inserts *WriteBatch) (WriteBatchResult, error) {
 	b.RLock()
-	if b.state != blockStateOpen {
+	if !b.writesAcceptedWithRLock() {
 		b.RUnlock()
 		return b.writeBatchResult(inserts, b.writeBatchErrorInvalidState(b.state))
 	}
+	if b.state == blockStateSealed {
+		coldBlock := b.coldMutableSegments[len(b.coldMutableSegments)-1]
+		b.RUnlock()
+		return b.writeBatchResult(inserts, coldBlock.WriteBatch(inserts))
+	}
 	b.RUnlock()
-	// Return result from the original insertion since compaction was successful.
 	return b.writeBatchResult(inserts, b.mutableSegments.WriteBatch(inserts))
 }
 
@@ -275,6 +292,14 @@ func (b *block) writeBatchResult(
 		NumSuccess: int64(inserts.Len() - numErr),
 		NumError:   int64(numErr),
 	}, partialErr
+}
+
+func (b *block) writesAcceptedWithRLock() bool {
+	if b.state == blockStateOpen {
+		return true
+	}
+	return b.state == blockStateSealed &&
+		b.nsMD.Options().ColdWritesEnabled()
 }
 
 func (b *block) executorWithRLock() (search.Executor, error) {
@@ -973,6 +998,48 @@ func (b *block) EvictMutableSegments() error {
 	}
 
 	return multiErr.FinalError()
+}
+
+func (b *block) NeedsColdMutableSegmentsEvicted() bool {
+	b.RLock()
+	defer b.RUnlock()
+	var anyColdMutableSegmentNeedsEviction bool
+	for _, coldSeg := range b.coldMutableSegments {
+		anyColdMutableSegmentNeedsEviction = anyColdMutableSegmentNeedsEviction || coldSeg.NeedsEviction()
+	}
+	return anyColdMutableSegmentNeedsEviction
+}
+
+func (b *block) EvictColdMutableSegments() error {
+	b.Lock()
+	defer b.Unlock()
+	if b.state != blockStateSealed {
+		return fmt.Errorf("unable to evict cold mutable segments, block must be sealed, found: %v", b.state)
+	}
+
+	// Evict/remove all but the most recent cold mutable segment (That is the one we are actively writing to).
+	for i, coldSeg := range b.coldMutableSegments {
+		if i < len(b.coldMutableSegments)-1 {
+			coldSeg.Evict()
+			b.coldMutableSegments[i] = nil
+		}
+	}
+	// Swap last w/ first and truncate the slice.
+	lastIdx := len(b.coldMutableSegments) - 1
+	b.coldMutableSegments[0], b.coldMutableSegments[lastIdx] = b.coldMutableSegments[lastIdx], b.coldMutableSegments[0]
+	b.coldMutableSegments = b.coldMutableSegments[:1]
+	return nil
+}
+
+func (b *block) RotateColdMutableSegments() {
+	b.Lock()
+	defer b.Unlock()
+	b.coldMutableSegments = append(b.coldMutableSegments, newMutableSegments(
+		b.blockStart,
+		b.opts,
+		b.blockOpts,
+		b.iopts,
+	))
 }
 
 func (b *block) MemorySegmentsData(ctx context.Context) ([]fst.SegmentData, error) {

--- a/src/dbnode/storage/index/index_mock.go
+++ b/src/dbnode/storage/index/index_mock.go
@@ -814,6 +814,46 @@ func (mr *MockBlockMockRecorder) EvictMutableSegments() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictMutableSegments", reflect.TypeOf((*MockBlock)(nil).EvictMutableSegments))
 }
 
+// NeedsColdMutableSegmentsEvicted mocks base method
+func (m *MockBlock) NeedsColdMutableSegmentsEvicted() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeedsColdMutableSegmentsEvicted")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NeedsColdMutableSegmentsEvicted indicates an expected call of NeedsColdMutableSegmentsEvicted
+func (mr *MockBlockMockRecorder) NeedsColdMutableSegmentsEvicted() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedsColdMutableSegmentsEvicted", reflect.TypeOf((*MockBlock)(nil).NeedsColdMutableSegmentsEvicted))
+}
+
+// EvictColdMutableSegments mocks base method
+func (m *MockBlock) EvictColdMutableSegments() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EvictColdMutableSegments")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EvictColdMutableSegments indicates an expected call of EvictColdMutableSegments
+func (mr *MockBlockMockRecorder) EvictColdMutableSegments() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictColdMutableSegments", reflect.TypeOf((*MockBlock)(nil).EvictColdMutableSegments))
+}
+
+// RotateColdMutableSegments mocks base method
+func (m *MockBlock) RotateColdMutableSegments() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RotateColdMutableSegments")
+}
+
+// RotateColdMutableSegments indicates an expected call of RotateColdMutableSegments
+func (mr *MockBlockMockRecorder) RotateColdMutableSegments() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateColdMutableSegments", reflect.TypeOf((*MockBlock)(nil).RotateColdMutableSegments))
+}
+
 // MemorySegmentsData mocks base method
 func (m *MockBlock) MemorySegmentsData(ctx context.Context) ([]fst.SegmentData, error) {
 	m.ctrl.T.Helper()

--- a/src/dbnode/storage/index/mutable_segments.go
+++ b/src/dbnode/storage/index/mutable_segments.go
@@ -42,6 +42,7 @@ import (
 
 var (
 	errUnableToWriteBlockConcurrent            = errors.New("unable to write, index block is being written to already")
+	errMutableSegmentsAlreadyClosed            = errors.New("mutable segments already closed")
 	errForegroundCompactorNoPlan               = errors.New("index foreground compactor failed to generate a plan")
 	errForegroundCompactorBadPlanFirstTask     = errors.New("index foreground compactor generated plan without mutable segment in first task")
 	errForegroundCompactorBadPlanSecondaryTask = errors.New("index foreground compactor generated plan with mutable segment a secondary task")
@@ -113,6 +114,10 @@ func newMutableSegments(
 
 func (m *mutableSegments) WriteBatch(inserts *WriteBatch) error {
 	m.Lock()
+	if m.state == mutableSegmentsStateClosed {
+		return errMutableSegmentsAlreadyClosed
+	}
+
 	if m.compact.compactingForeground {
 		m.Unlock()
 		return errUnableToWriteBlockConcurrent
@@ -397,7 +402,7 @@ func (m *mutableSegments) backgroundCompactWithPlan(plan *compaction.Plan) {
 				zap.Int("task", i),
 				zap.Int("numMutable", summary.NumMutable),
 				zap.Int("numFST", summary.NumFST),
-				zap.String("cumulativeMutableAge", summary.CumulativeMutableAge.String()),
+				zap.Stringer("cumulativeMutableAge", summary.CumulativeMutableAge.String()),
 				zap.Int64("cumulativeSize", summary.CumulativeSize),
 			)
 		}

--- a/src/dbnode/storage/index/mutable_segments.go
+++ b/src/dbnode/storage/index/mutable_segments.go
@@ -402,7 +402,7 @@ func (m *mutableSegments) backgroundCompactWithPlan(plan *compaction.Plan) {
 				zap.Int("task", i),
 				zap.Int("numMutable", summary.NumMutable),
 				zap.Int("numFST", summary.NumFST),
-				zap.Stringer("cumulativeMutableAge", summary.CumulativeMutableAge.String()),
+				zap.Stringer("cumulativeMutableAge", summary.CumulativeMutableAge),
 				zap.Int64("cumulativeSize", summary.CumulativeSize),
 			)
 		}

--- a/src/dbnode/storage/index/types.go
+++ b/src/dbnode/storage/index/types.go
@@ -362,6 +362,18 @@ type Block interface {
 	// data the mutable segments should have held at this time.
 	EvictMutableSegments() error
 
+	// NeedsMutableSegmentsEvicted returns whether this block has any cold mutable segments
+	// that are not-empty and sealed.
+	NeedsColdMutableSegmentsEvicted() bool
+
+	// EvictMutableSegments closes any stale cold mutable segments up to the currently active
+	// cold mutable segment (the one we are actively writing to).
+	EvictColdMutableSegments() error
+
+	// RotateColdMutableSegments rotates the currently active cold mutable segment out for a
+	// new cold mutable segment to write to.
+	RotateColdMutableSegments()
+
 	// MemorySegmentsData returns all in memory segments data.
 	MemorySegmentsData(ctx context.Context) ([]fst.SegmentData, error)
 

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -299,7 +299,7 @@ func TestNamespaceIndexFlushSuccess(t *testing.T) {
 	mockBlock.EXPECT().AddResults(gomock.Any()).Return(nil)
 	mockBlock.EXPECT().EvictMutableSegments().Return(nil)
 
-	require.NoError(t, idx.Flush(mockFlush, shards))
+	require.NoError(t, idx.WarmFlush(mockFlush, shards))
 	require.True(t, persistCalled)
 	require.True(t, persistClosed)
 }
@@ -336,7 +336,7 @@ func TestNamespaceIndexFlushShardStateNotSuccess(t *testing.T) {
 
 	mockFlush := persist.NewMockIndexFlush(ctrl)
 
-	require.NoError(t, idx.Flush(mockFlush, shards))
+	require.NoError(t, idx.WarmFlush(mockFlush, shards))
 }
 
 func TestNamespaceIndexFlushSuccessMultipleShards(t *testing.T) {
@@ -414,7 +414,7 @@ func TestNamespaceIndexFlushSuccessMultipleShards(t *testing.T) {
 	mockBlock.EXPECT().AddResults(gomock.Any()).Return(nil)
 	mockBlock.EXPECT().EvictMutableSegments().Return(nil)
 
-	require.NoError(t, idx.Flush(mockFlush, shards))
+	require.NoError(t, idx.WarmFlush(mockFlush, shards))
 	require.Equal(t, 1, numPersistCalls)
 	require.True(t, persistClosed)
 }

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1221,7 +1221,7 @@ func (n *dbNamespace) FlushIndex(flush persist.IndexFlush) error {
 	}
 
 	shards := n.OwnedShards()
-	err := n.reverseIndex.Flush(flush, shards)
+	err := n.reverseIndex.WarmFlush(flush, shards)
 	n.metrics.flushIndex.ReportSuccessOrError(err, n.nowFn().Sub(callStart))
 	return err
 }

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1181,7 +1181,7 @@ func (n *dbNamespace) ColdFlush(flushPersist persist.FlushPreparer) error {
 	// we actually cold flush the data to disk we will be making writes to the newly active mutable seg.
 	// This means that some series can live doubly in-mem and loaded from disk until the next cold flush
 	// where they will be evicted from the in-mem index.
-	onColdFlushDone, err := n.reverseIndex.ColdFlush()
+	onColdFlushDone, err := n.reverseIndex.ColdFlush(shards)
 	if err != nil {
 		return err
 	}

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2175,18 +2175,33 @@ func (mr *MockNamespaceIndexMockRecorder) Tick(c, startTime interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tick", reflect.TypeOf((*MockNamespaceIndex)(nil).Tick), c, startTime)
 }
 
-// Flush mocks base method
-func (m *MockNamespaceIndex) Flush(flush persist.IndexFlush, shards []databaseShard) error {
+// WarmFlush mocks base method
+func (m *MockNamespaceIndex) WarmFlush(flush persist.IndexFlush, shards []databaseShard) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Flush", flush, shards)
+	ret := m.ctrl.Call(m, "WarmFlush", flush, shards)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Flush indicates an expected call of Flush
-func (mr *MockNamespaceIndexMockRecorder) Flush(flush, shards interface{}) *gomock.Call {
+// WarmFlush indicates an expected call of WarmFlush
+func (mr *MockNamespaceIndexMockRecorder) WarmFlush(flush, shards interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockNamespaceIndex)(nil).Flush), flush, shards)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WarmFlush", reflect.TypeOf((*MockNamespaceIndex)(nil).WarmFlush), flush, shards)
+}
+
+// ColdFlush mocks base method
+func (m *MockNamespaceIndex) ColdFlush(shards []databaseShard) (OnColdFlushDone, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ColdFlush", shards)
+	ret0, _ := ret[0].(OnColdFlushDone)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ColdFlush indicates an expected call of ColdFlush
+func (mr *MockNamespaceIndexMockRecorder) ColdFlush(shards interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ColdFlush", reflect.TypeOf((*MockNamespaceIndex)(nil).ColdFlush), shards)
 }
 
 // DebugMemorySegments mocks base method

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -632,12 +632,17 @@ type NamespaceIndex interface {
 	// data eviction, and so on.
 	Tick(c context.Cancellable, startTime time.Time) (namespaceIndexTickResult, error)
 
-	// Flush performs any flushes that the index has outstanding using
+	// WarmFlush performs any warm flushes that the index has outstanding using
 	// the owned shards of the database.
-	Flush(
+	WarmFlush(
 		flush persist.IndexFlush,
 		shards []databaseShard,
 	) error
+
+	// ColdFlush performs any cold flushes that the index has outstanding using
+	// the owned shards of the database. Also returns a callback to be called when
+	// cold flushing completes to perform houskeeping.
+	ColdFlush(shards []databaseShard) (OnColdFlushDone, error)
 
 	// DebugMemorySegments allows for debugging memory segments.
 	DebugMemorySegments(opts DebugMemorySegmentsOptions) error
@@ -645,6 +650,9 @@ type NamespaceIndex interface {
 	// Close will release the index resources and close the index.
 	Close() error
 }
+
+// OnColdFlushDone is a callback that performs house keeping once cold flushing completes.
+type OnColdFlushDone func() error
 
 // DebugMemorySegmentsOptions is a set of options to debug memory segments.
 type DebugMemorySegmentsOptions struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds knowledge of cold mutable segs to an index block. Also exposes APIs to rotate cold segs and evict them. 
Handle both cases in namespace cold flush.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
