### PR TITLE
Update commit log writer flush fn refs after we swap them.

### DIFF
--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -222,6 +222,8 @@ func (w *mockCommitLogWriter) Close() error {
 	return w.closeFn()
 }
 
+func (w *mockCommitLogWriter) updateFlushFn(_ flushFn) {}
+
 func newTestCommitLog(t *testing.T, opts Options) *commitLog {
 	commitLogI, err := NewCommitLog(opts)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Commit log writer flush fn refs go stale when we swap them. We need to update them accordingly. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
