### PR TITLE
[dbnode] Let cold writes through and seal cold created index blocks

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -838,7 +838,7 @@ func (i *nsIndex) Tick(c context.Cancellable, startTime time.Time) (namespaceInd
 		result.NumTotalDocs += blockTickResult.NumDocs
 
 		// seal any blocks that are sealable
-		if blockStart.ToTime().Before(i.lastSealableBlockStart(startTime)) && !block.IsSealed() {
+		if !blockStart.ToTime().After(i.lastSealableBlockStart(startTime)) && !block.IsSealed() {
 			multiErr = multiErr.Add(block.Seal())
 			result.NumBlocksSealed++
 		}
@@ -1566,7 +1566,7 @@ func (i *nsIndex) ensureBlockPresentWithRLock(blockStart time.Time) (index.Block
 
 	// NB(bodu): Use same time barrier as `Tick` to make sealing of cold index blocks consistent.
 	// We need to seal cold blocks write away for cold writes.
-	if blockStart.Before(i.lastSealableBlockStart(i.nowFn())) {
+	if !blockStart.After(i.lastSealableBlockStart(i.nowFn())) {
 		if err := block.Seal(); err != nil {
 			return nil, err
 		}

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -207,7 +207,6 @@ type dbShardMetrics struct {
 	insertAsyncWriteInternalErrors      tally.Counter
 	insertAsyncWriteInvalidParamsErrors tally.Counter
 	insertAsyncIndexErrors              tally.Counter
-	insertColdWriteSkipIndex            tally.Counter
 }
 
 func newDatabaseShardMetrics(shardID uint32, scope tally.Scope) dbShardMetrics {
@@ -236,7 +235,6 @@ func newDatabaseShardMetrics(shardID uint32, scope tally.Scope) dbShardMetrics {
 			"error_type":    "reverse-index",
 			"suberror_type": "write-batch-error",
 		}).Counter(insertErrorName),
-		insertColdWriteSkipIndex: scope.Counter("insert-cold-write-skip-index"),
 	}
 }
 

--- a/src/dbnode/storage/shard_index_test.go
+++ b/src/dbnode/storage/shard_index_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/index"
-	"github.com/m3db/m3/src/dbnode/storage/series/lookup"
 	"github.com/m3db/m3/src/m3ninx/doc"
 	xclock "github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/context"
@@ -321,85 +320,6 @@ func TestShardAsyncIndexIfExpired(t *testing.T) {
 	// make sure we indexed the second write
 	assert.True(t, entry.IndexedForBlockStart(
 		xtime.ToUnixNano(nextWriteTime.Truncate(blockSize))))
-}
-
-func TestShardColdWriteInsertSkipsIndexInsertQueue(t *testing.T) {
-	defer leaktest.CheckTimeout(t, 2*time.Second)()
-
-	opts := DefaultTestOptions()
-	lock := sync.RWMutex{}
-	indexWrites := []doc.Document{}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	idx := NewMockNamespaceIndex(ctrl)
-	idx.EXPECT().WriteBatch(gomock.Any()).Do(
-		func(batch *index.WriteBatch) {
-			lock.Lock()
-			indexWrites = append(indexWrites, batch.PendingDocs()...)
-			lock.Unlock()
-			// Mark successful.
-			batch.MarkUnmarkedEntriesSuccess()
-		}).Return(nil).AnyTimes()
-
-	shard := testDatabaseShardWithIndexFn(t, opts, idx, true)
-	shard.SetRuntimeOptions(runtime.NewOptions().SetWriteNewSeriesAsync(true))
-	defer shard.Close()
-
-	indexBlockSize := shard.namespace.Options().IndexOptions().BlockSize()
-	writeTimestamp := time.Now().Add(-3 * indexBlockSize)
-	writeBlockStart := xtime.ToUnixNano(writeTimestamp.Truncate(indexBlockSize))
-	idx.EXPECT().BlockStartForWriteTime(writeTimestamp).Return(writeBlockStart)
-
-	ctx := context.NewContext()
-	defer ctx.Close()
-	// Cold write foo.
-	coldWriteID := ident.StringID("foo")
-	_, wasWritten, err := shard.WriteTagged(ctx, coldWriteID,
-		ident.NewTagsIterator(ident.NewTags(ident.StringTag("name", "value"))),
-		writeTimestamp, 1.0, xtime.Second, nil, series.WriteOptions{})
-	assert.NoError(t, err)
-	assert.True(t, wasWritten)
-	// Warm write bar.
-	warmWriteID := ident.StringID("bar")
-	now := time.Now()
-	_, wasWritten, err = shard.WriteTagged(ctx, warmWriteID,
-		ident.NewTagsIterator(ident.NewTags(ident.StringTag("name", "value"))),
-		now, 1.0, xtime.Second, nil, series.WriteOptions{})
-	assert.NoError(t, err)
-	assert.True(t, wasWritten)
-
-	ensureIndexedFn := func(t *testing.T, id ident.ID, blockStart xtime.UnixNano) {
-		for {
-			entry, _, err := shard.tryRetrieveWritableSeries(id)
-			assert.NoError(t, err)
-			if entry != nil {
-				// We take a ref when we retrieve the entry so we need to dec here.
-				entry.DecrementReaderWriterCount()
-				if !entry.NeedsIndexUpdate(blockStart) {
-					break
-				}
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-	}
-
-	// Make sure we've written our cold data first.
-	ensureIndexedFn(t, coldWriteID, writeBlockStart)
-	// Make sure we've written our warm data next.
-	ensureIndexedFn(t, warmWriteID, xtime.ToUnixNano(now.Truncate(indexBlockSize)))
-	assert.Len(t, indexWrites, 1)
-	assert.Equal(t, indexWrites[0].ID, warmWriteID.Bytes())
-
-	// Make sure the ref counts are correct.
-	entryFn := func(entry *lookup.Entry) bool {
-		// forEachShardEntry takes a ref so we make sure that we have only have 1
-		// outstanding ref for each shard entry.
-		assert.Equal(t, int32(1), entry.ReaderWriterCount())
-		return true
-	}
-	shard.forEachShardEntry(entryFn)
 }
 
 // TODO(prateek): wire tests above to use the field `ts`


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Removes prior optimization preventing cold writes from making it into shard index queue. Also immediately seal cold index blocks when we create them. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
