### PR TITLE
[query] Set warning headers in remote read debug endpoint (json format)

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/read.go
+++ b/src/query/api/v1/handler/prometheus/remote/read.go
@@ -174,6 +174,8 @@ func (h *promReadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		handleroptions.AddWarningHeaders(w, readResult.Meta)
+
 		err = json.NewEncoder(w).Encode(result)
 	default:
 		err = WriteSnappyCompressed(w, readResult, logger)


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets the `M3-Results-Limited` header in /prom/remote/read?**format=json** responses. 

**Special notes for your reviewer**:

Oneliner.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:

NONE

**Does this PR require updating code package or user-facing documentation?**:

NONE