### PR TITLE
[dbnode] Add ability to configure peer streaming shard concurrency

### DIFF
--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -99,7 +99,7 @@ func newDefaultBootstrapCommitlogConfiguration() BootstrapCommitlogConfiguration
 	}
 }
 
-// BootstrapPeersConfiguration specifies config for th epeers bootstrapper.
+// BootstrapPeersConfiguration specifies config for the peers bootstrapper.
 type BootstrapPeersConfiguration struct {
 	// StreamShardConcurrency controls how many shards in parallel to stream
 	// for in memory data being streamed between peers (most recent block).

--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -58,6 +58,9 @@ type BootstrapConfiguration struct {
 	// Commitlog bootstrapper configuration.
 	Commitlog *BootstrapCommitlogConfiguration `yaml:"commitlog"`
 
+	// Peers bootstrapper configuration.
+	Peers *BootstrapPeersConfiguration `yaml:"peers"`
+
 	// CacheSeriesMetadata determines whether individual bootstrappers cache
 	// series metadata across all calls (namespaces / shards / blocks).
 	CacheSeriesMetadata *bool `yaml:"cacheSeriesMetadata"`
@@ -93,6 +96,25 @@ type BootstrapCommitlogConfiguration struct {
 func newDefaultBootstrapCommitlogConfiguration() BootstrapCommitlogConfiguration {
 	return BootstrapCommitlogConfiguration{
 		ReturnUnfulfilledForCorruptCommitLogFiles: commitlog.DefaultReturnUnfulfilledForCorruptCommitLogFiles,
+	}
+}
+
+// BootstrapPeersConfiguration specifies config for th epeers bootstrapper.
+type BootstrapPeersConfiguration struct {
+	// StreamShardConcurrency controls how many shards in parallel to stream
+	// for in memory data being streamed between peers (most recent block).
+	// Defaults to: numCPU.
+	StreamShardConcurrency int `yaml:"streamShardConcurrency"`
+	// StreamPersistShardConcurrency controls how many shards in parallel to stream
+	// for historical data being streamed between peers (historical blocks).
+	// Defaults to: numCPU / 2.
+	StreamPersistShardConcurrency int `yaml:"streamPersistShardConcurrency"`
+}
+
+func newDefaultBootstrapPeersConfiguration() BootstrapPeersConfiguration {
+	return BootstrapPeersConfiguration{
+		StreamShardConcurrency:        peers.DefaultShardConcurrency,
+		StreamPersistShardConcurrency: peers.DefaultShardPersistenceConcurrency,
 	}
 }
 
@@ -187,6 +209,7 @@ func (bsc BootstrapConfiguration) New(
 				return nil, err
 			}
 		case peers.PeersBootstrapperName:
+			pCfg := bsc.peersConfig()
 			pOpts := peers.NewOptions().
 				SetResultOptions(rsOpts).
 				SetFilesystemOptions(fsOpts).
@@ -195,7 +218,9 @@ func (bsc BootstrapConfiguration) New(
 				SetPersistManager(opts.PersistManager()).
 				SetCompactor(compactor).
 				SetRuntimeOptionsManager(opts.RuntimeOptionsManager()).
-				SetContextPool(opts.ContextPool())
+				SetContextPool(opts.ContextPool()).
+				SetDefaultShardConcurrency(pCfg.StreamShardConcurrency).
+				SetShardPersistenceConcurrency(pCfg.StreamPersistShardConcurrency)
 			if err := validator.ValidatePeersBootstrapperOptions(pOpts); err != nil {
 				return nil, err
 			}
@@ -237,6 +262,13 @@ func (bsc BootstrapConfiguration) commitlogConfig() BootstrapCommitlogConfigurat
 		return *cfg
 	}
 	return newDefaultBootstrapCommitlogConfiguration()
+}
+
+func (bsc BootstrapConfiguration) peersConfig() BootstrapPeersConfiguration {
+	if cfg := bsc.Peers; cfg != nil {
+		return *cfg
+	}
+	return newDefaultBootstrapPeersConfiguration()
 }
 
 type bootstrapConfigurationValidator struct {

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -421,6 +421,7 @@ func TestConfiguration(t *testing.T) {
       numProcessorsPerCPU: 0.42
     commitlog:
       returnUnfulfilledForCorruptCommitLogFiles: false
+    peers: null
     cacheSeriesMetadata: null
   blockRetrieve: null
   cache:

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/options.go
@@ -37,8 +37,16 @@ import (
 )
 
 var (
-	defaultDefaultShardConcurrency     = runtime.NumCPU()
-	defaultShardPersistenceConcurrency = int(math.Max(1, float64(runtime.NumCPU())/2))
+	// DefaultShardConcurrency controls how many shards in parallel to stream
+	// for in memory data being streamed between peers (most recent block).
+	// Update BootstrapPeersConfiguration comment in
+	// src/cmd/services/m3dbnode/config package if this is changed.
+	DefaultShardConcurrency = runtime.NumCPU()
+	// DefaultShardPersistenceConcurrency controls how many shards in parallel to stream
+	// for historical data being streamed between peers (historical blocks).
+	// Update BootstrapPeersConfiguration comment in
+	// src/cmd/services/m3dbnode/config package if this is changed.
+	DefaultShardPersistenceConcurrency = int(math.Max(1, float64(runtime.NumCPU())/2))
 	defaultPersistenceMaxQueueSize     = 0
 )
 
@@ -69,8 +77,8 @@ type options struct {
 func NewOptions() Options {
 	return &options{
 		resultOpts:                  result.NewOptions(),
-		defaultShardConcurrency:     defaultDefaultShardConcurrency,
-		shardPersistenceConcurrency: defaultShardPersistenceConcurrency,
+		defaultShardConcurrency:     DefaultShardConcurrency,
+		shardPersistenceConcurrency: DefaultShardPersistenceConcurrency,
 		persistenceMaxQueueSize:     defaultPersistenceMaxQueueSize,
 		// Use a zero pool, this should be overriden at config time.
 		contextPool: context.NewPool(context.NewOptions().


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds ability to tweak from config the parallelism for shard concurrency from config.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
