### PR TITLE
[dbnode] Add option for experimental TChannel server use

### DIFF
--- a/src/dbnode/integration/serve.go
+++ b/src/dbnode/integration/serve.go
@@ -105,7 +105,8 @@ func openAndServe(
 	contextPool := opts.ContextPool()
 	ttopts := tchannelthrift.NewOptions()
 	service := ttnode.NewService(db, ttopts)
-	nativeNodeClose, err := ttnode.NewServer(service, tchannelNodeAddr, contextPool, nil).ListenAndServe()
+	nodeOpts := ttnode.NewOptions(nil)
+	nativeNodeClose, err := ttnode.NewServer(service, tchannelNodeAddr, contextPool, nodeOpts).ListenAndServe()
 	if err != nil {
 		return fmt.Errorf("could not open tchannelthrift interface %s: %v", tchannelNodeAddr, err)
 	}

--- a/src/dbnode/network/server/tchannelthrift/node/options.go
+++ b/src/dbnode/network/server/tchannelthrift/node/options.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package node
+
+import (
+	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
+	"github.com/m3db/m3/src/x/instrument"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/thrift"
+)
+
+// NewTChanNodeServerFn creates a tchan node server.
+type NewTChanNodeServerFn func(
+	service Service,
+	iOpts instrument.Options,
+) thrift.TChanServer
+
+func defaultTChanNodeServerFn(
+	service Service,
+	_ instrument.Options,
+) thrift.TChanServer {
+	return rpc.NewTChanNodeServer(service)
+}
+
+// Options are thrift options.
+type Options interface {
+	// SetChannelOptions sets a tchan channel options.
+	SetChannelOptions(value *tchannel.ChannelOptions) Options
+
+	// ChannelOptions returns the tchan channel options.
+	ChannelOptions() *tchannel.ChannelOptions
+
+	// SetTChanNodeServerFn sets a tchan node server builder.
+	SetTChanNodeServerFn(value NewTChanNodeServerFn) Options
+
+	// TChanNodeServerFn returns a tchan node server builder.
+	TChanNodeServerFn() NewTChanNodeServerFn
+
+	// SetInstrumentOptions sets the instrumentation options.
+	SetInstrumentOptions(value instrument.Options) Options
+
+	// InstrumentOptions returns the instrumentation options.
+	InstrumentOptions() instrument.Options
+}
+
+type options struct {
+	channelOptions    *tchannel.ChannelOptions
+	instrumentOpts    instrument.Options
+	tchanNodeServerFn NewTChanNodeServerFn
+}
+
+// NewOptions creates a new options.
+func NewOptions(chanOpts *tchannel.ChannelOptions) Options {
+	return &options{
+		channelOptions:    chanOpts,
+		tchanNodeServerFn: defaultTChanNodeServerFn,
+	}
+}
+func (o *options) SetChannelOptions(value *tchannel.ChannelOptions) Options {
+	opts := *o
+	opts.channelOptions = value
+	return &opts
+}
+
+func (o *options) ChannelOptions() *tchannel.ChannelOptions {
+	return o.channelOptions
+}
+
+func (o *options) SetTChanNodeServerFn(value NewTChanNodeServerFn) Options {
+	opts := *o
+	opts.tchanNodeServerFn = value
+	return &opts
+}
+
+func (o *options) TChanNodeServerFn() NewTChanNodeServerFn {
+	return o.tchanNodeServerFn
+}
+
+func (o *options) SetInstrumentOptions(value instrument.Options) Options {
+	opts := *o
+	opts.instrumentOpts = value
+	return &opts
+}
+
+func (o *options) InstrumentOptions() instrument.Options {
+	return o.instrumentOpts
+}

--- a/src/dbnode/server/options.go
+++ b/src/dbnode/server/options.go
@@ -20,10 +20,14 @@
 
 package server
 
-import "github.com/m3db/m3/src/dbnode/storage"
+import (
+	"github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/node"
+	"github.com/m3db/m3/src/dbnode/storage"
+)
 
 // StorageOptions are options to apply to the database storage options.
 type StorageOptions struct {
 	OnColdFlush            storage.OnColdFlush
 	ForceColdWritesEnabled bool
+	TChanNodeServerFn      node.NewTChanNodeServerFn
 }

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -635,8 +635,13 @@ func Run(runOpts RunOptions) {
 		tchannelOpts.MaxIdleTime = cfg.TChannel.MaxIdleTime
 		tchannelOpts.IdleCheckInterval = cfg.TChannel.IdleCheckInterval
 	}
+	tchanOpts := ttnode.NewOptions(tchannelOpts).
+		SetInstrumentOptions(opts.InstrumentOptions())
+	if fn := runOpts.StorageOptions.TChanNodeServerFn; fn != nil {
+		tchanOpts = tchanOpts.SetTChanNodeServerFn(fn)
+	}
 	tchannelthriftNodeClose, err := ttnode.NewServer(service,
-		cfg.ListenAddress, contextPool, tchannelOpts).ListenAndServe()
+		cfg.ListenAddress, contextPool, tchanOpts).ListenAndServe()
 	if err != nil {
 		logger.Fatal("could not open tchannelthrift interface",
 			zap.String("address", cfg.ListenAddress), zap.Error(err))


### PR DESCRIPTION
Adds better control over tchannel servers. Allows for easier experimentation with third party plugins.