### PR TITLE
Reduce ObjectPool overhead

### DIFF
--- a/src/x/pool/object.go
+++ b/src/x/pool/object.go
@@ -25,31 +25,31 @@ import (
 	"math"
 	"sync/atomic"
 
+	"github.com/m3db/m3/src/x/unsafe"
+
 	"github.com/uber-go/tally"
+	"golang.org/x/sys/cpu"
 )
 
 var (
-	errPoolAlreadyInitialized   = errors.New("object pool already initialized")
-	errPoolGetBeforeInitialized = errors.New("object pool get before initialized")
-	errPoolPutBeforeInitialized = errors.New("object pool put before initialized")
+	errPoolAlreadyInitialized      = errors.New("object pool already initialized")
+	errPoolAccessBeforeInitialized = errors.New("object pool accessed before it was initialized")
 )
 
-const (
-	// TODO(r): Use tally sampling when available
-	sampleObjectPoolLengthEvery = 100
-)
+const sampleObjectPoolLengthEvery = 2048
 
 type objectPool struct {
-	opts                ObjectPoolOptions
+	_                   cpu.CacheLinePad
 	values              chan interface{}
+	_                   cpu.CacheLinePad
 	alloc               Allocator
+	metrics             objectPoolMetrics
+	onPoolAccessErrorFn OnPoolAccessErrorFn
 	size                int
 	refillLowWatermark  int
 	refillHighWatermark int
 	filling             int32
 	initialized         int32
-	dice                int32
-	metrics             objectPoolMetrics
 }
 
 type objectPoolMetrics struct {
@@ -68,7 +68,6 @@ func NewObjectPool(opts ObjectPoolOptions) ObjectPool {
 	m := opts.InstrumentOptions().MetricsScope()
 
 	p := &objectPool{
-		opts:   opts,
 		values: make(chan interface{}, opts.Size()),
 		size:   opts.Size(),
 		refillLowWatermark: int(math.Ceil(
@@ -81,6 +80,12 @@ func NewObjectPool(opts ObjectPoolOptions) ObjectPool {
 			getOnEmpty: m.Counter("get-on-empty"),
 			putOnFull:  m.Counter("put-on-full"),
 		},
+		onPoolAccessErrorFn: opts.OnPoolAccessErrorFn(),
+		alloc: func() interface{} {
+			fn := opts.OnPoolAccessErrorFn()
+			fn(errPoolAccessBeforeInitialized)
+			return nil
+		},
 	}
 
 	p.setGauges()
@@ -90,36 +95,36 @@ func NewObjectPool(opts ObjectPoolOptions) ObjectPool {
 
 func (p *objectPool) Init(alloc Allocator) {
 	if !atomic.CompareAndSwapInt32(&p.initialized, 0, 1) {
-		fn := p.opts.OnPoolAccessErrorFn()
-		fn(errPoolAlreadyInitialized)
+		p.onPoolAccessErrorFn(errPoolAlreadyInitialized)
 		return
 	}
 
-	p.alloc = alloc
-
 	for i := 0; i < cap(p.values); i++ {
-		p.values <- p.alloc()
+		p.values <- alloc()
 	}
 
+	p.alloc = alloc
 	p.setGauges()
 }
 
 func (p *objectPool) Get() interface{} {
-	if atomic.LoadInt32(&p.initialized) != 1 {
-		fn := p.opts.OnPoolAccessErrorFn()
-		fn(errPoolGetBeforeInitialized)
-		return p.alloc()
-	}
+	var (
+		metrics = p.metrics
+		v       interface{}
+	)
 
-	var v interface{}
 	select {
 	case v = <-p.values:
 	default:
 		v = p.alloc()
-		p.metrics.getOnEmpty.Inc(1)
+		metrics.getOnEmpty.Inc(1)
 	}
 
-	p.trySetGauges()
+	if unsafe.Fastrandn(sampleObjectPoolLengthEvery) == 0 {
+		// inlined setGauges()
+		metrics.free.Update(float64(len(p.values)))
+		metrics.total.Update(float64(p.size))
+	}
 
 	if p.refillLowWatermark > 0 && len(p.values) <= p.refillLowWatermark {
 		p.tryFill()
@@ -129,24 +134,10 @@ func (p *objectPool) Get() interface{} {
 }
 
 func (p *objectPool) Put(obj interface{}) {
-	if atomic.LoadInt32(&p.initialized) != 1 {
-		fn := p.opts.OnPoolAccessErrorFn()
-		fn(errPoolPutBeforeInitialized)
-		return
-	}
-
 	select {
 	case p.values <- obj:
 	default:
 		p.metrics.putOnFull.Inc(1)
-	}
-
-	p.trySetGauges()
-}
-
-func (p *objectPool) trySetGauges() {
-	if atomic.AddInt32(&p.dice, 1)%sampleObjectPoolLengthEvery == 0 {
-		p.setGauges()
 	}
 }
 

--- a/src/x/pool/object_test.go
+++ b/src/x/pool/object_test.go
@@ -88,6 +88,7 @@ func TestObjectPoolGetBeforeInitError(t *testing.T) {
 	var accessErr error
 	opts := NewObjectPoolOptions().SetOnPoolAccessErrorFn(func(err error) {
 		accessErr = err
+		panic(err)
 	})
 
 	pool := NewObjectPool(opts)

--- a/src/x/pool/object_test.go
+++ b/src/x/pool/object_test.go
@@ -99,7 +99,7 @@ func TestObjectPoolGetBeforeInitError(t *testing.T) {
 	})
 
 	assert.Error(t, accessErr)
-	assert.Equal(t, errPoolGetBeforeInitialized, accessErr)
+	assert.Equal(t, errPoolAccessBeforeInitialized, accessErr)
 }
 
 func TestObjectPoolPutBeforeInitError(t *testing.T) {
@@ -115,7 +115,7 @@ func TestObjectPoolPutBeforeInitError(t *testing.T) {
 	pool.Put(1)
 
 	assert.Error(t, accessErr)
-	assert.Equal(t, errPoolPutBeforeInitialized, accessErr)
+	assert.Equal(t, errPoolAccessBeforeInitialized, accessErr)
 }
 
 func BenchmarkObjectPoolGetPut(b *testing.B) {

--- a/src/x/pool/object_test.go
+++ b/src/x/pool/object_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var neverGonnaOptimizeYouAway interface{}
-
 func TestObjectPoolRefillOnLowWaterMark(t *testing.T) {
 	opts := NewObjectPoolOptions().
 		SetSize(100).
@@ -124,96 +122,32 @@ func BenchmarkObjectPoolGetPut(b *testing.B) {
 	opts := NewObjectPoolOptions().SetSize(1)
 	pool := NewObjectPool(opts)
 	pool.Init(func() interface{} {
-		return make([]byte, 0, 16)
+		b := make([]byte, 0, 16)
+		return &b
 	})
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		o := pool.Get()
-		neverGonnaOptimizeYouAway = o
+		o := pool.Get().(*[]byte)
+		_ = *o
 		pool.Put(o)
 	}
 }
 
-func BenchmarkObjectPoolGetMultiPutContended(b *testing.B) {
-	opts := NewObjectPoolOptions().
-		SetSize(256)
-	p := NewObjectPool(opts)
-	p.Init(func() interface{} {
-		return make([]byte, 0, 32)
-	})
-	objs := make([]interface{}, 16)
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			for i := 0; i < len(objs); i++ {
-				o := p.Get()
-				objs[i] = o
-			}
-
-			for _, obj := range objs {
-				o, ok := obj.([]byte)
-				if !ok {
-					b.Fail()
-				}
-				o = strconv.AppendInt(o[:0], 12344321, 10)
-				p.Put(o)
-			}
-		}
-	})
-}
-
-func BenchmarkObjectPoolGetMultiPutContendedWithRefill(b *testing.B) {
-	opts := NewObjectPoolOptions().
-		SetSize(32).
-		SetRefillLowWatermark(0.05).
-		SetRefillHighWatermark(0.25)
-
-	p := NewObjectPool(opts)
-	p.Init(func() interface{} {
-		return make([]byte, 0, 32)
-	})
-	objs := make([]interface{}, 16)
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			for i := 0; i < len(objs); i++ {
-				o := p.Get()
-				objs[i] = o
-			}
-
-			for _, obj := range objs {
-				o, ok := obj.([]byte)
-				if !ok {
-					b.Fail()
-				}
-				o = strconv.AppendInt(o[:0], 12344321, 10)
-				neverGonnaOptimizeYouAway = o
-				p.Put(o)
-			}
-		}
-	})
-}
-
 // go test -benchmem -run=^$ github.com/m3db/m3/src/x/pool -bench '^(BenchmarkObjectPoolParallel)$' -cpu 1,2,4,6,8,12
-func BenchmarkObjectPoolParallel(b *testing.B) {
+func BenchmarkObjectPoolParallelGetPut(b *testing.B) {
 	type poolObj struct {
-		arr  []byte
 		a, b int
-		c    *bool
+		c    *int64
 		ts   int64
 	}
 
 	p := NewObjectPool(NewObjectPoolOptions().SetSize(1024))
 	p.Init(func() interface{} {
-		return &poolObj{
-			arr: make([]byte, 0, 16),
-		}
+		return &poolObj{}
 	})
 
-	now := time.Now()
+	ts := time.Now().UnixNano()
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -223,12 +157,76 @@ func BenchmarkObjectPoolParallel(b *testing.B) {
 			if !ok {
 				b.Fail()
 			}
-			// do something with object:
+			// do something with object, so there's something going on between gets/puts:
 			obj.a = b.N
-			obj.b = len(obj.arr)
-			obj.ts = now.Unix() + int64(b.N)
-			neverGonnaOptimizeYouAway = obj
-			p.Put(op)
+			obj.c = &ts
+			obj.ts = ts + int64(b.N)
+			p.Put(obj)
+		}
+	})
+}
+
+func BenchmarkObjectPoolParallelGetMultiPutContended(b *testing.B) {
+	opts := NewObjectPoolOptions().
+		SetSize(256)
+
+	p := NewObjectPool(opts)
+	p.Init(func() interface{} {
+		b := make([]byte, 0, 64)
+		return &b
+	})
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bufs := make([]*[]byte, 16)
+			for i := 0; i < len(bufs); i++ {
+				o, ok := p.Get().(*[]byte)
+				if !ok {
+					b.Fail()
+				}
+				bufs[i] = o
+			}
+			for i := 0; i < len(bufs); i++ {
+				o := bufs[i]
+				buf := *o
+				buf = strconv.AppendInt(buf[:0], 12344321, 10)
+				p.Put(o)
+			}
+		}
+	})
+}
+
+func BenchmarkObjectPoolParallelGetMultiPutContendedWithRefill(b *testing.B) {
+	opts := NewObjectPoolOptions().
+		SetSize(32).
+		SetRefillLowWatermark(0.05).
+		SetRefillHighWatermark(0.25)
+
+	p := NewObjectPool(opts)
+	p.Init(func() interface{} {
+		b := make([]byte, 0, 32)
+		return &b
+	})
+	objs := make([]interface{}, 16)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for i := 0; i < len(objs); i++ {
+				o := p.Get()
+				objs[i] = o
+			}
+
+			for _, obj := range objs {
+				o, ok := obj.(*[]byte)
+				if !ok {
+					b.Fail()
+				}
+				buf := *o
+				buf = strconv.AppendInt(buf[:0], 12344321, 10)
+				p.Put(o)
+			}
 		}
 	})
 }

--- a/src/x/unsafe/rand.go
+++ b/src/x/unsafe/rand.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package unsafe contains operations that step around the type safety of Go programs.
+package unsafe
+
+import (
+	_ "unsafe" // needed for go:linkname hack
+)
+
+//go:linkname fastrand runtime.fastrand
+func fastrand() uint32
+
+// Fastrandn returns a uint32 in range of 0..n, like rand() % n, but faster not as precise,
+// https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+func Fastrandn(n uint32) uint32 {
+	// This is similar to fastrand() % n, but faster.
+	return uint32(uint64(fastrand()) * uint64(n) >> 32)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Add rudimentary benchmarks to measure impact of any changes to pooling
Reduce instrumentation and raw get/put overhead due to contention
```
name                                                 old time/op    new time/op    delta
ObjectPoolGetPut                                       68.3ns ± 3%    58.6ns ± 3%  -14.24%  (p=0.000 n=10+10)
ObjectPoolGetPut-2                                     68.0ns ± 1%    58.5ns ± 2%  -13.95%  (p=0.000 n=10+10)
ObjectPoolGetPut-4                                     68.5ns ± 2%    58.0ns ± 1%  -15.36%  (p=0.000 n=10+9)
ObjectPoolGetPut-6                                     68.6ns ± 3%    58.2ns ± 1%  -15.16%  (p=0.000 n=10+10)
ObjectPoolGetPut-8                                     68.3ns ± 2%    58.2ns ± 2%  -14.76%  (p=0.000 n=10+10)
ObjectPoolGetPut-12                                    68.5ns ± 3%    58.3ns ± 2%  -14.77%  (p=0.000 n=10+10)
ObjectPoolParallelGetPut                               73.4ns ± 2%    63.2ns ± 2%  -13.98%  (p=0.000 n=10+9)
ObjectPoolParallelGetPut-2                             86.0ns ± 1%    74.8ns ± 0%  -13.02%  (p=0.000 n=9+10)
ObjectPoolParallelGetPut-4                             97.7ns ± 1%    84.9ns ± 1%  -13.12%  (p=0.000 n=10+10)
ObjectPoolParallelGetPut-6                              112ns ± 3%      98ns ± 2%  -12.31%  (p=0.000 n=10+10)
ObjectPoolParallelGetPut-8                              143ns ± 2%     123ns ± 3%  -14.15%  (p=0.000 n=10+9)
ObjectPoolParallelGetPut-12                             176ns ± 5%     163ns ± 5%   -7.24%  (p=0.000 n=10+10)
ObjectPoolParallelGetMultiPutContended                 1.41µs ± 2%    1.28µs ± 6%   -8.96%  (p=0.000 n=9+10)
ObjectPoolParallelGetMultiPutContended-2               1.65µs ± 2%    1.47µs ± 1%  -10.82%  (p=0.000 n=10+9)
ObjectPoolParallelGetMultiPutContended-4               1.96µs ± 1%    1.72µs ± 1%  -11.97%  (p=0.000 n=10+9)
ObjectPoolParallelGetMultiPutContended-6               2.27µs ± 5%    1.95µs ± 1%  -14.32%  (p=0.000 n=10+9)
ObjectPoolParallelGetMultiPutContended-8               2.55µs ± 0%    2.28µs ± 1%  -10.64%  (p=0.000 n=8+10)
ObjectPoolParallelGetMultiPutContended-12              3.32µs ± 7%    3.11µs ± 6%   -6.35%  (p=0.002 n=10+10)
ObjectPoolParallelGetMultiPutContendedWithRefill       1.45µs ± 7%    1.30µs ± 6%  -10.29%  (p=0.000 n=10+10)
ObjectPoolParallelGetMultiPutContendedWithRefill-2     1.58µs ± 1%    1.41µs ± 1%  -10.98%  (p=0.000 n=9+10)
ObjectPoolParallelGetMultiPutContendedWithRefill-4     1.98µs ± 0%    1.63µs ± 3%  -17.57%  (p=0.000 n=9+10)
ObjectPoolParallelGetMultiPutContendedWithRefill-6     2.32µs ± 2%    1.93µs ± 7%  -16.74%  (p=0.000 n=9+10)
ObjectPoolParallelGetMultiPutContendedWithRefill-8     2.76µs ± 1%    2.32µs ± 4%  -15.96%  (p=0.000 n=10+10)
ObjectPoolParallelGetMultiPutContendedWithRefill-12    3.36µs ± 8%    3.10µs ± 7%   -7.75%  (p=0.002 n=10+10)
```
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
