### PR TITLE
[dbnode] Report a histogram of loaded docs per query

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1895,7 +1895,7 @@ func newNamespaceIndexMetrics(
 		blockMetrics:                 newNamespaceIndexBlocksMetrics(opts, blocksScope),
 		loadedDocsPerQuery: scope.Histogram(
 			"loaded-docs-per-query",
-			tally.MustMakeExponentialValueBuckets(10, 10, 7),
+			tally.MustMakeExponentialValueBuckets(10, 2, 16),
 		),
 	}
 }

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1359,6 +1359,8 @@ func (i *nsIndex) queryWithSpan(
 		}
 	}
 
+	i.metrics.loadedDocsPerQuery.RecordValue(float64(results.Size()))
+
 	state.Lock()
 	// Take reference to vars to return while locked.
 	exhaustive := state.exhaustive
@@ -1844,6 +1846,8 @@ type nsIndexMetrics struct {
 	insertEndToEndLatency        tally.Timer
 	blocksEvictedMutableSegments tally.Counter
 	blockMetrics                 nsIndexBlocksMetrics
+
+	loadedDocsPerQuery tally.Histogram
 }
 
 func newNamespaceIndexMetrics(
@@ -1889,6 +1893,10 @@ func newNamespaceIndexMetrics(
 			"insert-end-to-end-latency", iopts.TimerOptions()),
 		blocksEvictedMutableSegments: scope.Counter("blocks-evicted-mutable-segments"),
 		blockMetrics:                 newNamespaceIndexBlocksMetrics(opts, blocksScope),
+		loadedDocsPerQuery: scope.Histogram(
+			"loaded-docs-per-query",
+			tally.MustMakeExponentialValueBuckets(10, 10, 7),
+		),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Reports a histogram of count of loaded documents per completed query.

**Special notes for your reviewer**:
@robskillington this is based on your suggestion: https://github.com/m3db/m3/pull/2357#discussion_r430740882
I did not use the `QueryStats` infra for this, as it did not seem to fit nicely there. Instead, decided to implement it in a straightforward way.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE