### PR TITLE
[dbnode] Clean up mutable segment resources

### DIFF
--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -1004,7 +1004,7 @@ func (b *block) EvictMutableSegments() error {
 		return fmt.Errorf("unable to evict mutable segments, block must be sealed, found: %v", b.state)
 	}
 
-	b.mutableSegments.Evict()
+	b.mutableSegments.Close()
 
 	// Close any other mutable segments that was added.
 	multiErr := xerrors.NewMultiError()
@@ -1046,7 +1046,7 @@ func (b *block) EvictColdMutableSegments() error {
 	// Evict/remove all but the most recent cold mutable segment (That is the one we are actively writing to).
 	for i, coldSeg := range b.coldMutableSegments {
 		if i < len(b.coldMutableSegments)-1 {
-			coldSeg.Evict()
+			coldSeg.Close()
 			b.coldMutableSegments[i] = nil
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Remove `Evict()` API from `mutableSegments` and call `Close()` instead.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
