### PR TITLE
[query] Sort grouped aggregate outputs by tags

### DIFF
--- a/src/query/executor/transform/exec.go
+++ b/src/query/executor/transform/exec.go
@@ -61,7 +61,7 @@ func ProcessSimpleBlock(
 	// be closed, as they would free underlying data. The general story in block
 	// lifecycle should be revisited to remove quirks arising from these edge
 	// cases (something where blocks are responsible for calling their own
-	// downstreams would seem more intuative and allow finer grained lifecycle
+	// downstreams would seem more intuitive and allow finer grained lifecycle
 	// control).
 	err = controller.Process(queryCtx, nextBlock)
 	if nextBlock.Info().Type() != block.BlockLazy {

--- a/src/query/functions/aggregation/base_test.go
+++ b/src/query/functions/aggregation/base_test.go
@@ -79,22 +79,22 @@ func TestFunctionFilteringWithA(t *testing.T) {
 	require.NoError(t, err)
 	sink := processAggregationOp(t, op)
 	expected := [][]float64{
+		// stddev of fifth and sixth series
+		{250, 250, 250, 250, 250},
 		// stddev of first three series
 		{5, 7, 12.19289, 16.39105, 20.60744},
 		// stddev of fourth series
 		{0, 0, 0, 0, 0},
-		// stddev of fifth and sixth series
-		{250, 250, 250, 250, 250},
 	}
 
 	expectedMetas := []block.SeriesMeta{
+		{Name: typeBytes, Tags: models.EmptyTags()},
 		{Name: typeBytes, Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("a"), Value: []byte("1")}})},
 		{Name: typeBytes, Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("a"), Value: []byte("2")}})},
-		{Name: typeBytes, Tags: models.EmptyTags()},
 	}
 	expectedMetaTags := models.EmptyTags()
 
-	test.CompareValues(t, sink.Metas, expectedMetas, sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, expectedMetas, sink.Values, expected)
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	assert.Equal(t, expectedMetaTags.Tags, sink.Meta.Tags.Tags)
 }
@@ -106,22 +106,22 @@ func TestFunctionFilteringWithoutA(t *testing.T) {
 	require.NoError(t, err)
 	sink := processAggregationOp(t, op)
 	expected := [][]float64{
-		// stddev of first two series
-		{0, 0, 2.5, 2.5, 2.5},
 		// stddev of third, fourth, and fifth series
 		{36.81787, 77.17225, 118.97712, 161.10728, 203.36065},
 		// stddev of sixth series
 		{0, 0, 0, 0, 0},
+		// stddev of first two series
+		{0, 0, 2.5, 2.5, 2.5},
 	}
 
 	expectedMetas := []block.SeriesMeta{
-		{Name: typeBytes, Tags: models.EmptyTags()},
 		{Name: typeBytes, Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("b"), Value: []byte("2")}})},
 		{Name: typeBytes, Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("c"), Value: []byte("3")}})},
+		{Name: typeBytes, Tags: models.EmptyTags()},
 	}
 
 	expectedMetaTags := test.TagSliceToTags([]models.Tag{{Name: []byte("d"), Value: []byte("4")}})
-	test.CompareValues(t, sink.Metas, expectedMetas, sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, expectedMetas, sink.Values, expected)
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	assert.Equal(t, expectedMetaTags.Tags, sink.Meta.Tags.Tags)
 }
@@ -142,7 +142,7 @@ func TestFunctionFilteringWithD(t *testing.T) {
 	}
 
 	expectedMetaTags := test.TagSliceToTags([]models.Tag{{Name: []byte("d"), Value: []byte("4")}})
-	test.CompareValues(t, sink.Metas, expectedMetas, sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, expectedMetas, sink.Values, expected)
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	assert.Equal(t, expectedMetaTags.Tags, sink.Meta.Tags.Tags)
 }
@@ -176,7 +176,7 @@ func TestFunctionFilteringWithoutD(t *testing.T) {
 	}
 	expectedMetaTags := models.EmptyTags()
 
-	test.CompareValues(t, sink.Metas, expectedMetas, sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, expectedMetas, sink.Values, expected)
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	assert.Equal(t, expectedMetaTags.Tags, sink.Meta.Tags.Tags)
 }

--- a/src/query/functions/aggregation/count_values_test.go
+++ b/src/query/functions/aggregation/count_values_test.go
@@ -119,7 +119,7 @@ func TestSimpleProcessCountValuesFunctionUnfiltered(t *testing.T) {
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	ex := test.TagSliceToTags([]models.Tag{{Name: []byte(tagName), Value: []byte("0")}})
 	assert.Equal(t, ex.Tags, sink.Meta.Tags.Tags)
-	test.CompareValues(t, sink.Metas, tagsToSeriesMeta(expectedTags), sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, tagsToSeriesMeta(expectedTags), sink.Values, expected)
 }
 
 func TestSimpleProcessCountValuesFunctionFilteringWithoutA(t *testing.T) {
@@ -143,7 +143,7 @@ func TestSimpleProcessCountValuesFunctionFilteringWithoutA(t *testing.T) {
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	exTags := test.TagSliceToTags([]models.Tag{{Name: []byte(tagName), Value: []byte("0")}})
 	assert.Equal(t, exTags.Tags, sink.Meta.Tags.Tags)
-	test.CompareValues(t, sink.Metas, tagsToSeriesMeta(expectedTags), sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, tagsToSeriesMeta(expectedTags), sink.Values, expected)
 }
 
 func TestCustomProcessCountValuesFunctionFilteringWithoutA(t *testing.T) {
@@ -195,7 +195,7 @@ func TestCustomProcessCountValuesFunctionFilteringWithoutA(t *testing.T) {
 	require.Equal(t, len(expectedTags), len(expected))
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	assert.Equal(t, models.EmptyTags(), sink.Meta.Tags)
-	test.CompareValues(t, sink.Metas, tagsToSeriesMeta(expectedTags), sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, tagsToSeriesMeta(expectedTags), sink.Values, expected)
 }
 
 func TestSimpleProcessCountValuesFunctionFilteringWithA(t *testing.T) {
@@ -213,7 +213,7 @@ func TestSimpleProcessCountValuesFunctionFilteringWithA(t *testing.T) {
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	assert.Equal(t, test.TagSliceToTags([]models.Tag{{Name: []byte(tagName), Value: []byte("0")},
 		{Name: []byte("a"), Value: []byte("1")}}).Tags, sink.Meta.Tags.Tags)
-	test.CompareValues(t, sink.Metas, tagsToSeriesMeta(expectedTags), sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, tagsToSeriesMeta(expectedTags), sink.Values, expected)
 }
 
 func TestProcessCountValuesFunctionFilteringWithoutA(t *testing.T) {

--- a/src/query/functions/aggregation/quantile_test.go
+++ b/src/query/functions/aggregation/quantile_test.go
@@ -142,22 +142,22 @@ func TestQuantileFunctionFilteringWithoutA(t *testing.T) {
 	require.NoError(t, err)
 	sink := processAggregationOp(t, op)
 	expected := [][]float64{
-		// 0.6 quantile of first two series
-		{0, 6, 5, 6, 7},
 		// 0.6 quantile of third, fourth, and fifth series
 		{60, 88, 116, 144, 172},
 		// stddev of sixth series
 		{600, 700, 800, 900, 1000},
+		// 0.6 quantile of first two series
+		{0, 6, 5, 6, 7},
 	}
 
 	expectedMetas := []block.SeriesMeta{
-		{Name: typeBytesQuantile, Tags: models.EmptyTags()},
 		{Name: typeBytesQuantile, Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("b"), Value: []byte("2")}})},
 		{Name: typeBytesQuantile, Tags: test.TagSliceToTags([]models.Tag{{Name: []byte("c"), Value: []byte("3")}})},
+		{Name: typeBytesQuantile, Tags: models.EmptyTags()},
 	}
 	expectedMetaTags := test.TagSliceToTags([]models.Tag{{Name: []byte("d"), Value: []byte("4")}})
 
-	test.CompareValues(t, sink.Metas, expectedMetas, sink.Values, expected)
+	test.CompareValuesInOrder(t, sink.Metas, expectedMetas, sink.Values, expected)
 	assert.Equal(t, bounds, sink.Meta.Bounds)
 	assert.Equal(t, expectedMetaTags.Tags, sink.Meta.Tags.Tags)
 }

--- a/src/query/functions/utils/group.go
+++ b/src/query/functions/utils/group.go
@@ -21,11 +21,19 @@
 package utils
 
 import (
+	"bytes"
+	"sort"
+
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/models"
 )
 
 type withKeysID func(tags models.Tags, matchingTags [][]byte) uint64
+
+type group struct {
+	buckets []int
+	tags    models.Tags
+}
 
 func includeKeysID(tags models.Tags, matchingTags [][]byte) uint64 {
 	return tags.TagsWithKeys(matchingTags).HashedID()
@@ -65,16 +73,11 @@ func GroupSeries(
 		tagsFunc = includeKeysTags
 	}
 
-	type tagMatch struct {
-		buckets []int
-		tags    models.Tags
-	}
-
-	tagMap := make(map[uint64]*tagMatch)
+	groups := make(map[uint64]*group)
 	for i, meta := range metas {
 		// NB(arnikola): Get the ID of the series with relevant tags
 		id := idFunc(meta.Tags, matchingTags)
-		if val, ok := tagMap[id]; ok {
+		if val, ok := groups[id]; ok {
 			// If ID has been seen, the corresponding grouped
 			// series for this index already exists; add the
 			// current index to the bucket for that
@@ -84,24 +87,60 @@ func GroupSeries(
 			// If ID has not been seen, create a grouped series
 			// with the appropriate tags, and add the current index
 			// to the bucket for that grouped series
-			tagMap[id] = &tagMatch{
+			groups[id] = &group{
 				buckets: []int{i},
 				tags:    tagsFunc(meta.Tags, matchingTags),
 			}
 		}
 	}
 
-	groupedBuckets := make([][]int, len(tagMap))
-	groupedMetas := make([]block.SeriesMeta, len(tagMap))
-	i := 0
-	for _, v := range tagMap {
-		groupedBuckets[i] = v.buckets
+	sortedGroups := sortGroups(groups)
+
+	groupedBuckets := make([][]int, len(groups))
+	groupedMetas := make([]block.SeriesMeta, len(groups))
+
+	for i, group := range sortedGroups {
+		groupedBuckets[i] = group.buckets
 		groupedMetas[i] = block.SeriesMeta{
-			Tags: v.tags,
+			Tags: group.tags,
 			Name: opName,
 		}
-		i++
 	}
 
 	return groupedBuckets, groupedMetas
+}
+
+func sortGroups(groups map[uint64]*group) []*group {
+	result := make([]*group, 0, len(groups))
+
+	for _, group := range groups {
+		result = append(result, group)
+	}
+
+	sort.Slice(result, func(i int, j int) bool {
+		return compareTagSets(result[i].tags, result[j].tags) < 0
+	})
+
+	return result
+}
+
+func compareTagSets(a, b models.Tags) int {
+	l := a.Len()
+
+	if b.Len() < l {
+		l = b.Len()
+	}
+
+	for i := 0; i < l; i++ {
+		byName := bytes.Compare(a.Tags[i].Name, b.Tags[i].Name)
+		if byName != 0 {
+			return byName
+		}
+		byValue := bytes.Compare(a.Tags[i].Value, b.Tags[i].Value)
+		if byValue != 0 {
+			return byValue
+		}
+	}
+	// If all tags so far were in common, the set with fewer tags comes first.
+	return a.Len() - b.Len()
 }

--- a/src/query/functions/utils/group_test.go
+++ b/src/query/functions/utils/group_test.go
@@ -50,13 +50,13 @@ var collectTest = []struct {
 		}),
 		[][]int{{0, 1, 2, 3, 4, 5}},
 		[]models.Tags{models.EmptyTags()},
-		[][]int{{0}, {1}, {2}, {3}, {4}, {5}},
+		[][]int{{0}, {3}, {1}, {4}, {2}, {5}},
 		multiTagsFromMaps([]map[string]string{
 			{"a": "1"},
-			{"a": "1", "b": "2", "c": "4"},
-			{"b": "2"},
 			{"a": "1", "b": "2", "c": "3"},
+			{"a": "1", "b": "2", "c": "4"},
 			{"a": "1", "b": "2", "d": "3"},
+			{"b": "2"},
 			{"c": "d"},
 		}),
 	},
@@ -73,13 +73,13 @@ var collectTest = []struct {
 		}),
 		[][]int{{0, 1, 2, 3, 4, 5}},
 		multiTagsFromMaps([]map[string]string{{}}),
-		[][]int{{0}, {1}, {2}, {3}, {4}, {5}},
+		[][]int{{0}, {3}, {1}, {4}, {2}, {5}},
 		multiTagsFromMaps([]map[string]string{
 			{"a": "1"},
-			{"a": "1", "b": "2", "c": "4"},
-			{"b": "2"},
 			{"a": "1", "b": "2", "c": "3"},
+			{"a": "1", "b": "2", "c": "4"},
 			{"a": "1", "b": "2", "d": "3"},
+			{"b": "2"},
 			{"c": "d"},
 		}),
 	},
@@ -94,17 +94,17 @@ var collectTest = []struct {
 			{"a": "1", "b": "2", "d": "3"},
 			{"c": "d"},
 		}),
-		[][]int{{0, 1, 3, 4}, {2, 5}},
+		[][]int{{2, 5}, {0, 1, 3, 4}},
 		multiTagsFromMaps([]map[string]string{
+			{},
 			{"a": "1"},
-			{},
 		}),
-		[][]int{{0}, {1}, {2}, {3}, {4}, {5}},
+		[][]int{{0}, {2}, {3}, {1}, {4}, {5}},
 		multiTagsFromMaps([]map[string]string{
 			{},
-			{"b": "2", "c": "4"},
 			{"b": "2"},
 			{"b": "2", "c": "3"},
+			{"b": "2", "c": "4"},
 			{"b": "2", "d": "3"},
 			{"c": "d"},
 		}),
@@ -120,17 +120,17 @@ var collectTest = []struct {
 			{"a": "1", "b": "2", "d": "3"},
 			{"c": "d"},
 		}),
-		[][]int{{0, 1, 3, 4}, {2, 5}},
+		[][]int{{2, 5}, {0, 1, 3, 4}},
 		multiTagsFromMaps([]map[string]string{
+			{},
 			{"a": "1"},
-			{},
 		}),
-		[][]int{{0}, {1}, {2}, {3}, {4}, {5}},
+		[][]int{{0}, {2}, {3}, {1}, {4}, {5}},
 		multiTagsFromMaps([]map[string]string{
 			{},
-			{"b": "2", "c": "4"},
 			{"b": "2"},
 			{"b": "2", "c": "3"},
+			{"b": "2", "c": "4"},
 			{"b": "2", "d": "3"},
 			{"c": "d"},
 		}),
@@ -152,11 +152,11 @@ var collectTest = []struct {
 			{"a": "2"},
 			{"a": "d"},
 		}),
-		[][]int{{0, 2, 5}, {1}, {3}, {4}},
+		[][]int{{0, 2, 5}, {3}, {1}, {4}},
 		multiTagsFromMaps([]map[string]string{
 			{},
-			{"b": "2", "c": "4"},
 			{"b": "2", "c": "3"},
+			{"b": "2", "c": "4"},
 			{"b": "2", "d": "3"},
 		}),
 	},
@@ -171,18 +171,18 @@ var collectTest = []struct {
 			{"a": "1", "b": "2", "d": "3"},
 			{"c": "3"},
 		}),
-		[][]int{{0}, {1, 3, 4}, {2}, {5}},
+		[][]int{{5}, {0}, {1, 3, 4}, {2}},
 		multiTagsFromMaps([]map[string]string{
+			{},
 			{"a": "1"},
 			{"a": "1", "b": "2"},
 			{"b": "2"},
-			{},
 		}),
-		[][]int{{0, 2}, {1}, {3, 5}, {4}},
+		[][]int{{0, 2}, {3, 5}, {1}, {4}},
 		multiTagsFromMaps([]map[string]string{
 			{},
-			{"c": "4"},
 			{"c": "3"},
+			{"c": "4"},
 			{"d": "3"},
 		}),
 	},
@@ -197,11 +197,11 @@ var collectTest = []struct {
 			{"b": "2"},
 			{"c": "3"},
 		}),
-		[][]int{{0, 1, 2}, {3}, {4, 5}},
+		[][]int{{4, 5}, {0, 1, 2}, {3}},
 		multiTagsFromMaps([]map[string]string{
+			{},
 			{"a": "1"},
 			{"a": "2"},
-			{},
 		}),
 		[][]int{{0, 1}, {2, 3, 4}, {5}},
 		multiTagsFromMaps([]map[string]string{
@@ -267,7 +267,7 @@ func testCollect(t *testing.T, without bool) {
 				}
 			}
 
-			test.CompareLists(t, collected, expectedMetas, buckets, expectedIndicies)
+			test.CompareListsInOrder(t, collected, expectedMetas, buckets, expectedIndicies)
 		})
 	}
 }

--- a/src/query/test/comparison.go
+++ b/src/query/test/comparison.go
@@ -122,25 +122,27 @@ func (m matches) Less(i, j int) bool {
 	) == -1
 }
 
-// CompareLists compares series meta / index pairs
-func CompareLists(t *testing.T, meta, exMeta []block.SeriesMeta, index, exIndex [][]int) {
+// CompareListsInOrder compares series meta / index pairs (order sensitive)
+func CompareListsInOrder(t *testing.T, meta, exMeta []block.SeriesMeta, index, exIndex [][]int) {
 	require.Equal(t, len(exIndex), len(exMeta))
-	require.Equal(t, len(exMeta), len(meta))
-	require.Equal(t, len(exIndex), len(index))
 
-	ex := make(matches, len(meta))
-	actual := make(matches, len(meta))
-	// build matchers
-	for i := range meta {
-		ex[i] = match{exIndex[i], exMeta[i].Tags.Tags, exMeta[i].Name, []float64{}}
-		actual[i] = match{index[i], meta[i].Tags.Tags, meta[i].Name, []float64{}}
-	}
-	sort.Sort(ex)
-	sort.Sort(actual)
-	assert.Equal(t, ex, actual)
+	assert.Equal(t, exMeta, meta)
+	assert.Equal(t, exIndex, index)
 }
 
-// CompareValues compares series meta / value pairs
+// CompareValuesInOrder compares series meta / value pairs (order sensitive)
+func CompareValuesInOrder(t *testing.T, meta, exMeta []block.SeriesMeta, vals, exVals [][]float64) {
+	require.Equal(t, len(exVals), len(exMeta))
+	require.Equal(t, len(exVals), len(vals), "Vals is", meta, "ExVals is", exMeta)
+
+	assert.Equal(t, exMeta, meta)
+
+	for i := range exVals {
+		EqualsWithNansWithDelta(t, exVals[i], vals[i], 0.00001)
+	}
+}
+
+// CompareValues compares series meta / value pairs (order insensitive)
 func CompareValues(t *testing.T, meta, exMeta []block.SeriesMeta, vals, exVals [][]float64) {
 	require.Equal(t, len(exVals), len(exMeta))
 	require.Equal(t, len(exMeta), len(meta), "Meta is", meta, "ExMeta is", exMeta)


### PR DESCRIPTION
**What this PR does / why we need it**:
This sorts grouped aggregate outputs by tags (in a way that is Prometheus compatible).
Previously the results were ordered non deterministically.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE