### PR TITLE
[query] Respect keepNans option for instant queries

### DIFF
--- a/src/query/api/v1/handler/prometheus/native/common.go
+++ b/src/query/api/v1/handler/prometheus/native/common.go
@@ -391,6 +391,7 @@ func RenderResultsJSON(
 func renderResultsInstantaneousJSON(
 	w io.Writer,
 	result ReadResult,
+	keepNaNs bool,
 ) {
 	var (
 		series   = result.Series
@@ -422,6 +423,15 @@ func renderResultsInstantaneousJSON(
 	jw.BeginObjectField("result")
 	jw.BeginArray()
 	for _, s := range series {
+		vals := s.Values()
+		length := s.Len()
+		dp := vals.DatapointAt(length - 1)
+
+		// If keepNaNs is set to false and the value is NaN, drop it from the response.
+		if !keepNaNs && math.IsNaN(dp.Value) {
+			continue
+		}
+
 		jw.BeginObject()
 		jw.BeginObjectField("metric")
 		jw.BeginObject()
@@ -432,9 +442,6 @@ func renderResultsInstantaneousJSON(
 		jw.EndObject()
 
 		jw.BeginObjectField("value")
-		vals := s.Values()
-		length := s.Len()
-		dp := vals.DatapointAt(length - 1)
 		jw.BeginArray()
 		jw.WriteInt(int(dp.Timestamp.Unix()))
 		jw.WriteString(utils.FormatFloat(dp.Value))

--- a/src/query/api/v1/handler/prometheus/native/common_test.go
+++ b/src/query/api/v1/handler/prometheus/native/common_test.go
@@ -358,13 +358,18 @@ func TestRenderResultsJSONWithDroppedNaNs(t *testing.T) {
 
 func TestRenderInstantaneousResultsJSON(t *testing.T) {
 	start := time.Unix(1535948880, 0)
-	buffer := bytes.NewBuffer(nil)
+
 	series := []*ts.Series{
 		ts.NewSeries([]byte("foo"),
 			ts.NewFixedStepValues(10*time.Second, 1, 1, start),
 			test.TagSliceToTags([]models.Tag{
 				{Name: []byte("bar"), Value: []byte("baz")},
 				{Name: []byte("qux"), Value: []byte("qaz")},
+			})),
+		ts.NewSeries([]byte("nan"),
+			ts.NewFixedStepValues(10*time.Second, 1, math.NaN(), start),
+			test.TagSliceToTags([]models.Tag{
+				{Name: []byte("baz"), Value: []byte("bar")},
 			})),
 		ts.NewSeries([]byte("bar"),
 			ts.NewFixedStepValues(10*time.Second, 1, 2, start),
@@ -379,37 +384,61 @@ func TestRenderInstantaneousResultsJSON(t *testing.T) {
 		Meta:   block.NewResultMetadata(),
 	}
 
-	renderResultsInstantaneousJSON(buffer, readResult)
-	expected := xtest.MustPrettyJSONMap(t, xjson.Map{
+	foo := xjson.Map{
+		"metric": xjson.Map{
+			"bar": "baz",
+			"qux": "qaz",
+		},
+		"value": xjson.Array{
+			1535948880,
+			"1",
+		},
+	}
+
+	bar := xjson.Map{
+		"metric": xjson.Map{
+			"baz": "bar",
+			"qaz": "qux",
+		},
+		"value": xjson.Array{
+			1535948880,
+			"2",
+		},
+	}
+
+	nan := xjson.Map{
+		"metric": xjson.Map{
+			"baz": "bar",
+		},
+		"value": xjson.Array{
+			1535948880,
+			"NaN",
+		},
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	renderResultsInstantaneousJSON(buffer, readResult, true)
+	expectedWithNaN := xtest.MustPrettyJSONMap(t, xjson.Map{
 		"status": "success",
 		"data": xjson.Map{
 			"resultType": "vector",
-			"result": xjson.Array{
-				xjson.Map{
-					"metric": xjson.Map{
-						"bar": "baz",
-						"qux": "qaz",
-					},
-					"value": xjson.Array{
-						1535948880,
-						"1",
-					},
-				},
-				xjson.Map{
-					"metric": xjson.Map{
-						"baz": "bar",
-						"qaz": "qux",
-					},
-					"value": xjson.Array{
-						1535948880,
-						"2",
-					},
-				},
-			},
+			"result": xjson.Array{foo, nan, bar},
 		},
 	})
-	actual := xtest.MustPrettyJSONString(t, buffer.String())
-	assert.Equal(t, expected, actual, xtest.Diff(expected, actual))
+	actualWithNaN := xtest.MustPrettyJSONString(t, buffer.String())
+	assert.Equal(t, expectedWithNaN, actualWithNaN, xtest.Diff(expectedWithNaN, actualWithNaN))
+
+	buffer = bytes.NewBuffer(nil)
+	renderResultsInstantaneousJSON(buffer, readResult, false)
+	expectedWithoutNaN := xtest.MustPrettyJSONMap(t, xjson.Map{
+		"status": "success",
+		"data": xjson.Map{
+			"resultType": "vector",
+			"result": xjson.Array{foo, bar},
+		},
+	})
+	actualWithoutNaN := xtest.MustPrettyJSONString(t, buffer.String())
+	assert.Equal(t, expectedWithoutNaN, actualWithoutNaN, xtest.Diff(expectedWithoutNaN, actualWithoutNaN))
 }
 
 func TestSanitizeSeries(t *testing.T) {

--- a/src/query/api/v1/handler/prometheus/native/read.go
+++ b/src/query/api/v1/handler/prometheus/native/read.go
@@ -136,7 +136,7 @@ func (h *promReadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.promReadMetrics.fetchSuccess.Inc(1)
 
 	if h.instant {
-		renderResultsInstantaneousJSON(w, result)
+		renderResultsInstantaneousJSON(w, result, h.opts.Config().ResultOptions.KeepNans)
 		return
 	}
 

--- a/src/query/ts/values.go
+++ b/src/query/ts/values.go
@@ -304,7 +304,6 @@ func newFixedStepValues(
 	startTime time.Time,
 ) *fixedResolutionValues {
 	values := make([]float64, numSteps)
-	// Faster way to initialize an array instead of a loop
 	util.Memset(values, initialValue)
 	return &fixedResolutionValues{
 		resolution: resolution,


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes instant query results respect the `keepNans` option.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE