### PR TITLE
[coordinator] Ingesting aggregated metrics with invalid params should always log error

### DIFF
--- a/src/cmd/services/m3coordinator/ingest/m3msg/ingest.go
+++ b/src/cmd/services/m3coordinator/ingest/m3msg/ingest.go
@@ -58,13 +58,19 @@ type Options struct {
 }
 
 type ingestMetrics struct {
-	ingestError   tally.Counter
-	ingestSuccess tally.Counter
+	ingestInternalError     tally.Counter
+	ingestNonRetryableError tally.Counter
+	ingestSuccess           tally.Counter
 }
 
 func newIngestMetrics(scope tally.Scope) ingestMetrics {
 	return ingestMetrics{
-		ingestError:   scope.Counter("ingest-error"),
+		ingestInternalError: scope.Tagged(map[string]string{
+			"error_type": "internal_error",
+		}).Counter("ingest-error"),
+		ingestNonRetryableError: scope.Tagged(map[string]string{
+			"error_type": "non_retryable_error",
+		}).Counter("ingest-error"),
 		ingestSuccess: scope.Counter("ingest-success"),
 	}
 }
@@ -163,7 +169,7 @@ func (op *ingestOp) sample() bool {
 
 func (op *ingestOp) ingest() {
 	if err := op.resetWriteQuery(); err != nil {
-		op.m.ingestError.Inc(1)
+		op.m.ingestInternalError.Inc(1)
 		op.callback.Callback(m3msg.OnRetriableError)
 		op.p.Put(op)
 		if op.sample() {
@@ -172,16 +178,25 @@ func (op *ingestOp) ingest() {
 		return
 	}
 	if err := op.r.Attempt(op.attemptFn); err != nil {
-		if xerrors.IsNonRetryableError(err) {
+		nonRetryableErr := xerrors.IsNonRetryableError(err)
+		if nonRetryableErr {
 			op.callback.Callback(m3msg.OnNonRetriableError)
+			op.m.ingestNonRetryableError.Inc(1)
 		} else {
 			op.callback.Callback(m3msg.OnRetriableError)
+			op.m.ingestInternalError.Inc(1)
 		}
-		op.m.ingestError.Inc(1)
+
+		// NB(r): Always log non-retriable errors since they are usually
+		// a very small minority and when they go missing it can be frustrating
+		// not being able to find them (usually bad request errors).
+		if nonRetryableErr || op.sample() {
+			op.logger.Error("could not write ingest op",
+				zap.Error(err),
+				zap.Bool("retryableError", !nonRetryableErr))
+		}
+
 		op.p.Put(op)
-		if op.sample() {
-			op.logger.Error("could not write ingest op", zap.Error(err))
-		}
 		return
 	}
 	op.m.ingestSuccess.Inc(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This makes sure bad request and invalid params errors being returned for writes from ingesting aggregated metrics are always written to the log. Helps sample rate impact seeing invalid params/bad request errors.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
