### PR TITLE
[query] Fix metrics registration issue for nativePromReadInstantHandler

### DIFF
--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -177,7 +177,7 @@ func (h *Handler) RegisterRoutes() error {
 	promqlQueryHandler := wrapped(prom.NewReadHandler(opts, nativeSourceOpts))
 	promqlInstantQueryHandler := wrapped(prom.NewReadInstantHandler(opts, nativeSourceOpts))
 	nativePromReadHandler := wrapped(native.NewPromReadHandler(nativeSourceOpts))
-	nativePromReadInstantHandler := wrapped(native.NewPromReadInstantHandler(h.options))
+	nativePromReadInstantHandler := wrapped(native.NewPromReadInstantHandler(nativeSourceOpts))
 
 	promqlMatcher := func(r *http.Request, rm *mux.RouteMatch) bool {
 		header := strings.ToLower(r.Header.Get(engineHeaderName))


### PR DESCRIPTION
**What this PR does / why we need it**:
A fix for:
```
{"level":"error","ts":1591814855.3818853,"msg":"register metric error","error":"a previously registered descriptor with the same fully-qualified name as Desc{fqName: \"query_fetch_success\", help: \"query_fetch_success counter\", constLabels: {}, variableLabels: [handler]} has different label names or a different help string"}

{"level":"error","ts":1591814855.3826127,"msg":"register metric error","error":"a previously registered descriptor with the same fully-qualified name as Desc{fqName: \"query_fetch_errors\", help: \"query_fetch_errors counter\", constLabels: {}, variableLabels: [handler code]} has different label names or a different help string"}

{"level":"error","ts":1591814855.3828459,"msg":"register metric error","error":"a previously registered descriptor with the same fully-qualified name as Desc{fqName: \"query_fetch_errors\", help: \"query_fetch_errors counter\", constLabels: {}, variableLabels: [handler code]} has different label names or a different help string"}

{"level":"error","ts":1591814855.383003,"msg":"register metric error","error":"a previously registered descriptor with the same fully-qualified name as Desc{fqName: \"query_fetch_success_latency\", help: \"query_fetch_success_latency summary\", constLabels: {}, variableLabels: [handler]} has different label names or a different help string"}

{"level":"error","ts":1591814855.3831947,"msg":"register metric error","error":"a previously registered descriptor with the same fully-qualified name as Desc{fqName: \"query_max_datapoints\", help: \"query_max_datapoints gauge\", constLabels: {}, variableLabels: [handler]} has different label names or a different help string"}
```
**Special notes for your reviewer**:
Oneliner.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:

**Does this PR require updating code package or user-facing documentation?**:
