### PR TITLE
[dbnode] Fix duplicate ID insertions causing transient error when flushing index block

### DIFF
--- a/src/m3ninx/index/segment/builder/builder.go
+++ b/src/m3ninx/index/segment/builder/builder.go
@@ -165,7 +165,13 @@ func (b *builder) InsertBatch(batch index.Batch) error {
 		return errClosed
 	}
 
-	return b.insertBatchWithRLock(batch)
+	// NB(r): This switch is required or else *index.BatchPartialError
+	// is returned as a non-nil wrapped "error" even though it is not
+	// an error and underlying error is nil.
+	if err := b.insertBatchWithRLock(batch); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *builder) insertBatchWithRLock(batch index.Batch) *index.BatchPartialError {

--- a/src/m3ninx/index/segment/builder/builder.go
+++ b/src/m3ninx/index/segment/builder/builder.go
@@ -138,11 +138,19 @@ func (b *builder) Reset(offset postings.ID) {
 }
 
 func (b *builder) Insert(d doc.Document) ([]byte, error) {
+	b.status.RLock()
+	defer b.status.RUnlock()
+
 	// Use a preallocated slice to make insert able to avoid alloc
 	// a slice to call insert batch with.
 	b.batchSizeOne.Docs[0] = d
-	err := b.InsertBatch(b.batchSizeOne)
+	err := b.insertBatchWithRLock(b.batchSizeOne)
 	if err != nil {
+		if errs := err.Errs(); len(errs) == 1 {
+			// Return concrete error instead of the batch partial error.
+			return nil, errs[0].Err
+		}
+		// Fallback to returning batch partial error if not what we expect.
 		return nil, err
 	}
 	last := b.docs[len(b.docs)-1]
@@ -157,6 +165,10 @@ func (b *builder) InsertBatch(batch index.Batch) error {
 		return errClosed
 	}
 
+	return b.insertBatchWithRLock(batch)
+}
+
+func (b *builder) insertBatchWithRLock(batch index.Batch) *index.BatchPartialError {
 	// NB(r): This is all kept in a single method to make the
 	// insertion path fast.
 	var wg sync.WaitGroup

--- a/src/m3ninx/index/segment/builder/builder_test.go
+++ b/src/m3ninx/index/segment/builder/builder_test.go
@@ -27,6 +27,7 @@ import (
 	"unsafe"
 
 	"github.com/m3db/m3/src/m3ninx/doc"
+	"github.com/m3db/m3/src/m3ninx/index"
 	"github.com/m3db/m3/src/m3ninx/index/segment"
 
 	"github.com/stretchr/testify/require"
@@ -140,6 +141,23 @@ func TestBuilderTerms(t *testing.T) {
 			require.Empty(t, expectedTerms)
 		}
 	}
+}
+
+// Test that calling Insert(...) API returns correct concrete errors
+// instead of partial batch error type.
+func TestBuilderInsertDuplicateReturnsErrDuplicateID(t *testing.T) {
+	builder, err := NewBuilderFromDocuments(testOptions)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, builder.Close())
+	}()
+
+	_, err = builder.Insert(testDocuments[0])
+	require.NoError(t, err)
+
+	_, err = builder.Insert(testDocuments[0])
+	require.Error(t, err)
+	require.Equal(t, index.ErrDuplicateID, err)
 }
 
 func toSlice(t *testing.T, iter segment.FieldsPostingsListIterator) [][]byte {

--- a/src/m3ninx/index/segment/builder/builder_test.go
+++ b/src/m3ninx/index/segment/builder/builder_test.go
@@ -152,10 +152,10 @@ func TestBuilderInsertDuplicateReturnsErrDuplicateID(t *testing.T) {
 		require.NoError(t, builder.Close())
 	}()
 
-	_, err = builder.Insert(testDocuments[0])
+	_, err = builder.Insert(testDocuments[2])
 	require.NoError(t, err)
 
-	_, err = builder.Insert(testDocuments[0])
+	_, err = builder.Insert(testDocuments[2])
 	require.Error(t, err)
 	require.Equal(t, index.ErrDuplicateID, err)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes duplicate IDs causing an error when creating segments on index flush.  This would have been a transient error, still it was special cased however the error type changed and this should just be a no-op.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
