### PR TITLE
[query] Fix PhysicalPlan.shiftTime

### DIFF
--- a/scripts/comparator/basic_queries/queries.json
+++ b/scripts/comparator/basic_queries/queries.json
@@ -24,16 +24,17 @@
   {
     "queryGroup":"temporal",
     "queries":[
-      "rate(quail[1m])",
-      "irate(quail[5m])",
-      "delta(quail[123s])",
-      "idelta(quail[1m] offset 5m)",
-      "deriv(quail[5m])"
+      "rate(multi_1[1m])",
+      "irate(multi_1[5m])",
+      "delta(multi_1[123s])",
+      "idelta(multi_1[1m] offset 1h)",
+      "deriv(multi_1[3m])"
     ],
     "steps" : [
       "15s",
       "30s", 
-      "1m"
+      "1m",
+      "5m"
     ]
   },
   {

--- a/src/query/plan/physical.go
+++ b/src/query/plan/physical.go
@@ -86,7 +86,7 @@ func NewPhysicalPlan(
 }
 
 func (p PhysicalPlan) shiftTime() PhysicalPlan {
-	var maxOffset, maxRange time.Duration
+	var maxRange time.Duration
 
 	for _, transformID := range p.pipeline {
 		node := p.steps[transformID]
@@ -96,16 +96,13 @@ func (p PhysicalPlan) shiftTime() PhysicalPlan {
 		}
 
 		spec := boundOp.Bounds()
-		if spec.Offset > maxOffset {
-			maxOffset = spec.Offset
-		}
 
 		if spec.Range > maxRange {
 			maxRange = spec.Range
 		}
 	}
 
-	startShift := p.LookbackDuration + maxOffset + maxRange
+	startShift := p.LookbackDuration + maxRange
 
 	remainder := startShift % p.TimeSpec.Step
 	var extraShift time.Duration

--- a/src/query/plan/physical.go
+++ b/src/query/plan/physical.go
@@ -86,9 +86,8 @@ func NewPhysicalPlan(
 }
 
 func (p PhysicalPlan) shiftTime() PhysicalPlan {
-	var maxRange time.Duration
-	// Start offset with lookback
-	maxOffset := p.LookbackDuration
+	var maxOffset, maxRange time.Duration
+
 	for _, transformID := range p.pipeline {
 		node := p.steps[transformID]
 		boundOp, ok := node.Transform.Op.(transform.BoundOp)
@@ -106,7 +105,7 @@ func (p PhysicalPlan) shiftTime() PhysicalPlan {
 		}
 	}
 
-	startShift := maxOffset + maxRange
+	startShift := p.LookbackDuration + maxOffset + maxRange
 
 	remainder := startShift % p.TimeSpec.Step
 	var extraShift time.Duration

--- a/src/query/plan/physical.go
+++ b/src/query/plan/physical.go
@@ -102,7 +102,10 @@ func (p PhysicalPlan) shiftTime() PhysicalPlan {
 		}
 	}
 
-	startShift := p.LookbackDuration + maxRange
+	startShift := p.LookbackDuration
+	if maxRange > 0 {
+		startShift = maxRange
+	}
 
 	remainder := startShift % p.TimeSpec.Step
 	var extraShift time.Duration

--- a/src/query/plan/physical_test.go
+++ b/src/query/plan/physical_test.go
@@ -80,11 +80,11 @@ func TestShiftTime(t *testing.T) {
 			wantShiftBy:      15 * time.Minute,
 		},
 		{
-			name:             "shift by lookbackDuration + offset + range",
-			fetchOp:          functions.FetchOp{Offset: 8 * time.Minute, Range: time.Hour},
+			name:             "shift by lookbackDuration + range",
+			fetchOp:          functions.FetchOp{Range: time.Hour},
 			lookbackDuration: 5 * time.Minute,
 			step:             time.Second,
-			wantShiftBy:      time.Hour + 13*time.Minute,
+			wantShiftBy:      time.Hour + 5*time.Minute,
 		},
 		{
 			name:             "align the shift by step",

--- a/src/query/plan/physical_test.go
+++ b/src/query/plan/physical_test.go
@@ -87,7 +87,14 @@ func TestShiftTime(t *testing.T) {
 			wantShiftBy:      time.Hour,
 		},
 		{
-			name:             "align the shift by step",
+			name:             "align the lookback based shift by step",
+			fetchOp:          functions.FetchOp{},
+			lookbackDuration: 5 * time.Second,
+			step:             15 * time.Second,
+			wantShiftBy:      15 * time.Second, // lookback = 5, aligned to 1x step (15)
+		},
+		{
+			name:             "align the range based shift by step",
 			fetchOp:          functions.FetchOp{Range: 16 * time.Second},
 			lookbackDuration: 5 * time.Second,
 			step:             15 * time.Second,
@@ -128,7 +135,7 @@ func TestShiftTime(t *testing.T) {
 
 			p, err := NewPhysicalPlan(lp, params)
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantShiftBy, params.Start.Sub(p.TimeSpec.Start), "start time shifted by")
+			assert.Equal(t, tt.wantShiftBy.String(), params.Start.Sub(p.TimeSpec.Start).String(), "start time shifted by")
 		})
 	}
 }

--- a/src/query/plan/physical_test.go
+++ b/src/query/plan/physical_test.go
@@ -80,18 +80,11 @@ func TestShiftTime(t *testing.T) {
 			wantShiftBy:      15 * time.Minute,
 		},
 		{
-			name:             "shift by range + lookbackDuration",
-			fetchOp:          functions.FetchOp{Offset: time.Minute, Range: time.Hour},
-			lookbackDuration: 5 * time.Minute,
-			step:             time.Second,
-			wantShiftBy:      time.Hour + 5*time.Minute, // range + max(offset, lookbackDuration)
-		},
-		{
-			name:             "shift by range + offset",
+			name:             "shift by lookbackDuration + offset + range",
 			fetchOp:          functions.FetchOp{Offset: 8 * time.Minute, Range: time.Hour},
 			lookbackDuration: 5 * time.Minute,
 			step:             time.Second,
-			wantShiftBy:      time.Hour + 8*time.Minute, // range + max(offset, lookbackDuration)
+			wantShiftBy:      time.Hour + 13*time.Minute,
 		},
 		{
 			name:             "align the shift by step",

--- a/src/query/plan/physical_test.go
+++ b/src/query/plan/physical_test.go
@@ -73,32 +73,32 @@ func TestShiftTime(t *testing.T) {
 		wantShiftBy      time.Duration
 	}{
 		{
-			name:             "by lookbackDuration",
+			name:             "shift by lookbackDuration",
 			fetchOp:          functions.FetchOp{},
 			lookbackDuration: 15 * time.Minute,
 			step:             time.Second,
 			wantShiftBy:      15 * time.Minute,
 		},
 		{
-			name:             "shift by lookbackDuration + range",
+			name:             "shift by range",
 			fetchOp:          functions.FetchOp{Range: time.Hour},
 			lookbackDuration: 5 * time.Minute,
 			step:             time.Second,
-			wantShiftBy:      time.Hour + 5*time.Minute,
+			wantShiftBy:      time.Hour,
 		},
 		{
 			name:             "align the shift by step",
-			fetchOp:          functions.FetchOp{Range: 15 * time.Second},
-			lookbackDuration: 10 * time.Second,
+			fetchOp:          functions.FetchOp{Range: 16 * time.Second},
+			lookbackDuration: 5 * time.Second,
 			step:             15 * time.Second,
-			wantShiftBy:      30 * time.Second, // range + lookbackDuration = 25, aligned to 2x step
+			wantShiftBy:      30 * time.Second, // range = 16, aligned to 2x step (2 * 15)
 		},
 		{
 			name:             "keep the same shift if already aligned by step",
-			fetchOp:          functions.FetchOp{Range: 20 * time.Second},
-			lookbackDuration: 10 * time.Second,
+			fetchOp:          functions.FetchOp{Range: 30 * time.Second},
+			lookbackDuration: 5 * time.Second,
 			step:             15 * time.Second,
-			wantShiftBy:      30 * time.Second, // range + lookbackDuration = 30, divisible by step
+			wantShiftBy:      30 * time.Second, // range = 30, divisible by step
 		},
 	}
 

--- a/src/query/plan/physical_test.go
+++ b/src/query/plan/physical_test.go
@@ -21,7 +21,6 @@
 package plan
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -34,14 +33,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	defaultLookbackDuration = time.Minute
-)
-
 func testRequestParams() models.RequestParams {
 	return models.RequestParams{
 		Now:              time.Now(),
-		LookbackDuration: defaultLookbackDuration,
+		LookbackDuration: 5 * time.Minute,
 		Step:             time.Second,
 	}
 }
@@ -70,34 +65,77 @@ func TestResultNode(t *testing.T) {
 }
 
 func TestShiftTime(t *testing.T) {
-	fetchTransform := parser.NewTransformFromOperation(functions.FetchOp{}, 1)
-	agg, err := aggregation.NewAggregationOp(aggregation.CountType, aggregation.NodeParams{})
-	require.NoError(t, err)
-	countTransform := parser.NewTransformFromOperation(agg, 2)
-	transforms := parser.Nodes{fetchTransform, countTransform}
-	edges := parser.Edges{
-		parser.Edge{
-			ParentID: fetchTransform.ID,
-			ChildID:  countTransform.ID,
+	tests := []struct {
+		name             string
+		fetchOp          functions.FetchOp
+		lookbackDuration time.Duration
+		step             time.Duration
+		wantShiftBy      time.Duration
+	}{
+		{
+			name:             "by lookbackDuration",
+			fetchOp:          functions.FetchOp{},
+			lookbackDuration: 15 * time.Minute,
+			step:             time.Second,
+			wantShiftBy:      15 * time.Minute,
+		},
+		{
+			name:             "shift by range + lookbackDuration",
+			fetchOp:          functions.FetchOp{Offset: time.Minute, Range: time.Hour},
+			lookbackDuration: 5 * time.Minute,
+			step:             time.Second,
+			wantShiftBy:      time.Hour + 5*time.Minute, // range + max(offset, lookbackDuration)
+		},
+		{
+			name:             "shift by range + offset",
+			fetchOp:          functions.FetchOp{Offset: 8 * time.Minute, Range: time.Hour},
+			lookbackDuration: 5 * time.Minute,
+			step:             time.Second,
+			wantShiftBy:      time.Hour + 8*time.Minute, // range + max(offset, lookbackDuration)
+		},
+		{
+			name:             "align the shift by step",
+			fetchOp:          functions.FetchOp{Range: 15 * time.Second},
+			lookbackDuration: 10 * time.Second,
+			step:             15 * time.Second,
+			wantShiftBy:      30 * time.Second, // range + lookbackDuration = 25, aligned to 2x step
+		},
+		{
+			name:             "keep the same shift if already aligned by step",
+			fetchOp:          functions.FetchOp{Range: 20 * time.Second},
+			lookbackDuration: 10 * time.Second,
+			step:             15 * time.Second,
+			wantShiftBy:      30 * time.Second, // range + lookbackDuration = 30, divisible by step
 		},
 	}
 
-	lp, _ := NewLogicalPlan(transforms, edges)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-	params := testRequestParams()
-	params.Start = params.Now.Add(-1 * time.Hour)
+			fetchTransform := parser.NewTransformFromOperation(tt.fetchOp, 1)
+			agg, err := aggregation.NewAggregationOp(aggregation.CountType, aggregation.NodeParams{})
+			require.NoError(t, err)
 
-	p, err := NewPhysicalPlan(lp, params)
-	require.NoError(t, err)
-	assert.Equal(t, params.Start.Add(-1*params.LookbackDuration),
-		p.TimeSpec.Start, fmt.Sprintf("start is not now - lookback"))
-	fetchTransform = parser.NewTransformFromOperation(
-		functions.FetchOp{Offset: time.Minute, Range: time.Hour}, 1)
-	transforms = parser.Nodes{fetchTransform, countTransform}
-	lp, _ = NewLogicalPlan(transforms, edges)
-	p, err = NewPhysicalPlan(lp, params)
-	require.NoError(t, err)
-	assert.Equal(t, params.Start.
-		Add(-1*(time.Hour+defaultLookbackDuration)), p.TimeSpec.Start,
-		"start time offset by fetch")
+			countTransform := parser.NewTransformFromOperation(agg, 2)
+			transforms := parser.Nodes{fetchTransform, countTransform}
+			edges := parser.Edges{
+				parser.Edge{
+					ParentID: fetchTransform.ID,
+					ChildID:  countTransform.ID,
+				},
+			}
+
+			lp, _ := NewLogicalPlan(transforms, edges)
+
+			params := models.RequestParams{
+				Now:              time.Now(),
+				LookbackDuration: tt.lookbackDuration,
+				Step:             tt.step,
+			}
+
+			p, err := NewPhysicalPlan(lp, params)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantShiftBy, params.Start.Sub(p.TimeSpec.Start), "start time shifted by")
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes 2 issues in `PhysicalPlan.shiftTime`:
1. `Offset` was not being used when computing time shift.
2. Shift alignment was not working properly, for example it could have changed the shift to zero in some cases (eg. `query=rate(multi_1[1m])&step=5m`).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
