### PR TITLE
Revert "[dbnode] Additional require-exhaustive test cases (#2412)"

### DIFF
--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -189,19 +189,6 @@ function test_query_limits_applied {
   echo "Test query limit with coordinator limit header"
   ATTEMPTS=50 TIMEOUT=2 MAX_TIMEOUT=4 retry_with_backoff  \
     '[[ $(curl -s -H "M3-Limit-Max-Series: 10" 0.0.0.0:7201/api/v1/query?query=\\{__name__!=\"\"\\} | jq -r ".data.result | length") -eq 10 ]]'
-  
-  echo "Test query limit with require-exhaustive headers false"
-  ATTEMPTS=50 TIMEOUT=2 MAX_TIMEOUT=4 retry_with_backoff  \
-    '[[ $(curl -s -H "M3-Limit-Max-Series: 2" -H "M3-Limit-Require-Exhaustive: false" 0.0.0.0:7201/api/v1/query?query=database_write_tagged_success | jq -r ".data.result | length") -eq 2 ]]'
-
-  echo "Test query limit with require-exhaustive headers true (below limit therefore no error)"
-  ATTEMPTS=50 TIMEOUT=2 MAX_TIMEOUT=4 retry_with_backoff  \
-    '[[ $(curl -s -H "M3-Limit-Max-Series: 4" -H "M3-Limit-Require-Exhaustive: true" 0.0.0.0:7201/api/v1/query?query=database_write_tagged_success | jq -r ".data.result | length") -eq 3 ]]'  
-  
-  echo "Test query limit with require-exhaustive headers true (above limit therefore error)"
-  failedOverLimit=$(curl -s -H "M3-Limit-Max-Series: 3" -H "M3-Limit-Require-Exhaustive: true" 0.0.0.0:7201/api/v1/query?query=database_write_tagged_success | jq)
-  test "$(echo $failedOverLimit | jq -r ".status")" = "error"
-  test "$(grep "query matched too many time series" <<< $failedOverLimit)"
 }
 
 function prometheus_query_native {

--- a/src/dbnode/storage/index_block_test.go
+++ b/src/dbnode/storage/index_block_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/m3db/m3/src/m3ninx/index/segment"
 	idxpersist "github.com/m3db/m3/src/m3ninx/persist"
 	"github.com/m3db/m3/src/x/context"
-	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
 	xtest "github.com/m3db/m3/src/x/test"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -644,7 +643,6 @@ func TestNamespaceIndexBlockQuery(t *testing.T) {
 			result, err = idx.Query(ctx, q, qOpts)
 			if test.requireExhaustive {
 				require.Error(t, err)
-				require.False(t, xerrors.IsRetryableError(err))
 			} else {
 				require.NoError(t, err)
 				require.False(t, result.Exhaustive)
@@ -881,7 +879,6 @@ func TestNamespaceIndexBlockAggregateQuery(t *testing.T) {
 			result, err = idx.AggregateQuery(ctx, q, aggOpts)
 			if test.requireExhaustive {
 				require.Error(t, err)
-				require.False(t, xerrors.IsRetryableError(err))
 			} else {
 				require.NoError(t, err)
 				require.False(t, result.Exhaustive)
@@ -1119,7 +1116,6 @@ func TestNamespaceIndexBlockAggregateQueryAggPath(t *testing.T) {
 				result, err = idx.AggregateQuery(ctx, q, aggOpts)
 				if test.requireExhaustive {
 					require.Error(t, err)
-					require.False(t, xerrors.IsRetryableError(err))
 				} else {
 					require.NoError(t, err)
 					require.False(t, result.Exhaustive)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This reverts commit 669609d3a18392d1c64902259e1705acf2ae7892 from PR #2412.

This was my bad, I accidentally merged a PR that was failing CI.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
