### PR TITLE
[dbnode] Negate possibility of point in time segment rotation returning query error 

### DIFF
--- a/src/dbnode/integration/index_single_node_high_concurrency_test.go
+++ b/src/dbnode/integration/index_single_node_high_concurrency_test.go
@@ -223,7 +223,7 @@ func testIndexSingleNodeHighConcurrency(
 						return
 					default:
 						randI := rng.Intn(opts.concurrencyEnqueueWorker)
-						randJ := opts.enqueuePerWorker
+						randJ := rng.Intn(opts.enqueuePerWorker)
 						id, tags := genIDTags(randI, randJ, opts.numTags)
 						_, err := isIndexedChecked(t, session, md.ID(), id, tags)
 						if err != nil {

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -131,7 +131,7 @@ type block struct {
 	coldMutableSegments             []*mutableSegments
 	shardRangesSegmentsByVolumeType shardRangesSegmentsByVolumeType
 	newFieldsAndTermsIteratorFn     newFieldsAndTermsIteratorFn
-	newExecutorFn                   newExecutorFn
+	newExecutorWithRLockFn          newExecutorFn
 	blockStart                      time.Time
 	blockEnd                        time.Time
 	blockSize                       time.Duration
@@ -234,7 +234,7 @@ func NewBlock(
 		queryStats:                      opts.QueryStats(),
 	}
 	b.newFieldsAndTermsIteratorFn = newFieldsAndTermsIterator
-	b.newExecutorFn = b.executorWithRLock
+	b.newExecutorWithRLockFn = b.executorWithRLock
 
 	return b, nil
 }
@@ -423,7 +423,7 @@ func (b *block) queryWithSpan(
 		return false, ErrUnableToQueryBlockClosed
 	}
 
-	exec, err := b.newExecutorFn()
+	exec, err := b.newExecutorWithRLockFn()
 	if err != nil {
 		return false, err
 	}

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -513,8 +513,8 @@ func (b *block) queryWithSpan(
 }
 
 func (b *block) closeExecutorAsync(exec search.Executor) {
-	// Note: This only happens if closing the readers isn't clean.
 	if err := exec.Close(); err != nil {
+		// Note: This only happens if closing the readers isn't clean.
 		b.logger.Error("could not close search exec", zap.Error(err))
 	}
 }

--- a/src/dbnode/storage/index/block_test.go
+++ b/src/dbnode/storage/index/block_test.go
@@ -393,9 +393,7 @@ func TestBlockQueryExecutorError(t *testing.T) {
 	b, ok := blk.(*block)
 	require.True(t, ok)
 
-	b.newExecutorFn = func() (search.Executor, error) {
-		b.RLock() // ensures we call newExecutorFn with RLock, or this would deadlock
-		defer b.RUnlock()
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return nil, fmt.Errorf("random-err")
 	}
 
@@ -479,7 +477,7 @@ func TestBlockMockQueryExecutorExecError(t *testing.T) {
 
 	// dIter:= doc.NewMockIterator(ctrl)
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 	gomock.InOrder(
@@ -504,7 +502,7 @@ func TestBlockMockQueryExecutorExecIterErr(t *testing.T) {
 	require.True(t, ok)
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 
@@ -544,7 +542,7 @@ func TestBlockMockQueryExecutorExecLimit(t *testing.T) {
 	require.True(t, ok)
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 
@@ -594,7 +592,7 @@ func TestBlockMockQueryExecutorExecIterCloseErr(t *testing.T) {
 	require.True(t, ok)
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 
@@ -632,7 +630,7 @@ func TestBlockMockQuerySeriesLimitNonExhaustive(t *testing.T) {
 	require.True(t, ok)
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 
@@ -681,7 +679,7 @@ func TestBlockMockQuerySeriesLimitExhaustive(t *testing.T) {
 	require.True(t, ok)
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 
@@ -732,7 +730,7 @@ func TestBlockMockQueryDocsLimitNonExhaustive(t *testing.T) {
 	require.True(t, ok)
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 
@@ -781,7 +779,7 @@ func TestBlockMockQueryDocsLimitExhaustive(t *testing.T) {
 	require.True(t, ok)
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 
@@ -833,7 +831,7 @@ func TestBlockMockQueryMergeResultsMapLimit(t *testing.T) {
 	require.NoError(t, b.Seal())
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 
@@ -885,7 +883,7 @@ func TestBlockMockQueryMergeResultsDupeID(t *testing.T) {
 	require.True(t, ok)
 
 	exec := search.NewMockExecutor(ctrl)
-	b.newExecutorFn = func() (search.Executor, error) {
+	b.newExecutorWithRLockFn = func() (search.Executor, error) {
 		return exec, nil
 	}
 

--- a/src/m3ninx/index/segment/fst/writer_reader_test.go
+++ b/src/m3ninx/index/segment/fst/writer_reader_test.go
@@ -476,7 +476,6 @@ func TestFieldsEqualsParallel(t *testing.T) {
 
 func TestPostingsListLifecycleSimple(t *testing.T) {
 	_, fstSeg := newTestSegments(t, fewTestDocuments)
-
 	require.NoError(t, fstSeg.Close())
 
 	_, err := fstSeg.FieldsIterable().Fields()
@@ -496,6 +495,55 @@ func TestPostingsListReaderLifecycle(t *testing.T) {
 	require.NoError(t, reader.Close())
 	_, err = fstSeg.Reader()
 	require.NoError(t, err)
+}
+
+func TestSegmentReaderValidUntilClose(t *testing.T) {
+	_, fstSeg := newTestSegments(t, fewTestDocuments)
+
+	reader, err := fstSeg.Reader()
+	require.NoError(t, err)
+
+	// Close segment early, expect reader still valid until close.
+	err = fstSeg.Close()
+	require.NoError(t, err)
+
+	// Make sure all methods allow for calls until the reader is closed.
+	var (
+		list postings.List
+	)
+	list, err = reader.MatchField([]byte("fruit"))
+	require.NoError(t, err)
+	assertPostingsList(t, list, []postings.ID{0, 1, 2})
+
+	list, err = reader.MatchTerm([]byte("color"), []byte("yellow"))
+	require.NoError(t, err)
+	assertPostingsList(t, list, []postings.ID{0, 2})
+
+	re, err := index.CompileRegex([]byte("^.*apple$"))
+	require.NoError(t, err)
+	list, err = reader.MatchRegexp([]byte("fruit"), re)
+	require.NoError(t, err)
+	assertPostingsList(t, list, []postings.ID{1, 2})
+
+	list, err = reader.MatchAll()
+	require.NoError(t, err)
+	assertPostingsList(t, list, []postings.ID{0, 1, 2})
+
+	_, err = reader.Doc(0)
+	require.NoError(t, err)
+
+	_, err = reader.Docs(list)
+	require.NoError(t, err)
+
+	_, err = reader.AllDocs()
+	require.NoError(t, err)
+
+	// Now close.
+	require.NoError(t, reader.Close())
+
+	// Make sure reader now starts returning errors.
+	_, err = reader.MatchTerm([]byte("color"), []byte("yellow"))
+	require.Error(t, err)
 }
 
 func newTestSegments(t *testing.T, docs []doc.Document) (memSeg sgmt.MutableSegment, fstSeg sgmt.Segment) {
@@ -533,6 +581,48 @@ func assertDocsEqual(t *testing.T, a, b doc.Iterator) {
 	for i := range aDocs {
 		require.True(t, aDocs[i].Equal(bDocs[i]))
 	}
+}
+
+func assertPostingsList(t *testing.T, l postings.List, exp []postings.ID) {
+	it := l.Iterator()
+
+	defer func() {
+		require.False(t, it.Next(), "should exhaust just once")
+		require.NoError(t, it.Err(), "should not complete with error")
+		require.NoError(t, it.Close(), "should not encounter error on close")
+	}()
+
+	match := make(map[postings.ID]struct{}, len(exp))
+	for _, v := range exp {
+		match[v] = struct{}{}
+	}
+
+	for it.Next() {
+		curr := it.Current()
+
+		_, ok := match[curr]
+		if !ok {
+			require.Fail(t,
+				fmt.Sprintf("expected %d, not found in postings iter", curr))
+			return
+		}
+
+		delete(match, curr)
+	}
+
+	if len(match) == 0 {
+		// Success.
+		return
+	}
+
+	remaining := make([]int, 0, len(match))
+	for id := range match {
+		remaining = append(remaining, int(id))
+	}
+
+	msg := fmt.Sprintf("unmatched expected IDs %v, not found in postings iter",
+		remaining)
+	require.Fail(t, msg)
 }
 
 func collectDocs(iter doc.Iterator) ([]doc.Document, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
During segment rotation during in-memory background compaction there is a moment where it is swapped out with the newly compacted segment and during that brief swap of acquiring lock and replacing the segments array there was the possibility a reader could reach a now closed segment which would return an error when executing an index search on that segment. 

This could sometimes be observed at sustained high levels of query concurrency.

This negates that possibility by extending the lifetime of the segment until it is finalized from the view of a segment reader.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
