### PR TITLE
[dbnode] Expose cluster total shards and replicas as metrics

### DIFF
--- a/src/dbnode/storage/cluster/database.go
+++ b/src/dbnode/storage/cluster/database.go
@@ -59,12 +59,14 @@ type databaseMetrics struct {
 }
 
 func newDatabaseMetrics(scope tally.Scope) databaseMetrics {
+	shardsScope := scope.SubScope("shards")
+	shardsClusterScope := scope.SubScope("shards-cluster")
 	return databaseMetrics{
-		initializing:          scope.Gauge("shards.initializing"),
-		leaving:               scope.Gauge("shards.leaving"),
-		available:             scope.Gauge("shards.available"),
-		shardsClusterTotal:    scope.Gauge("shards-cluster.total"),
-		shardsClusterReplicas: scope.Gauge("shards-cluster.replicas"),
+		initializing:          shardsScope.Gauge("initializing"),
+		leaving:               shardsScope.Gauge("leaving"),
+		available:             shardsScope.Gauge("available"),
+		shardsClusterTotal:    shardsClusterScope.Gauge("total"),
+		shardsClusterReplicas: shardsClusterScope.Gauge("replicas"),
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2257. Allows for alerting to be done based on existing shard available/etc metrics.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
