### PR TITLE
[db] Set gauge when DB requires restart

### DIFF
--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -127,7 +127,7 @@ type databaseMetrics struct {
 	unknownNamespaceQueryIDs            tally.Counter
 	errQueryIDsIndexDisabled            tally.Counter
 	errWriteTaggedIndexDisabled         tally.Counter
-	databaseRestartRequired             tally.Gauge
+	pendingNamespaceChange              tally.Gauge
 }
 
 func newDatabaseMetrics(scope tally.Scope) databaseMetrics {
@@ -145,7 +145,7 @@ func newDatabaseMetrics(scope tally.Scope) databaseMetrics {
 		unknownNamespaceQueryIDs:            unknownNamespaceScope.Counter("query-ids"),
 		errQueryIDsIndexDisabled:            indexDisabledScope.Counter("err-query-ids"),
 		errWriteTaggedIndexDisabled:         indexDisabledScope.Counter("err-write-tagged"),
-		databaseRestartRequired:             scope.Gauge("restart-required"),
+		pendingNamespaceChange:              scope.Gauge("pending-namespace-change"),
 	}
 }
 
@@ -264,7 +264,7 @@ func (d *db) UpdateOwnedNamespaces(newNamespaces namespace.Map) error {
 
 	// log that updates and removals are skipped
 	if len(removes) > 0 || len(updates) > 0 {
-		d.metrics.databaseRestartRequired.Update(1)
+		d.metrics.pendingNamespaceChange.Update(1)
 		d.log.Warn("skipping namespace removals and updates (except schema updates), restart process if you want changes to take effect.")
 	}
 

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -127,6 +127,7 @@ type databaseMetrics struct {
 	unknownNamespaceQueryIDs            tally.Counter
 	errQueryIDsIndexDisabled            tally.Counter
 	errWriteTaggedIndexDisabled         tally.Counter
+	databaseRestartRequired             tally.Gauge
 }
 
 func newDatabaseMetrics(scope tally.Scope) databaseMetrics {
@@ -144,6 +145,7 @@ func newDatabaseMetrics(scope tally.Scope) databaseMetrics {
 		unknownNamespaceQueryIDs:            unknownNamespaceScope.Counter("query-ids"),
 		errQueryIDsIndexDisabled:            indexDisabledScope.Counter("err-query-ids"),
 		errWriteTaggedIndexDisabled:         indexDisabledScope.Counter("err-write-tagged"),
+		databaseRestartRequired:             scope.Gauge("restart-required"),
 	}
 }
 
@@ -262,6 +264,7 @@ func (d *db) UpdateOwnedNamespaces(newNamespaces namespace.Map) error {
 
 	// log that updates and removals are skipped
 	if len(removes) > 0 || len(updates) > 0 {
+		d.metrics.databaseRestartRequired.Update(1)
 		d.log.Warn("skipping namespace removals and updates (except schema updates), restart process if you want changes to take effect.")
 	}
 


### PR DESCRIPTION
DB nodes need to be restarted after namespace changes.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[dbnode] Add a metric indicating a database restart is required after namespace changes
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
