### PR TITLE
[dbnode] Reference existing doc in shard map on index flush

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1139,8 +1139,10 @@ func (i *nsIndex) flushBlockSegment(
 					if err != nil {
 						return err
 					}
+					i.metrics.flushDocsNew.Inc(1)
+				} else {
+					i.metrics.flushDocsCached.Inc(1)
 				}
-				fmt.Println("DOC", exists, err)
 
 				_, err = builder.Insert(doc)
 				if err != nil && err != m3ninxindex.ErrDuplicateID {
@@ -1971,6 +1973,8 @@ type nsIndexMetrics struct {
 	insertEndToEndLatency        tally.Timer
 	blocksEvictedMutableSegments tally.Counter
 	blockMetrics                 nsIndexBlocksMetrics
+	flushDocsNew                 tally.Counter
+	flushDocsCached              tally.Counter
 
 	loadedDocsPerQuery                 tally.Histogram
 	queryExhaustiveSuccess             tally.Counter
@@ -2025,6 +2029,12 @@ func newNamespaceIndexMetrics(
 			"insert-end-to-end-latency", iopts.TimerOptions()),
 		blocksEvictedMutableSegments: scope.Counter("blocks-evicted-mutable-segments"),
 		blockMetrics:                 newNamespaceIndexBlocksMetrics(opts, blocksScope),
+		flushDocsNew: scope.Tagged(map[string]string{
+			"status": "new",
+		}).Counter("flush-docs"),
+		flushDocsCached: scope.Tagged(map[string]string{
+			"status": "cached",
+		}).Counter("flush-docs"),
 		loadedDocsPerQuery: scope.Histogram(
 			"loaded-docs-per-query",
 			tally.MustMakeExponentialValueBuckets(10, 2, 16),

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1130,10 +1130,14 @@ func (i *nsIndex) flushBlockSegment(
 			}
 
 			for _, result := range results.Results() {
-				doc, err := convert.FromSeriesIDAndTagIter(result.ID, result.Tags)
-				if err != nil {
-					return err
+				doc, exists := shard.TryGetDocument(result.ID)
+				if !exists {
+					doc, err = convert.FromSeriesIDAndTagIter(result.ID, result.Tags)
+					if err != nil {
+						return err
+					}
 				}
+				fmt.Println("DOC", exists)
 
 				_, err = builder.Insert(doc)
 				if err != nil && err != m3ninxindex.ErrDuplicateID {

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1130,14 +1130,17 @@ func (i *nsIndex) flushBlockSegment(
 			}
 
 			for _, result := range results.Results() {
-				doc, exists := shard.TryGetDocument(result.ID)
+				doc, exists, err := shard.DocRef(result.ID)
+				if err != nil {
+					return err
+				}
 				if !exists {
 					doc, err = convert.FromSeriesIDAndTagIter(result.ID, result.Tags)
 					if err != nil {
 						return err
 					}
 				}
-				fmt.Println("DOC", exists)
+				fmt.Println("DOC", exists, err)
 
 				_, err = builder.Insert(doc)
 				if err != nil && err != m3ninxindex.ErrDuplicateID {

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -84,6 +84,8 @@ var (
 	// ErrDatabaseLoadLimitHit is the error returned when the database load limit
 	// is hit or exceeded.
 	ErrDatabaseLoadLimitHit = errors.New("error loading series, database load limit hit")
+
+	emptyDoc = doc.Document{}
 )
 
 type filesetsFn func(
@@ -2541,6 +2543,20 @@ func (s *dbShard) BootstrapState() BootstrapState {
 	bs := s.bootstrapState
 	s.RUnlock()
 	return bs
+}
+
+func (s *dbShard) DocRef(id ident.ID) (doc.Document, bool, error) {
+	s.RLock()
+	defer s.RUnlock()
+
+	entry, _, err := s.lookupEntryWithLock(id)
+	if err == nil {
+		return entry.Series.Metadata(), true, nil
+	}
+	if err == errShardEntryNotFound {
+		return emptyDoc, false, nil
+	}
+	return emptyDoc, false, err
 }
 
 func (s *dbShard) logFlushResult(r dbShardFlushResult) {

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -46,6 +46,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/ts/writes"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	"github.com/m3db/m3/src/dbnode/x/xpool"
+	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
@@ -1989,6 +1990,22 @@ func (m *MockdatabaseShard) SeriesReadWriteRef(id ident.ID, tags ident.TagIterat
 func (mr *MockdatabaseShardMockRecorder) SeriesReadWriteRef(id, tags, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeriesReadWriteRef", reflect.TypeOf((*MockdatabaseShard)(nil).SeriesReadWriteRef), id, tags, opts)
+}
+
+// DocRef mocks base method
+func (m *MockdatabaseShard) DocRef(id ident.ID) (doc.Document, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DocRef", id)
+	ret0, _ := ret[0].(doc.Document)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DocRef indicates an expected call of DocRef
+func (mr *MockdatabaseShardMockRecorder) DocRef(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocRef", reflect.TypeOf((*MockdatabaseShard)(nil).DocRef), id)
 }
 
 // MockShardColdFlush is a mock of ShardColdFlush interface

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -44,6 +44,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/ts/writes"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	"github.com/m3db/m3/src/dbnode/x/xpool"
+	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
@@ -577,6 +578,9 @@ type databaseShard interface {
 		tags ident.TagIterator,
 		opts ShardSeriesReadWriteRefOptions,
 	) (SeriesReadWriteRef, error)
+
+	// DocRef returns the doc if already present in a shard series.
+	DocRef(id ident.ID) (doc.Document, bool, error)
 }
 
 // ShardColdFlush exposes a done method to finalize shard cold flush


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
When accumulating the docs to flush in the index, attempt to reference existing allocated docs in the shard’s series (in the shardmap). This should reduce memory spikes in cases where segments are very dense with docs from having high cardinality. 

Looks like cache hit/miss ratio is very strong based on initial testing
![image](https://user-images.githubusercontent.com/9585325/87322690-b7efc180-c4fb-11ea-89ea-ceafb43f2d4c.png)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
