### PR TITLE
[dbnode] Fix namespace index flush test

### DIFF
--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -368,7 +368,7 @@ func verifyFlushForShards(
 	var (
 		mockFlush          = persist.NewMockIndexFlush(ctrl)
 		shardMap           = make(map[uint32]struct{})
-		now                = idx.nowFn()
+		now                = time.Now()
 		warmBlockStart     = now.Truncate(idx.blockSize)
 		mockShards         []*MockdatabaseShard
 		dbShards           []databaseShard
@@ -376,6 +376,10 @@ func verifyFlushForShards(
 		persistClosedTimes int
 		persistCalledTimes int
 	)
+	// NB(bodu): Always align now w/ the index's view of now.
+	idx.nowFn = func() time.Time {
+		return now
+	}
 	for _, shard := range shards {
 		mockShard := NewMockdatabaseShard(ctrl)
 		mockShard.EXPECT().ID().Return(uint32(0)).AnyTimes()


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
CI is failing like so:
```
--- FAIL: TestNamespaceIndexFlushSuccess (0.01s)^M
    assertions.go:221: ^M                        ^M     Error Trace:    index_test.go:435^M
        ^M                      index_test.go:251^M
        ^M      Error:          Not equal: 11 (expected)^M
                        != 12 (actual)^M
```
Looks like the index's view of time and the test data's view of time are out of sync, sometimes causing the index to attempt to flush an extra (non-mocked) block. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
