### PR TITLE
[dbnode] Fix flaky TestNamespaceIndexFlushSuccess

### DIFF
--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -369,7 +369,7 @@ func verifyFlushForShards(
 		mockFlush          = persist.NewMockIndexFlush(ctrl)
 		shardMap           = make(map[uint32]struct{})
 		now                = time.Now()
-		warmBlockStart     = now.Truncate(idx.blockSize)
+		warmBlockStart     = now.Add(-idx.bufferPast).Truncate(idx.blockSize)
 		mockShards         []*MockdatabaseShard
 		dbShards           []databaseShard
 		numBlocks          int
@@ -415,7 +415,7 @@ func verifyFlushForShards(
 			NamespaceMetadata: idx.nsMetadata,
 			BlockStart:        blockStart,
 			FileSetType:       persist.FileSetFlushType,
-			Shards:            map[uint32]struct{}{0: struct{}{}},
+			Shards:            map[uint32]struct{}{0: {}},
 			IndexVolumeType:   idxpersist.DefaultIndexVolumeType,
 		})).Return(preparedPersist, nil)
 
@@ -436,8 +436,8 @@ func verifyFlushForShards(
 		mockBlock.EXPECT().EvictMutableSegments().Return(nil)
 	}
 	require.NoError(t, idx.WarmFlush(mockFlush, dbShards))
-	require.Equal(t, persistClosedTimes, numBlocks)
-	require.Equal(t, persistCalledTimes, numBlocks)
+	require.Equal(t, numBlocks, persistClosedTimes)
+	require.Equal(t, numBlocks, persistCalledTimes)
 }
 
 type testIndex struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes flaky TestNamespaceIndexFlushSuccess.

**Special notes for your reviewer**:

It was failing with `Not equal: 11 (expected) != 12 (actual)` consistently between `hh:00` and `hh:30`, where `xx` is an even hour in UTC (so, 25% of the time). The reason was that production code was taking `idx.bufferPast` (which is 30 mins) into consideration, affecting `persistClosedTimes` and `persistCalledTimes` counters, while the test code was not taking it into consideration, thus sometimes overcounting `numBlocks`.
I'm not 100% sure if my proposed solution is the best, but at least we know the cause.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
