### PR TITLE
[query] Auto-set reasonable range on remote match

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/read_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/read_test.go
@@ -357,8 +357,8 @@ func TestMultipleRead(t *testing.T) {
 
 	req := &prompb.ReadRequest{
 		Queries: []*prompb.Query{
-			{StartTimestampMs: 10},
-			{StartTimestampMs: 20},
+			{StartTimestampMs: 10, EndTimestampMs: 100},
+			{StartTimestampMs: 20, EndTimestampMs: 200},
 		},
 	}
 
@@ -435,7 +435,7 @@ func TestReadWithOptions(t *testing.T) {
 	}
 
 	req := &prompb.ReadRequest{
-		Queries: []*prompb.Query{{StartTimestampMs: 10}},
+		Queries: []*prompb.Query{{StartTimestampMs: 10, EndTimestampMs: 100}},
 	}
 
 	q, err := storage.PromReadQueryToM3(req.Queries[0])

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -115,10 +115,17 @@ func PromReadQueryToM3(query *prompb.Query) (*FetchQuery, error) {
 		return nil, err
 	}
 
+	start := PromTimestampToTime(query.StartTimestampMs)
+	end := PromTimestampToTime(query.EndTimestampMs)
+	if start.After(end) {
+		start = time.Time{}
+		end = time.Now()
+	}
+
 	return &FetchQuery{
 		TagMatchers: tagMatchers,
-		Start:       PromTimestampToTime(query.StartTimestampMs),
-		End:         PromTimestampToTime(query.EndTimestampMs),
+		Start:       start,
+		End:         end,
 	}, nil
 }
 

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -71,6 +71,19 @@ var (
 	value = []byte("bar")
 )
 
+func TestPromReadQueryToM3BadStartEnd(t *testing.T) {
+	q, err := PromReadQueryToM3(&prompb.Query{
+		StartTimestampMs: 100,
+		EndTimestampMs:   -100,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, time.Time{}, q.Start)
+	// NB: check end is approximately correct.
+	diff := math.Abs(float64(time.Since(q.End)))
+	assert.True(t, diff < float64(time.Minute))
+}
+
 func TestPromReadQueryToM3(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #2471 