### PR TITLE
[query] Standardize parse function logic

### DIFF
--- a/src/query/api/v1/handler/prometheus/common.go
+++ b/src/query/api/v1/handler/prometheus/common.go
@@ -39,7 +39,6 @@ import (
 	xhttp "github.com/m3db/m3/src/x/net/http"
 
 	"github.com/golang/snappy"
-	promql "github.com/prometheus/prometheus/promql/parser"
 )
 
 const (
@@ -223,6 +222,7 @@ func parseTagCompletionQueries(r *http.Request) ([]string, error) {
 // ParseSeriesMatchQuery parses all params from the GET request.
 func ParseSeriesMatchQuery(
 	r *http.Request,
+	parseOpts xpromql.ParseOptions,
 	tagOptions models.TagOptions,
 ) ([]*storage.FetchQuery, *xhttp.ParseError) {
 	r.ParseForm()
@@ -244,8 +244,9 @@ func ParseSeriesMatchQuery(
 	}
 
 	queries := make([]*storage.FetchQuery, len(matcherValues))
+	fn := parseOpts.MetricSelectorFn()
 	for i, s := range matcherValues {
-		promMatchers, err := promql.ParseMetricSelector(s)
+		promMatchers, err := fn(s)
 		if err != nil {
 			return nil, xhttp.NewParseError(err, http.StatusBadRequest)
 		}

--- a/src/query/api/v1/handler/prometheus/remote/match.go
+++ b/src/query/api/v1/handler/prometheus/remote/match.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3/src/query/api/v1/options"
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/parser/promql"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/util/logging"
 	"github.com/m3db/m3/src/x/instrument"
@@ -55,6 +56,7 @@ type PromSeriesMatchHandler struct {
 	tagOptions          models.TagOptions
 	fetchOptionsBuilder handleroptions.FetchOptionsBuilder
 	instrumentOpts      instrument.Options
+	parseOpts           promql.ParseOptions
 }
 
 // NewPromSeriesMatchHandler returns a new instance of handler.
@@ -64,6 +66,7 @@ func NewPromSeriesMatchHandler(opts options.HandlerOptions) http.Handler {
 		storage:             opts.Storage(),
 		fetchOptionsBuilder: opts.FetchOptionsBuilder(),
 		instrumentOpts:      opts.InstrumentOpts(),
+		parseOpts:           opts.Engine().Options().ParseOptions(),
 	}
 }
 
@@ -73,7 +76,7 @@ func (h *PromSeriesMatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	w.Header().Set(xhttp.HeaderContentType, xhttp.ContentTypeJSON)
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
-	queries, err := prometheus.ParseSeriesMatchQuery(r, h.tagOptions)
+	queries, err := prometheus.ParseSeriesMatchQuery(r, h.parseOpts, h.tagOptions)
 	if err != nil {
 		logger.Error("unable to parse series match values to query", zap.Error(err))
 		xhttp.Error(w, err, http.StatusBadRequest)

--- a/src/query/api/v1/handler/prometheus/remote/read_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/read_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/m3db/m3/src/query/executor"
 	"github.com/m3db/m3/src/query/generated/proto/prompb"
 	"github.com/m3db/m3/src/query/models"
+	xpromql "github.com/m3db/m3/src/query/parser/promql"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/test"
 	"github.com/m3db/m3/src/query/test/m3"
@@ -91,7 +92,7 @@ func TestParseExpr(t *testing.T) {
 	start := time.Now().Truncate(time.Hour)
 	req := httptest.NewRequest(http.MethodPost, "/", buildBody(query, start))
 	req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeFormURLEncoded)
-	readReq, err := ParseExpr(req)
+	readReq, err := ParseExpr(req, xpromql.NewParseOptions())
 	require.NoError(t, err)
 
 	q := func(start, end time.Time, matchers []*prompb.LabelMatcher) *prompb.Query {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes some places where parser functions were called directly rather than through options
