### PR TITLE
Actually assert expected case in integration tests

### DIFF
--- a/src/dbnode/integration/fs_commitlog_snapshot_mixed_mode_read_write_prop_test.go
+++ b/src/dbnode/integration/fs_commitlog_snapshot_mixed_mode_read_write_prop_test.go
@@ -29,8 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/x/context"
 	xtime "github.com/m3db/m3/src/x/time"
 	"go.uber.org/zap"
@@ -192,8 +192,8 @@ func TestFsCommitLogMixedModeReadWriteProp(t *testing.T) {
 
 					expectedSeriesMap := datapoints[:lastDatapointsIdx].toSeriesMap(ns1BlockSize)
 					log.Info("verifying data in database equals expected data")
-					if !verifySeriesMaps(t, setup, nsID, expectedSeriesMap) {
-						// verifySeriesMaps will make sure the actual failure is included
+					if !seriesMapsIsExpected(t, setup, nsID, expectedSeriesMap) {
+						// seriesMapsIsExpected will make sure the actual failure is included
 						// in the go test output, but it uses assert() under the hood so
 						// there is not a clean way to return the explicit error to gopter
 						// as well.

--- a/src/dbnode/integration/integration_data_verify.go
+++ b/src/dbnode/integration/integration_data_verify.go
@@ -276,6 +276,15 @@ func verifySeriesMaps(
 	ts TestSetup,
 	namespace ident.ID,
 	seriesMaps map[xtime.UnixNano]generate.SeriesBlock,
+) {
+	assert.True(t, seriesMapsIsExpected(t, ts, namespace, seriesMaps))
+}
+
+func seriesMapsIsExpected(
+	t *testing.T,
+	ts TestSetup,
+	namespace ident.ID,
+	seriesMaps map[xtime.UnixNano]generate.SeriesBlock,
 ) bool {
 	debugFilePathPrefix := ts.Opts().VerifySeriesDebugFilePathPrefix()
 	expectedDebugFilePath, ok := createFileIfPrefixSet(t, debugFilePathPrefix, fmt.Sprintf("%s-expected.log", namespace.String()))


### PR DESCRIPTION
In all but one instance, `verifySeriesMaps(...)` is used with the assumption that it internally does test assertions - that is, its return value is not used.

This PR makes this function actually assert.