### PR TITLE
[query] Fix to regexes with leading wildcard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ docker-integration-test:
 .PHONY: docker-compatibility-test
 docker-compatibility-test:
 	@echo "--- Running Prometheus compatibility test"
-  ./scripts/comparator/run.sh
+	./scripts/comparator/run.sh
 
 .PHONY: prom-compat
 prom-compat:

--- a/Makefile
+++ b/Makefile
@@ -251,11 +251,15 @@ docker-integration-test:
 	@echo "--- Running Docker integration test"
 	./scripts/docker-integration-tests/run.sh
 
-
 .PHONY: docker-compatibility-test
 docker-compatibility-test:
 	@echo "--- Running Prometheus compatibility test"
-	./scripts/comparator/run.sh
+./scripts/comparator/run.sh
+
+.PHONY: prom-compat
+prom-compat:
+	@echo "--- Running local Prometheus compatibility test"
+	CI="false" make docker-compatibility-test
 
 .PHONY: site-build
 site-build:

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ docker-integration-test:
 .PHONY: docker-compatibility-test
 docker-compatibility-test:
 	@echo "--- Running Prometheus compatibility test"
-./scripts/comparator/run.sh
+  ./scripts/comparator/run.sh
 
 .PHONY: prom-compat
 prom-compat:

--- a/src/query/storage/index.go
+++ b/src/query/storage/index.go
@@ -195,7 +195,7 @@ func isSpecialCaseMatcher(matcher models.Matcher) specialCase {
 		return specialCase{}
 	}
 
-	if len(matcher.Value) != 2 && matcher.Value[0] != dot {
+	if len(matcher.Value) != 2 || matcher.Value[0] != dot {
 		return specialCase{}
 	}
 
@@ -235,6 +235,7 @@ func matcherToQuery(matcher models.Matcher) (idx.Query, error) {
 			query idx.Query
 			err   error
 		)
+
 		query, err = idx.NewRegexpQuery(matcher.Name, matcher.Value)
 		if err != nil {
 			return idx.Query{}, err

--- a/src/query/storage/index_test.go
+++ b/src/query/storage/index_test.go
@@ -123,17 +123,6 @@ func TestFetchQueryToM3Query(t *testing.T) {
 			},
 		},
 		{
-			name:     "regexp match dot plus -> field",
-			expected: "field(t1)",
-			matchers: models.Matchers{
-				{
-					Type:  models.MatchRegexp,
-					Name:  []byte("t1"),
-					Value: []byte(".+"),
-				},
-			},
-		},
-		{
 			name:     "regexp match negated",
 			expected: "negation(regexp(t1, v1))",
 			matchers: models.Matchers{
@@ -188,6 +177,50 @@ func TestFetchQueryToM3Query(t *testing.T) {
 			matchers: models.Matchers{
 				{
 					Type: models.MatchAll,
+				},
+			},
+		},
+		{
+			name:     "regexp match dot star with trailing characters -> regex",
+			expected: "regexp(t1, .*foo)",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchRegexp,
+					Name:  []byte("t1"),
+					Value: []byte(".*foo"),
+				},
+			},
+		},
+		{
+			name:     "regexp match dot plus with trailing characters -> regex",
+			expected: "regexp(t1, .+foo)",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchRegexp,
+					Name:  []byte("t1"),
+					Value: []byte(".+foo"),
+				},
+			},
+		},
+		{
+			name:     "not regexp match dot star with trailing characters -> regex",
+			expected: "negation(regexp(t1, .*foo))",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchNotRegexp,
+					Name:  []byte("t1"),
+					Value: []byte(".*foo"),
+				},
+			},
+		},
+		{
+			name:     "not regexp match dot plus with trailing characters -> regex",
+			expected: "negation(regexp(t1, .+foo))",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchNotRegexp,
+					Name:  []byte("t1"),
+					Value: []byte(".+foo"),
 				},
 			},
 		},

--- a/src/query/storage/index_test.go
+++ b/src/query/storage/index_test.go
@@ -112,13 +112,24 @@ func TestFetchQueryToM3Query(t *testing.T) {
 			},
 		},
 		{
-			name:     "regexp match dot star -> field",
+			name:     "regexp match dot star -> all",
 			expected: "all()",
 			matchers: models.Matchers{
 				{
 					Type:  models.MatchRegexp,
 					Name:  []byte("t1"),
 					Value: []byte(".*"),
+				},
+			},
+		},
+		{
+			name:     "regexp match dot plus -> field",
+			expected: "field(t1)",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchRegexp,
+					Name:  []byte("t1"),
+					Value: []byte(".+"),
 				},
 			},
 		},

--- a/src/query/test/compatibility/testdata/regression.test
+++ b/src/query/test/compatibility/testdata/regression.test
@@ -8,8 +8,8 @@ load 5m
   http_requests{instance="baz", group="foo"} 0+60x10 
 
 eval instant at 0s http_requests{job=~".*foo"}
-	http_requests{job="foo", instance="bar"} 0
-	http_requests{job="foo", instance="baz"} 0
+  http_requests{job="foo", instance="bar"} 0
+  http_requests{job="foo", instance="baz"} 0
 
 eval instant at 0s http_requests{job!~".*foo"}
   http_requests{job="baz", instance="bar"}   0
@@ -18,8 +18,8 @@ eval instant at 0s http_requests{job!~".*foo"}
   http_requests{instance="baz", group="foo"} 0
 
 eval instant at 0s http_requests{job=~".+oo"}
-	http_requests{job="foo", instance="bar"} 0
-	http_requests{job="foo", instance="baz"} 0
+  http_requests{job="foo", instance="bar"} 0
+  http_requests{job="foo", instance="baz"} 0
 
 eval instant at 0s http_requests{job!~".+oo"}
   http_requests{job="baz", instance="bar"}   0

--- a/src/query/test/compatibility/testdata/regression.test
+++ b/src/query/test/compatibility/testdata/regression.test
@@ -1,0 +1,44 @@
+# this test data represents previous regressions
+load 5m
+  http_requests{job="foo", instance="bar"}   0+10x10
+  http_requests{job="foo", instance="baz"}   0+20x10 
+  http_requests{job="baz", instance="bar"}   0+30x10
+  http_requests{instance="bar", group="foo"} 0+40x10
+  http_requests{instance="bar", group="baz"} 0+50x10
+  http_requests{instance="baz", group="foo"} 0+60x10 
+
+eval instant at 0s http_requests{job=~".*foo"}
+	http_requests{job="foo", instance="bar"} 0
+	http_requests{job="foo", instance="baz"} 0
+
+eval instant at 0s http_requests{job!~".*foo"}
+  http_requests{job="baz", instance="bar"}   0
+  http_requests{instance="bar", group="foo"} 0
+  http_requests{instance="bar", group="baz"} 0
+  http_requests{instance="baz", group="foo"} 0
+
+eval instant at 0s http_requests{job=~".+oo"}
+	http_requests{job="foo", instance="bar"} 0
+	http_requests{job="foo", instance="baz"} 0
+
+eval instant at 0s http_requests{job!~".+oo"}
+  http_requests{job="baz", instance="bar"}   0
+  http_requests{instance="bar", group="foo"} 0
+  http_requests{instance="bar", group="baz"} 0
+  http_requests{instance="baz", group="foo"} 0
+
+eval instant at 0s http_requests{job=~".*"}
+  http_requests{job="foo", instance="bar"}   0
+  http_requests{job="foo", instance="baz"}   0
+  http_requests{job="baz", instance="bar"}   0
+  http_requests{instance="bar", group="foo"} 0
+  http_requests{instance="bar", group="baz"} 0
+  http_requests{instance="baz", group="foo"} 0
+
+eval instant at 0s http_requests{job=~".+"}
+  http_requests{job="foo", instance="bar"}   0
+  http_requests{job="foo", instance="baz"}   0
+  http_requests{job="baz", instance="bar"}   0
+
+clear
+

--- a/src/query/test/compatibility/testdata/selectors.test
+++ b/src/query/test/compatibility/testdata/selectors.test
@@ -100,3 +100,4 @@ eval instant at 0s http_requests{foo!~".+", job="api-server", instance="0", grou
 
 eval instant at 0s http_requests{foo!~".*", job="api-server", instance="0", group="production"}
 
+clear

--- a/src/query/test/compatibility/testdata/staleness.test
+++ b/src/query/test/compatibility/testdata/staleness.test
@@ -32,7 +32,6 @@ eval instant at 10s count_over_time(metric[1s])
 eval instant at 20s count_over_time(metric[10s])
   {} 1
 
-
 clear
 
 load 10s


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a recently introduced bug where selector like `{foo=~".*bar"}` would be parsed as a FieldMatcher rather than a RegexMatcher as intended

Fixes #2503
