### PR TITLE
[m3cluster] Split out m3cluster placement service into stateless and stateful classes

### DIFF
--- a/src/cluster/placement/placement_mock.go
+++ b/src/cluster/placement/placement_mock.go
@@ -2391,6 +2391,320 @@ func (mr *MockServiceMockRecorder) MarkAllShardsAvailable() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAllShardsAvailable", reflect.TypeOf((*MockService)(nil).MarkAllShardsAvailable))
 }
 
+// MockOperator is a mock of Operator interface
+type MockOperator struct {
+	ctrl     *gomock.Controller
+	recorder *MockOperatorMockRecorder
+}
+
+// MockOperatorMockRecorder is the mock recorder for MockOperator
+type MockOperatorMockRecorder struct {
+	mock *MockOperator
+}
+
+// NewMockOperator creates a new mock instance
+func NewMockOperator(ctrl *gomock.Controller) *MockOperator {
+	mock := &MockOperator{ctrl: ctrl}
+	mock.recorder = &MockOperatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
+	return m.recorder
+}
+
+// BuildInitialPlacement mocks base method
+func (m *MockOperator) BuildInitialPlacement(instances []Instance, numShards, rf int) (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildInitialPlacement", instances, numShards, rf)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BuildInitialPlacement indicates an expected call of BuildInitialPlacement
+func (mr *MockOperatorMockRecorder) BuildInitialPlacement(instances, numShards, rf interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildInitialPlacement", reflect.TypeOf((*MockOperator)(nil).BuildInitialPlacement), instances, numShards, rf)
+}
+
+// AddReplica mocks base method
+func (m *MockOperator) AddReplica() (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddReplica")
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddReplica indicates an expected call of AddReplica
+func (mr *MockOperatorMockRecorder) AddReplica() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddReplica", reflect.TypeOf((*MockOperator)(nil).AddReplica))
+}
+
+// AddInstances mocks base method
+func (m *MockOperator) AddInstances(candidates []Instance) (Placement, []Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddInstances", candidates)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].([]Instance)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// AddInstances indicates an expected call of AddInstances
+func (mr *MockOperatorMockRecorder) AddInstances(candidates interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInstances", reflect.TypeOf((*MockOperator)(nil).AddInstances), candidates)
+}
+
+// RemoveInstances mocks base method
+func (m *MockOperator) RemoveInstances(leavingInstanceIDs []string) (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveInstances", leavingInstanceIDs)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveInstances indicates an expected call of RemoveInstances
+func (mr *MockOperatorMockRecorder) RemoveInstances(leavingInstanceIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveInstances", reflect.TypeOf((*MockOperator)(nil).RemoveInstances), leavingInstanceIDs)
+}
+
+// ReplaceInstances mocks base method
+func (m *MockOperator) ReplaceInstances(leavingInstanceIDs []string, candidates []Instance) (Placement, []Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplaceInstances", leavingInstanceIDs, candidates)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].([]Instance)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ReplaceInstances indicates an expected call of ReplaceInstances
+func (mr *MockOperatorMockRecorder) ReplaceInstances(leavingInstanceIDs, candidates interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceInstances", reflect.TypeOf((*MockOperator)(nil).ReplaceInstances), leavingInstanceIDs, candidates)
+}
+
+// MarkShardsAvailable mocks base method
+func (m *MockOperator) MarkShardsAvailable(instanceID string, shardIDs ...uint32) (Placement, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{instanceID}
+	for _, a := range shardIDs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MarkShardsAvailable", varargs...)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkShardsAvailable indicates an expected call of MarkShardsAvailable
+func (mr *MockOperatorMockRecorder) MarkShardsAvailable(instanceID interface{}, shardIDs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{instanceID}, shardIDs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkShardsAvailable", reflect.TypeOf((*MockOperator)(nil).MarkShardsAvailable), varargs...)
+}
+
+// MarkInstanceAvailable mocks base method
+func (m *MockOperator) MarkInstanceAvailable(instanceID string) (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkInstanceAvailable", instanceID)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkInstanceAvailable indicates an expected call of MarkInstanceAvailable
+func (mr *MockOperatorMockRecorder) MarkInstanceAvailable(instanceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkInstanceAvailable", reflect.TypeOf((*MockOperator)(nil).MarkInstanceAvailable), instanceID)
+}
+
+// MarkAllShardsAvailable mocks base method
+func (m *MockOperator) MarkAllShardsAvailable() (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkAllShardsAvailable")
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkAllShardsAvailable indicates an expected call of MarkAllShardsAvailable
+func (mr *MockOperatorMockRecorder) MarkAllShardsAvailable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAllShardsAvailable", reflect.TypeOf((*MockOperator)(nil).MarkAllShardsAvailable))
+}
+
+// Placement mocks base method
+func (m *MockOperator) Placement() Placement {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Placement")
+	ret0, _ := ret[0].(Placement)
+	return ret0
+}
+
+// Placement indicates an expected call of Placement
+func (mr *MockOperatorMockRecorder) Placement() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Placement", reflect.TypeOf((*MockOperator)(nil).Placement))
+}
+
+// Mockoperations is a mock of operations interface
+type Mockoperations struct {
+	ctrl     *gomock.Controller
+	recorder *MockoperationsMockRecorder
+}
+
+// MockoperationsMockRecorder is the mock recorder for Mockoperations
+type MockoperationsMockRecorder struct {
+	mock *Mockoperations
+}
+
+// NewMockoperations creates a new mock instance
+func NewMockoperations(ctrl *gomock.Controller) *Mockoperations {
+	mock := &Mockoperations{ctrl: ctrl}
+	mock.recorder = &MockoperationsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *Mockoperations) EXPECT() *MockoperationsMockRecorder {
+	return m.recorder
+}
+
+// BuildInitialPlacement mocks base method
+func (m *Mockoperations) BuildInitialPlacement(instances []Instance, numShards, rf int) (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BuildInitialPlacement", instances, numShards, rf)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BuildInitialPlacement indicates an expected call of BuildInitialPlacement
+func (mr *MockoperationsMockRecorder) BuildInitialPlacement(instances, numShards, rf interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildInitialPlacement", reflect.TypeOf((*Mockoperations)(nil).BuildInitialPlacement), instances, numShards, rf)
+}
+
+// AddReplica mocks base method
+func (m *Mockoperations) AddReplica() (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddReplica")
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddReplica indicates an expected call of AddReplica
+func (mr *MockoperationsMockRecorder) AddReplica() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddReplica", reflect.TypeOf((*Mockoperations)(nil).AddReplica))
+}
+
+// AddInstances mocks base method
+func (m *Mockoperations) AddInstances(candidates []Instance) (Placement, []Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddInstances", candidates)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].([]Instance)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// AddInstances indicates an expected call of AddInstances
+func (mr *MockoperationsMockRecorder) AddInstances(candidates interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddInstances", reflect.TypeOf((*Mockoperations)(nil).AddInstances), candidates)
+}
+
+// RemoveInstances mocks base method
+func (m *Mockoperations) RemoveInstances(leavingInstanceIDs []string) (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveInstances", leavingInstanceIDs)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveInstances indicates an expected call of RemoveInstances
+func (mr *MockoperationsMockRecorder) RemoveInstances(leavingInstanceIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveInstances", reflect.TypeOf((*Mockoperations)(nil).RemoveInstances), leavingInstanceIDs)
+}
+
+// ReplaceInstances mocks base method
+func (m *Mockoperations) ReplaceInstances(leavingInstanceIDs []string, candidates []Instance) (Placement, []Instance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplaceInstances", leavingInstanceIDs, candidates)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].([]Instance)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ReplaceInstances indicates an expected call of ReplaceInstances
+func (mr *MockoperationsMockRecorder) ReplaceInstances(leavingInstanceIDs, candidates interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceInstances", reflect.TypeOf((*Mockoperations)(nil).ReplaceInstances), leavingInstanceIDs, candidates)
+}
+
+// MarkShardsAvailable mocks base method
+func (m *Mockoperations) MarkShardsAvailable(instanceID string, shardIDs ...uint32) (Placement, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{instanceID}
+	for _, a := range shardIDs {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MarkShardsAvailable", varargs...)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkShardsAvailable indicates an expected call of MarkShardsAvailable
+func (mr *MockoperationsMockRecorder) MarkShardsAvailable(instanceID interface{}, shardIDs ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{instanceID}, shardIDs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkShardsAvailable", reflect.TypeOf((*Mockoperations)(nil).MarkShardsAvailable), varargs...)
+}
+
+// MarkInstanceAvailable mocks base method
+func (m *Mockoperations) MarkInstanceAvailable(instanceID string) (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkInstanceAvailable", instanceID)
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkInstanceAvailable indicates an expected call of MarkInstanceAvailable
+func (mr *MockoperationsMockRecorder) MarkInstanceAvailable(instanceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkInstanceAvailable", reflect.TypeOf((*Mockoperations)(nil).MarkInstanceAvailable), instanceID)
+}
+
+// MarkAllShardsAvailable mocks base method
+func (m *Mockoperations) MarkAllShardsAvailable() (Placement, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkAllShardsAvailable")
+	ret0, _ := ret[0].(Placement)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkAllShardsAvailable indicates an expected call of MarkAllShardsAvailable
+func (mr *MockoperationsMockRecorder) MarkAllShardsAvailable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAllShardsAvailable", reflect.TypeOf((*Mockoperations)(nil).MarkAllShardsAvailable))
+}
+
 // MockAlgorithm is a mock of Algorithm interface
 type MockAlgorithm struct {
 	ctrl     *gomock.Controller

--- a/src/cluster/placement/service/operator.go
+++ b/src/cluster/placement/service/operator.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package service
+
+import (
+	"errors"
+
+	"github.com/m3db/m3/src/cluster/placement"
+)
+
+// NewPlacementOperator constructs a placement.Operator which performs transformations on the
+// given placement.
+// If initialPlacement is nil, BuildInitialPlacement must be called before any operations on the
+// placement.
+func NewPlacementOperator(initialPlacement placement.Placement, opts placement.Options) placement.Operator {
+	store := newDummyStore(initialPlacement)
+	return &placementOperator{
+		placementServiceImpl: newPlacementServiceImpl(opts, store),
+		store:                store,
+	}
+}
+
+// placementOperator is implemented by a placementServiceImpl backed by a dummyStore, which just
+// sets in memory state and doesn't touch versions.
+type placementOperator struct {
+	*placementServiceImpl
+	store *dummyStore
+}
+
+func (p *placementOperator) Placement() placement.Placement {
+	return p.store.curPlacement
+}
+
+// dummyStore is a helper class for placementOperator. It stores a single placement in memory,
+// allowing us to use the same code to implement the actual placement.Service (which typically talks
+// to a fully fledged backing store) and placement.Operator, which only operates on memory.
+// Unlike proper placement.Storage implementations, all operations are unversioned;
+// version arguments are ignored, and the store never calls Placement.SetVersion. This makes it
+// distinct from e.g. the implementation in mem.NewStore.
+type dummyStore struct {
+	curPlacement placement.Placement
+}
+
+func newDummyStore(initialPlacement placement.Placement) *dummyStore {
+	return &dummyStore{curPlacement: initialPlacement}
+}
+
+func (d *dummyStore) Set(p placement.Placement) (placement.Placement, error) {
+	d.set(p)
+	return d.curPlacement, nil
+}
+
+func (d *dummyStore) set(p placement.Placement) {
+	d.curPlacement = p
+}
+
+// CheckAndSet on the dummy store is unconditional (no check).
+func (d *dummyStore) CheckAndSet(p placement.Placement, _ int) (placement.Placement, error) {
+	d.curPlacement = p
+	return d.curPlacement, nil
+}
+
+func (d *dummyStore) SetIfNotExist(p placement.Placement) (placement.Placement, error) {
+	if d.curPlacement != nil {
+		return nil, errors.New(
+			"placement already exists and can't be rebuilt. Construct a new placement.Operator",
+		)
+	}
+	d.curPlacement = p
+	return d.curPlacement, nil
+}
+
+func (d *dummyStore) Placement() (placement.Placement, error) {
+	if d.curPlacement == nil {
+		return nil, errors.New(
+			"no initial placement specified at operator construction; call BuildInitialPlacement or pass one in",
+		)
+	}
+	return d.curPlacement, nil
+}
+

--- a/src/cluster/placement/service/operator_test.go
+++ b/src/cluster/placement/service/operator_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+package service
+
+import (
+	"testing"
+
+	"github.com/m3db/m3/src/cluster/placement"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperator(t *testing.T) {
+	type testDeps struct {
+		options placement.Options
+		op placement.Operator
+	}
+	setup := func(t *testing.T) testDeps {
+		options := placement.NewOptions().SetAllowAllZones(true)
+		return testDeps{
+			options: options,
+			op: NewPlacementOperator(nil, options),
+		}
+	}
+
+	t.Run("errors when operations called on unset placement", func(t *testing.T) {
+		tdeps := setup(t)
+		_, _, err := tdeps.op.AddInstances([]placement.Instance{newTestInstance()})
+		require.Error(t, err)
+	})
+
+	t.Run("BuildInitialPlacement twice errors", func(t *testing.T) {
+		tdeps := setup(t)
+		_, err := tdeps.op.BuildInitialPlacement([]placement.Instance{newTestInstance()}, 10, 1)
+		require.NoError(t, err)
+
+		_, err = tdeps.op.BuildInitialPlacement([]placement.Instance{newTestInstance()}, 10, 1)
+		assertErrContains(t, err, "placement already exists and can't be rebuilt")
+	})
+
+	t.Run("end-to-end flow", func(t *testing.T) {
+		tdeps := setup(t)
+		op := NewPlacementOperator(nil, tdeps.options)
+		store := newMockStorage()
+
+		pl, err := op.BuildInitialPlacement([]placement.Instance{newTestInstance()}, 10, 1)
+		require.NoError(t, err)
+
+		initialVersion := pl.Version()
+
+		_, _, err = op.AddInstances([]placement.Instance{newTestInstance()})
+		require.NoError(t, err)
+
+		_, err = op.MarkAllShardsAvailable()
+		require.NoError(t, err)
+
+		_, err = store.SetIfNotExist(op.Placement())
+		require.NoError(t, err)
+
+		pl, err = store.Placement()
+		require.NoError(t, err)
+
+		// expect exactly one version increment, from store.SetIfNotExist
+		assert.Equal(t, initialVersion + 1, pl.Version())
+
+		// spot check the results
+		allAvailable := true
+		instances := pl.Instances()
+		assert.Len(t, instances, 2)
+		for _, inst := range instances {
+			allAvailable = allAvailable && inst.IsAvailable()
+		}
+		assert.True(t, allAvailable)
+	})
+}
+
+type dummyStoreTestDeps struct{
+	store *dummyStore
+	pl placement.Placement
+}
+
+func dummyStoreSetup(t *testing.T) dummyStoreTestDeps {
+	return dummyStoreTestDeps{
+		store: newDummyStore(nil),
+		pl: placement.NewPlacement(),
+	}
+}
+
+func TestDummyStore_Set(t *testing.T) {
+	t.Run("sets without touching version", func(t *testing.T) {
+		tdeps := dummyStoreSetup(t)
+		testSetsCorrectly(t, tdeps, tdeps.store.Set)
+	})
+}
+
+func TestDummyStore_Placement(t *testing.T) {
+	t.Run("returns placement", func(t *testing.T) {
+		tdeps := dummyStoreSetup(t)
+
+		store := newDummyStore(tdeps.pl)
+		actual, err := store.Placement()
+		require.NoError(t, err)
+		assert.Equal(t, actual, tdeps.pl)
+	})
+
+	t.Run("errors when nil", func(t *testing.T) {
+		tdeps := dummyStoreSetup(t)
+		_, err := tdeps.store.Placement()
+		assertErrContains(t, err, "no initial placement specified at operator construction")
+	})
+}
+
+func TestDummyStore_CheckAndSet(t *testing.T) {
+	t.Run("sets without touching version", func(t *testing.T) {
+		tdeps := dummyStoreSetup(t)
+		testSetsCorrectly(t, tdeps, func(pl placement.Placement) (placement.Placement, error) {
+			return tdeps.store.CheckAndSet(pl, 5)
+		})
+	})
+
+	t.Run("ignores version mismatches", func(t *testing.T) {
+		tdeps := dummyStoreSetup(t)
+		_, err := tdeps.store.CheckAndSet(tdeps.pl, 2)
+		require.NoError(t, err)
+
+		_, err = tdeps.store.CheckAndSet(tdeps.pl.SetVersion(5), 3)
+		require.NoError(t, err)
+
+		pl, err := tdeps.store.Placement()
+		require.NoError(t, err)
+		assert.Equal(t, tdeps.pl, pl)
+	})
+}
+
+func TestDummyStore_SetIfNotExists(t *testing.T) {
+	t.Run("sets without touching version", func(t *testing.T) {
+		tdeps := dummyStoreSetup(t)
+		testSetsCorrectly(t, tdeps, func(pl placement.Placement) (placement.Placement, error) {
+			return tdeps.store.SetIfNotExist(pl)
+		})
+	})
+
+	t.Run("errors if placement exists", func(t *testing.T) {
+		tdeps := dummyStoreSetup(t)
+		_, err := tdeps.store.SetIfNotExist(tdeps.pl)
+		require.NoError(t, err)
+		_, err = tdeps.store.SetIfNotExist(tdeps.pl)
+		assertErrContains(t, err, "placement already exists and can't be rebuilt")
+	})
+}
+
+// Run a *Set* function and check that it returned the right thing, didn't touch the version,
+// and actually set the value.
+func testSetsCorrectly(t *testing.T, tdeps dummyStoreTestDeps, set func(pl placement.Placement) (placement.Placement, error)) {
+	_, err := tdeps.store.Placement()
+	// should not be set yet
+	require.Error(t, err)
+
+	curVersion := tdeps.pl.Version()
+	rtn, err := set(tdeps.pl)
+	require.NoError(t, err)
+
+	assert.Equal(t, curVersion, rtn.Version())
+	assert.Equal(t, tdeps.pl, rtn)
+	curState, err := tdeps.store.Placement()
+	require.NoError(t, err)
+	assert.Equal(t, tdeps.pl, curState)
+}
+
+func assertErrContains(t *testing.T, err error, contained string) {
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), contained)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR splits out some placement service functionality into a stateless `placement.Operator` class; `placement.Service` remains the same.  Currently, `placement.Service` is responsible for both performing manipulations on placement.Placement objects (node adds etc) and for storing the results back. 

This is inconvenient for certain automation cases, where you may need to perform multiple operations on a placement before storing it back. In my particular case, I'm doing:

```
curPlacement := svc.Placement()
// check with external system if placement changes are needed
// do placement changes
svc.CheckAndSet(modifiedPlacement)
```
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
Added code comments to the public interfaces
```
