### PR TITLE
[large-tiles] Shard based concurrency

### DIFF
--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -499,8 +499,9 @@ struct AggregateTilesRequest {
 	3: required i64 rangeStart
 	4: required i64 rangeEnd
 	5: required string step
-	6: bool removeResets
+	6: bool removeResets // TODO: remove when metrics type is available from series metadata
 	7: optional TimeType rangeType = TimeType.UNIX_SECONDS
+	8: i32 concurrency // TODO: remove, should go to config
 }
 
 struct AggregateTilesResult {

--- a/src/dbnode/generated/thrift/rpc/rpc.go
+++ b/src/dbnode/generated/thrift/rpc/rpc.go
@@ -12914,6 +12914,7 @@ func (p *Query) String() string {
 //  - Step
 //  - RemoveResets
 //  - RangeType
+//  - Concurrency
 type AggregateTilesRequest struct {
 	SourceNameSpace string   `thrift:"sourceNameSpace,1,required" db:"sourceNameSpace" json:"sourceNameSpace"`
 	TargetNameSpace string   `thrift:"targetNameSpace,2,required" db:"targetNameSpace" json:"targetNameSpace"`
@@ -12922,6 +12923,7 @@ type AggregateTilesRequest struct {
 	Step            string   `thrift:"step,5,required" db:"step" json:"step"`
 	RemoveResets    bool     `thrift:"removeResets,6" db:"removeResets" json:"removeResets"`
 	RangeType       TimeType `thrift:"rangeType,7" db:"rangeType" json:"rangeType,omitempty"`
+	Concurrency     int32    `thrift:"concurrency,8" db:"concurrency" json:"concurrency"`
 }
 
 func NewAggregateTilesRequest() *AggregateTilesRequest {
@@ -12958,6 +12960,10 @@ var AggregateTilesRequest_RangeType_DEFAULT TimeType = 0
 
 func (p *AggregateTilesRequest) GetRangeType() TimeType {
 	return p.RangeType
+}
+
+func (p *AggregateTilesRequest) GetConcurrency() int32 {
+	return p.Concurrency
 }
 func (p *AggregateTilesRequest) IsSetRangeType() bool {
 	return p.RangeType != AggregateTilesRequest_RangeType_DEFAULT
@@ -13014,6 +13020,10 @@ func (p *AggregateTilesRequest) Read(iprot thrift.TProtocol) error {
 			}
 		case 7:
 			if err := p.ReadField7(iprot); err != nil {
+				return err
+			}
+		case 8:
+			if err := p.ReadField8(iprot); err != nil {
 				return err
 			}
 		default:
@@ -13110,6 +13120,15 @@ func (p *AggregateTilesRequest) ReadField7(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *AggregateTilesRequest) ReadField8(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI32(); err != nil {
+		return thrift.PrependError("error reading field 8: ", err)
+	} else {
+		p.Concurrency = v
+	}
+	return nil
+}
+
 func (p *AggregateTilesRequest) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("AggregateTilesRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -13134,6 +13153,9 @@ func (p *AggregateTilesRequest) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField7(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField8(oprot); err != nil {
 			return err
 		}
 	}
@@ -13235,6 +13257,19 @@ func (p *AggregateTilesRequest) writeField7(oprot thrift.TProtocol) (err error) 
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 7:rangeType: ", p), err)
 		}
+	}
+	return err
+}
+
+func (p *AggregateTilesRequest) writeField8(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("concurrency", thrift.I32, 8); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 8:concurrency: ", p), err)
+	}
+	if err := oprot.WriteI32(int32(p.Concurrency)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.concurrency (8) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 8:concurrency: ", p), err)
 	}
 	return err
 }

--- a/src/dbnode/integration/large_tiles_test.go
+++ b/src/dbnode/integration/large_tiles_test.go
@@ -117,7 +117,7 @@ func TestReadAggregateWrite(t *testing.T) {
 	require.True(t, flushed)
 	log.Info("verified data has been cold flushed", zap.Duration("took", time.Since(start)))
 
-	aggOpts, err := storage.NewAggregateTilesOptions(dpTimeStart, dpTimeStart.Add(blockSize), time.Hour, false)
+	aggOpts, err := storage.NewAggregateTilesOptions(dpTimeStart, dpTimeStart.Add(blockSize), time.Hour, false, 4)
 	require.NoError(t, err)
 
 	// Retry aggregation as persist manager could be still locked by cold writes.

--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -576,7 +576,7 @@ func (s *service) aggregateTiles(
 	start, rangeStartErr := convert.ToTime(req.RangeStart, req.RangeType)
 	end, rangeEndErr := convert.ToTime(req.RangeEnd, req.RangeType)
 	step, stepErr := time.ParseDuration(req.Step)
-	opts, optsErr := storage.NewAggregateTilesOptions(start, end, step, req.RemoveResets)
+	opts, optsErr := storage.NewAggregateTilesOptions(start, end, step, req.RemoveResets, int(req.Concurrency))
 	if rangeStartErr != nil || rangeEndErr != nil || stepErr != nil || optsErr != nil {
 		multiErr := xerrors.NewMultiError().Add(rangeStartErr).Add(rangeEndErr).Add(stepErr).Add(optsErr)
 		return 0, tterrors.NewBadRequestError(multiErr.FinalError())

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -1168,6 +1168,7 @@ func NewAggregateTilesOptions(
 	start, end time.Time,
 	step time.Duration,
 	handleCounterResets bool,
+	concurrency int,
 ) (AggregateTilesOptions, error) {
 	if !end.After(start) {
 		return AggregateTilesOptions{}, fmt.Errorf("AggregateTilesOptions.End must be after Start, got %s - %s", start, end)
@@ -1177,5 +1178,11 @@ func NewAggregateTilesOptions(
 		return AggregateTilesOptions{}, fmt.Errorf("AggregateTilesOptions.Step must be positive, got %s", step)
 	}
 
-	return AggregateTilesOptions{Start: start, End: end, Step: step, HandleCounterResets: handleCounterResets}, nil
+	return AggregateTilesOptions{
+		Start: start,
+		End: end,
+		Step: step,
+		HandleCounterResets: handleCounterResets,
+		Concurrency: concurrency,
+	}, nil
 }

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -1305,7 +1305,7 @@ func TestDatabaseAggregateTiles(t *testing.T) {
 		start      = time.Now().Truncate(time.Hour)
 	)
 
-	opts, err := NewAggregateTilesOptions(start, start.Add(-time.Second), time.Minute, true)
+	opts, err := NewAggregateTilesOptions(start, start.Add(-time.Second), time.Minute, true, 1)
 	require.NotNil(t, err)
 
 	sourceNs := dbAddNewMockNamespace(ctrl, d, sourceNsID.String())
@@ -1320,18 +1320,18 @@ func TestDatabaseAggregateTiles(t *testing.T) {
 func TestNewAggregateTilesOptions(t *testing.T) {
 	start := time.Now().Truncate(time.Hour)
 
-	_, err := NewAggregateTilesOptions(start, start.Add(-time.Second), time.Minute, false)
+	_, err := NewAggregateTilesOptions(start, start.Add(-time.Second), time.Minute, false, 1)
 	assert.Error(t, err)
 
-	_, err = NewAggregateTilesOptions(start, start, time.Minute, false)
+	_, err = NewAggregateTilesOptions(start, start, time.Minute, false, 1)
 	assert.Error(t, err)
 
-	_, err = NewAggregateTilesOptions(start, start.Add(time.Second), -time.Minute, false)
+	_, err = NewAggregateTilesOptions(start, start.Add(time.Second), -time.Minute, false, 1)
 	assert.Error(t, err)
 
-	_, err = NewAggregateTilesOptions(start, start.Add(time.Second), 0, false)
+	_, err = NewAggregateTilesOptions(start, start.Add(time.Second), 0, false, 1)
 	assert.Error(t, err)
 
-	_, err = NewAggregateTilesOptions(start, start.Add(time.Second), time.Minute, false)
+	_, err = NewAggregateTilesOptions(start, start.Add(time.Second), time.Minute, false, 1)
 	assert.NoError(t, err)
 }

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -1350,7 +1350,7 @@ func TestNamespaceAggregateTiles(t *testing.T) {
 		sourceBlockSize        = time.Hour
 		targetBlockSize        = 2 * time.Hour
 		start                  = time.Now().Truncate(targetBlockSize)
-		opts                   = AggregateTilesOptions{Start: start, End: start.Add(targetBlockSize)}
+		opts                   = AggregateTilesOptions{Start: start, End: start.Add(targetBlockSize), Concurrency: 2}
 		secondSourceBlockStart = start.Add(sourceBlockSize)
 		sourceShard0ID uint32  = 10
 		sourceShard1ID uint32  = 20

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -1265,9 +1265,11 @@ type newFSMergeWithMemFn func(
 ) fs.MergeWith
 
 type AggregateTilesOptions struct {
-	Start, End          time.Time
-	Step                time.Duration
+	Start, End time.Time
+	Step       time.Duration
 	// HandleCounterResets is temporarily used to force counter reset handling logics on the processed series.
 	// TODO: remove once we have metrics type stored in the metadata.
 	HandleCounterResets bool
+	// Concurrency should go to config TODO
+	Concurrency int
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Concurrency level (number of shards processed in parallel) for large tiles aggregation can be specified as RPC parameter for experimenting.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
