### PR TITLE
[query] Took windowSize parsing logic out of the movingAverage function

### DIFF
--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -555,61 +555,76 @@ func lowestCurrent(_ *common.Context, input singlePathSpec, n int) (ts.SeriesLis
 // windowSizeFunc calculates window size for moving average calculation
 type windowSizeFunc func(stepSize int) int
 
-// movingAverage calculates the moving average of a metric (or metrics) over a time interval.
-func movingAverage(ctx *common.Context, input singlePathSpec, windowSizeValue genericInterface) (*binaryContextShifter, error) {
-	if len(input.Values) == 0 {
-		return nil, nil
-	}
+type windowSizeParsed struct {
+	deltaValue time.Duration
+	stringValue string
+	windowSizeFunc windowSizeFunc
+}
 
-	var delta time.Duration
-	var wf windowSizeFunc
-	var ws string
+func parseWindowSize(windowSizeValue genericInterface, input singlePathSpec) (windowSizeParsed, error) {
+	windowSize := windowSizeParsed{}
 
 	switch windowSizeValue := windowSizeValue.(type) {
 	case string:
 		interval, err := common.ParseInterval(windowSizeValue)
 		if err != nil {
-			return nil, err
+			return windowSize, err
 		}
 		if interval <= 0 {
 			err := errors.NewInvalidParamsError(fmt.Errorf(
 				"windowSize must be positive but instead is %v",
 				interval))
-			return nil, err
+			return windowSize, err
 		}
-		wf = func(stepSize int) int { return int(int64(delta/time.Millisecond) / int64(stepSize)) }
-		ws = fmt.Sprintf("%q", windowSizeValue)
-		delta = interval
+		windowSize.windowSizeFunc = func(stepSize int) int {
+			return int(int64(windowSize.deltaValue/time.Millisecond) / int64(stepSize))
+		}
+		windowSize.stringValue = fmt.Sprintf("%q", windowSizeValue)
+		windowSize.deltaValue = interval
 	case float64:
 		windowSizeInt := int(windowSizeValue)
 		if windowSizeInt <= 0 {
 			err := errors.NewInvalidParamsError(fmt.Errorf(
 				"windowSize must be positive but instead is %d",
 				windowSizeInt))
-			return nil, err
+			return windowSize, err
 		}
-		wf = func(_ int) int { return windowSizeInt }
-		ws = fmt.Sprintf("%d", windowSizeInt)
+		windowSize.windowSizeFunc = func(_ int) int { return windowSizeInt }
+		windowSize.stringValue = fmt.Sprintf("%d", windowSizeInt)
 		maxStepSize := input.Values[0].MillisPerStep()
 		for i := 1; i < len(input.Values); i++ {
 			maxStepSize = int(math.Max(float64(maxStepSize), float64(input.Values[i].MillisPerStep())))
 		}
-		delta = time.Duration(maxStepSize*windowSizeInt) * time.Millisecond
+		windowSize.deltaValue = time.Duration(maxStepSize*windowSizeInt) * time.Millisecond
 	default:
 		err := errors.NewInvalidParamsError(fmt.Errorf(
 			"windowSize must be either a string or an int but instead is a %T",
 			windowSizeValue))
+		return windowSize, err
+	}
+	return windowSize, nil
+}
+
+// movingAverage calculates the moving average of a metric (or metrics) over a time interval.
+func movingAverage(ctx *common.Context, input singlePathSpec, windowSizeValue genericInterface) (*binaryContextShifter, error) {
+	if len(input.Values) == 0 {
+		return nil, nil
+	}
+
+	widowSize, err := parseWindowSize(windowSizeValue, input)
+
+	if err != nil {
 		return nil, err
 	}
 
 	contextShiftingFn := func(c *common.Context) *common.Context {
 		opts := common.NewChildContextOptions()
-		opts.AdjustTimeRange(0, 0, delta, 0)
+		opts.AdjustTimeRange(0, 0, widowSize.deltaValue, 0)
 		childCtx := c.NewChildContext(opts)
 		return childCtx
 	}
 
-	bootstrapStartTime, bootstrapEndTime := ctx.StartTime.Add(-delta), ctx.StartTime
+	bootstrapStartTime, bootstrapEndTime := ctx.StartTime.Add(-widowSize.deltaValue), ctx.StartTime
 	transformerFn := func(bootstrapped, original ts.SeriesList) (ts.SeriesList, error) {
 		bootstrapList, err := combineBootstrapWithOriginal(ctx,
 			bootstrapStartTime, bootstrapEndTime,
@@ -622,7 +637,7 @@ func movingAverage(ctx *common.Context, input singlePathSpec, windowSizeValue ge
 		for i, bootstrap := range bootstrapList.Values {
 			series := original.Values[i]
 			stepSize := series.MillisPerStep()
-			windowPoints := wf(stepSize)
+			windowPoints := widowSize.windowSizeFunc(stepSize)
 			if windowPoints == 0 {
 				err := errors.NewInvalidParamsError(fmt.Errorf(
 					"windowSize should not be smaller than stepSize, windowSize=%v, stepSize=%d",

--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -680,7 +680,7 @@ func movingAverage(ctx *common.Context, input singlePathSpec, windowSizeValue ge
 					vals.SetValueAt(i, sum/float64(num))
 				}
 			}
-			name := fmt.Sprintf("movingAverage(%s,%s)", series.Name(), ws)
+			name := fmt.Sprintf("movingAverage(%s,%s)", series.Name(), widowSize.stringValue)
 			newSeries := ts.NewSeries(ctx, name, series.StartTime(), vals)
 			results = append(results, newSeries)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR is a simple refactor of the `movingAverage` graphite function. In the `movingAverage` function, there is about 40 lines of logic to parse the window size, from `windowSizeValue genericInterface` into `delta time.Duration`. Right now, this logic is only being used in `movingAverage`, but I am going to implement `movingMin`, `movingSum`, and `movingMax`, so I wanted to make sure this function was reusable.


Fixes # `N/A`

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
