### PR TITLE
Fix races in m3msg consumer test code

### DIFF
--- a/src/msg/integration/integration_test.go
+++ b/src/msg/integration/integration_test.go
@@ -57,7 +57,7 @@ func TestSharedConsumer(t *testing.T) {
 	}
 }
 
-func TestReplicatedConsumerx(t *testing.T) {
+func TestReplicatedConsumer(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
@@ -129,9 +129,9 @@ func TestSharedConsumerWithDeadInstance(t *testing.T) {
 		s.Run(t, ctrl)
 		s.VerifyConsumers(t)
 		testConsumers := s.consumerServices[0].testConsumers
-		require.True(t, testConsumers[len(testConsumers)-1].consumed <= s.TotalMessages()*10/100)
+		require.True(t, testConsumers[len(testConsumers)-1].numConsumed() <= s.TotalMessages()*10/100)
 		testConsumers = s.consumerServices[1].testConsumers
-		require.True(t, testConsumers[len(testConsumers)-1].consumed <= s.TotalMessages()*20/100)
+		require.True(t, testConsumers[len(testConsumers)-1].numConsumed() <= s.TotalMessages()*20/100)
 	}
 }
 
@@ -546,8 +546,8 @@ func TestRemoveConsumerService(t *testing.T) {
 		)
 		s.Run(t, ctrl)
 		s.VerifyConsumers(t)
-		require.Equal(t, msgPerShard*numberOfShards, len(s.consumerServices[0].consumed))
-		require.Equal(t, msgPerShard*numberOfShards, len(s.consumerServices[1].consumed))
+		require.Equal(t, msgPerShard*numberOfShards, s.consumerServices[0].numConsumed())
+		require.Equal(t, msgPerShard*numberOfShards, s.consumerServices[1].numConsumed())
 	}
 }
 
@@ -574,8 +574,8 @@ func TestAddConsumerService(t *testing.T) {
 			},
 		)
 		s.Run(t, ctrl)
-		require.Equal(t, s.ExpectedNumMessages(), len(s.consumerServices[0].consumed))
-		require.Equal(t, s.ExpectedNumMessages(), len(s.consumerServices[1].consumed))
-		require.True(t, len(s.consumerServices[2].consumed) <= s.ExpectedNumMessages()*80/100)
+		require.Equal(t, s.ExpectedNumMessages(), s.consumerServices[0].numConsumed())
+		require.Equal(t, s.ExpectedNumMessages(), s.consumerServices[1].numConsumed())
+		require.True(t, s.consumerServices[2].numConsumed() <= s.ExpectedNumMessages()*80/100)
 	}
 }

--- a/src/msg/integration/setup.go
+++ b/src/msg/integration/setup.go
@@ -553,8 +553,8 @@ writer:
   topicName: topicName
   topicWatchInitTimeout: 100ms
   placementWatchInitTimeout: 100ms
-  messagePool:
-    size: 100
+  # FIXME: Consumers sharing the same pool trigger false-positives in race detector
+  messagePool: ~
   messageRetry:
     initialBackoff: 20ms
     maxBackoff: 50ms

--- a/src/msg/producer/ref_counted.go
+++ b/src/msg/producer/ref_counted.go
@@ -31,24 +31,24 @@ type OnFinalizeFn func(rm *RefCountedMessage)
 
 // RefCountedMessage is a reference counted message.
 type RefCountedMessage struct {
-	sync.RWMutex
+	mu sync.RWMutex
 	Message
 
 	size         uint64
 	onFinalizeFn OnFinalizeFn
 
-	refCount            *atomic.Int32
-	isDroppedOrConsumed *atomic.Bool
+	// RefCountedMessage must not be copied by value due to RWMutex,
+	// safe to store values here and not just pointers
+	refCount            atomic.Int32
+	isDroppedOrConsumed atomic.Bool
 }
 
 // NewRefCountedMessage creates RefCountedMessage.
 func NewRefCountedMessage(m Message, fn OnFinalizeFn) *RefCountedMessage {
 	return &RefCountedMessage{
-		Message:             m,
-		refCount:            atomic.NewInt32(0),
-		size:                uint64(m.Size()),
-		onFinalizeFn:        fn,
-		isDroppedOrConsumed: atomic.NewBool(false),
+		Message:      m,
+		size:         uint64(m.Size()),
+		onFinalizeFn: fn,
 	}
 }
 
@@ -76,12 +76,12 @@ func (rm *RefCountedMessage) DecRef() {
 
 // IncReads increments the reads count.
 func (rm *RefCountedMessage) IncReads() {
-	rm.RLock()
+	rm.mu.RLock()
 }
 
 // DecReads decrements the reads count.
 func (rm *RefCountedMessage) DecReads() {
-	rm.RUnlock()
+	rm.mu.RUnlock()
 }
 
 // NumRef returns the number of references remaining.
@@ -107,13 +107,13 @@ func (rm *RefCountedMessage) IsDroppedOrConsumed() bool {
 func (rm *RefCountedMessage) finalize(r FinalizeReason) bool {
 	// NB: This lock prevents the message from being finalized when its still
 	// being read.
-	rm.Lock()
+	rm.mu.Lock()
 	if rm.isDroppedOrConsumed.Load() {
-		rm.Unlock()
+		rm.mu.Unlock()
 		return false
 	}
 	rm.isDroppedOrConsumed.Store(true)
-	rm.Unlock()
+	rm.mu.Unlock()
 	if rm.onFinalizeFn != nil {
 		rm.onFinalizeFn(rm)
 	}

--- a/src/msg/producer/writer/message_benchmark_test.go
+++ b/src/msg/producer/writer/message_benchmark_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package writer
+
+import (
+	"testing"
+
+	"github.com/m3db/m3/src/msg/producer"
+)
+
+var (
+	// BenchMessage prevents optimization
+	BenchMessage *message
+	// BenchBool prevents optimization
+	BenchBool bool
+)
+
+type emptyMessage struct{}
+
+// Shard returns the shard of the message.
+func (e emptyMessage) Shard() uint32 { return 0 }
+
+// Bytes returns the bytes of the message.
+func (e emptyMessage) Bytes() []byte { return nil }
+
+// Size returns the size of the bytes of the message.
+func (e emptyMessage) Size() int { return 0 }
+
+// Finalize will be called by producer to indicate the end of its lifecycle.
+func (e emptyMessage) Finalize(_ producer.FinalizeReason) {}
+
+func BenchmarkMessageAtomics(b *testing.B) {
+	rm := producer.NewRefCountedMessage(emptyMessage{}, nil)
+	msg := newMessage()
+	for n := 0; n < b.N; n++ {
+		msg.Set(metadata{}, rm, 500)
+		rm.IncRef()
+		msg.Ack()
+		BenchBool = msg.IsAcked()
+		_, BenchBool = msg.Marshaler()
+		msg.Close()
+		BenchMessage = msg
+	}
+}
+
+func BenchmarkMessageAtomicsAllocs(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		rm := producer.NewRefCountedMessage(emptyMessage{}, nil)
+		msg := newMessage()
+		msg.Set(metadata{}, rm, 500)
+		rm.IncRef()
+		msg.Ack()
+		BenchBool = msg.IsAcked()
+		_, BenchBool = msg.Marshaler()
+		msg.Close()
+		BenchMessage = msg
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes various data races in m3msg consumer, producer tests (followup after #2583, updates #2540). 
Consumers are sharing message object pool, which makes go race detector go nuts - as a workaround, simply disabled pooling in `src/msg/integration` test suite.
Also, cleaned up some unnecessary indirection in message structs, should reduce GC overhead overall.

```
name                     old time/op    new time/op    delta
MessageAtomics-12          50.1ns ± 3%    49.8ns ± 1%     ~     (p=0.317 n=5+5)
MessageAtomicsAllocs-12     184ns ± 0%     138ns ± 0%  -25.38%  (p=0.008 n=5+5)

name                     old allocs/op  new allocs/op  delta
MessageAtomics-12            0.00           0.00          ~     (all equal)
MessageAtomicsAllocs-12      5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.008 n=5+5)
```

Example:
```
==================
WARNING: DATA RACE
Write at 0x00c00079f080 by goroutine 11:
  github.com/m3db/m3/src/msg/producer/writer.(*message).Set()
      /Users/vytenis/darbas/m3/src/msg/producer/writer/message.go:56 +0x28a
  github.com/m3db/m3/src/msg/producer/writer.(*messageWriterImpl).Write()
...

Previous read at 0x00c00079f080 by goroutine 145:
  github.com/m3db/m3/src/msg/producer/writer.(*message).Ack()
      /Users/vytenis/darbas/m3/src/msg/producer/writer/message.go:101 +0x68
  github.com/m3db/m3/src/msg/producer/writer.(*acks).ack()
...
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
