### PR TITLE
[dbnode] Load and cache info files during bootstrap 

### DIFF
--- a/src/cmd/services/m3dbnode/config/bootstrap.go
+++ b/src/cmd/services/m3dbnode/config/bootstrap.go
@@ -283,7 +283,7 @@ func (bsc BootstrapConfiguration) New(
 	if bsc.CacheSeriesMetadata != nil {
 		providerOpts = providerOpts.SetCacheSeriesMetadata(*bsc.CacheSeriesMetadata)
 	}
-	return bootstrap.NewProcessProvider(bs, providerOpts, rsOpts)
+	return bootstrap.NewProcessProvider(bs, providerOpts, rsOpts, fsOpts)
 }
 
 func (bsc BootstrapConfiguration) filesystemConfig() BootstrapFilesystemConfiguration {

--- a/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
+++ b/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
@@ -134,7 +134,7 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 			if err != nil {
 				return bootstrap.NamespaceResults{}, err
 			}
-			return bs.Bootstrap(ctx, namespaces, state)
+			return bs.Bootstrap(ctx, namespaces, cache)
 		},
 	}, bootstrapOpts, bs)
 

--- a/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
+++ b/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
@@ -125,7 +125,7 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 		read: func(
 			ctx context.Context,
 			namespaces bootstrap.Namespaces,
-			state bootstrap.State,
+			cache bootstrap.Cache,
 		) (bootstrap.NamespaceResults, error) {
 			<-signalCh
 			// Mark all as unfulfilled so the commitlog bootstrapper will be called after

--- a/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
+++ b/src/dbnode/integration/bootstrap_after_buffer_rotation_regression_test.go
@@ -125,6 +125,7 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 		read: func(
 			ctx context.Context,
 			namespaces bootstrap.Namespaces,
+			state bootstrap.State,
 		) (bootstrap.NamespaceResults, error) {
 			<-signalCh
 			// Mark all as unfulfilled so the commitlog bootstrapper will be called after
@@ -133,7 +134,7 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 			if err != nil {
 				return bootstrap.NamespaceResults{}, err
 			}
-			return bs.Bootstrap(ctx, namespaces)
+			return bs.Bootstrap(ctx, namespaces, state)
 		},
 	}, bootstrapOpts, bs)
 
@@ -142,7 +143,7 @@ func TestBootstrapAfterBufferRotation(t *testing.T) {
 		SetOrigin(setup.Origin())
 
 	processProvider, err := bootstrap.NewProcessProvider(
-		test, processOpts, bootstrapOpts)
+		test, processOpts, bootstrapOpts, fsOpts)
 	require.NoError(t, err)
 	setup.SetStorageOpts(setup.StorageOpts().SetBootstrapProcessProvider(processProvider))
 

--- a/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
+++ b/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
@@ -139,7 +139,7 @@ func TestBootstrapBeforeBufferRotationNoTick(t *testing.T) {
 		read: func(
 			ctx context.Context,
 			namespaces bootstrap.Namespaces,
-			state bootstrap.State,
+			cache bootstrap.Cache,
 		) (bootstrap.NamespaceResults, error) {
 			<-signalCh
 			// Mark all as unfulfilled so the commitlog bootstrapper will be called after

--- a/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
+++ b/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
@@ -148,7 +148,7 @@ func TestBootstrapBeforeBufferRotationNoTick(t *testing.T) {
 			if err != nil {
 				return bootstrap.NamespaceResults{}, err
 			}
-			return bs.Bootstrap(ctx, namespaces, state)
+			return bs.Bootstrap(ctx, namespaces, cache)
 		},
 	}, bootstrapOpts, bs)
 

--- a/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
+++ b/src/dbnode/integration/bootstrap_before_buffer_rotation_no_tick_regression_test.go
@@ -139,6 +139,7 @@ func TestBootstrapBeforeBufferRotationNoTick(t *testing.T) {
 		read: func(
 			ctx context.Context,
 			namespaces bootstrap.Namespaces,
+			state bootstrap.State,
 		) (bootstrap.NamespaceResults, error) {
 			<-signalCh
 			// Mark all as unfulfilled so the commitlog bootstrapper will be called after
@@ -147,14 +148,14 @@ func TestBootstrapBeforeBufferRotationNoTick(t *testing.T) {
 			if err != nil {
 				return bootstrap.NamespaceResults{}, err
 			}
-			return bs.Bootstrap(ctx, namespaces)
+			return bs.Bootstrap(ctx, namespaces, state)
 		},
 	}, bootstrapOpts, bs)
 
 	processOpts := bootstrap.NewProcessOptions().
 		SetTopologyMapProvider(setup).
 		SetOrigin(setup.Origin())
-	process, err := bootstrap.NewProcessProvider(test, processOpts, bootstrapOpts)
+	process, err := bootstrap.NewProcessProvider(test, processOpts, bootstrapOpts, fsOpts)
 	require.NoError(t, err)
 	setup.SetStorageOpts(setup.StorageOpts().SetBootstrapProcessProvider(process))
 

--- a/src/dbnode/integration/bootstrap_helpers.go
+++ b/src/dbnode/integration/bootstrap_helpers.go
@@ -45,7 +45,7 @@ func newTestBootstrapperSource(
 	if opts.availableData != nil {
 		src.availableData = opts.availableData
 	} else {
-		src.availableData = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.RunOptions) (result.ShardTimeRanges, error) {
+		src.availableData = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.State, _ bootstrap.RunOptions) (result.ShardTimeRanges, error) {
 			return shardsTimeRanges, nil
 		}
 	}
@@ -53,7 +53,7 @@ func newTestBootstrapperSource(
 	if opts.availableIndex != nil {
 		src.availableIndex = opts.availableIndex
 	} else {
-		src.availableIndex = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.RunOptions) (result.ShardTimeRanges, error) {
+		src.availableIndex = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.State, _ bootstrap.RunOptions) (result.ShardTimeRanges, error) {
 			return shardsTimeRanges, nil
 		}
 	}
@@ -61,7 +61,7 @@ func newTestBootstrapperSource(
 	if opts.read != nil {
 		src.read = opts.read
 	} else {
-		src.read = func(ctx context.Context, namespaces bootstrap.Namespaces) (bootstrap.NamespaceResults, error) {
+		src.read = func(_ context.Context, namespaces bootstrap.Namespaces, _ bootstrap.State) (bootstrap.NamespaceResults, error) {
 			return bootstrap.NewNamespaceResults(namespaces), nil
 		}
 	}
@@ -96,40 +96,43 @@ type testBootstrapper struct {
 }
 
 type testBootstrapperSourceOptions struct {
-	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) (result.ShardTimeRanges, error)
-	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) (result.ShardTimeRanges, error)
-	read           func(ctx context.Context, namespaces bootstrap.Namespaces) (bootstrap.NamespaceResults, error)
+	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.State, bootstrap.RunOptions) (result.ShardTimeRanges, error)
+	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.State, bootstrap.RunOptions) (result.ShardTimeRanges, error)
+	read           func(ctx context.Context, namespaces bootstrap.Namespaces, state bootstrap.State) (bootstrap.NamespaceResults, error)
 }
 
 var _ bootstrap.Source = &testBootstrapperSource{}
 
 type testBootstrapperSource struct {
-	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) (result.ShardTimeRanges, error)
-	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.RunOptions) (result.ShardTimeRanges, error)
-	read           func(ctx context.Context, namespaces bootstrap.Namespaces) (bootstrap.NamespaceResults, error)
+	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.State, bootstrap.RunOptions) (result.ShardTimeRanges, error)
+	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.State, bootstrap.RunOptions) (result.ShardTimeRanges, error)
+	read           func(ctx context.Context, namespaces bootstrap.Namespaces, state bootstrap.State) (bootstrap.NamespaceResults, error)
 }
 
 func (t testBootstrapperSource) AvailableData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	state bootstrap.State,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
-	return t.availableData(ns, shardsTimeRanges, runOpts)
+	return t.availableData(ns, shardsTimeRanges, state, runOpts)
 }
 
 func (t testBootstrapperSource) AvailableIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	state bootstrap.State,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
-	return t.availableIndex(ns, shardsTimeRanges, runOpts)
+	return t.availableIndex(ns, shardsTimeRanges, state, runOpts)
 }
 
 func (t testBootstrapperSource) Read(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
+	state bootstrap.State,
 ) (bootstrap.NamespaceResults, error) {
-	return t.read(ctx, namespaces)
+	return t.read(ctx, namespaces, state)
 }
 
 func (t testBootstrapperSource) String() string {

--- a/src/dbnode/integration/bootstrap_helpers.go
+++ b/src/dbnode/integration/bootstrap_helpers.go
@@ -115,7 +115,7 @@ func (t testBootstrapperSource) AvailableData(
 	cache bootstrap.Cache,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
-	return t.availableData(ns, shardsTimeRanges, state, runOpts)
+	return t.availableData(ns, shardsTimeRanges, cache, runOpts)
 }
 
 func (t testBootstrapperSource) AvailableIndex(
@@ -124,7 +124,7 @@ func (t testBootstrapperSource) AvailableIndex(
 	cache bootstrap.Cache,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
-	return t.availableIndex(ns, shardsTimeRanges, state, runOpts)
+	return t.availableIndex(ns, shardsTimeRanges, cache, runOpts)
 }
 
 func (t testBootstrapperSource) Read(
@@ -132,7 +132,7 @@ func (t testBootstrapperSource) Read(
 	namespaces bootstrap.Namespaces,
 	cache bootstrap.Cache,
 ) (bootstrap.NamespaceResults, error) {
-	return t.read(ctx, namespaces, state)
+	return t.read(ctx, namespaces, cache)
 }
 
 func (t testBootstrapperSource) String() string {

--- a/src/dbnode/integration/bootstrap_helpers.go
+++ b/src/dbnode/integration/bootstrap_helpers.go
@@ -45,7 +45,7 @@ func newTestBootstrapperSource(
 	if opts.availableData != nil {
 		src.availableData = opts.availableData
 	} else {
-		src.availableData = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.State, _ bootstrap.RunOptions) (result.ShardTimeRanges, error) {
+		src.availableData = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.Cache, _ bootstrap.RunOptions) (result.ShardTimeRanges, error) {
 			return shardsTimeRanges, nil
 		}
 	}
@@ -53,7 +53,7 @@ func newTestBootstrapperSource(
 	if opts.availableIndex != nil {
 		src.availableIndex = opts.availableIndex
 	} else {
-		src.availableIndex = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.State, _ bootstrap.RunOptions) (result.ShardTimeRanges, error) {
+		src.availableIndex = func(_ namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, _ bootstrap.Cache, _ bootstrap.RunOptions) (result.ShardTimeRanges, error) {
 			return shardsTimeRanges, nil
 		}
 	}
@@ -61,7 +61,7 @@ func newTestBootstrapperSource(
 	if opts.read != nil {
 		src.read = opts.read
 	} else {
-		src.read = func(_ context.Context, namespaces bootstrap.Namespaces, _ bootstrap.State) (bootstrap.NamespaceResults, error) {
+		src.read = func(_ context.Context, namespaces bootstrap.Namespaces, _ bootstrap.Cache) (bootstrap.NamespaceResults, error) {
 			return bootstrap.NewNamespaceResults(namespaces), nil
 		}
 	}
@@ -96,23 +96,23 @@ type testBootstrapper struct {
 }
 
 type testBootstrapperSourceOptions struct {
-	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.State, bootstrap.RunOptions) (result.ShardTimeRanges, error)
-	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.State, bootstrap.RunOptions) (result.ShardTimeRanges, error)
-	read           func(ctx context.Context, namespaces bootstrap.Namespaces, state bootstrap.State) (bootstrap.NamespaceResults, error)
+	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.Cache, bootstrap.RunOptions) (result.ShardTimeRanges, error)
+	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.Cache, bootstrap.RunOptions) (result.ShardTimeRanges, error)
+	read           func(ctx context.Context, namespaces bootstrap.Namespaces, cache bootstrap.Cache) (bootstrap.NamespaceResults, error)
 }
 
 var _ bootstrap.Source = &testBootstrapperSource{}
 
 type testBootstrapperSource struct {
-	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.State, bootstrap.RunOptions) (result.ShardTimeRanges, error)
-	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.State, bootstrap.RunOptions) (result.ShardTimeRanges, error)
-	read           func(ctx context.Context, namespaces bootstrap.Namespaces, state bootstrap.State) (bootstrap.NamespaceResults, error)
+	availableData  func(namespace.Metadata, result.ShardTimeRanges, bootstrap.Cache, bootstrap.RunOptions) (result.ShardTimeRanges, error)
+	availableIndex func(namespace.Metadata, result.ShardTimeRanges, bootstrap.Cache, bootstrap.RunOptions) (result.ShardTimeRanges, error)
+	read           func(ctx context.Context, namespaces bootstrap.Namespaces, cache bootstrap.Cache) (bootstrap.NamespaceResults, error)
 }
 
 func (t testBootstrapperSource) AvailableData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
-	state bootstrap.State,
+	cache bootstrap.Cache,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	return t.availableData(ns, shardsTimeRanges, state, runOpts)
@@ -121,7 +121,7 @@ func (t testBootstrapperSource) AvailableData(
 func (t testBootstrapperSource) AvailableIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
-	state bootstrap.State,
+	cache bootstrap.Cache,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	return t.availableIndex(ns, shardsTimeRanges, state, runOpts)
@@ -130,7 +130,7 @@ func (t testBootstrapperSource) AvailableIndex(
 func (t testBootstrapperSource) Read(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
-	state bootstrap.State,
+	cache bootstrap.Cache,
 ) (bootstrap.NamespaceResults, error) {
 	return t.read(ctx, namespaces, state)
 }

--- a/src/dbnode/integration/integration.go
+++ b/src/dbnode/integration/integration.go
@@ -299,7 +299,7 @@ func newDefaultBootstrappableTestSetups(
 		processOpts := bootstrap.NewProcessOptions().
 			SetTopologyMapProvider(setup).
 			SetOrigin(setup.Origin())
-		provider, err := bootstrap.NewProcessProvider(fsBootstrapper, processOpts, bsOpts)
+		provider, err := bootstrap.NewProcessProvider(fsBootstrapper, processOpts, bsOpts, fsOpts)
 		require.NoError(t, err)
 
 		setup.SetStorageOpts(setup.StorageOpts().SetBootstrapProcessProvider(provider))

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -952,7 +952,7 @@ func (ts *testSetup) InitializeBootstrappers(opts InitializeBootstrappersOptions
 	processOpts := bootstrap.NewProcessOptions().
 		SetTopologyMapProvider(ts).
 		SetOrigin(ts.Origin())
-	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts)
+	process, err := bootstrap.NewProcessProvider(bs, processOpts, bsOpts, fsOpts)
 	if err != nil {
 		return err
 	}

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -679,9 +679,3 @@ type CrossBlockIterator interface {
 	// Reset resets the iterator to the given block records.
 	Reset(records []BlockRecord)
 }
-
-// InfoFileResultsPerShard maps shards to info files.
-type InfoFileResultsPerShard map[uint32][]ReadInfoFileResult
-
-// InfoFilesByNamespace maps a namespace to info files grouped by shard.
-type InfoFilesByNamespace map[namespace.Metadata]InfoFileResultsPerShard

--- a/src/dbnode/storage/bootstrap/bootstrap_mock.go
+++ b/src/dbnode/storage/bootstrap/bootstrap_mock.go
@@ -712,32 +712,32 @@ func (mr *MockCacheOptionsMockRecorder) FilesystemOptions() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilesystemOptions", reflect.TypeOf((*MockCacheOptions)(nil).FilesystemOptions))
 }
 
-// SetInfoFilesFinders mocks base method
-func (m *MockCacheOptions) SetInfoFilesFinders(value []InfoFilesFinder) CacheOptions {
+// SetNamespaceDetails mocks base method
+func (m *MockCacheOptions) SetNamespaceDetails(value []NamespaceDetails) CacheOptions {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetInfoFilesFinders", value)
+	ret := m.ctrl.Call(m, "SetNamespaceDetails", value)
 	ret0, _ := ret[0].(CacheOptions)
 	return ret0
 }
 
-// SetInfoFilesFinders indicates an expected call of SetInfoFilesFinders
-func (mr *MockCacheOptionsMockRecorder) SetInfoFilesFinders(value interface{}) *gomock.Call {
+// SetNamespaceDetails indicates an expected call of SetNamespaceDetails
+func (mr *MockCacheOptionsMockRecorder) SetNamespaceDetails(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInfoFilesFinders", reflect.TypeOf((*MockCacheOptions)(nil).SetInfoFilesFinders), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNamespaceDetails", reflect.TypeOf((*MockCacheOptions)(nil).SetNamespaceDetails), value)
 }
 
-// InfoFilesFinders mocks base method
-func (m *MockCacheOptions) InfoFilesFinders() []InfoFilesFinder {
+// NamespaceDetails mocks base method
+func (m *MockCacheOptions) NamespaceDetails() []NamespaceDetails {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InfoFilesFinders")
-	ret0, _ := ret[0].([]InfoFilesFinder)
+	ret := m.ctrl.Call(m, "NamespaceDetails")
+	ret0, _ := ret[0].([]NamespaceDetails)
 	return ret0
 }
 
-// InfoFilesFinders indicates an expected call of InfoFilesFinders
-func (mr *MockCacheOptionsMockRecorder) InfoFilesFinders() *gomock.Call {
+// NamespaceDetails indicates an expected call of NamespaceDetails
+func (mr *MockCacheOptionsMockRecorder) NamespaceDetails() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InfoFilesFinders", reflect.TypeOf((*MockCacheOptions)(nil).InfoFilesFinders))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceDetails", reflect.TypeOf((*MockCacheOptions)(nil).NamespaceDetails))
 }
 
 // SetInstrumentOptions mocks base method

--- a/src/dbnode/storage/bootstrap/bootstrap_mock.go
+++ b/src/dbnode/storage/bootstrap/bootstrap_mock.go
@@ -565,18 +565,18 @@ func (mr *MockBootstrapperMockRecorder) String() *gomock.Call {
 }
 
 // Bootstrap mocks base method
-func (m *MockBootstrapper) Bootstrap(ctx context.Context, namespaces Namespaces, state State) (NamespaceResults, error) {
+func (m *MockBootstrapper) Bootstrap(ctx context.Context, namespaces Namespaces, cache Cache) (NamespaceResults, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", ctx, namespaces, state)
+	ret := m.ctrl.Call(m, "Bootstrap", ctx, namespaces, cache)
 	ret0, _ := ret[0].(NamespaceResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockBootstrapperMockRecorder) Bootstrap(ctx, namespaces, state interface{}) *gomock.Call {
+func (mr *MockBootstrapperMockRecorder) Bootstrap(ctx, namespaces, cache interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockBootstrapper)(nil).Bootstrap), ctx, namespaces, state)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockBootstrapper)(nil).Bootstrap), ctx, namespaces, cache)
 }
 
 // MockSource is a mock of Source interface
@@ -603,75 +603,75 @@ func (m *MockSource) EXPECT() *MockSourceMockRecorder {
 }
 
 // AvailableData mocks base method
-func (m *MockSource) AvailableData(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, state State, runOpts RunOptions) (result.ShardTimeRanges, error) {
+func (m *MockSource) AvailableData(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, cache Cache, runOpts RunOptions) (result.ShardTimeRanges, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailableData", ns, shardsTimeRanges, state, runOpts)
+	ret := m.ctrl.Call(m, "AvailableData", ns, shardsTimeRanges, cache, runOpts)
 	ret0, _ := ret[0].(result.ShardTimeRanges)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailableData indicates an expected call of AvailableData
-func (mr *MockSourceMockRecorder) AvailableData(ns, shardsTimeRanges, state, runOpts interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) AvailableData(ns, shardsTimeRanges, cache, runOpts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableData", reflect.TypeOf((*MockSource)(nil).AvailableData), ns, shardsTimeRanges, state, runOpts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableData", reflect.TypeOf((*MockSource)(nil).AvailableData), ns, shardsTimeRanges, cache, runOpts)
 }
 
 // AvailableIndex mocks base method
-func (m *MockSource) AvailableIndex(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, state State, opts RunOptions) (result.ShardTimeRanges, error) {
+func (m *MockSource) AvailableIndex(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, cache Cache, opts RunOptions) (result.ShardTimeRanges, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailableIndex", ns, shardsTimeRanges, state, opts)
+	ret := m.ctrl.Call(m, "AvailableIndex", ns, shardsTimeRanges, cache, opts)
 	ret0, _ := ret[0].(result.ShardTimeRanges)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailableIndex indicates an expected call of AvailableIndex
-func (mr *MockSourceMockRecorder) AvailableIndex(ns, shardsTimeRanges, state, opts interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) AvailableIndex(ns, shardsTimeRanges, cache, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIndex", reflect.TypeOf((*MockSource)(nil).AvailableIndex), ns, shardsTimeRanges, state, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIndex", reflect.TypeOf((*MockSource)(nil).AvailableIndex), ns, shardsTimeRanges, cache, opts)
 }
 
 // Read mocks base method
-func (m *MockSource) Read(ctx context.Context, namespaces Namespaces, state State) (NamespaceResults, error) {
+func (m *MockSource) Read(ctx context.Context, namespaces Namespaces, cache Cache) (NamespaceResults, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, namespaces, state)
+	ret := m.ctrl.Call(m, "Read", ctx, namespaces, cache)
 	ret0, _ := ret[0].(NamespaceResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read
-func (mr *MockSourceMockRecorder) Read(ctx, namespaces, state interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) Read(ctx, namespaces, cache interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockSource)(nil).Read), ctx, namespaces, state)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockSource)(nil).Read), ctx, namespaces, cache)
 }
 
-// MockStateOptions is a mock of StateOptions interface
-type MockStateOptions struct {
+// MockCacheOptions is a mock of CacheOptions interface
+type MockCacheOptions struct {
 	ctrl     *gomock.Controller
-	recorder *MockStateOptionsMockRecorder
+	recorder *MockCacheOptionsMockRecorder
 }
 
-// MockStateOptionsMockRecorder is the mock recorder for MockStateOptions
-type MockStateOptionsMockRecorder struct {
-	mock *MockStateOptions
+// MockCacheOptionsMockRecorder is the mock recorder for MockCacheOptions
+type MockCacheOptionsMockRecorder struct {
+	mock *MockCacheOptions
 }
 
-// NewMockStateOptions creates a new mock instance
-func NewMockStateOptions(ctrl *gomock.Controller) *MockStateOptions {
-	mock := &MockStateOptions{ctrl: ctrl}
-	mock.recorder = &MockStateOptionsMockRecorder{mock}
+// NewMockCacheOptions creates a new mock instance
+func NewMockCacheOptions(ctrl *gomock.Controller) *MockCacheOptions {
+	mock := &MockCacheOptions{ctrl: ctrl}
+	mock.recorder = &MockCacheOptionsMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockStateOptions) EXPECT() *MockStateOptionsMockRecorder {
+func (m *MockCacheOptions) EXPECT() *MockCacheOptionsMockRecorder {
 	return m.recorder
 }
 
 // Validate mocks base method
-func (m *MockStateOptions) Validate() error {
+func (m *MockCacheOptions) Validate() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate")
 	ret0, _ := ret[0].(error)
@@ -679,27 +679,27 @@ func (m *MockStateOptions) Validate() error {
 }
 
 // Validate indicates an expected call of Validate
-func (mr *MockStateOptionsMockRecorder) Validate() *gomock.Call {
+func (mr *MockCacheOptionsMockRecorder) Validate() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockStateOptions)(nil).Validate))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockCacheOptions)(nil).Validate))
 }
 
 // SetFilesystemOptions mocks base method
-func (m *MockStateOptions) SetFilesystemOptions(value fs.Options) StateOptions {
+func (m *MockCacheOptions) SetFilesystemOptions(value fs.Options) CacheOptions {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetFilesystemOptions", value)
-	ret0, _ := ret[0].(StateOptions)
+	ret0, _ := ret[0].(CacheOptions)
 	return ret0
 }
 
 // SetFilesystemOptions indicates an expected call of SetFilesystemOptions
-func (mr *MockStateOptionsMockRecorder) SetFilesystemOptions(value interface{}) *gomock.Call {
+func (mr *MockCacheOptionsMockRecorder) SetFilesystemOptions(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFilesystemOptions", reflect.TypeOf((*MockStateOptions)(nil).SetFilesystemOptions), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFilesystemOptions", reflect.TypeOf((*MockCacheOptions)(nil).SetFilesystemOptions), value)
 }
 
 // FilesystemOptions mocks base method
-func (m *MockStateOptions) FilesystemOptions() fs.Options {
+func (m *MockCacheOptions) FilesystemOptions() fs.Options {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilesystemOptions")
 	ret0, _ := ret[0].(fs.Options)
@@ -707,27 +707,27 @@ func (m *MockStateOptions) FilesystemOptions() fs.Options {
 }
 
 // FilesystemOptions indicates an expected call of FilesystemOptions
-func (mr *MockStateOptionsMockRecorder) FilesystemOptions() *gomock.Call {
+func (mr *MockCacheOptionsMockRecorder) FilesystemOptions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilesystemOptions", reflect.TypeOf((*MockStateOptions)(nil).FilesystemOptions))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilesystemOptions", reflect.TypeOf((*MockCacheOptions)(nil).FilesystemOptions))
 }
 
 // SetInfoFilesFinders mocks base method
-func (m *MockStateOptions) SetInfoFilesFinders(value []InfoFilesFinder) StateOptions {
+func (m *MockCacheOptions) SetInfoFilesFinders(value []InfoFilesFinder) CacheOptions {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInfoFilesFinders", value)
-	ret0, _ := ret[0].(StateOptions)
+	ret0, _ := ret[0].(CacheOptions)
 	return ret0
 }
 
 // SetInfoFilesFinders indicates an expected call of SetInfoFilesFinders
-func (mr *MockStateOptionsMockRecorder) SetInfoFilesFinders(value interface{}) *gomock.Call {
+func (mr *MockCacheOptionsMockRecorder) SetInfoFilesFinders(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInfoFilesFinders", reflect.TypeOf((*MockStateOptions)(nil).SetInfoFilesFinders), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInfoFilesFinders", reflect.TypeOf((*MockCacheOptions)(nil).SetInfoFilesFinders), value)
 }
 
 // InfoFilesFinders mocks base method
-func (m *MockStateOptions) InfoFilesFinders() []InfoFilesFinder {
+func (m *MockCacheOptions) InfoFilesFinders() []InfoFilesFinder {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InfoFilesFinders")
 	ret0, _ := ret[0].([]InfoFilesFinder)
@@ -735,27 +735,27 @@ func (m *MockStateOptions) InfoFilesFinders() []InfoFilesFinder {
 }
 
 // InfoFilesFinders indicates an expected call of InfoFilesFinders
-func (mr *MockStateOptionsMockRecorder) InfoFilesFinders() *gomock.Call {
+func (mr *MockCacheOptionsMockRecorder) InfoFilesFinders() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InfoFilesFinders", reflect.TypeOf((*MockStateOptions)(nil).InfoFilesFinders))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InfoFilesFinders", reflect.TypeOf((*MockCacheOptions)(nil).InfoFilesFinders))
 }
 
 // SetInstrumentOptions mocks base method
-func (m *MockStateOptions) SetInstrumentOptions(value instrument.Options) StateOptions {
+func (m *MockCacheOptions) SetInstrumentOptions(value instrument.Options) CacheOptions {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetInstrumentOptions", value)
-	ret0, _ := ret[0].(StateOptions)
+	ret0, _ := ret[0].(CacheOptions)
 	return ret0
 }
 
 // SetInstrumentOptions indicates an expected call of SetInstrumentOptions
-func (mr *MockStateOptionsMockRecorder) SetInstrumentOptions(value interface{}) *gomock.Call {
+func (mr *MockCacheOptionsMockRecorder) SetInstrumentOptions(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstrumentOptions", reflect.TypeOf((*MockStateOptions)(nil).SetInstrumentOptions), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstrumentOptions", reflect.TypeOf((*MockCacheOptions)(nil).SetInstrumentOptions), value)
 }
 
 // InstrumentOptions mocks base method
-func (m *MockStateOptions) InstrumentOptions() instrument.Options {
+func (m *MockCacheOptions) InstrumentOptions() instrument.Options {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstrumentOptions")
 	ret0, _ := ret[0].(instrument.Options)
@@ -763,7 +763,7 @@ func (m *MockStateOptions) InstrumentOptions() instrument.Options {
 }
 
 // InstrumentOptions indicates an expected call of InstrumentOptions
-func (mr *MockStateOptionsMockRecorder) InstrumentOptions() *gomock.Call {
+func (mr *MockCacheOptionsMockRecorder) InstrumentOptions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstrumentOptions", reflect.TypeOf((*MockStateOptions)(nil).InstrumentOptions))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstrumentOptions", reflect.TypeOf((*MockCacheOptions)(nil).InstrumentOptions))
 }

--- a/src/dbnode/storage/bootstrap/bootstrap_mock.go
+++ b/src/dbnode/storage/bootstrap/bootstrap_mock.go
@@ -29,10 +29,12 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/instrument"
 
 	"github.com/golang/mock/gomock"
 )
@@ -563,18 +565,18 @@ func (mr *MockBootstrapperMockRecorder) String() *gomock.Call {
 }
 
 // Bootstrap mocks base method
-func (m *MockBootstrapper) Bootstrap(ctx context.Context, namespaces Namespaces) (NamespaceResults, error) {
+func (m *MockBootstrapper) Bootstrap(ctx context.Context, namespaces Namespaces, state State) (NamespaceResults, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bootstrap", ctx, namespaces)
+	ret := m.ctrl.Call(m, "Bootstrap", ctx, namespaces, state)
 	ret0, _ := ret[0].(NamespaceResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Bootstrap indicates an expected call of Bootstrap
-func (mr *MockBootstrapperMockRecorder) Bootstrap(ctx, namespaces interface{}) *gomock.Call {
+func (mr *MockBootstrapperMockRecorder) Bootstrap(ctx, namespaces, state interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockBootstrapper)(nil).Bootstrap), ctx, namespaces)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bootstrap", reflect.TypeOf((*MockBootstrapper)(nil).Bootstrap), ctx, namespaces, state)
 }
 
 // MockSource is a mock of Source interface
@@ -601,46 +603,167 @@ func (m *MockSource) EXPECT() *MockSourceMockRecorder {
 }
 
 // AvailableData mocks base method
-func (m *MockSource) AvailableData(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, runOpts RunOptions) (result.ShardTimeRanges, error) {
+func (m *MockSource) AvailableData(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, state State, runOpts RunOptions) (result.ShardTimeRanges, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailableData", ns, shardsTimeRanges, runOpts)
+	ret := m.ctrl.Call(m, "AvailableData", ns, shardsTimeRanges, state, runOpts)
 	ret0, _ := ret[0].(result.ShardTimeRanges)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailableData indicates an expected call of AvailableData
-func (mr *MockSourceMockRecorder) AvailableData(ns, shardsTimeRanges, runOpts interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) AvailableData(ns, shardsTimeRanges, state, runOpts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableData", reflect.TypeOf((*MockSource)(nil).AvailableData), ns, shardsTimeRanges, runOpts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableData", reflect.TypeOf((*MockSource)(nil).AvailableData), ns, shardsTimeRanges, state, runOpts)
 }
 
 // AvailableIndex mocks base method
-func (m *MockSource) AvailableIndex(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, opts RunOptions) (result.ShardTimeRanges, error) {
+func (m *MockSource) AvailableIndex(ns namespace.Metadata, shardsTimeRanges result.ShardTimeRanges, state State, opts RunOptions) (result.ShardTimeRanges, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailableIndex", ns, shardsTimeRanges, opts)
+	ret := m.ctrl.Call(m, "AvailableIndex", ns, shardsTimeRanges, state, opts)
 	ret0, _ := ret[0].(result.ShardTimeRanges)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailableIndex indicates an expected call of AvailableIndex
-func (mr *MockSourceMockRecorder) AvailableIndex(ns, shardsTimeRanges, opts interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) AvailableIndex(ns, shardsTimeRanges, state, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIndex", reflect.TypeOf((*MockSource)(nil).AvailableIndex), ns, shardsTimeRanges, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIndex", reflect.TypeOf((*MockSource)(nil).AvailableIndex), ns, shardsTimeRanges, state, opts)
 }
 
 // Read mocks base method
-func (m *MockSource) Read(ctx context.Context, namespaces Namespaces) (NamespaceResults, error) {
+func (m *MockSource) Read(ctx context.Context, namespaces Namespaces, state State) (NamespaceResults, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, namespaces)
+	ret := m.ctrl.Call(m, "Read", ctx, namespaces, state)
 	ret0, _ := ret[0].(NamespaceResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read
-func (mr *MockSourceMockRecorder) Read(ctx, namespaces interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) Read(ctx, namespaces, state interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockSource)(nil).Read), ctx, namespaces)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockSource)(nil).Read), ctx, namespaces, state)
+}
+
+// MockStateOptions is a mock of StateOptions interface
+type MockStateOptions struct {
+	ctrl     *gomock.Controller
+	recorder *MockStateOptionsMockRecorder
+}
+
+// MockStateOptionsMockRecorder is the mock recorder for MockStateOptions
+type MockStateOptionsMockRecorder struct {
+	mock *MockStateOptions
+}
+
+// NewMockStateOptions creates a new mock instance
+func NewMockStateOptions(ctrl *gomock.Controller) *MockStateOptions {
+	mock := &MockStateOptions{ctrl: ctrl}
+	mock.recorder = &MockStateOptionsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockStateOptions) EXPECT() *MockStateOptionsMockRecorder {
+	return m.recorder
+}
+
+// Validate mocks base method
+func (m *MockStateOptions) Validate() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validate")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Validate indicates an expected call of Validate
+func (mr *MockStateOptionsMockRecorder) Validate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockStateOptions)(nil).Validate))
+}
+
+// SetFilesystemOptions mocks base method
+func (m *MockStateOptions) SetFilesystemOptions(value fs.Options) StateOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetFilesystemOptions", value)
+	ret0, _ := ret[0].(StateOptions)
+	return ret0
+}
+
+// SetFilesystemOptions indicates an expected call of SetFilesystemOptions
+func (mr *MockStateOptionsMockRecorder) SetFilesystemOptions(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFilesystemOptions", reflect.TypeOf((*MockStateOptions)(nil).SetFilesystemOptions), value)
+}
+
+// FilesystemOptions mocks base method
+func (m *MockStateOptions) FilesystemOptions() fs.Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FilesystemOptions")
+	ret0, _ := ret[0].(fs.Options)
+	return ret0
+}
+
+// FilesystemOptions indicates an expected call of FilesystemOptions
+func (mr *MockStateOptionsMockRecorder) FilesystemOptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilesystemOptions", reflect.TypeOf((*MockStateOptions)(nil).FilesystemOptions))
+}
+
+// SetInfoFilesFinders mocks base method
+func (m *MockStateOptions) SetInfoFilesFinders(value []InfoFilesFinder) StateOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInfoFilesFinders", value)
+	ret0, _ := ret[0].(StateOptions)
+	return ret0
+}
+
+// SetInfoFilesFinders indicates an expected call of SetInfoFilesFinders
+func (mr *MockStateOptionsMockRecorder) SetInfoFilesFinders(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInfoFilesFinders", reflect.TypeOf((*MockStateOptions)(nil).SetInfoFilesFinders), value)
+}
+
+// InfoFilesFinders mocks base method
+func (m *MockStateOptions) InfoFilesFinders() []InfoFilesFinder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InfoFilesFinders")
+	ret0, _ := ret[0].([]InfoFilesFinder)
+	return ret0
+}
+
+// InfoFilesFinders indicates an expected call of InfoFilesFinders
+func (mr *MockStateOptionsMockRecorder) InfoFilesFinders() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InfoFilesFinders", reflect.TypeOf((*MockStateOptions)(nil).InfoFilesFinders))
+}
+
+// SetInstrumentOptions mocks base method
+func (m *MockStateOptions) SetInstrumentOptions(value instrument.Options) StateOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInstrumentOptions", value)
+	ret0, _ := ret[0].(StateOptions)
+	return ret0
+}
+
+// SetInstrumentOptions indicates an expected call of SetInstrumentOptions
+func (mr *MockStateOptionsMockRecorder) SetInstrumentOptions(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstrumentOptions", reflect.TypeOf((*MockStateOptions)(nil).SetInstrumentOptions), value)
+}
+
+// InstrumentOptions mocks base method
+func (m *MockStateOptions) InstrumentOptions() instrument.Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstrumentOptions")
+	ret0, _ := ret[0].(instrument.Options)
+	return ret0
+}
+
+// InstrumentOptions indicates an expected call of InstrumentOptions
+func (mr *MockStateOptionsMockRecorder) InstrumentOptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstrumentOptions", reflect.TypeOf((*MockStateOptions)(nil).InstrumentOptions))
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/base.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base.go
@@ -78,7 +78,7 @@ func (b baseBootstrapper) String() string {
 func (b baseBootstrapper) Bootstrap(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
-	state bootstrap.State,
+	cache bootstrap.Cache,
 ) (bootstrap.NamespaceResults, error) {
 	logFields := []zapcore.Field{
 		zap.String("bootstrapper", b.name),
@@ -97,7 +97,7 @@ func (b baseBootstrapper) Bootstrap(
 			logFields, currNamespace)
 
 		dataAvailable, err := b.src.AvailableData(currNamespace.Metadata,
-			currNamespace.DataRunOptions.ShardTimeRanges.Copy(), state,
+			currNamespace.DataRunOptions.ShardTimeRanges.Copy(), cache,
 			currNamespace.DataRunOptions.RunOptions)
 		if err != nil {
 			return bootstrap.NamespaceResults{}, err
@@ -108,7 +108,7 @@ func (b baseBootstrapper) Bootstrap(
 		// Prepare index if required.
 		if currNamespace.Metadata.Options().IndexOptions().Enabled() {
 			indexAvailable, err := b.src.AvailableIndex(currNamespace.Metadata,
-				currNamespace.IndexRunOptions.ShardTimeRanges.Copy(), state,
+				currNamespace.IndexRunOptions.ShardTimeRanges.Copy(), cache,
 				currNamespace.IndexRunOptions.RunOptions)
 			if err != nil {
 				return bootstrap.NamespaceResults{}, err
@@ -138,7 +138,7 @@ func (b baseBootstrapper) Bootstrap(
 	b.log.Info("bootstrap from source started", logFields...)
 
 	// Run the bootstrap source.
-	currResults, err := b.src.Read(ctx, curr, state)
+	currResults, err := b.src.Read(ctx, curr, cache)
 
 	logFields = append(logFields, zap.Duration("took", nowFn().Sub(begin)))
 	if err != nil {
@@ -167,7 +167,7 @@ func (b baseBootstrapper) Bootstrap(
 	// If there are some time ranges the current bootstrapper could not fulfill,
 	// that we can attempt then pass it along to the next bootstrapper.
 	if next.Namespaces.Len() > 0 {
-		nextResults, err := b.next.Bootstrap(ctx, next, state)
+		nextResults, err := b.next.Bootstrap(ctx, next, cache)
 		if err != nil {
 			return bootstrap.NamespaceResults{}, err
 		}

--- a/src/dbnode/storage/bootstrap/bootstrapper/base.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base.go
@@ -78,6 +78,7 @@ func (b baseBootstrapper) String() string {
 func (b baseBootstrapper) Bootstrap(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
+	state bootstrap.State,
 ) (bootstrap.NamespaceResults, error) {
 	logFields := []zapcore.Field{
 		zap.String("bootstrapper", b.name),
@@ -96,7 +97,7 @@ func (b baseBootstrapper) Bootstrap(
 			logFields, currNamespace)
 
 		dataAvailable, err := b.src.AvailableData(currNamespace.Metadata,
-			currNamespace.DataRunOptions.ShardTimeRanges.Copy(),
+			currNamespace.DataRunOptions.ShardTimeRanges.Copy(), state,
 			currNamespace.DataRunOptions.RunOptions)
 		if err != nil {
 			return bootstrap.NamespaceResults{}, err
@@ -107,7 +108,7 @@ func (b baseBootstrapper) Bootstrap(
 		// Prepare index if required.
 		if currNamespace.Metadata.Options().IndexOptions().Enabled() {
 			indexAvailable, err := b.src.AvailableIndex(currNamespace.Metadata,
-				currNamespace.IndexRunOptions.ShardTimeRanges.Copy(),
+				currNamespace.IndexRunOptions.ShardTimeRanges.Copy(), state,
 				currNamespace.IndexRunOptions.RunOptions)
 			if err != nil {
 				return bootstrap.NamespaceResults{}, err
@@ -137,7 +138,7 @@ func (b baseBootstrapper) Bootstrap(
 	b.log.Info("bootstrap from source started", logFields...)
 
 	// Run the bootstrap source.
-	currResults, err := b.src.Read(ctx, curr)
+	currResults, err := b.src.Read(ctx, curr, state)
 
 	logFields = append(logFields, zap.Duration("took", nowFn().Sub(begin)))
 	if err != nil {
@@ -166,7 +167,7 @@ func (b baseBootstrapper) Bootstrap(
 	// If there are some time ranges the current bootstrapper could not fulfill,
 	// that we can attempt then pass it along to the next bootstrapper.
 	if next.Namespaces.Len() > 0 {
-		nextResults, err := b.next.Bootstrap(ctx, next)
+		nextResults, err := b.next.Bootstrap(ctx, next, state)
 		if err != nil {
 			return bootstrap.NamespaceResults{}, err
 		}

--- a/src/dbnode/storage/bootstrap/bootstrapper/base_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base_test.go
@@ -137,26 +137,29 @@ func testBaseBootstrapperEmptyRange(t *testing.T, withIndex bool) {
 	nsResults := testResult(testNs, withIndex, testShard, unfulfilled)
 	nextResult := testResult(testNs, withIndex, testShard, xtime.NewRanges())
 	shardRangeMatcher := bootstrap.ShardTimeRangesMatcher{Ranges: rngs}
-	src.EXPECT().AvailableData(testNs, shardRangeMatcher, testDefaultRunOpts).
-		Return(rngs, nil)
-	if withIndex {
-		src.EXPECT().AvailableIndex(testNs, shardRangeMatcher, testDefaultRunOpts).
-			Return(rngs, nil)
-	}
 
 	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, rngs, testNs)
 	defer tester.Finish()
 
+	state := tester.State
+	src.EXPECT().AvailableData(testNs, shardRangeMatcher, state, testDefaultRunOpts).
+		Return(rngs, nil)
+	if withIndex {
+		src.EXPECT().AvailableIndex(testNs, shardRangeMatcher, state, testDefaultRunOpts).
+			Return(rngs, nil)
+	}
+
 	matcher := bootstrap.NamespaceMatcher{Namespaces: tester.Namespaces}
 	src.EXPECT().
-		Read(gomock.Any(), matcher).
+		Read(gomock.Any(), matcher, state).
 		DoAndReturn(func(
 			ctx context.Context,
 			namespaces bootstrap.Namespaces,
+			state bootstrap.State,
 		) (bootstrap.NamespaceResults, error) {
 			return nsResults, nil
 		})
-	next.EXPECT().Bootstrap(gomock.Any(), matcher).Return(nextResult, nil)
+	next.EXPECT().Bootstrap(gomock.Any(), matcher, state).Return(nextResult, nil)
 
 	// Test non-nil empty range
 	tester.TestBootstrapWith(base)
@@ -186,27 +189,30 @@ func testBaseBootstrapperCurrentNoUnfulfilled(t *testing.T, withIndex bool) {
 	nextResult := testResult(testNs, withIndex, testShard, xtime.NewRanges())
 
 	targetRanges := testShardTimeRanges()
-	src.EXPECT().AvailableData(testNs, targetRanges, testDefaultRunOpts).
-		Return(targetRanges, nil)
-	if withIndex {
-		src.EXPECT().AvailableIndex(testNs, targetRanges, testDefaultRunOpts).
-			Return(targetRanges, nil)
-	}
 
 	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, targetRanges,
 		testNs)
 	defer tester.Finish()
 
+	state := tester.State
+	src.EXPECT().AvailableData(testNs, targetRanges, state, testDefaultRunOpts).
+		Return(targetRanges, nil)
+	if withIndex {
+		src.EXPECT().AvailableIndex(testNs, targetRanges, state, testDefaultRunOpts).
+			Return(targetRanges, nil)
+	}
+
 	matcher := bootstrap.NamespaceMatcher{Namespaces: tester.Namespaces}
 	src.EXPECT().
-		Read(gomock.Any(), matcher).
+		Read(gomock.Any(), matcher, state).
 		DoAndReturn(func(
 			ctx context.Context,
 			namespaces bootstrap.Namespaces,
+			state bootstrap.State,
 		) (bootstrap.NamespaceResults, error) {
 			return nsResults, nil
 		})
-	next.EXPECT().Bootstrap(gomock.Any(), matcher).Return(nextResult, nil)
+	next.EXPECT().Bootstrap(gomock.Any(), matcher, state).Return(nextResult, nil)
 
 	tester.TestBootstrapWith(base)
 	assert.Equal(t, nsResults, tester.Results)
@@ -235,22 +241,23 @@ func testBaseBootstrapperCurrentSomeUnfulfilled(t *testing.T, withIndex bool) {
 		End:   testTargetStart.Add(time.Hour * 2),
 	})
 
-	src.EXPECT().AvailableData(testNs, targetRanges, testDefaultRunOpts).
-		Return(targetRanges, nil)
-	if withIndex {
-		src.EXPECT().AvailableIndex(testNs, targetRanges, testDefaultRunOpts).
-			Return(targetRanges, nil)
-	}
-
 	currResult := testResult(testNs, withIndex, testShard, currUnfulfilled)
 	nextResult := testResult(testNs, withIndex, testShard, xtime.NewRanges())
 	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, targetRanges,
 		testNs)
 	defer tester.Finish()
 
+	state := tester.State
+	src.EXPECT().AvailableData(testNs, targetRanges, state, testDefaultRunOpts).
+		Return(targetRanges, nil)
+	if withIndex {
+		src.EXPECT().AvailableIndex(testNs, targetRanges, state, testDefaultRunOpts).
+			Return(targetRanges, nil)
+	}
+
 	matcher := bootstrap.NamespaceMatcher{Namespaces: tester.Namespaces}
-	src.EXPECT().Read(gomock.Any(), matcher).Return(currResult, nil)
-	next.EXPECT().Bootstrap(gomock.Any(), matcher).Return(nextResult, nil)
+	src.EXPECT().Read(gomock.Any(), matcher, state).Return(currResult, nil)
+	next.EXPECT().Bootstrap(gomock.Any(), matcher, state).Return(nextResult, nil)
 
 	tester.TestBootstrapWith(base)
 	tester.TestUnfulfilledForNamespaceIsEmpty(testNs)
@@ -267,24 +274,25 @@ func testBasebootstrapperNext(
 	testNs := testNsMetadata(t, withIndex)
 	targetRanges := testShardTimeRanges()
 
-	src.EXPECT().
-		AvailableData(testNs, targetRanges, testDefaultRunOpts).
-		Return(result.NewShardTimeRanges(), nil)
-	if withIndex {
-		src.EXPECT().
-			AvailableIndex(testNs, targetRanges, testDefaultRunOpts).
-			Return(result.NewShardTimeRanges(), nil)
-	}
-
 	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, targetRanges,
 		testNs)
 	defer tester.Finish()
 
+	state := tester.State
+	src.EXPECT().
+		AvailableData(testNs, targetRanges, state, testDefaultRunOpts).
+		Return(result.NewShardTimeRanges(), nil)
+	if withIndex {
+		src.EXPECT().
+			AvailableIndex(testNs, targetRanges, state, testDefaultRunOpts).
+			Return(result.NewShardTimeRanges(), nil)
+	}
+
 	emptyResult := testEmptyResult(testNs)
 	nextResult := testResult(testNs, withIndex, testShard, nextUnfulfilled)
 	matcher := bootstrap.NamespaceMatcher{Namespaces: tester.Namespaces}
-	src.EXPECT().Read(gomock.Any(), matcher).Return(emptyResult, nil)
-	next.EXPECT().Bootstrap(gomock.Any(), matcher).Return(nextResult, nil)
+	src.EXPECT().Read(gomock.Any(), matcher, state).Return(emptyResult, nil)
+	next.EXPECT().Bootstrap(gomock.Any(), matcher, state).Return(nextResult, nil)
 
 	tester.TestBootstrapWith(base)
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/base_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base_test.go
@@ -141,25 +141,25 @@ func testBaseBootstrapperEmptyRange(t *testing.T, withIndex bool) {
 	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, rngs, testNs)
 	defer tester.Finish()
 
-	state := tester.State
-	src.EXPECT().AvailableData(testNs, shardRangeMatcher, state, testDefaultRunOpts).
+	cache := tester.Cache
+	src.EXPECT().AvailableData(testNs, shardRangeMatcher, cache, testDefaultRunOpts).
 		Return(rngs, nil)
 	if withIndex {
-		src.EXPECT().AvailableIndex(testNs, shardRangeMatcher, state, testDefaultRunOpts).
+		src.EXPECT().AvailableIndex(testNs, shardRangeMatcher, cache, testDefaultRunOpts).
 			Return(rngs, nil)
 	}
 
 	matcher := bootstrap.NamespaceMatcher{Namespaces: tester.Namespaces}
 	src.EXPECT().
-		Read(gomock.Any(), matcher, state).
+		Read(gomock.Any(), matcher, cache).
 		DoAndReturn(func(
 			ctx context.Context,
 			namespaces bootstrap.Namespaces,
-			state bootstrap.State,
+			cache bootstrap.Cache,
 		) (bootstrap.NamespaceResults, error) {
 			return nsResults, nil
 		})
-	next.EXPECT().Bootstrap(gomock.Any(), matcher, state).Return(nextResult, nil)
+	next.EXPECT().Bootstrap(gomock.Any(), matcher, cache).Return(nextResult, nil)
 
 	// Test non-nil empty range
 	tester.TestBootstrapWith(base)
@@ -194,25 +194,25 @@ func testBaseBootstrapperCurrentNoUnfulfilled(t *testing.T, withIndex bool) {
 		testNs)
 	defer tester.Finish()
 
-	state := tester.State
-	src.EXPECT().AvailableData(testNs, targetRanges, state, testDefaultRunOpts).
+	cache := tester.Cache
+	src.EXPECT().AvailableData(testNs, targetRanges, cache, testDefaultRunOpts).
 		Return(targetRanges, nil)
 	if withIndex {
-		src.EXPECT().AvailableIndex(testNs, targetRanges, state, testDefaultRunOpts).
+		src.EXPECT().AvailableIndex(testNs, targetRanges, cache, testDefaultRunOpts).
 			Return(targetRanges, nil)
 	}
 
 	matcher := bootstrap.NamespaceMatcher{Namespaces: tester.Namespaces}
 	src.EXPECT().
-		Read(gomock.Any(), matcher, state).
+		Read(gomock.Any(), matcher, cache).
 		DoAndReturn(func(
 			ctx context.Context,
 			namespaces bootstrap.Namespaces,
-			state bootstrap.State,
+			cache bootstrap.Cache,
 		) (bootstrap.NamespaceResults, error) {
 			return nsResults, nil
 		})
-	next.EXPECT().Bootstrap(gomock.Any(), matcher, state).Return(nextResult, nil)
+	next.EXPECT().Bootstrap(gomock.Any(), matcher, cache).Return(nextResult, nil)
 
 	tester.TestBootstrapWith(base)
 	assert.Equal(t, nsResults, tester.Results)
@@ -247,17 +247,17 @@ func testBaseBootstrapperCurrentSomeUnfulfilled(t *testing.T, withIndex bool) {
 		testNs)
 	defer tester.Finish()
 
-	state := tester.State
-	src.EXPECT().AvailableData(testNs, targetRanges, state, testDefaultRunOpts).
+	cache := tester.Cache
+	src.EXPECT().AvailableData(testNs, targetRanges, cache, testDefaultRunOpts).
 		Return(targetRanges, nil)
 	if withIndex {
-		src.EXPECT().AvailableIndex(testNs, targetRanges, state, testDefaultRunOpts).
+		src.EXPECT().AvailableIndex(testNs, targetRanges, cache, testDefaultRunOpts).
 			Return(targetRanges, nil)
 	}
 
 	matcher := bootstrap.NamespaceMatcher{Namespaces: tester.Namespaces}
-	src.EXPECT().Read(gomock.Any(), matcher, state).Return(currResult, nil)
-	next.EXPECT().Bootstrap(gomock.Any(), matcher, state).Return(nextResult, nil)
+	src.EXPECT().Read(gomock.Any(), matcher, cache).Return(currResult, nil)
+	next.EXPECT().Bootstrap(gomock.Any(), matcher, cache).Return(nextResult, nil)
 
 	tester.TestBootstrapWith(base)
 	tester.TestUnfulfilledForNamespaceIsEmpty(testNs)
@@ -278,21 +278,21 @@ func testBasebootstrapperNext(
 		testNs)
 	defer tester.Finish()
 
-	state := tester.State
+	cache := tester.Cache
 	src.EXPECT().
-		AvailableData(testNs, targetRanges, state, testDefaultRunOpts).
+		AvailableData(testNs, targetRanges, cache, testDefaultRunOpts).
 		Return(result.NewShardTimeRanges(), nil)
 	if withIndex {
 		src.EXPECT().
-			AvailableIndex(testNs, targetRanges, state, testDefaultRunOpts).
+			AvailableIndex(testNs, targetRanges, cache, testDefaultRunOpts).
 			Return(result.NewShardTimeRanges(), nil)
 	}
 
 	emptyResult := testEmptyResult(testNs)
 	nextResult := testResult(testNs, withIndex, testShard, nextUnfulfilled)
 	matcher := bootstrap.NamespaceMatcher{Namespaces: tester.Namespaces}
-	src.EXPECT().Read(gomock.Any(), matcher, state).Return(emptyResult, nil)
-	next.EXPECT().Bootstrap(gomock.Any(), matcher, state).Return(nextResult, nil)
+	src.EXPECT().Read(gomock.Any(), matcher, cache).Return(emptyResult, nil)
+	next.EXPECT().Bootstrap(gomock.Any(), matcher, cache).Return(nextResult, nil)
 
 	tester.TestBootstrapWith(base)
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -714,7 +714,10 @@ func (s *commitLogSource) bootstrapShardSnapshots(
 	// We do this instead of cross refing blockstarts and current time to handle the case of bootstrapping a
 	// once warm block start after a node has been shut down for a long time. We consider all block starts we
 	// haven't flushed data for yet a warm block start.
-	readInfoFilesResults := cache.InfoFilesForShard(ns, shard)
+	readInfoFilesResults, err := cache.InfoFilesForShard(ns, shard)
+	if err != nil {
+		return err
+	}
 	shardBlockStartsOnDisk := make(map[xtime.UnixNano]struct{})
 	for _, result := range readInfoFilesResults {
 		if err := result.Err.Error(); err != nil {

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -152,6 +152,7 @@ func newCommitLogSource(
 func (s *commitLogSource) AvailableData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	_ bootstrap.State,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	return s.availability(ns, shardsTimeRanges, runOpts)
@@ -160,6 +161,7 @@ func (s *commitLogSource) AvailableData(
 func (s *commitLogSource) AvailableIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	_ bootstrap.State,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	return s.availability(ns, shardsTimeRanges, runOpts)
@@ -177,6 +179,7 @@ type readNamespaceResult struct {
 func (s *commitLogSource) Read(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
+	state bootstrap.State,
 ) (bootstrap.NamespaceResults, error) {
 	ctx, span, _ := ctx.StartSampledTraceSpan(tracepoint.BootstrapperCommitLogSourceRead)
 	defer span.Finish()
@@ -226,7 +229,7 @@ func (s *commitLogSource) Read(
 		for shard, tr := range shardTimeRanges.Iter() {
 			err := s.bootstrapShardSnapshots(
 				ns.Metadata, accumulator, shard, tr, blockSize,
-				mostRecentCompleteSnapshotByBlockShard)
+				mostRecentCompleteSnapshotByBlockShard, state)
 			if err != nil {
 				return bootstrap.NamespaceResults{}, err
 			}
@@ -705,14 +708,13 @@ func (s *commitLogSource) bootstrapShardSnapshots(
 	shardTimeRanges xtime.Ranges,
 	blockSize time.Duration,
 	mostRecentCompleteSnapshotByBlockShard map[xtime.UnixNano]map[uint32]fs.FileSetFile,
+	state bootstrap.State,
 ) error {
 	// NB(bodu): We use info files on disk to check if a snapshot should be loaded in as cold or warm.
 	// We do this instead of cross refing blockstarts and current time to handle the case of bootstrapping a
 	// once warm block start after a node has been shut down for a long time. We consider all block starts we
 	// haven't flushed data for yet a warm block start.
-	fsOpts := s.opts.CommitLogOptions().FilesystemOptions()
-	readInfoFilesResults := fs.ReadInfoFiles(fsOpts.FilePathPrefix(), ns.ID(), shard,
-		fsOpts.InfoReaderBufferSize(), fsOpts.DecodingOptions(), persist.FileSetFlushType)
+	readInfoFilesResults := state.InfoFilesForShard(ns, shard)
 	shardBlockStartsOnDisk := make(map[xtime.UnixNano]struct{})
 	for _, result := range readInfoFilesResults {
 		if err := result.Err.Error(); err != nil {

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/m3db/m3/src/x/checked"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/pool"
 	xtime "github.com/m3db/m3/src/x/time"
 
@@ -58,11 +59,20 @@ func testNsMetadata(t *testing.T) namespace.Metadata {
 	return md
 }
 
+func testState(t *testing.T) bootstrap.State {
+	state, err := bootstrap.NewState(bootstrap.NewStateOptions().
+		SetFilesystemOptions(fs.NewOptions()).
+		SetInstrumentOptions(instrument.NewOptions()))
+	require.NoError(t, err)
+
+	return state
+}
+
 func TestAvailableEmptyRangeError(t *testing.T) {
 	var (
 		opts     = testDefaultOpts
 		src      = newCommitLogSource(opts, fs.Inspection{})
-		res, err = src.AvailableData(testNsMetadata(t), result.NewShardTimeRanges(), testDefaultRunOpts)
+		res, err = src.AvailableData(testNsMetadata(t), result.NewShardTimeRanges(), testState(t), testDefaultRunOpts)
 	)
 	require.NoError(t, err)
 	require.True(t, result.NewShardTimeRanges().Equal(res))
@@ -160,7 +170,7 @@ func TestReadErrorOnNewIteratorError(t *testing.T) {
 	ctx := context.NewContext()
 	defer ctx.Close()
 
-	res, err := src.Read(ctx, tester.Namespaces)
+	res, err := src.Read(ctx, tester.Namespaces, tester.State)
 	require.Error(t, err)
 	require.Nil(t, res.Results)
 	tester.EnsureNoLoadedBlocks()
@@ -457,6 +467,7 @@ func testItMergesSnapshotsAndCommitLogs(t *testing.T, opts Options,
 		testDefaultRunOpts,
 		targetRanges,
 		opts.ResultOptions().DatabaseBlockOptions().MultiReaderIteratorPool(),
+		fs.NewOptions(),
 		md,
 	)
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -59,20 +59,20 @@ func testNsMetadata(t *testing.T) namespace.Metadata {
 	return md
 }
 
-func testState(t *testing.T) bootstrap.State {
-	state, err := bootstrap.NewState(bootstrap.NewStateOptions().
+func testCache(t *testing.T) bootstrap.Cache {
+	cache, err := bootstrap.NewCache(bootstrap.NewCacheOptions().
 		SetFilesystemOptions(fs.NewOptions()).
 		SetInstrumentOptions(instrument.NewOptions()))
 	require.NoError(t, err)
 
-	return state
+	return cache
 }
 
 func TestAvailableEmptyRangeError(t *testing.T) {
 	var (
 		opts     = testDefaultOpts
 		src      = newCommitLogSource(opts, fs.Inspection{})
-		res, err = src.AvailableData(testNsMetadata(t), result.NewShardTimeRanges(), testState(t), testDefaultRunOpts)
+		res, err = src.AvailableData(testNsMetadata(t), result.NewShardTimeRanges(), testCache(t), testDefaultRunOpts)
 	)
 	require.NoError(t, err)
 	require.True(t, result.NewShardTimeRanges().Equal(res))
@@ -170,7 +170,7 @@ func TestReadErrorOnNewIteratorError(t *testing.T) {
 	ctx := context.NewContext()
 	defer ctx.Close()
 
-	res, err := src.Read(ctx, tester.Namespaces, tester.State)
+	res, err := src.Read(ctx, tester.Namespaces, tester.Cache)
 	require.Error(t, err)
 	require.Nil(t, res.Results)
 	tester.EnsureNoLoadedBlocks()

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -375,7 +375,7 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 			ctx := context.NewContext()
 			defer ctx.Close()
 
-			bootstrapResults, err := source.Bootstrap(ctx, tester.Namespaces, tester.State)
+			bootstrapResults, err := source.Bootstrap(ctx, tester.Namespaces, tester.Cache)
 			if err != nil {
 				return false, err
 			}

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_prop_test.go
@@ -370,12 +370,12 @@ func TestCommitLogSourcePropCorrectlyBootstrapsFromCommitlog(t *testing.T) {
 			}
 
 			runOpts := testDefaultRunOpts.SetInitialTopologyState(initialTopoState)
-			tester := bootstrap.BuildNamespacesTester(t, runOpts, shardTimeRanges, nsMeta)
+			tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, runOpts, shardTimeRanges, fsOpts, nsMeta)
 
 			ctx := context.NewContext()
 			defer ctx.Close()
 
-			bootstrapResults, err := source.Bootstrap(ctx, tester.Namespaces)
+			bootstrapResults, err := source.Bootstrap(ctx, tester.Namespaces, tester.State)
 			if err != nil {
 				return false, err
 			}

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
@@ -28,9 +28,11 @@ import (
 	"github.com/m3db/m3/src/cluster/shard"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/runtime"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
 	tu "github.com/m3db/m3/src/dbnode/topology/testutil"
+	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/stretchr/testify/require"
@@ -53,6 +55,9 @@ func TestAvailableData(t *testing.T) {
 			Start: blockStart,
 			End:   blockStart.Add(blockSize),
 		})
+		stateOptions = bootstrap.NewStateOptions().
+				SetFilesystemOptions(fs.NewOptions()).
+				SetInstrumentOptions(instrument.NewOptions())
 	)
 
 	for i := 0; i < int(numShards); i++ {
@@ -121,10 +126,23 @@ func TestAvailableData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
+			var shards []uint32
+			for shard := range tc.shardsTimeRangesToBootstrap.Iter() {
+				shards = append(shards, shard)
+			}
+			state, sErr := bootstrap.NewState(stateOptions.
+				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
+					{
+						Namespace: nsMetadata,
+						Shards:    shards,
+					},
+				}))
+			require.NoError(t, sErr)
+
 			var (
 				src          = newCommitLogSource(testDefaultOpts, fs.Inspection{})
 				runOpts      = testDefaultRunOpts.SetInitialTopologyState(tc.topoState)
-				dataRes, err = src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+				dataRes, err = src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
 			)
 
 			if tc.expectedErr != nil {
@@ -134,7 +152,7 @@ func TestAvailableData(t *testing.T) {
 				require.Equal(t, tc.expectedAvailableShardsTimeRanges, dataRes)
 			}
 
-			indexRes, err := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+			indexRes, err := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
 			if tc.expectedErr != nil {
 				require.Equal(t, err, tc.expectedErr)
 			} else {

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
@@ -55,7 +55,7 @@ func TestAvailableData(t *testing.T) {
 			Start: blockStart,
 			End:   blockStart.Add(blockSize),
 		})
-		stateOptions = bootstrap.NewStateOptions().
+		cacheOptions = bootstrap.NewCacheOptions().
 				SetFilesystemOptions(fs.NewOptions()).
 				SetInstrumentOptions(instrument.NewOptions())
 	)
@@ -130,7 +130,7 @@ func TestAvailableData(t *testing.T) {
 			for shard := range tc.shardsTimeRangesToBootstrap.Iter() {
 				shards = append(shards, shard)
 			}
-			state, sErr := bootstrap.NewState(stateOptions.
+			cache, sErr := bootstrap.NewCache(cacheOptions.
 				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
 					{
 						Namespace: nsMetadata,
@@ -142,7 +142,7 @@ func TestAvailableData(t *testing.T) {
 			var (
 				src          = newCommitLogSource(testDefaultOpts, fs.Inspection{})
 				runOpts      = testDefaultRunOpts.SetInitialTopologyState(tc.topoState)
-				dataRes, err = src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
+				dataRes, err = src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, cache, runOpts)
 			)
 
 			if tc.expectedErr != nil {
@@ -152,7 +152,7 @@ func TestAvailableData(t *testing.T) {
 				require.Equal(t, tc.expectedAvailableShardsTimeRanges, dataRes)
 			}
 
-			indexRes, err := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
+			indexRes, err := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, cache, runOpts)
 			if tc.expectedErr != nil {
 				require.Equal(t, err, tc.expectedErr)
 			} else {

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_test.go
@@ -131,7 +131,7 @@ func TestAvailableData(t *testing.T) {
 				shards = append(shards, shard)
 			}
 			cache, sErr := bootstrap.NewCache(cacheOptions.
-				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
+				SetNamespaceDetails([]bootstrap.NamespaceDetails{
 					{
 						Namespace: nsMetadata,
 						Shards:    shards,

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/migrator.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/migrator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/migration"
 	"github.com/m3db/m3/src/dbnode/storage"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/tracepoint"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/instrument"
@@ -44,7 +45,7 @@ type worker struct {
 // the info files.
 type Migrator struct {
 	migrationTaskFn      MigrationTaskFn
-	infoFilesByNamespace fs.InfoFilesByNamespace
+	infoFilesByNamespace bootstrap.InfoFilesByNamespace
 	migrationOpts        migration.Options
 	fsOpts               fs.Options
 	instrumentOpts       instrument.Options

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/migrator_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/migrator_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/migration"
 	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/storage"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
@@ -50,7 +51,7 @@ func TestMigratorRun(t *testing.T) {
 
 	// Create some dummy ReadInfoFileResults as these are used to determine if we need to run a migration or not.
 	// Put some in a state requiring migrations and others not to flex both paths.
-	infoFilesByNamespace := fs.InfoFilesByNamespace{
+	infoFilesByNamespace := bootstrap.InfoFilesByNamespace{
 		md1: {
 			1: {testInfoFileWithVolumeIndex(0), testInfoFileWithVolumeIndex(1)},
 			2: {testInfoFileWithVolumeIndex(0), testInfoFileWithVolumeIndex(1)},

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/migration"
 	"github.com/m3db/m3/src/dbnode/storage"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/x/instrument"
 )
 
@@ -40,7 +41,7 @@ var (
 
 type options struct {
 	migrationTaskFn      MigrationTaskFn
-	infoFilesByNamespace fs.InfoFilesByNamespace
+	infoFilesByNamespace bootstrap.InfoFilesByNamespace
 	migrationOpts        migration.Options
 	fsOpts               fs.Options
 	instrumentOpts       instrument.Options
@@ -93,13 +94,13 @@ func (o *options) MigrationTaskFn() MigrationTaskFn {
 	return o.migrationTaskFn
 }
 
-func (o *options) SetInfoFilesByNamespace(value fs.InfoFilesByNamespace) Options {
+func (o *options) SetInfoFilesByNamespace(value bootstrap.InfoFilesByNamespace) Options {
 	opts := *o
 	opts.infoFilesByNamespace = value
 	return &opts
 }
 
-func (o *options) InfoFilesByNamespace() fs.InfoFilesByNamespace {
+func (o *options) InfoFilesByNamespace() bootstrap.InfoFilesByNamespace {
 	return o.infoFilesByNamespace
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/options_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/options_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/migration"
 	"github.com/m3db/m3/src/dbnode/storage"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	xtest "github.com/m3db/m3/src/x/test"
 
 	"github.com/golang/mock/gomock"
@@ -109,7 +110,7 @@ func newTestOptions(ctrl *gomock.Controller) Options {
 		SetMigrationTaskFn(func(result fs.ReadInfoFileResult) (migration.NewTaskFn, bool) {
 			return nil, false
 		}).
-		SetInfoFilesByNamespace(make(fs.InfoFilesByNamespace)).
+		SetInfoFilesByNamespace(make(bootstrap.InfoFilesByNamespace)).
 		SetStorageOptions(mockOpts).
 		SetFilesystemOptions(fs.NewOptions())
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/types.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/migration"
 	"github.com/m3db/m3/src/dbnode/storage"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/x/instrument"
 )
 
@@ -42,10 +43,10 @@ type Options interface {
 	MigrationTaskFn() MigrationTaskFn
 
 	// SetInfoFilesByNamespaces sets the info file results to operate on keyed by namespace.
-	SetInfoFilesByNamespace(value fs.InfoFilesByNamespace) Options
+	SetInfoFilesByNamespace(value bootstrap.InfoFilesByNamespace) Options
 
 	// InfoFilesByNamespaces returns the info file results to operate on keyed by namespace.
-	InfoFilesByNamespace() fs.InfoFilesByNamespace
+	InfoFilesByNamespace() bootstrap.InfoFilesByNamespace
 
 	// SetMigrationOptions sets the migration options.
 	SetMigrationOptions(value migration.Options) Options

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
@@ -142,7 +142,7 @@ func testCache(t *testing.T, md namespace.Metadata, ranges result.ShardTimeRange
 	cache, err := bootstrap.NewCache(bootstrap.NewCacheOptions().
 		SetFilesystemOptions(fsOpts).
 		SetInstrumentOptions(fsOpts.InstrumentOptions()).
-		SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
+		SetNamespaceDetails([]bootstrap.NamespaceDetails{
 			{
 				Namespace: md,
 				Shards:    shards,

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
@@ -134,12 +134,12 @@ func testNsMetadataWithIndex(t require.TestingT, indexOn bool) namespace.Metadat
 	return md
 }
 
-func testState(t *testing.T, md namespace.Metadata, ranges result.ShardTimeRanges, fsOpts fs.Options) bootstrap.State {
+func testCache(t *testing.T, md namespace.Metadata, ranges result.ShardTimeRanges, fsOpts fs.Options) bootstrap.Cache {
 	var shards []uint32
 	for shard := range ranges.Iter() {
 		shards = append(shards, shard)
 	}
-	state, err := bootstrap.NewState(bootstrap.NewStateOptions().
+	cache, err := bootstrap.NewCache(bootstrap.NewCacheOptions().
 		SetFilesystemOptions(fsOpts).
 		SetInstrumentOptions(fsOpts.InstrumentOptions()).
 		SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
@@ -150,7 +150,7 @@ func testState(t *testing.T, md namespace.Metadata, ranges result.ShardTimeRange
 		}))
 	require.NoError(t, err)
 
-	return state
+	return cache
 }
 
 func createTempDir(t *testing.T) string {
@@ -349,11 +349,11 @@ func TestAvailableEmptyRangeError(t *testing.T) {
 	require.NoError(t, err)
 	md := testNsMetadata(t)
 	shardRanges := result.NewShardTimeRanges().Set(0, xtime.NewRanges())
-	state := testState(t, md, shardRanges, opts.FilesystemOptions())
+	cache := testCache(t, md, shardRanges, opts.FilesystemOptions())
 	res, err := src.AvailableData(
 		md,
 		shardRanges,
-		state,
+		cache,
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -369,7 +369,7 @@ func TestAvailablePatternError(t *testing.T) {
 	res, err := src.AvailableData(
 		md,
 		testShardRanges,
-		testState(t, md, testShardRanges, opts.FilesystemOptions()),
+		testCache(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -395,7 +395,7 @@ func TestAvailableReadInfoError(t *testing.T) {
 	res, err := src.AvailableData(
 		md,
 		testShardRanges,
-		testState(t, md, testShardRanges, opts.FilesystemOptions()),
+		testCache(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -421,7 +421,7 @@ func TestAvailableDigestOfDigestMismatch(t *testing.T) {
 	res, err := src.AvailableData(
 		md,
 		testShardRanges,
-		testState(t, md, testShardRanges, opts.FilesystemOptions()),
+		testCache(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -443,7 +443,7 @@ func TestAvailableTimeRangeFilter(t *testing.T) {
 	res, err := src.AvailableData(
 		md,
 		testShardRanges,
-		testState(t, md, testShardRanges, opts.FilesystemOptions()),
+		testCache(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -476,7 +476,7 @@ func TestAvailableTimeRangePartialError(t *testing.T) {
 	res, err := src.AvailableData(
 		md,
 		testShardRanges,
-		testState(t, md, testShardRanges, opts.FilesystemOptions()),
+		testCache(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
@@ -76,6 +76,7 @@ var (
 	testDefaultOpts       = NewOptions().SetResultOptions(testDefaultResultOpts).
 				SetBoostrapDataNumProcessors(1).
 				SetBoostrapIndexNumProcessors(1)
+	testShardRanges = testShardTimeRanges()
 )
 
 func newTestOptions(t require.TestingT, filePathPrefix string) Options {
@@ -131,6 +132,25 @@ func testNsMetadataWithIndex(t require.TestingT, indexOn bool) namespace.Metadat
 			SetBlockSize(testIndexBlockSize)))
 	require.NoError(t, err)
 	return md
+}
+
+func testState(t *testing.T, md namespace.Metadata, ranges result.ShardTimeRanges, fsOpts fs.Options) bootstrap.State {
+	var shards []uint32
+	for shard := range ranges.Iter() {
+		shards = append(shards, shard)
+	}
+	state, err := bootstrap.NewState(bootstrap.NewStateOptions().
+		SetFilesystemOptions(fsOpts).
+		SetInstrumentOptions(fsOpts.InstrumentOptions()).
+		SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
+			{
+				Namespace: md,
+				Shards:    shards,
+			},
+		}))
+	require.NoError(t, err)
+
+	return state
 }
 
 func createTempDir(t *testing.T) string {
@@ -324,11 +344,16 @@ func validateTimeRanges(t *testing.T, tr xtime.Ranges, expected xtime.Ranges) {
 }
 
 func TestAvailableEmptyRangeError(t *testing.T) {
-	src, err := newFileSystemSource(newTestOptions(t, "foo"))
+	opts := newTestOptions(t, "foo")
+	src, err := newFileSystemSource(opts)
 	require.NoError(t, err)
+	md := testNsMetadata(t)
+	shardRanges := result.NewShardTimeRanges().Set(0, xtime.NewRanges())
+	state := testState(t, md, shardRanges, opts.FilesystemOptions())
 	res, err := src.AvailableData(
-		testNsMetadata(t),
-		result.NewShardTimeRanges().Set(0, xtime.NewRanges()),
+		md,
+		shardRanges,
+		state,
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -337,11 +362,14 @@ func TestAvailableEmptyRangeError(t *testing.T) {
 }
 
 func TestAvailablePatternError(t *testing.T) {
-	src, err := newFileSystemSource(newTestOptions(t, "[["))
+	opts := newTestOptions(t, "[[")
+	src, err := newFileSystemSource(opts)
 	require.NoError(t, err)
+	md := testNsMetadata(t)
 	res, err := src.AvailableData(
-		testNsMetadata(t),
-		testShardTimeRanges(),
+		md,
+		testShardRanges,
+		testState(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -360,11 +388,14 @@ func TestAvailableReadInfoError(t *testing.T) {
 	// Intentionally corrupt the info file
 	writeInfoFile(t, dir, testNs1ID, shard, testStart, []byte{0x1, 0x2})
 
-	src, err := newFileSystemSource(newTestOptions(t, dir))
+	opts := newTestOptions(t, dir)
+	src, err := newFileSystemSource(opts)
 	require.NoError(t, err)
+	md := testNsMetadata(t)
 	res, err := src.AvailableData(
-		testNsMetadata(t),
-		testShardTimeRanges(),
+		md,
+		testShardRanges,
+		testState(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -383,11 +414,14 @@ func TestAvailableDigestOfDigestMismatch(t *testing.T) {
 	// Intentionally corrupt the digest file
 	writeDigestFile(t, dir, testNs1ID, shard, testStart, nil)
 
-	src, err := newFileSystemSource(newTestOptions(t, dir))
+	opts := newTestOptions(t, dir)
+	src, err := newFileSystemSource(opts)
 	require.NoError(t, err)
+	md := testNsMetadata(t)
 	res, err := src.AvailableData(
-		testNsMetadata(t),
-		testShardTimeRanges(),
+		md,
+		testShardRanges,
+		testState(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -402,11 +436,14 @@ func TestAvailableTimeRangeFilter(t *testing.T) {
 	shard := uint32(0)
 	writeGoodFiles(t, dir, testNs1ID, shard)
 
-	src, err := newFileSystemSource(newTestOptions(t, dir))
+	opts := newTestOptions(t, dir)
+	src, err := newFileSystemSource(opts)
 	require.NoError(t, err)
+	md := testNsMetadata(t)
 	res, err := src.AvailableData(
-		testNsMetadata(t),
-		testShardTimeRanges(),
+		md,
+		testShardRanges,
+		testState(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -432,11 +469,14 @@ func TestAvailableTimeRangePartialError(t *testing.T) {
 	// Intentionally write a corrupted info file
 	writeInfoFile(t, dir, testNs1ID, shard, testStart.Add(4*time.Hour), []byte{0x1, 0x2})
 
-	src, err := newFileSystemSource(newTestOptions(t, dir))
+	opts := newTestOptions(t, dir)
+	src, err := newFileSystemSource(opts)
 	require.NoError(t, err)
+	md := testNsMetadata(t)
 	res, err := src.AvailableData(
-		testNsMetadata(t),
-		testShardTimeRanges(),
+		md,
+		testShardRanges,
+		testState(t, md, testShardRanges, opts.FilesystemOptions()),
 		testDefaultRunOpts,
 	)
 	require.NoError(t, err)
@@ -490,7 +530,8 @@ func validateReadResults(
 	strs result.ShardTimeRanges,
 ) {
 	nsMD := testNsMetadata(t)
-	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, strs, nsMD)
+	fsOpts := newTestOptions(t, dir).FilesystemOptions()
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, testDefaultRunOpts, strs, fsOpts, nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)
@@ -591,13 +632,14 @@ func testReadDataCorruptionErrorWithIndexEnabled(
 	// Intentionally corrupt the data file
 	writeDataFile(t, dir, testNs1ID, shard, testStart, []byte{0x2})
 
-	src, err := newFileSystemSource(newTestOptions(t, dir))
+	testOpts := newTestOptions(t, dir)
+	src, err := newFileSystemSource(testOpts)
 	require.NoError(t, err)
 
 	strs := testShardTimeRanges()
 
 	nsMD := testNsMetadataWithIndex(t, withIndex)
-	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, strs, nsMD)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, testDefaultRunOpts, strs, testOpts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)
@@ -653,7 +695,8 @@ func testReadValidateErrorWithIndexEnabled(
 
 	reader := fs.NewMockDataFileSetReader(ctrl)
 
-	fsSrc, err := newFileSystemSource(newTestOptions(t, dir))
+	testOpts := newTestOptions(t, dir)
+	fsSrc, err := newFileSystemSource(testOpts)
 	require.NoError(t, err)
 
 	src, ok := fsSrc.(*fileSystemSource)
@@ -698,8 +741,8 @@ func testReadValidateErrorWithIndexEnabled(
 
 	nsMD := testNsMetadataWithIndex(t, enabled)
 	ranges := testShardTimeRanges()
-	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts,
-		ranges, nsMD)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, testDefaultRunOpts,
+		ranges, testOpts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)
@@ -730,7 +773,8 @@ func testReadOpenError(
 
 	reader := fs.NewMockDataFileSetReader(ctrl)
 
-	fsSrc, err := newFileSystemSource(newTestOptions(t, dir))
+	testOpts := newTestOptions(t, dir)
+	fsSrc, err := newFileSystemSource(testOpts)
 	require.NoError(t, err)
 
 	src, ok := fsSrc.(*fileSystemSource)
@@ -765,8 +809,8 @@ func testReadOpenError(
 
 	nsMD := testNsMetadataWithIndex(t, enabled)
 	ranges := testShardTimeRanges()
-	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts,
-		ranges, nsMD)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, testDefaultRunOpts,
+		ranges, testOpts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)
@@ -784,7 +828,8 @@ func TestReadDeleteOnError(t *testing.T) {
 
 	reader := fs.NewMockDataFileSetReader(ctrl)
 
-	fsSrc, err := newFileSystemSource(newTestOptions(t, dir))
+	testOpts := newTestOptions(t, dir)
+	fsSrc, err := newFileSystemSource(testOpts)
 	require.NoError(t, err)
 
 	src, ok := fsSrc.(*fileSystemSource)
@@ -836,8 +881,8 @@ func TestReadDeleteOnError(t *testing.T) {
 
 	nsMD := testNsMetadata(t)
 	ranges := testShardTimeRanges()
-	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts,
-		ranges, nsMD)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, testDefaultRunOpts,
+		ranges, testOpts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)
@@ -860,13 +905,14 @@ func TestReadTags(t *testing.T) {
 		{id, tags, data},
 	})
 
-	src, err := newFileSystemSource(newTestOptions(t, dir))
+	testOpts := newTestOptions(t, dir)
+	src, err := newFileSystemSource(testOpts)
 	require.NoError(t, err)
 
 	nsMD := testNsMetadata(t)
 	ranges := testShardTimeRanges()
-	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts,
-		ranges, nsMD)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, testDefaultRunOpts,
+		ranges, testOpts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -330,8 +330,8 @@ func TestBootstrapIndex(t *testing.T) {
 	require.True(t, ok)
 
 	nsMD := testNsMetadata(t)
-	tester := bootstrap.BuildNamespacesTester(t, runOpts,
-		times.shardTimeRanges, nsMD)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, runOpts,
+		times.shardTimeRanges, opts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)
@@ -410,8 +410,8 @@ func TestBootstrapIndexIgnoresPersistConfigIfSnapshotType(t *testing.T) {
 	require.True(t, ok)
 
 	nsMD := testNsMetadata(t)
-	tester := bootstrap.BuildNamespacesTester(t, runOpts,
-		times.shardTimeRanges, nsMD)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, runOpts,
+		times.shardTimeRanges, opts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)
@@ -483,8 +483,8 @@ func TestBootstrapIndexWithPersistPrefersPersistedIndexBlocks(t *testing.T) {
 	require.True(t, ok)
 
 	nsMD := testNsMetadata(t)
-	tester := bootstrap.BuildNamespacesTester(t, runOpts,
-		times.shardTimeRanges, nsMD)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, runOpts,
+		times.shardTimeRanges, opts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)
@@ -588,8 +588,8 @@ func TestBootstrapIndexWithPersistForIndexBlockAtRetentionEdge(t *testing.T) {
 			End:   times.end,
 		}),
 	)
-	tester := bootstrap.BuildNamespacesTester(t, runOpts,
-		times.shardTimeRanges, ns)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, runOpts,
+		times.shardTimeRanges, opts.FilesystemOptions(), ns)
 	defer tester.Finish()
 
 	tester.TestReadWith(src)

--- a/src/dbnode/storage/bootstrap/bootstrapper/noop.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/noop.go
@@ -64,7 +64,7 @@ func (noop noOpNoneBootstrapper) String() string {
 func (noop noOpNoneBootstrapper) Bootstrap(
 	_ context.Context,
 	namespaces bootstrap.Namespaces,
-	_ bootstrap.State,
+	_ bootstrap.Cache,
 ) (bootstrap.NamespaceResults, error) {
 	results := bootstrap.NewNamespaceResults(namespaces)
 	for _, elem := range results.Results.Iter() {
@@ -122,7 +122,7 @@ func (noop noOpAllBootstrapper) String() string {
 func (noop noOpAllBootstrapper) Bootstrap(
 	_ context.Context,
 	namespaces bootstrap.Namespaces,
-	_ bootstrap.State,
+	_ bootstrap.Cache,
 ) (bootstrap.NamespaceResults, error) {
 	return bootstrap.NewNamespaceResults(namespaces), nil
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/noop.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/noop.go
@@ -62,8 +62,9 @@ func (noop noOpNoneBootstrapper) String() string {
 }
 
 func (noop noOpNoneBootstrapper) Bootstrap(
-	ctx context.Context,
+	_ context.Context,
 	namespaces bootstrap.Namespaces,
+	_ bootstrap.State,
 ) (bootstrap.NamespaceResults, error) {
 	results := bootstrap.NewNamespaceResults(namespaces)
 	for _, elem := range results.Results.Iter() {
@@ -119,8 +120,9 @@ func (noop noOpAllBootstrapper) String() string {
 }
 
 func (noop noOpAllBootstrapper) Bootstrap(
-	ctx context.Context,
+	_ context.Context,
 	namespaces bootstrap.Namespaces,
+	_ bootstrap.State,
 ) (bootstrap.NamespaceResults, error) {
 	return bootstrap.NewNamespaceResults(namespaces), nil
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -95,6 +95,7 @@ type shardPeerAvailability struct {
 func (s *peersSource) AvailableData(
 	nsMetadata namespace.Metadata,
 	shardTimeRanges result.ShardTimeRanges,
+	_ bootstrap.State,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	if err := s.validateRunOpts(runOpts); err != nil {
@@ -106,6 +107,7 @@ func (s *peersSource) AvailableData(
 func (s *peersSource) AvailableIndex(
 	nsMetadata namespace.Metadata,
 	shardTimeRanges result.ShardTimeRanges,
+	_ bootstrap.State,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	if err := s.validateRunOpts(runOpts); err != nil {
@@ -117,6 +119,7 @@ func (s *peersSource) AvailableIndex(
 func (s *peersSource) Read(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
+	state bootstrap.State,
 ) (bootstrap.NamespaceResults, error) {
 	ctx, span, _ := ctx.StartSampledTraceSpan(tracepoint.BootstrapperPeersSourceRead)
 	defer span.Finish()
@@ -192,8 +195,10 @@ func (s *peersSource) Read(
 		r, err := s.readIndex(md,
 			namespace.IndexRunOptions.ShardTimeRanges,
 			builder,
+			span,
+			state,
 			namespace.IndexRunOptions.RunOptions,
-			span)
+		)
 		if err != nil {
 			return bootstrap.NamespaceResults{}, err
 		}
@@ -659,8 +664,9 @@ func (s *peersSource) readIndex(
 	ns namespace.Metadata,
 	shardTimeRanges result.ShardTimeRanges,
 	builder *result.IndexBuilder,
-	opts bootstrap.RunOptions,
 	span opentracing.Span,
+	state bootstrap.State,
+	opts bootstrap.RunOptions,
 ) (result.IndexBootstrapResult, error) {
 	if err := s.validateRunOpts(opts); err != nil {
 		return nil, err
@@ -707,6 +713,7 @@ func (s *peersSource) readIndex(
 		Logger:                    s.log,
 		Span:                      span,
 		NowFn:                     s.nowFn,
+		State:                     state,
 	})
 
 	for timeWindowReaders := range readersCh {
@@ -984,7 +991,7 @@ func (s *peersSource) readBlockMetadataAndIndex(
 }
 
 func (s *peersSource) peerAvailability(
-	nsMetadata namespace.Metadata,
+	_ namespace.Metadata,
 	shardTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -95,7 +95,7 @@ type shardPeerAvailability struct {
 func (s *peersSource) AvailableData(
 	nsMetadata namespace.Metadata,
 	shardTimeRanges result.ShardTimeRanges,
-	_ bootstrap.State,
+	_ bootstrap.Cache,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	if err := s.validateRunOpts(runOpts); err != nil {
@@ -107,7 +107,7 @@ func (s *peersSource) AvailableData(
 func (s *peersSource) AvailableIndex(
 	nsMetadata namespace.Metadata,
 	shardTimeRanges result.ShardTimeRanges,
-	_ bootstrap.State,
+	_ bootstrap.Cache,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	if err := s.validateRunOpts(runOpts); err != nil {
@@ -119,7 +119,7 @@ func (s *peersSource) AvailableIndex(
 func (s *peersSource) Read(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
-	state bootstrap.State,
+	cache bootstrap.Cache,
 ) (bootstrap.NamespaceResults, error) {
 	ctx, span, _ := ctx.StartSampledTraceSpan(tracepoint.BootstrapperPeersSourceRead)
 	defer span.Finish()
@@ -196,7 +196,7 @@ func (s *peersSource) Read(
 			namespace.IndexRunOptions.ShardTimeRanges,
 			builder,
 			span,
-			state,
+			cache,
 			namespace.IndexRunOptions.RunOptions,
 		)
 		if err != nil {
@@ -665,7 +665,7 @@ func (s *peersSource) readIndex(
 	shardTimeRanges result.ShardTimeRanges,
 	builder *result.IndexBuilder,
 	span opentracing.Span,
-	state bootstrap.State,
+	cache bootstrap.Cache,
 	opts bootstrap.RunOptions,
 ) (result.IndexBootstrapResult, error) {
 	if err := s.validateRunOpts(opts); err != nil {
@@ -713,7 +713,7 @@ func (s *peersSource) readIndex(
 		Logger:                    s.log,
 		Span:                      span,
 		NowFn:                     s.nowFn,
-		State:                     state,
+		Cache:                     cache,
 	})
 
 	for timeWindowReaders := range readersCh {

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
@@ -146,11 +146,11 @@ func TestPeersSourceEmptyShardTimeRanges(t *testing.T) {
 		target     = result.NewShardTimeRanges()
 		runOpts    = testDefaultRunOpts.SetInitialTopologyState(&topology.StateSnapshot{})
 	)
-	state, err := bootstrap.NewState(bootstrap.NewStateOptions().
+	cache, err := bootstrap.NewCache(bootstrap.NewCacheOptions().
 		SetFilesystemOptions(opts.FilesystemOptions()).
 		SetInstrumentOptions(opts.FilesystemOptions().InstrumentOptions()))
 	require.NoError(t, err)
-	available, err := src.AvailableData(nsMetadata, target, state, runOpts)
+	available, err := src.AvailableData(nsMetadata, target, cache, runOpts)
 	require.NoError(t, err)
 	require.Equal(t, target, available)
 
@@ -195,7 +195,7 @@ func TestPeersSourceReturnsErrorForAdminSession(t *testing.T) {
 	ctx := context.NewContext()
 	defer ctx.Close()
 
-	_, err = src.Read(ctx, tester.Namespaces, tester.State)
+	_, err = src.Read(ctx, tester.Namespaces, tester.Cache)
 	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
 	tester.EnsureNoLoadedBlocks()

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_data_test.go
@@ -146,7 +146,11 @@ func TestPeersSourceEmptyShardTimeRanges(t *testing.T) {
 		target     = result.NewShardTimeRanges()
 		runOpts    = testDefaultRunOpts.SetInitialTopologyState(&topology.StateSnapshot{})
 	)
-	available, err := src.AvailableData(nsMetadata, target, runOpts)
+	state, err := bootstrap.NewState(bootstrap.NewStateOptions().
+		SetFilesystemOptions(opts.FilesystemOptions()).
+		SetInstrumentOptions(opts.FilesystemOptions().InstrumentOptions()))
+	require.NoError(t, err)
+	available, err := src.AvailableData(nsMetadata, target, state, runOpts)
 	require.NoError(t, err)
 	require.Equal(t, target, available)
 
@@ -191,7 +195,7 @@ func TestPeersSourceReturnsErrorForAdminSession(t *testing.T) {
 	ctx := context.NewContext()
 	defer ctx.Close()
 
-	_, err = src.Read(ctx, tester.Namespaces)
+	_, err = src.Read(ctx, tester.Namespaces, tester.State)
 	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
 	tester.EnsureNoLoadedBlocks()

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_index_test.go
@@ -272,7 +272,8 @@ func TestBootstrapIndex(t *testing.T) {
 
 	src, err := newPeersSource(opts)
 	require.NoError(t, err)
-	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, shardTimeRanges, nsMetadata)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, testDefaultRunOpts, shardTimeRanges,
+		opts.FilesystemOptions(), nsMetadata)
 	defer tester.Finish()
 	tester.TestReadWith(src)
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -60,7 +60,7 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 			Start: blockStart,
 			End:   blockStart.Add(blockSize),
 		})
-		stateOptions = bootstrap.NewStateOptions().
+		cacheOptions = bootstrap.NewCacheOptions().
 				SetFilesystemOptions(fs.NewOptions()).
 				SetInstrumentOptions(instrument.NewOptions())
 	)
@@ -162,7 +162,7 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 			for shard := range tc.shardsTimeRangesToBootstrap.Iter() {
 				shards = append(shards, shard)
 			}
-			state, sErr := bootstrap.NewState(stateOptions.
+			cache, sErr := bootstrap.NewCache(cacheOptions.
 				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
 					{
 						Namespace: nsMetadata,
@@ -172,7 +172,7 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 			require.NoError(t, sErr)
 
 			runOpts := testDefaultRunOpts.SetInitialTopologyState(tc.topoState)
-			dataRes, err := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
+			dataRes, err := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, cache, runOpts)
 			if tc.expectedErr != nil {
 				require.Equal(t, tc.expectedErr, err)
 			} else {
@@ -180,7 +180,7 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 				require.Equal(t, tc.expectedAvailableShardsTimeRanges, dataRes)
 			}
 
-			indexRes, err := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
+			indexRes, err := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, cache, runOpts)
 			if tc.expectedErr != nil {
 				require.Equal(t, tc.expectedErr, err)
 			} else {
@@ -222,7 +222,7 @@ func TestPeersSourceReturnsErrorIfUnknownPersistenceFileSetType(t *testing.T) {
 	ctx := context.NewContext()
 	defer ctx.Close()
 
-	_, err = src.Read(ctx, tester.Namespaces, tester.State)
+	_, err = src.Read(ctx, tester.Namespaces, tester.Cache)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "unknown persist config fileset file type"))
 	tester.EnsureNoLoadedBlocks()

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -27,12 +27,14 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/cluster/shard"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
 	m3dbruntime "github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
 	tu "github.com/m3db/m3/src/dbnode/topology/testutil"
 	"github.com/m3db/m3/src/x/context"
+	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/golang/mock/gomock"
@@ -58,6 +60,9 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 			Start: blockStart,
 			End:   blockStart.Add(blockSize),
 		})
+		stateOptions = bootstrap.NewStateOptions().
+				SetFilesystemOptions(fs.NewOptions()).
+				SetInstrumentOptions(instrument.NewOptions())
 	)
 
 	for i := 0; i < int(numShards); i++ {
@@ -153,8 +158,21 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 			src, err := newPeersSource(opts)
 			require.NoError(t, err)
 
+			var shards []uint32
+			for shard := range tc.shardsTimeRangesToBootstrap.Iter() {
+				shards = append(shards, shard)
+			}
+			state, sErr := bootstrap.NewState(stateOptions.
+				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
+					{
+						Namespace: nsMetadata,
+						Shards:    shards,
+					},
+				}))
+			require.NoError(t, sErr)
+
 			runOpts := testDefaultRunOpts.SetInitialTopologyState(tc.topoState)
-			dataRes, err := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+			dataRes, err := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
 			if tc.expectedErr != nil {
 				require.Equal(t, tc.expectedErr, err)
 			} else {
@@ -162,7 +180,7 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 				require.Equal(t, tc.expectedAvailableShardsTimeRanges, dataRes)
 			}
 
-			indexRes, err := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+			indexRes, err := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
 			if tc.expectedErr != nil {
 				require.Equal(t, tc.expectedErr, err)
 			} else {
@@ -198,13 +216,13 @@ func TestPeersSourceReturnsErrorIfUnknownPersistenceFileSetType(t *testing.T) {
 	)
 
 	runOpts := testRunOptsWithPersist.SetPersistConfig(bootstrap.PersistConfig{Enabled: true, FileSetType: 999})
-	tester := bootstrap.BuildNamespacesTester(t, runOpts, target, testNsMd)
+	tester := bootstrap.BuildNamespacesTesterWithFilesystemOptions(t, runOpts, target, opts.FilesystemOptions(), testNsMd)
 	defer tester.Finish()
 
 	ctx := context.NewContext()
 	defer ctx.Close()
 
-	_, err = src.Read(ctx, tester.Namespaces)
+	_, err = src.Read(ctx, tester.Namespaces, tester.State)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "unknown persist config fileset file type"))
 	tester.EnsureNoLoadedBlocks()

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source_test.go
@@ -163,7 +163,7 @@ func TestPeersSourceAvailableDataAndIndex(t *testing.T) {
 				shards = append(shards, shard)
 			}
 			cache, sErr := bootstrap.NewCache(cacheOptions.
-				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
+				SetNamespaceDetails([]bootstrap.NamespaceDetails{
 					{
 						Namespace: nsMetadata,
 						Shards:    shards,

--- a/src/dbnode/storage/bootstrap/bootstrapper/readers.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/readers.go
@@ -121,7 +121,16 @@ func enqueueReadersGroupedByBlockSize(
 	for _, group := range groupedByBlockSize {
 		readers := make(map[ShardID]ShardReaders, group.Ranges.Len())
 		for shard, tr := range group.Ranges.Iter() {
-			readInfoFilesResults := cache.InfoFilesForShard(ns, shard)
+			readInfoFilesResults, err := cache.InfoFilesForShard(ns, shard)
+			if err != nil {
+				logger.Error("fs bootstrapper unable to read info files for the shard",
+					zap.Uint32("shard", shard),
+					zap.Stringer("namespace", ns.ID()),
+					zap.Error(err),
+					zap.String("timeRange", tr.String()),
+				)
+				continue
+			}
 			shardReaders := newShardReaders(ns, fsOpts, readerPool, shard, tr,
 				optimizedReadMetadataOnly, logger, span, nowFn, readInfoFilesResults)
 			readers[ShardID(shard)] = shardReaders

--- a/src/dbnode/storage/bootstrap/bootstrapper/readers.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/readers.go
@@ -76,7 +76,7 @@ type EnqueueReadersOptions struct {
 	Logger                    *zap.Logger
 	Span                      opentracing.Span
 	NowFn                     clock.NowFn
-	State                     bootstrap.State
+	Cache                     bootstrap.Cache
 }
 
 // EnqueueReaders into a readers channel grouped by data block.
@@ -96,7 +96,7 @@ func EnqueueReaders(opts EnqueueReadersOptions) {
 		opts.Logger,
 		opts.Span,
 		opts.NowFn,
-		opts.State,
+		opts.Cache,
 	)
 }
 
@@ -111,7 +111,7 @@ func enqueueReadersGroupedByBlockSize(
 	logger *zap.Logger,
 	span opentracing.Span,
 	nowFn clock.NowFn,
-	state bootstrap.State,
+	cache bootstrap.Cache,
 ) {
 	// Group them by block size.
 	groupFn := NewShardTimeRangesTimeWindowGroups
@@ -121,7 +121,7 @@ func enqueueReadersGroupedByBlockSize(
 	for _, group := range groupedByBlockSize {
 		readers := make(map[ShardID]ShardReaders, group.Ranges.Len())
 		for shard, tr := range group.Ranges.Iter() {
-			readInfoFilesResults := state.InfoFilesForShard(ns, shard)
+			readInfoFilesResults := cache.InfoFilesForShard(ns, shard)
 			shardReaders := newShardReaders(ns, fsOpts, readerPool, shard, tr,
 				optimizedReadMetadataOnly, logger, span, nowFn, readInfoFilesResults)
 			readers[ShardID(shard)] = shardReaders

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -55,6 +55,7 @@ func newTopologyUninitializedSource(opts Options) bootstrap.Source {
 func (s *uninitializedTopologySource) AvailableData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	_ bootstrap.State,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	return s.availability(ns, shardsTimeRanges, runOpts)
@@ -63,13 +64,14 @@ func (s *uninitializedTopologySource) AvailableData(
 func (s *uninitializedTopologySource) AvailableIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
+	_ bootstrap.State,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	return s.availability(ns, shardsTimeRanges, runOpts)
 }
 
 func (s *uninitializedTopologySource) availability(
-	ns namespace.Metadata,
+	_ namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
@@ -140,6 +142,7 @@ func (s *uninitializedTopologySource) availability(
 func (s *uninitializedTopologySource) Read(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
+	_ bootstrap.State,
 ) (bootstrap.NamespaceResults, error) {
 	ctx, span, _ := ctx.StartSampledTraceSpan(tracepoint.BootstrapperUninitializedSourceRead)
 	defer span.Finish()

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source.go
@@ -55,7 +55,7 @@ func newTopologyUninitializedSource(opts Options) bootstrap.Source {
 func (s *uninitializedTopologySource) AvailableData(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
-	_ bootstrap.State,
+	_ bootstrap.Cache,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	return s.availability(ns, shardsTimeRanges, runOpts)
@@ -64,7 +64,7 @@ func (s *uninitializedTopologySource) AvailableData(
 func (s *uninitializedTopologySource) AvailableIndex(
 	ns namespace.Metadata,
 	shardsTimeRanges result.ShardTimeRanges,
-	_ bootstrap.State,
+	_ bootstrap.Cache,
 	runOpts bootstrap.RunOptions,
 ) (result.ShardTimeRanges, error) {
 	return s.availability(ns, shardsTimeRanges, runOpts)
@@ -142,7 +142,7 @@ func (s *uninitializedTopologySource) availability(
 func (s *uninitializedTopologySource) Read(
 	ctx context.Context,
 	namespaces bootstrap.Namespaces,
-	_ bootstrap.State,
+	_ bootstrap.Cache,
 ) (bootstrap.NamespaceResults, error) {
 	ctx, span, _ := ctx.StartSampledTraceSpan(tracepoint.BootstrapperUninitializedSourceRead)
 	defer span.Finish()

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
@@ -194,7 +194,7 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 				shards = append(shards, shard)
 			}
 			cache, sErr := bootstrap.NewCache(cacheOptions.
-				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
+				SetNamespaceDetails([]bootstrap.NamespaceDetails{
 					{
 						Namespace: nsMetadata,
 						Shards:    shards,

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
@@ -57,7 +57,7 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 			Start: blockStart,
 			End:   blockStart.Add(blockSize),
 		})
-		stateOptions = bootstrap.NewStateOptions().
+		cacheOptions = bootstrap.NewCacheOptions().
 				SetFilesystemOptions(fs.NewOptions()).
 				SetInstrumentOptions(instrument.NewOptions())
 	)
@@ -193,7 +193,7 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 			for shard := range tc.shardsTimeRangesToBootstrap.Iter() {
 				shards = append(shards, shard)
 			}
-			state, sErr := bootstrap.NewState(stateOptions.
+			cache, sErr := bootstrap.NewCache(cacheOptions.
 				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
 					{
 						Namespace: nsMetadata,
@@ -202,8 +202,8 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 				}))
 			require.NoError(t, sErr)
 
-			dataAvailabilityResult, dataErr := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
-			indexAvailabilityResult, indexErr := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
+			dataAvailabilityResult, dataErr := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, cache, runOpts)
+			indexAvailabilityResult, indexErr := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, cache, runOpts)
 
 			if tc.expectedErr != nil {
 				require.Equal(t, tc.expectedErr, dataErr)

--- a/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/uninitialized/source_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/m3db/m3/src/cluster/shard"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
@@ -56,6 +57,9 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 			Start: blockStart,
 			End:   blockStart.Add(blockSize),
 		})
+		stateOptions = bootstrap.NewStateOptions().
+				SetFilesystemOptions(fs.NewOptions()).
+				SetInstrumentOptions(instrument.NewOptions())
 	)
 	nsOpts := namespace.NewOptions()
 	nsOpts = nsOpts.SetIndexOptions(nsOpts.IndexOptions().SetEnabled(true))
@@ -185,8 +189,21 @@ func TestUnitializedTopologySourceAvailableDataAndAvailableIndex(t *testing.T) {
 				src     = newTopologyUninitializedSource(srcOpts)
 				runOpts = testDefaultRunOpts.SetInitialTopologyState(tc.topoState)
 			)
-			dataAvailabilityResult, dataErr := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
-			indexAvailabilityResult, indexErr := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, runOpts)
+			var shards []uint32
+			for shard := range tc.shardsTimeRangesToBootstrap.Iter() {
+				shards = append(shards, shard)
+			}
+			state, sErr := bootstrap.NewState(stateOptions.
+				SetInfoFilesFinders([]bootstrap.InfoFilesFinder{
+					{
+						Namespace: nsMetadata,
+						Shards:    shards,
+					},
+				}))
+			require.NoError(t, sErr)
+
+			dataAvailabilityResult, dataErr := src.AvailableData(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
+			indexAvailabilityResult, indexErr := src.AvailableIndex(nsMetadata, tc.shardsTimeRangesToBootstrap, state, runOpts)
 
 			if tc.expectedErr != nil {
 				require.Equal(t, tc.expectedErr, dataErr)

--- a/src/dbnode/storage/bootstrap/cache.go
+++ b/src/dbnode/storage/bootstrap/cache.go
@@ -44,7 +44,7 @@ func NewCache(options CacheOptions) (Cache, error) {
 	}
 	return Cache{
 		fsOpts:           options.FilesystemOptions(),
-		infoFilesFinders: options.InfoFilesFinders(),
+		namespaceDetails: options.NamespaceDetails(),
 		iOpts:            options.InstrumentOptions(),
 	}, nil
 }
@@ -82,8 +82,8 @@ func (c *Cache) ReadInfoFiles() InfoFilesByNamespace {
 		return c.infoFilesByNamespace
 	}
 
-	c.infoFilesByNamespace = make(InfoFilesByNamespace, len(c.infoFilesFinders))
-	for _, finder := range c.infoFilesFinders {
+	c.infoFilesByNamespace = make(InfoFilesByNamespace, len(c.namespaceDetails))
+	for _, finder := range c.namespaceDetails {
 		result := make(InfoFileResultsPerShard, len(finder.Shards))
 		for _, shard := range finder.Shards {
 			result[shard] = fs.ReadInfoFiles(c.fsOpts.FilePathPrefix(),
@@ -99,7 +99,7 @@ func (c *Cache) ReadInfoFiles() InfoFilesByNamespace {
 
 type cacheOptions struct {
 	fsOpts           fs.Options
-	infoFilesFinders []InfoFilesFinder
+	namespaceDetails []NamespaceDetails
 	iOpts            instrument.Options
 }
 
@@ -131,14 +131,14 @@ func (c *cacheOptions) FilesystemOptions() fs.Options {
 	return c.fsOpts
 }
 
-func (c *cacheOptions) SetInfoFilesFinders(value []InfoFilesFinder) CacheOptions {
+func (c *cacheOptions) SetNamespaceDetails(value []NamespaceDetails) CacheOptions {
 	opts := *c
-	opts.infoFilesFinders = value
+	opts.namespaceDetails = value
 	return &opts
 }
 
-func (c *cacheOptions) InfoFilesFinders() []InfoFilesFinder {
-	return c.infoFilesFinders
+func (c *cacheOptions) NamespaceDetails() []NamespaceDetails {
+	return c.namespaceDetails
 }
 
 func (c *cacheOptions) SetInstrumentOptions(value instrument.Options) CacheOptions {

--- a/src/dbnode/storage/bootstrap/cache_test.go
+++ b/src/dbnode/storage/bootstrap/cache_test.go
@@ -64,7 +64,7 @@ func TestCacheReadInfoFiles(t *testing.T) {
 	opts := NewCacheOptions().
 		SetFilesystemOptions(fsOpts).
 		SetInstrumentOptions(fsOpts.InstrumentOptions()).
-		SetInfoFilesFinders([]InfoFilesFinder{
+		SetNamespaceDetails([]NamespaceDetails{
 			{
 				Namespace: md1,
 				Shards:    []uint32{0, 1},
@@ -117,7 +117,7 @@ func TestCacheReadInfoFilesInvariantViolation(t *testing.T) {
 	opts := NewCacheOptions().
 		SetFilesystemOptions(fsOpts).
 		SetInstrumentOptions(fsOpts.InstrumentOptions()).
-		SetInfoFilesFinders([]InfoFilesFinder{
+		SetNamespaceDetails([]NamespaceDetails{
 			{
 				Namespace: md1,
 				Shards:    []uint32{0, 1},

--- a/src/dbnode/storage/bootstrap/cache_test.go
+++ b/src/dbnode/storage/bootstrap/cache_test.go
@@ -62,7 +62,7 @@ func TestStateReadInfoFiles(t *testing.T) {
 	writeFilesets(t, md2.ID(), 0, fsOpts)
 	writeFilesets(t, md2.ID(), 1, fsOpts)
 
-	opts := NewStateOptions().
+	opts := NewCacheOptions().
 		SetFilesystemOptions(fsOpts).
 		SetInstrumentOptions(fsOpts.InstrumentOptions()).
 		SetInfoFilesFinders([]InfoFilesFinder{
@@ -75,23 +75,23 @@ func TestStateReadInfoFiles(t *testing.T) {
 				Shards:    []uint32{0, 1},
 			},
 		})
-	state, err := NewState(opts)
+	cache, err := NewCache(opts)
 	require.NoError(t, err)
 
-	infoFilesByNamespace := state.ReadInfoFiles()
+	infoFilesByNamespace := cache.ReadInfoFiles()
 	require.NotEmpty(t, infoFilesByNamespace)
 
 	// Ensure we have two namespaces.
 	require.Equal(t, 2, len(infoFilesByNamespace))
 
 	// Ensure we have two shards.
-	require.Equal(t, 2, len(state.InfoFilesForNamespace(md1)))
-	require.Equal(t, 2, len(state.InfoFilesForNamespace(md2)))
+	require.Equal(t, 2, len(cache.InfoFilesForNamespace(md1)))
+	require.Equal(t, 2, len(cache.InfoFilesForNamespace(md2)))
 
 	// Ensure each shard has three info files (one for each fileset written).
 	for shard := uint32(0); shard < 2; shard++ {
-		require.Equal(t, 3, len(state.InfoFilesForShard(md1, shard)))
-		require.Equal(t, 3, len(state.InfoFilesForShard(md2, shard)))
+		require.Equal(t, 3, len(cache.InfoFilesForShard(md1, shard)))
+		require.Equal(t, 3, len(cache.InfoFilesForShard(md2, shard)))
 	}
 }
 
@@ -105,7 +105,7 @@ func TestStateReadInfoFilesInvariantViolation(t *testing.T) {
 	fsOpts := testFilesystemOptions.SetFilePathPrefix(dir)
 	writeFilesets(t, md1.ID(), 0, fsOpts)
 
-	opts := NewStateOptions().
+	opts := NewCacheOptions().
 		SetFilesystemOptions(fsOpts).
 		SetInstrumentOptions(fsOpts.InstrumentOptions()).
 		SetInfoFilesFinders([]InfoFilesFinder{
@@ -114,7 +114,7 @@ func TestStateReadInfoFilesInvariantViolation(t *testing.T) {
 				Shards:    []uint32{0, 1},
 			},
 		})
-	state, err := NewState(opts)
+	cache, err := NewCache(opts)
 	require.NoError(t, err)
 
 	// Force invariant violations to panic for easier testability.
@@ -122,11 +122,11 @@ func TestStateReadInfoFilesInvariantViolation(t *testing.T) {
 	defer os.Setenv(instrument.ShouldPanicEnvironmentVariableName, "false")
 
 	require.Panics(t, func() {
-		state.InfoFilesForNamespace(md2)
+		cache.InfoFilesForNamespace(md2)
 	})
 
 	require.Panics(t, func() {
-		state.InfoFilesForShard(md1, 12)
+		cache.InfoFilesForShard(md1, 12)
 	})
 }
 

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -223,7 +223,7 @@ func (b bootstrapProcess) Run(
 			Shards:    namespace.Shards,
 		})
 	}
-	state, err := NewState(NewStateOptions().
+	cache, err := NewCache(NewCacheOptions().
 		SetFilesystemOptions(b.fsOpts).
 		SetInfoFilesFinders(finders).
 		SetInstrumentOptions(b.fsOpts.InstrumentOptions()))
@@ -236,7 +236,7 @@ func (b bootstrapProcess) Run(
 		namespacesRunFirst,
 		namespacesRunSecond,
 	} {
-		res, err := b.runPass(ctx, namespaces, state)
+		res, err := b.runPass(ctx, namespaces, cache)
 		if err != nil {
 			return NamespaceResults{}, err
 		}
@@ -250,7 +250,7 @@ func (b bootstrapProcess) Run(
 func (b bootstrapProcess) runPass(
 	ctx context.Context,
 	namespaces Namespaces,
-	state State,
+	cache Cache,
 ) (NamespaceResults, error) {
 	ctx, span, sampled := ctx.StartSampledTraceSpan(tracepoint.BootstrapProcessRun)
 	defer span.Finish()
@@ -277,7 +277,7 @@ func (b bootstrapProcess) runPass(
 	}
 
 	begin := b.nowFn()
-	res, err := b.bootstrapper.Bootstrap(ctx, namespaces, state)
+	res, err := b.bootstrapper.Bootstrap(ctx, namespaces, cache)
 	took := b.nowFn().Sub(begin)
 	if err != nil {
 		b.log.Error("bootstrap process error",

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -170,7 +170,7 @@ func (b bootstrapProcess) Run(
 	namespacesRunSecond := Namespaces{
 		Namespaces: NewNamespacesMap(NamespacesMapOptions{}),
 	}
-	finders := make([]InfoFilesFinder, 0, len(namespaces))
+	namespaceDetails := make([]NamespaceDetails, 0, len(namespaces))
 	for _, namespace := range namespaces {
 		ropts := namespace.Metadata.Options().RetentionOptions()
 		idxopts := namespace.Metadata.Options().IndexOptions()
@@ -218,14 +218,14 @@ func (b bootstrapProcess) Run(
 				RunOptions:            indexRanges.secondRangeWithPersistFalse.RunOptions,
 			},
 		})
-		finders = append(finders, InfoFilesFinder{
+		namespaceDetails = append(namespaceDetails, NamespaceDetails{
 			Namespace: namespace.Metadata,
 			Shards:    namespace.Shards,
 		})
 	}
 	cache, err := NewCache(NewCacheOptions().
 		SetFilesystemOptions(b.fsOpts).
-		SetInfoFilesFinders(finders).
+		SetNamespaceDetails(namespaceDetails).
 		SetInstrumentOptions(b.fsOpts.InstrumentOptions()))
 	if err != nil {
 		return NamespaceResults{}, err

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/clock"
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/topology"
@@ -45,6 +46,7 @@ type bootstrapProcessProvider struct {
 	sync.RWMutex
 	processOpts          ProcessOptions
 	resultOpts           result.Options
+	fsOpts               fs.Options
 	log                  *zap.Logger
 	bootstrapperProvider BootstrapperProvider
 }
@@ -61,6 +63,7 @@ func NewProcessProvider(
 	bootstrapperProvider BootstrapperProvider,
 	processOpts ProcessOptions,
 	resultOpts result.Options,
+	fsOpts fs.Options,
 ) (ProcessProvider, error) {
 	if err := processOpts.Validate(); err != nil {
 		return nil, err
@@ -69,6 +72,7 @@ func NewProcessProvider(
 	return &bootstrapProcessProvider{
 		processOpts:          processOpts,
 		resultOpts:           resultOpts,
+		fsOpts:               fsOpts,
 		log:                  resultOpts.InstrumentOptions().Logger(),
 		bootstrapperProvider: bootstrapperProvider,
 	}, nil
@@ -102,6 +106,7 @@ func (b *bootstrapProcessProvider) Provide() (Process, error) {
 	return bootstrapProcess{
 		processOpts:          b.processOpts,
 		resultOpts:           b.resultOpts,
+		fsOpts:               b.fsOpts,
 		nowFn:                b.resultOpts.ClockOptions().NowFn(),
 		log:                  b.log,
 		bootstrapper:         bootstrapper,
@@ -147,6 +152,7 @@ func (b *bootstrapProcessProvider) newInitialTopologyState() (*topology.StateSna
 type bootstrapProcess struct {
 	processOpts          ProcessOptions
 	resultOpts           result.Options
+	fsOpts               fs.Options
 	nowFn                clock.NowFn
 	log                  *zap.Logger
 	bootstrapper         Bootstrapper
@@ -164,6 +170,7 @@ func (b bootstrapProcess) Run(
 	namespacesRunSecond := Namespaces{
 		Namespaces: NewNamespacesMap(NamespacesMapOptions{}),
 	}
+	finders := make([]InfoFilesFinder, 0, len(namespaces))
 	for _, namespace := range namespaces {
 		ropts := namespace.Metadata.Options().RetentionOptions()
 		idxopts := namespace.Metadata.Options().IndexOptions()
@@ -211,6 +218,17 @@ func (b bootstrapProcess) Run(
 				RunOptions:            indexRanges.secondRangeWithPersistFalse.RunOptions,
 			},
 		})
+		finders = append(finders, InfoFilesFinder{
+			Namespace: namespace.Metadata,
+			Shards:    namespace.Shards,
+		})
+	}
+	state, err := NewState(NewStateOptions().
+		SetFilesystemOptions(b.fsOpts).
+		SetInfoFilesFinders(finders).
+		SetInstrumentOptions(b.fsOpts.InstrumentOptions()))
+	if err != nil {
+		return NamespaceResults{}, err
 	}
 
 	bootstrapResult := NewNamespaceResults(namespacesRunFirst)
@@ -218,7 +236,7 @@ func (b bootstrapProcess) Run(
 		namespacesRunFirst,
 		namespacesRunSecond,
 	} {
-		res, err := b.runPass(ctx, namespaces)
+		res, err := b.runPass(ctx, namespaces, state)
 		if err != nil {
 			return NamespaceResults{}, err
 		}
@@ -232,6 +250,7 @@ func (b bootstrapProcess) Run(
 func (b bootstrapProcess) runPass(
 	ctx context.Context,
 	namespaces Namespaces,
+	state State,
 ) (NamespaceResults, error) {
 	ctx, span, sampled := ctx.StartSampledTraceSpan(tracepoint.BootstrapProcessRun)
 	defer span.Finish()
@@ -258,7 +277,7 @@ func (b bootstrapProcess) runPass(
 	}
 
 	begin := b.nowFn()
-	res, err := b.bootstrapper.Bootstrap(ctx, namespaces)
+	res, err := b.bootstrapper.Bootstrap(ctx, namespaces, state)
 	took := b.nowFn().Sub(begin)
 	if err != nil {
 		b.log.Error("bootstrap process error",

--- a/src/dbnode/storage/bootstrap/state.go
+++ b/src/dbnode/storage/bootstrap/state.go
@@ -79,9 +79,6 @@ func (r *State) InfoFilesForShard(ns namespace.Metadata, shard uint32) []fs.Read
 	return infoFileResults
 }
 
-// TODO(nate): Make this threadsafe? If so, we'll need to clone the map
-// before returning, provide an update method, and incorporate locking.
-//
 // ReadInfoFiles returns info file results for each shard grouped by namespace. A cached copy
 // is returned if the info files have already been read.
 func (r *State) ReadInfoFiles() InfoFilesByNamespace {

--- a/src/dbnode/storage/bootstrap/state.go
+++ b/src/dbnode/storage/bootstrap/state.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2020  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bootstrap
+
+import (
+	"errors"
+
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
+	"github.com/m3db/m3/src/x/instrument"
+
+	"go.uber.org/zap"
+)
+
+var (
+	errFilesystemOptsNotSet = errors.New("filesystemOptions not set")
+	errInstrumentOptsNotSet = errors.New("instrumentOptions not set")
+)
+
+// NewState creates state specifically to be used during the bootstrap process.
+// Primarily a mechanism for passing info files along without needing to re-read them at each
+// stage of the bootstrap process.
+func NewState(options StateOptions) (State, error) {
+	if err := options.Validate(); err != nil {
+		return State{}, err
+	}
+	return State{
+		fsOpts:           options.FilesystemOptions(),
+		infoFilesFinders: options.InfoFilesFinders(),
+		iOpts:            options.InstrumentOptions(),
+	}, nil
+}
+
+// InfoFilesForNamespace returns the info files grouped by shard for the provided namespace.
+func (r *State) InfoFilesForNamespace(ns namespace.Metadata) InfoFileResultsPerShard {
+	infoFilesByShard, ok := r.ReadInfoFiles()[ns]
+	// This should never happen as State object is initialized with all namespaces to bootstrap.
+	if !ok {
+		instrument.EmitAndLogInvariantViolation(r.iOpts, func(l *zap.Logger) {
+			l.Error("attempting to read info files for namespace not specified at bootstrap startup",
+				zap.String("namespace", ns.ID().String()))
+		})
+		return make(InfoFileResultsPerShard)
+	}
+	return infoFilesByShard
+}
+
+// InfoFilesForShard returns the info files grouped by shard for the provided namespace.
+func (r *State) InfoFilesForShard(ns namespace.Metadata, shard uint32) []fs.ReadInfoFileResult {
+	infoFileResults, ok := r.InfoFilesForNamespace(ns)[shard]
+	// This should never happen as State object is initialized with all shards to bootstrap.
+	if !ok {
+		instrument.EmitAndLogInvariantViolation(r.iOpts, func(l *zap.Logger) {
+			l.Error("attempting to read info files for shard not specified at bootstrap startup",
+				zap.String("namespace", ns.ID().String()), zap.Uint32("shard", shard))
+
+		})
+		return make([]fs.ReadInfoFileResult, 0)
+	}
+	return infoFileResults
+}
+
+// TODO(nate): Make this threadsafe? If so, we'll need to clone the map
+// before returning, provide an update method, and incorporate locking.
+//
+// ReadInfoFiles returns info file results for each shard grouped by namespace. A cached copy
+// is returned if the info files have already been read.
+func (r *State) ReadInfoFiles() InfoFilesByNamespace {
+	if r.infoFilesByNamespace != nil {
+		return r.infoFilesByNamespace
+	}
+
+	r.infoFilesByNamespace = make(InfoFilesByNamespace, len(r.infoFilesFinders))
+	for _, finder := range r.infoFilesFinders {
+		result := make(InfoFileResultsPerShard, len(finder.Shards))
+		for _, shard := range finder.Shards {
+			result[shard] = fs.ReadInfoFiles(r.fsOpts.FilePathPrefix(),
+				finder.Namespace.ID(), shard, r.fsOpts.InfoReaderBufferSize(), r.fsOpts.DecodingOptions(),
+				persist.FileSetFlushType)
+		}
+
+		r.infoFilesByNamespace[finder.Namespace] = result
+	}
+
+	return r.infoFilesByNamespace
+}
+
+type stateOptions struct {
+	fsOpts           fs.Options
+	infoFilesFinders []InfoFilesFinder
+	iOpts            instrument.Options
+}
+
+// NewStateOptions creates new StateOptions.
+func NewStateOptions() StateOptions {
+	return &stateOptions{}
+}
+
+func (s *stateOptions) Validate() error {
+	if s.fsOpts == nil {
+		return errFilesystemOptsNotSet
+	}
+	if err := s.fsOpts.Validate(); err != nil {
+		return err
+	}
+	if s.iOpts == nil {
+		return errInstrumentOptsNotSet
+	}
+	return nil
+}
+
+func (s *stateOptions) SetFilesystemOptions(value fs.Options) StateOptions {
+	opts := *s
+	opts.fsOpts = value
+	return &opts
+}
+
+func (s *stateOptions) FilesystemOptions() fs.Options {
+	return s.fsOpts
+}
+
+func (s *stateOptions) SetInfoFilesFinders(value []InfoFilesFinder) StateOptions {
+	opts := *s
+	opts.infoFilesFinders = value
+	return &opts
+}
+
+func (s *stateOptions) InfoFilesFinders() []InfoFilesFinder {
+	return s.infoFilesFinders
+}
+
+func (s *stateOptions) SetInstrumentOptions(value instrument.Options) StateOptions {
+	opts := *s
+	opts.iOpts = value
+	return &opts
+}
+
+func (s *stateOptions) InstrumentOptions() instrument.Options {
+	return s.iOpts
+}

--- a/src/dbnode/storage/bootstrap/state_test.go
+++ b/src/dbnode/storage/bootstrap/state_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2020  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bootstrap
+
+import (
+	"io/ioutil"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/digest"
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
+	"github.com/m3db/m3/src/dbnode/retention"
+	"github.com/m3db/m3/src/x/checked"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/instrument"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testBlockSize             = 2 * time.Hour
+	testStart                 = time.Now().Truncate(testBlockSize)
+	testNamespaceIndexOptions = namespace.NewIndexOptions()
+	testNamespaceOptions      = namespace.NewOptions()
+	testRetentionOptions      = retention.NewOptions()
+	testFilesystemOptions     = fs.NewOptions()
+)
+
+func TestStateReadInfoFiles(t *testing.T) {
+	dir := createTempDir(t)
+	defer os.RemoveAll(dir)
+
+	md1 := testNamespaceMetadata(t, ident.StringID("ns1"))
+	md2 := testNamespaceMetadata(t, ident.StringID("ns2"))
+
+	fsOpts := testFilesystemOptions.SetFilePathPrefix(dir)
+
+	writeFilesets(t, md1.ID(), 0, fsOpts)
+	writeFilesets(t, md1.ID(), 1, fsOpts)
+	writeFilesets(t, md2.ID(), 0, fsOpts)
+	writeFilesets(t, md2.ID(), 1, fsOpts)
+
+	opts := NewStateOptions().
+		SetFilesystemOptions(fsOpts).
+		SetInstrumentOptions(fsOpts.InstrumentOptions()).
+		SetInfoFilesFinders([]InfoFilesFinder{
+			{
+				Namespace: md1,
+				Shards:    []uint32{0, 1},
+			},
+			{
+				Namespace: md2,
+				Shards:    []uint32{0, 1},
+			},
+		})
+	state, err := NewState(opts)
+	require.NoError(t, err)
+
+	infoFilesByNamespace := state.ReadInfoFiles()
+	require.NotEmpty(t, infoFilesByNamespace)
+
+	// Ensure we have two namespaces.
+	require.Equal(t, 2, len(infoFilesByNamespace))
+
+	// Ensure we have two shards.
+	require.Equal(t, 2, len(state.InfoFilesForNamespace(md1)))
+	require.Equal(t, 2, len(state.InfoFilesForNamespace(md2)))
+
+	// Ensure each shard has three info files (one for each fileset written).
+	for shard := uint32(0); shard < 2; shard++ {
+		require.Equal(t, 3, len(state.InfoFilesForShard(md1, shard)))
+		require.Equal(t, 3, len(state.InfoFilesForShard(md2, shard)))
+	}
+}
+
+func TestStateReadInfoFilesInvariantViolation(t *testing.T) {
+	dir := createTempDir(t)
+	defer os.RemoveAll(dir)
+
+	md1 := testNamespaceMetadata(t, ident.StringID("ns1"))
+	md2 := testNamespaceMetadata(t, ident.StringID("ns2"))
+
+	fsOpts := testFilesystemOptions.SetFilePathPrefix(dir)
+	writeFilesets(t, md1.ID(), 0, fsOpts)
+
+	opts := NewStateOptions().
+		SetFilesystemOptions(fsOpts).
+		SetInstrumentOptions(fsOpts.InstrumentOptions()).
+		SetInfoFilesFinders([]InfoFilesFinder{
+			{
+				Namespace: md1,
+				Shards:    []uint32{0, 1},
+			},
+		})
+	state, err := NewState(opts)
+	require.NoError(t, err)
+
+	// Force invariant violations to panic for easier testability.
+	os.Setenv(instrument.ShouldPanicEnvironmentVariableName, "true")
+	defer os.Setenv(instrument.ShouldPanicEnvironmentVariableName, "false")
+
+	require.Panics(t, func() {
+		state.InfoFilesForNamespace(md2)
+	})
+
+	require.Panics(t, func() {
+		state.InfoFilesForShard(md1, 12)
+	})
+}
+
+func testNamespaceMetadata(t *testing.T, nsID ident.ID) namespace.Metadata {
+	rOpts := testRetentionOptions.SetBlockSize(testBlockSize)
+	md, err := namespace.NewMetadata(nsID, testNamespaceOptions.
+		SetRetentionOptions(rOpts).
+		SetIndexOptions(testNamespaceIndexOptions))
+	require.NoError(t, err)
+	return md
+}
+
+func createTempDir(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "foo")
+	require.NoError(t, err)
+	return dir
+}
+
+type testSeries struct {
+	id   string
+	tags map[string]string
+	data []byte
+}
+
+func writeFilesets(t *testing.T, namespace ident.ID, shard uint32, fsOpts fs.Options) {
+	inputs := []struct {
+		start time.Time
+		id    string
+		tags  map[string]string
+		data  []byte
+	}{
+		{testStart, "foo", map[string]string{"n": "0"}, []byte{1, 2, 3}},
+		{testStart.Add(10 * time.Hour), "bar", map[string]string{"n": "1"}, []byte{4, 5, 6}},
+		{testStart.Add(20 * time.Hour), "baz", nil, []byte{7, 8, 9}},
+	}
+
+	for _, input := range inputs {
+		writeTSDBFiles(t, namespace, shard, input.start,
+			[]testSeries{{input.id, input.tags, input.data}}, fsOpts)
+	}
+}
+
+func writeTSDBFiles(
+	t require.TestingT,
+	namespace ident.ID,
+	shard uint32,
+	start time.Time,
+	series []testSeries,
+	opts fs.Options,
+) {
+	w, err := fs.NewWriter(opts)
+	require.NoError(t, err)
+	writerOpts := fs.DataWriterOpenOptions{
+		Identifier: fs.FileSetFileIdentifier{
+			Namespace:  namespace,
+			Shard:      shard,
+			BlockStart: start,
+		},
+		BlockSize: testBlockSize,
+	}
+	require.NoError(t, w.Open(writerOpts))
+
+	for _, v := range series {
+		bytes := checked.NewBytes(v.data, nil)
+		bytes.IncRef()
+		metadata := persist.NewMetadataFromIDAndTags(ident.StringID(v.id), sortedTagsFromTagsMap(v.tags),
+			persist.MetadataOptions{})
+		require.NoError(t, w.Write(metadata, bytes, digest.Checksum(bytes.Bytes())))
+		bytes.DecRef()
+	}
+
+	require.NoError(t, w.Close())
+}
+
+func sortedTagsFromTagsMap(tags map[string]string) ident.Tags {
+	var (
+		seriesTags ident.Tags
+		tagNames   []string
+	)
+	for name := range tags {
+		tagNames = append(tagNames, name)
+	}
+	sort.Strings(tagNames)
+	for _, name := range tagNames {
+		seriesTags.Append(ident.StringTag(name, tags[name]))
+	}
+	return seriesTags
+}

--- a/src/dbnode/storage/bootstrap/types.go
+++ b/src/dbnode/storage/bootstrap/types.go
@@ -434,7 +434,7 @@ type InfoFilesByNamespace map[namespace.Metadata]InfoFileResultsPerShard
 // process.
 type Cache struct {
 	fsOpts               fs.Options
-	infoFilesFinders     []InfoFilesFinder
+	namespaceDetails     []NamespaceDetails
 	infoFilesByNamespace InfoFilesByNamespace
 	iOpts                instrument.Options
 }
@@ -450,11 +450,11 @@ type CacheOptions interface {
 	// FilesystemOptions returns the filesystem options.
 	FilesystemOptions() fs.Options
 
-	// SetInfoFilesFinders sets the finders used to load info files for all namespaces provided.
-	SetInfoFilesFinders(value []InfoFilesFinder) CacheOptions
+	// SetNamespaceDetails sets the namespaces to cache information for.
+	SetNamespaceDetails(value []NamespaceDetails) CacheOptions
 
-	// InfoFilesFinders returns the finders used to load info files for all namespaces provided.
-	InfoFilesFinders() []InfoFilesFinder
+	// NamespaceDetails returns the namespaces to cache information for.
+	NamespaceDetails() []NamespaceDetails
 
 	// SetInstrumentOptions sets the instrument options.
 	SetInstrumentOptions(value instrument.Options) CacheOptions
@@ -463,8 +463,8 @@ type CacheOptions interface {
 	InstrumentOptions() instrument.Options
 }
 
-// InfoFilesFinder is used to lookup info files for the given combination of namespace and shards.
-type InfoFilesFinder struct {
+// NamespaceDetails are used to lookup info files for the given combination of namespace and shards.
+type NamespaceDetails struct {
 	// Namespace is the namespace to retrieve info files for.
 	Namespace namespace.Metadata
 	// Shards are the shards to retrieve info files for in the specified namespace.

--- a/src/dbnode/storage/bootstrap/util.go
+++ b/src/dbnode/storage/bootstrap/util.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
 	"github.com/m3db/m3/src/dbnode/storage/series"
@@ -307,6 +308,8 @@ type NamespacesTester struct {
 
 	// Namespaces are the namespaces for this tester.
 	Namespaces Namespaces
+	// State is a snapshot of state useful during bootstrapping.
+	State State
 	// Results are the namespace results after bootstrapping.
 	Results NamespaceResults
 }
@@ -334,6 +337,25 @@ func BuildNamespacesTester(
 		runOpts,
 		ranges,
 		nil,
+		fs.NewOptions(),
+		mds...,
+	)
+}
+
+// BuildNamespacesTesterWithFilesystemOptions builds a NamespacesTester with fs.Options
+func BuildNamespacesTesterWithFilesystemOptions(
+	t require.TestingT,
+	runOpts RunOptions,
+	ranges result.ShardTimeRanges,
+	fsOpts fs.Options,
+	mds ...namespace.Metadata,
+) NamespacesTester {
+	return BuildNamespacesTesterWithReaderIteratorPool(
+		t,
+		runOpts,
+		ranges,
+		nil,
+		fsOpts,
 		mds...,
 	)
 }
@@ -345,6 +367,7 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 	runOpts RunOptions,
 	ranges result.ShardTimeRanges,
 	iterPool encoding.MultiReaderIteratorPool,
+	fsOpts fs.Options,
 	mds ...namespace.Metadata,
 ) NamespacesTester {
 	shards := make([]uint32, 0, ranges.Len())
@@ -359,6 +382,7 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 	ctrl := xtest.NewController(t)
 	namespacesMap := NewNamespacesMap(NamespacesMapOptions{})
 	accumulators := make([]*TestDataAccumulator, 0, len(mds))
+	finders := make([]InfoFilesFinder, 0, len(mds))
 	for _, md := range mds {
 		nsCtx := namespace.NewContextFrom(md)
 		acc := &TestDataAccumulator{
@@ -388,13 +412,23 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 				RunOptions:            runOpts,
 			},
 		})
+		finders = append(finders, InfoFilesFinder{
+			Namespace: md,
+			Shards:    shards,
+		})
 	}
+	state, err := NewState(NewStateOptions().
+		SetFilesystemOptions(fsOpts).
+		SetInstrumentOptions(fsOpts.InstrumentOptions()).
+		SetInfoFilesFinders(finders))
+	require.NoError(t, err)
 
 	return NamespacesTester{
 		t:            t,
 		ctrl:         ctrl,
 		pool:         iterPool,
 		Accumulators: accumulators,
+		State:        state,
 		Namespaces: Namespaces{
 			Namespaces: namespacesMap,
 		},
@@ -540,7 +574,7 @@ func (nt *NamespacesTester) ResultForNamespace(id ident.ID) NamespaceResult {
 func (nt *NamespacesTester) TestBootstrapWith(b Bootstrapper) {
 	ctx := context.NewContext()
 	defer ctx.Close()
-	res, err := b.Bootstrap(ctx, nt.Namespaces)
+	res, err := b.Bootstrap(ctx, nt.Namespaces, nt.State)
 	assert.NoError(nt.t, err)
 	nt.Results = res
 }
@@ -550,7 +584,7 @@ func (nt *NamespacesTester) TestBootstrapWith(b Bootstrapper) {
 func (nt *NamespacesTester) TestReadWith(s Source) {
 	ctx := context.NewContext()
 	defer ctx.Close()
-	res, err := s.Read(ctx, nt.Namespaces)
+	res, err := s.Read(ctx, nt.Namespaces, nt.State)
 	require.NoError(nt.t, err)
 	nt.Results = res
 }

--- a/src/dbnode/storage/bootstrap/util.go
+++ b/src/dbnode/storage/bootstrap/util.go
@@ -382,7 +382,7 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 	ctrl := xtest.NewController(t)
 	namespacesMap := NewNamespacesMap(NamespacesMapOptions{})
 	accumulators := make([]*TestDataAccumulator, 0, len(mds))
-	finders := make([]InfoFilesFinder, 0, len(mds))
+	finders := make([]NamespaceDetails, 0, len(mds))
 	for _, md := range mds {
 		nsCtx := namespace.NewContextFrom(md)
 		acc := &TestDataAccumulator{
@@ -412,7 +412,7 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 				RunOptions:            runOpts,
 			},
 		})
-		finders = append(finders, InfoFilesFinder{
+		finders = append(finders, NamespaceDetails{
 			Namespace: md,
 			Shards:    shards,
 		})
@@ -420,7 +420,7 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 	cache, err := NewCache(NewCacheOptions().
 		SetFilesystemOptions(fsOpts).
 		SetInstrumentOptions(fsOpts.InstrumentOptions()).
-		SetInfoFilesFinders(finders))
+		SetNamespaceDetails(finders))
 	require.NoError(t, err)
 
 	return NamespacesTester{

--- a/src/dbnode/storage/bootstrap/util.go
+++ b/src/dbnode/storage/bootstrap/util.go
@@ -308,8 +308,8 @@ type NamespacesTester struct {
 
 	// Namespaces are the namespaces for this tester.
 	Namespaces Namespaces
-	// State is a snapshot of state useful during bootstrapping.
-	State State
+	// Cache is a snapshot of data useful during bootstrapping.
+	Cache Cache
 	// Results are the namespace results after bootstrapping.
 	Results NamespaceResults
 }
@@ -417,7 +417,7 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 			Shards:    shards,
 		})
 	}
-	state, err := NewState(NewStateOptions().
+	cache, err := NewCache(NewCacheOptions().
 		SetFilesystemOptions(fsOpts).
 		SetInstrumentOptions(fsOpts.InstrumentOptions()).
 		SetInfoFilesFinders(finders))
@@ -428,7 +428,7 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 		ctrl:         ctrl,
 		pool:         iterPool,
 		Accumulators: accumulators,
-		State:        state,
+		Cache:        cache,
 		Namespaces: Namespaces{
 			Namespaces: namespacesMap,
 		},
@@ -574,7 +574,7 @@ func (nt *NamespacesTester) ResultForNamespace(id ident.ID) NamespaceResult {
 func (nt *NamespacesTester) TestBootstrapWith(b Bootstrapper) {
 	ctx := context.NewContext()
 	defer ctx.Close()
-	res, err := b.Bootstrap(ctx, nt.Namespaces, nt.State)
+	res, err := b.Bootstrap(ctx, nt.Namespaces, nt.Cache)
 	assert.NoError(nt.t, err)
 	nt.Results = res
 }
@@ -584,7 +584,7 @@ func (nt *NamespacesTester) TestBootstrapWith(b Bootstrapper) {
 func (nt *NamespacesTester) TestReadWith(s Source) {
 	ctx := context.NewContext()
 	defer ctx.Close()
-	res, err := s.Read(ctx, nt.Namespaces, nt.State)
+	res, err := s.Read(ctx, nt.Namespaces, nt.Cache)
 	require.NoError(nt.t, err)
 	nt.Results = res
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR attempts to reduce the number of redundant calls to `fs.ReadInfoFiles` during bootstrapping. In the worst case, we'll make 5 different calls to `fs.ReadInfoFiles` (often times in a loop to get all shards). With this refactor, we'll do this one time and read from a cache for the remainder. `State` is thread through all bootstrapping stages so it's always available.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
