### PR TITLE
[dbnode] Make panic on double close of pooled tags decoder

### DIFF
--- a/src/x/serialize/decoder.go
+++ b/src/x/serialize/decoder.go
@@ -32,6 +32,7 @@ var (
 	errIncorrectHeader               = errors.New("header magic number does not match expected value")
 	errInvalidByteStreamIDDecoding   = errors.New("internal error, invalid byte stream while decoding ID")
 	errInvalidByteStreamUintDecoding = errors.New("internal error, invalid byte stream while decoding uint")
+	errTagsDoubleClose               = errors.New("closing already closed tags decoder")
 )
 
 type decoder struct {
@@ -219,9 +220,13 @@ func (d *decoder) resetForReuse() {
 }
 
 func (d *decoder) Close() {
+	checkedDataBeforeClose := d.checkedData
 	d.resetForReuse()
 	if d.pool == nil {
 		return
+	}
+	if checkedDataBeforeClose == nil {
+		panic(errTagsDoubleClose)
 	}
 	d.pool.Put(d)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Panics immediately on double close of pooled tags decoder. Makes it much easier to diagnose issues where the object is returned to the pool twice, resulting in eventual data race.

**Special notes for your reviewer**:
Possibly there are other approaches to achieve a similar goal, really open to discussion.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE

CC @gediminasgu @arnikola 