### PR TITLE
[dbnode] Enforce single Finalize on pooled objects

### DIFF
--- a/src/x/checked/finalizeable_once.go
+++ b/src/x/checked/finalizeable_once.go
@@ -1,0 +1,15 @@
+package checked
+
+import "go.uber.org/atomic"
+
+type FinalizeableOnce struct {
+	finalized     atomic.Bool
+}
+
+func (c *FinalizeableOnce) Finalized() bool {
+	return c.finalized.Load()
+}
+
+func (c *FinalizeableOnce) SetFinalized(f bool) {
+	c.finalized.Store(f)
+}

--- a/src/x/checked/finalizeable_once.go
+++ b/src/x/checked/finalizeable_once.go
@@ -2,14 +2,17 @@ package checked
 
 import "go.uber.org/atomic"
 
+// FinalizeableOnce implements the logics needed to enforce single Finalize on pool.ObjectPool.
 type FinalizeableOnce struct {
 	finalized     atomic.Bool
 }
 
+// Finalized returns true iff the object has been finalized.
 func (c *FinalizeableOnce) Finalized() bool {
 	return c.finalized.Load()
 }
 
+// SetFinalized sets the flag of object finalize.
 func (c *FinalizeableOnce) SetFinalized(f bool) {
 	c.finalized.Store(f)
 }

--- a/src/x/checked/finalizeable_once.go
+++ b/src/x/checked/finalizeable_once.go
@@ -1,18 +1,53 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package checked
 
-import "go.uber.org/atomic"
+import (
+	"errors"
 
-// FinalizeableOnce implements the logics needed to enforce single Finalize on pool.ObjectPool.
+	"go.uber.org/atomic"
+)
+
+var (
+	errAlreadyFinalized = errors.New("double finalize")
+	errNotFinalized     = errors.New("unfinalizing without prior finalize")
+)
+
+// FinalizeableOnce implements the logics needed to enforce a single finalize on pool.ObjectPool.
 type FinalizeableOnce struct {
-	finalized     atomic.Bool
+	finalized atomic.Bool
 }
 
-// Finalized returns true iff the object has been finalized.
-func (c *FinalizeableOnce) Finalized() bool {
-	return c.finalized.Load()
+// SetFinalized marks the object as finalized and returns an error in case of double finalize.
+func (c *FinalizeableOnce) SetFinalized() error {
+	if oldValue := c.finalized.Swap(true); oldValue == true {
+		return errAlreadyFinalized
+	}
+	return nil
 }
 
-// SetFinalized sets the flag of object finalize.
-func (c *FinalizeableOnce) SetFinalized(f bool) {
-	c.finalized.Store(f)
+// SetUnfinalized marks the object as not finalized and returns an error in case it was not finalize previously.
+func (c *FinalizeableOnce) SetUnfinalized() error {
+	if oldValue := c.finalized.Swap(false); oldValue == false {
+		return errNotFinalized
+	}
+	return nil
 }

--- a/src/x/checked/finalizeable_once_test.go
+++ b/src/x/checked/finalizeable_once_test.go
@@ -1,18 +1,49 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package checked
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestGetSetFinalized(t *testing.T) {
+func TestFinalizeUnfinalizeFinalize(t *testing.T) {
 	obj := RefCount{}
-	assert.False(t, obj.Finalized())
+	require.NoError(t, obj.SetFinalized())
+	require.NoError(t, obj.SetUnfinalized())
+	require.NoError(t, obj.SetFinalized())
+}
 
-	obj.SetFinalized(true)
-	assert.True(t, obj.Finalized())
+func TestDoubleFinalizeError(t *testing.T) {
+	obj := RefCount{}
+	require.NoError(t, obj.SetFinalized())
 
-	obj.SetFinalized(false)
-	assert.False(t, obj.Finalized())
+	err := obj.SetFinalized()
+	assert.Equal(t, errAlreadyFinalized, err)
+}
+
+func TestUnfinalizeNonFinalizedError(t *testing.T) {
+	obj := RefCount{}
+	err := obj.SetUnfinalized()
+	assert.Equal(t, errNotFinalized, err)
 }

--- a/src/x/checked/finalizeable_once_test.go
+++ b/src/x/checked/finalizeable_once_test.go
@@ -1,0 +1,18 @@
+package checked
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSetFinalized(t *testing.T) {
+	obj := RefCount{}
+	assert.False(t, obj.Finalized())
+
+	obj.SetFinalized(true)
+	assert.True(t, obj.Finalized())
+
+	obj.SetFinalized(false)
+	assert.False(t, obj.Finalized())
+}

--- a/src/x/checked/ref.go
+++ b/src/x/checked/ref.go
@@ -33,6 +33,7 @@ import (
 
 // RefCount is an embeddable checked.Ref.
 type RefCount struct {
+	FinalizeableOnce
 	ref           int32
 	reads         int32
 	writes        int32
@@ -102,7 +103,7 @@ func (c *RefCount) finalizeWithLock() {
 // DelayFinalizer will delay calling the finalizer on this entity
 // until the closer returned by the method is called at least once.
 // This is useful for dependent resources requiring the lifetime of this
-// entityt to be extended.
+// entity to be extended.
 func (c *RefCount) DelayFinalizer() resource.Closer {
 	c.finalizeState.Lock()
 	c.finalizeState.delayRef++

--- a/src/x/pool/object.go
+++ b/src/x/pool/object.go
@@ -60,6 +60,7 @@ type objectPoolMetrics struct {
 	putOnFull  tally.Counter
 }
 
+// FinalizeableOnce must be implemented by objects that require enforcement of single finalization (wrt. objectPool).
 type FinalizeableOnce interface {
 	Finalized() bool
 	SetFinalized(f bool)

--- a/src/x/pool/object_test.go
+++ b/src/x/pool/object_test.go
@@ -22,7 +22,6 @@ package pool
 
 import (
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -140,8 +139,8 @@ func TestObjectPoolDoublePutError(t *testing.T) {
 	require.NoError(t, accessErr)
 
 	pool.Put(bytes)
-	assert.Error(t, accessErr)
-	assert.True(t, strings.HasPrefix(accessErr.Error(), "double finalize"))
+	require.Error(t, accessErr)
+	assert.Equal(t, "double finalize: *checked.bytesRef", accessErr.Error())
 }
 
 func BenchmarkObjectPoolGetPut(b *testing.B) {

--- a/src/x/serialize/decoder.go
+++ b/src/x/serialize/decoder.go
@@ -35,6 +35,7 @@ var (
 )
 
 type decoder struct {
+	checked.FinalizeableOnce
 	checkedData checked.Bytes
 	data        []byte
 	nextCalls   int

--- a/src/x/serialize/decoder_test.go
+++ b/src/x/serialize/decoder_test.go
@@ -22,7 +22,6 @@ package serialize
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/m3db/m3/src/x/checked"
@@ -346,7 +345,7 @@ func TestDecodeDuplicateLifecycleMocks(t *testing.T) {
 	dupe.Close()
 }
 
-func TestDecodeDoubleCloseError(t *testing.T) {
+func TestDecoderDoubleCloseError(t *testing.T) {
 	var _ pool.FinalizeableOnce = (*decoder)(nil) // ensure interface compliance
 
 	var accessErr error
@@ -364,7 +363,7 @@ func TestDecodeDoubleCloseError(t *testing.T) {
 
 	d.Close()
 	require.Error(t, accessErr)
-	assert.True(t, strings.HasPrefix(accessErr.Error(), "double finalize"))
+	assert.Equal(t, "double finalize: *serialize.decoder", accessErr.Error())
 }
 
 func newTestTagDecoder() TagDecoder {

--- a/src/x/serialize/encoder.go
+++ b/src/x/serialize/encoder.go
@@ -70,6 +70,8 @@ type newCheckedBytesFn func([]byte, checked.BytesOptions) checked.Bytes
 var defaultNewCheckedBytesFn = checked.NewBytes
 
 type encoder struct {
+	checked.FinalizeableOnce
+
 	buf               *bytes.Buffer
 	checkedBytes      checked.Bytes
 	staticBuffer      [2]byte


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes object pool panic on double `Finalize` of `RefCount`, tags `decoder` (which is not refcounted itself), or any other type that embeds `checked.FinalizeableOnce` struct.


**Special notes for your reviewer**:
A broader alternative to https://github.com/m3db/m3/pull/2603.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE