### PR TITLE
Make WiredList Start/Stop race-free

### DIFF
--- a/src/dbnode/storage/block/wired_list.go
+++ b/src/dbnode/storage/block/wired_list.go
@@ -75,7 +75,7 @@ var (
 
 // WiredList is a database block wired list.
 type WiredList struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	nowFn clock.NowFn
 
@@ -224,6 +224,11 @@ func (l *WiredList) Stop() error {
 //
 // We use a channel and a background processing goroutine to reduce blocking / lock contention.
 func (l *WiredList) BlockingUpdate(v DatabaseBlock) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.updatesCh == nil {
+		return
+	}
 	l.updatesCh <- v
 }
 

--- a/src/dbnode/storage/block/wired_list.go
+++ b/src/dbnode/storage/block/wired_list.go
@@ -226,6 +226,7 @@ func (l *WiredList) Stop() error {
 func (l *WiredList) BlockingUpdate(v DatabaseBlock) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
+
 	if l.updatesCh == nil {
 		return
 	}
@@ -236,6 +237,9 @@ func (l *WiredList) BlockingUpdate(v DatabaseBlock) {
 // if the channel is full. Used in cases where a blocking update could trigger deadlock with
 // the WiredList itself.
 func (l *WiredList) NonBlockingUpdate(v DatabaseBlock) bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
 	select {
 	case l.updatesCh <- v:
 		return true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes race detector failures in TestRoundtrip by making sure the update/doneCh are not mutated unsafely in different goroutines.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
