### PR TITLE
Fail if FetchTagged partially retrieves results due to error

### DIFF
--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -183,6 +183,8 @@ struct FetchTaggedIDResult {
 	2: required binary nameSpace
 	3: required binary encodedTags
 	4: optional list<Segments> segments
+
+	// Deprecated -- do not use.
 	5: optional Error err
 }
 

--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -1879,6 +1879,96 @@ func TestServiceFetchTaggedErrs(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestServiceFetchTaggedReturnOnFirstErr(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := storage.NewMockDatabase(ctrl)
+	mockDB.EXPECT().Options().Return(testStorageOpts).AnyTimes()
+	mockDB.EXPECT().IsOverloaded().Return(false)
+
+	service := NewService(mockDB, testTChannelThriftOptions).(*service)
+
+	tctx, _ := tchannelthrift.NewContext(time.Minute)
+	ctx := tchannelthrift.Context(tctx)
+	defer ctx.Close()
+
+	mtr := mocktracer.New()
+	sp := mtr.StartSpan("root")
+	ctx.SetGoContext(opentracing.ContextWithSpan(gocontext.Background(), sp))
+
+	start := time.Now().Add(-2 * time.Hour)
+	end := start.Add(2 * time.Hour)
+	start, end = start.Truncate(time.Second), end.Truncate(time.Second)
+
+	nsID := "metrics"
+
+	id := "foo"
+	s := []struct {
+		t time.Time
+		v float64
+	}{
+		{start.Add(10 * time.Second), 1.0},
+		{start.Add(20 * time.Second), 2.0},
+	}
+	enc := testStorageOpts.EncoderPool().Get()
+	enc.Reset(start, 0, nil)
+	for _, v := range s {
+		dp := ts.Datapoint{
+			Timestamp: v.t,
+			Value:     v.v,
+		}
+		require.NoError(t, enc.Encode(dp, xtime.Second, nil))
+	}
+
+	stream, _ := enc.Stream(ctx)
+	mockDB.EXPECT().
+		ReadEncoded(gomock.Any(), ident.NewIDMatcher(nsID), ident.NewIDMatcher(id), start, end).
+		Return([][]xio.BlockReader{{
+			xio.BlockReader{
+				SegmentReader: stream,
+			},
+		}}, fmt.Errorf("random err")) // Return error that should trigger failure of the entire call
+
+	req, err := idx.NewRegexpQuery([]byte("foo"), []byte("b.*"))
+	require.NoError(t, err)
+	qry := index.Query{Query: req}
+
+	resMap := index.NewQueryResults(ident.StringID(nsID),
+		index.QueryResultsOptions{}, testIndexOptions)
+	resMap.Map().Set(ident.StringID("foo"), ident.NewTagsIterator(ident.NewTags(
+		ident.StringTag("foo", "bar"),
+		ident.StringTag("baz", "dxk"),
+	)))
+
+	mockDB.EXPECT().QueryIDs(
+		gomock.Any(),
+		ident.NewIDMatcher(nsID),
+		index.NewQueryMatcher(qry),
+		index.QueryOptions{
+			StartInclusive: start,
+			EndExclusive:   end,
+			SeriesLimit:    10,
+		}).Return(index.QueryResult{Results: resMap, Exhaustive: true}, nil)
+
+	startNanos, err := convert.ToValue(start, rpc.TimeType_UNIX_NANOSECONDS)
+	require.NoError(t, err)
+	endNanos, err := convert.ToValue(end, rpc.TimeType_UNIX_NANOSECONDS)
+	require.NoError(t, err)
+	var limit int64 = 10
+	data, err := idx.Marshal(req)
+	require.NoError(t, err)
+	_, err = service.FetchTagged(tctx, &rpc.FetchTaggedRequest{
+		NameSpace:  []byte(nsID),
+		Query:      data,
+		RangeStart: startNanos,
+		RangeEnd:   endNanos,
+		FetchData:  true,
+		Limit:      &limit,
+	})
+	require.Error(t, err)
+}
+
 func TestServiceAggregate(t *testing.T) {
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Currently, if the `FetchTagged` endpoint fails while retrieving some subset of the desired data, the error is not propagated to the top-level RPC call. This means that dashboards will only show a subset of resulting metrics to users. Additionally, there's no indication given to the caller that this has happened unless the results are egregiously wrong. This PR bubbles failures up to the top-level and returns it instead of treating the RPC call as successful.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
