### PR TITLE
[dbnode] Finalize seg and only close encoder once

### DIFF
--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -602,6 +602,7 @@ func (b *dbBuffer) Snapshot(
 		}
 
 		segment = encoder.Discard()
+		defer segment.Finalize()
 	}
 
 	afterMergeAcrossBuckets := b.nowFn()

--- a/src/dbnode/storage/series/buffer.go
+++ b/src/dbnode/storage/series/buffer.go
@@ -586,7 +586,8 @@ func (b *dbBuffer) Snapshot(
 		encoder.Reset(blockStart, bopts.DatabaseBlockAllocSize(), nsCtx.Schema)
 		iter := b.opts.MultiReaderIteratorPool().Get()
 		defer func() {
-			encoder.Close()
+			// NB(bodu): encoder.Discard() closes the encoder so we don't need to close
+			// it here.
 			iter.Close()
 		}()
 		iter.Reset(sr, blockStart, b.opts.RetentionOptions().BlockSize(), nsCtx.Schema)


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Finalizes segment after taking ownership and only close encoder once (`encoder.Discard()` also closes the encoder).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
