### PR TITLE
[dbnode] Add graphite tag pooling optimization for peer streaming 

### DIFF
--- a/src/query/graphite/graphite/tags.go
+++ b/src/query/graphite/graphite/tags.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/unsafe"
 )
 
@@ -49,6 +50,8 @@ const (
 var (
 	// Should never be modified after init().
 	preFormattedTagNames [][]byte
+	// Should never be modified after init().
+	preFormattedTagNameIDs []ident.ID
 
 	// Prefix is the prefix for graphite metrics
 	Prefix = []byte("__g")
@@ -61,6 +64,7 @@ func init() {
 	for i := 0; i < numPreFormattedTagNames; i++ {
 		name := generateTagName(i)
 		preFormattedTagNames = append(preFormattedTagNames, name)
+		preFormattedTagNameIDs = append(preFormattedTagNameIDs, ident.BytesID(name))
 	}
 }
 
@@ -72,6 +76,16 @@ func TagName(idx int) []byte {
 	}
 
 	return []byte(fmt.Sprintf(graphiteFormat, idx))
+}
+
+// TagNameID gets a preallocated or generate a tag name ID for the given graphite
+// path index.
+func TagNameID(idx int) ident.ID {
+	if idx < len(preFormattedTagNameIDs) {
+		return preFormattedTagNameIDs[idx]
+	}
+
+	return ident.StringID(fmt.Sprintf(graphiteFormat, idx))
 }
 
 func generateTagName(idx int) []byte {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This optimizes converting tags from streamed from peer to use the static pre-allocated Graphite tags they are Graphite tag names. This allows for better use of memory, since the other optimization of using the bytes backed by the ID cannot be done here since Graphite IDs don't contain the Graphite tag names representing each dimension.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
