### PR TITLE
[query] Expose Graphite Compile method.

### DIFF
--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -151,7 +151,7 @@ func (e mockEngine) FetchByQuery(
 }
 
 func TestVariadicSumSeries(t *testing.T) {
-	expr, err := compile("sumSeries(foo.bar.*, foo.baz.*)")
+	expr, err := Compile("sumSeries(foo.bar.*, foo.baz.*)")
 	require.NoError(t, err)
 	ctx := common.NewTestContext()
 	ctx.Engine = mockEngine{fn: func(
@@ -485,7 +485,7 @@ func TestGroupByNodes(t *testing.T) {
 
 	tests := []struct {
 		fname           string
-		nodes            []int
+		nodes           []int
 		expectedResults []result
 	}{
 		{"avg", []int{2, 4}, []result{ // test normal group by nodes
@@ -507,7 +507,7 @@ func TestGroupByNodes(t *testing.T) {
 			{"pod2.500", 8 * 12},
 		}},
 		{"sum", []int{}, []result{ // test empty slice handing.
-			{"*", (2 + 4 + 6 + 8 + 10 + 20 + 30 + 40)  * 12},
+			{"*", (2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},
 		}},
 	}
 

--- a/src/query/graphite/native/compiler.go
+++ b/src/query/graphite/native/compiler.go
@@ -30,8 +30,8 @@ import (
 	"github.com/m3db/m3/src/query/graphite/lexer"
 )
 
-// compile converts an input stream into the corresponding Expression
-func compile(input string) (Expression, error) {
+// Compile converts an input stream into the corresponding Expression.
+func Compile(input string) (Expression, error) {
 	booleanLiterals := map[string]lexer.TokenType{
 		"true":  lexer.True,
 		"false": lexer.False,
@@ -322,7 +322,7 @@ func (c *compiler) errorf(msg string, args ...interface{}) error {
 
 // ExtractFetchExpressions extracts timeseries fetch expressions from the given query
 func ExtractFetchExpressions(s string) ([]string, error) {
-	expr, err := compile(s)
+	expr, err := Compile(s)
 	if err != nil {
 		return nil, err
 	}

--- a/src/query/graphite/native/compiler_test.go
+++ b/src/query/graphite/native/compiler_test.go
@@ -381,7 +381,7 @@ func TestCompileErrors(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		expr, err := compile(test.input)
+		expr, err := Compile(test.input)
 		require.NotNil(t, err, "no error for %s", test.input)
 		assert.Equal(t, test.err, err.Error(), "wrong error for %s", test.input)
 		assert.Nil(t, expr, "non-nil expression for %s", test.input)

--- a/src/query/graphite/native/compiler_test.go
+++ b/src/query/graphite/native/compiler_test.go
@@ -276,7 +276,7 @@ func TestCompile1(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		expr, err := compile(test.input)
+		expr, err := Compile(test.input)
 		require.Nil(t, err, "error compiling: expression='%s', error='%v'", test.input, err)
 		require.NotNil(t, expr)
 		assertExprTree(t, test.result, expr, fmt.Sprintf("invalid result for %s: %v vs %v",

--- a/src/query/graphite/native/engine.go
+++ b/src/query/graphite/native/engine.go
@@ -50,5 +50,5 @@ func (e *Engine) FetchByQuery(
 
 // Compile compiles an expression from an expression string
 func (e *Engine) Compile(s string) (Expression, error) {
-	return compile(s)
+	return Compile(s)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes graphite's compile method to make it easier to check for function validity.