### PR TITLE
[m3admin] Allow /set for new placements

### DIFF
--- a/src/query/api/v1/handler/placement/set.go
+++ b/src/query/api/v1/handler/placement/set.go
@@ -60,7 +60,9 @@ var (
 		M3CoordinatorServicePlacementPathName, setPathName)
 )
 
-// SetHandler is the type for placement replaces.
+// SetHandler is the type for manually setting a placement value. If none
+// currently exists, this will set the initial placement. Otherwise it will
+// override the existing placement.
 type SetHandler Handler
 
 // NewSetHandler returns a new SetHandler.

--- a/src/query/api/v1/handler/placement/set_test.go
+++ b/src/query/api/v1/handler/placement/set_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/cluster/generated/proto/placementpb"
+	"github.com/m3db/m3/src/cluster/kv"
 	"github.com/m3db/m3/src/cluster/placement"
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
@@ -43,7 +44,7 @@ import (
 var (
 	setExistingTestPlacementProto = &placementpb.Placement{
 		Instances: map[string]*placementpb.Instance{
-			"host1": &placementpb.Instance{
+			"host1": {
 				Id:             "host1",
 				IsolationGroup: "rack1",
 				Zone:           "test",
@@ -56,7 +57,7 @@ var (
 	}
 	setNewTestPlacementProto = &placementpb.Placement{
 		Instances: map[string]*placementpb.Instance{
-			"host1": &placementpb.Instance{
+			"host1": {
 				Id:             "host1",
 				IsolationGroup: "rack1",
 				Zone:           "test",
@@ -65,7 +66,7 @@ var (
 				Hostname:       "host1",
 				Port:           1234,
 			},
-			"host2": &placementpb.Instance{
+			"host2": {
 				Id:             "host2",
 				IsolationGroup: "rack1",
 				Zone:           "test",
@@ -149,5 +150,72 @@ func TestPlacementSetHandler(t *testing.T) {
 		actual := xtest.MustPrettyJSONString(t, body)
 
 		assert.Equal(t, expected, actual, xtest.Diff(expected, actual))
+	})
+}
+
+func TestPlacementSetHandler_NewPlacement(t *testing.T) {
+	runForAllAllowedServices(func(serviceName string) {
+		var url string
+		switch serviceName {
+		case handleroptions.M3DBServiceName:
+			url = M3DBSetURL
+		case handleroptions.M3AggregatorServiceName:
+			url = M3AggSetURL
+		case handleroptions.M3CoordinatorServiceName:
+			url = M3CoordinatorSetURL
+		default:
+			require.FailNow(t, "unexpected service name")
+		}
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockClient, mockPlacementService := SetupPlacementTest(t, ctrl)
+		handlerOpts, err := NewHandlerOptions(
+			mockClient, config.Configuration{}, nil, instrument.NewOptions())
+		require.NoError(t, err)
+		handler := NewSetHandler(handlerOpts)
+
+		// Test placement init success
+		reqBody, err := (&jsonpb.Marshaler{}).MarshalToString(setTestPlacementReqProto)
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(SetHTTPMethod, url, strings.NewReader(reqBody))
+		require.NotNil(t, req)
+
+		mockPlacementService.EXPECT().
+			Placement().
+			Return(nil, kv.ErrNotFound)
+
+		newPlacement, err := placement.NewPlacementFromProto(setNewTestPlacementProto)
+		require.NoError(t, err)
+
+		mockPlacementService.EXPECT().
+			SetIfNotExist(gomock.Any()).
+			Return(newPlacement, nil)
+
+		svcDefaults := handleroptions.ServiceNameAndDefaults{
+			ServiceName: serviceName,
+		}
+
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(svcDefaults, w, req)
+		resp := w.Result()
+		body := w.Body.String()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		expectedBody, err := (&jsonpb.Marshaler{
+			EmitDefaults: true,
+		}).MarshalToString(&admin.PlacementSetResponse{
+			Placement: setNewTestPlacementProto,
+			DryRun:    !setTestPlacementReqProto.Confirm,
+		})
+		require.NoError(t, err)
+
+		expected := xtest.MustPrettyJSONString(t, expectedBody)
+		actual := xtest.MustPrettyJSONString(t, body)
+
+		assert.Equal(t, expected, actual, xtest.Diff(expected, actual))
+		assert.Equal(t, 0, newPlacement.Version())
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:

Previously `/set` required that a placement already exists in order to
set it. This hinders operations such as preemptively creating a
placement or replacing one that had been deleted via safe APIs.

This PR allows using `/set` even if a placement didn't previously exist
at that key.

<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Placement `/set` now works if a placement previously did not exist.
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
