### PR TITLE
[dbnode] RPC plumbing for index checksum queries

### DIFF
--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -579,6 +579,10 @@ func IsSeedNode(initialCluster []environment.SeedNode, hostID string) bool {
 
 // TChannelConfiguration holds TChannel config options.
 type TChannelConfiguration struct {
-	MaxIdleTime       time.Duration `yaml:"maxIdleTime"`
+	// MaxIdleTime is the maximum idle time.
+	MaxIdleTime time.Duration `yaml:"maxIdleTime"`
+	// IdleCheckInterval is the idle check interval.
 	IdleCheckInterval time.Duration `yaml:"idleCheckInterval"`
+	// BatchSize represents batch size for wide operations.
+	BatchSize int `yaml:"batchSize"`
 }

--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -43,44 +43,45 @@ exception WriteBatchRawErrors {
 
 service Node {
 	// Friendly not highly performant read/write endpoints
-	QueryResult query(1: QueryRequest req) throws (1: Error err)
+	QueryResult          query(1: QueryRequest req) throws (1: Error err)
 	AggregateQueryResult aggregate(1: AggregateQueryRequest req) throws (1: Error err)
-	FetchResult fetch(1: FetchRequest req) throws (1: Error err)
-	void write(1: WriteRequest req) throws (1: Error err)
-	void writeTagged(1: WriteTaggedRequest req) throws (1: Error err)
+	FetchResult          fetch(1: FetchRequest req) throws (1: Error err)
+	void                 write(1: WriteRequest req) throws (1: Error err)
+	void                 writeTagged(1: WriteTaggedRequest req) throws (1: Error err)
 
 	// Performant read/write endpoints
-	FetchBatchRawResult fetchBatchRaw(1: FetchBatchRawRequest req) throws (1: Error err)
-	FetchBatchRawResult fetchBatchRawV2(1: FetchBatchRawV2Request req) throws (1: Error err)
-	FetchBlocksRawResult fetchBlocksRaw(1: FetchBlocksRawRequest req) throws (1: Error err)
-	FetchTaggedResult fetchTagged(1: FetchTaggedRequest req) throws (1: Error err)
-	AggregateQueryRawResult aggregateRaw(1: AggregateQueryRawRequest req) throws (1: Error err)
+	AggregateQueryRawResult        aggregateRaw(1: AggregateQueryRawRequest req) throws (1: Error err)
+	FetchBatchRawResult            fetchBatchRaw(1: FetchBatchRawRequest req) throws (1: Error err)
+	FetchBatchRawResult            fetchBatchRawV2(1: FetchBatchRawV2Request req) throws (1: Error err)
+	FetchBlocksRawResult           fetchBlocksRaw(1: FetchBlocksRawRequest req) throws (1: Error err)
+	FetchTaggedResult              fetchTagged(1: FetchTaggedRequest req) throws (1: Error err)
 	FetchBlocksMetadataRawV2Result fetchBlocksMetadataRawV2(1: FetchBlocksMetadataRawV2Request req) throws (1: Error err)
-	void writeBatchRaw(1: WriteBatchRawRequest req) throws (1: WriteBatchRawErrors err)
-	void writeBatchRawV2(1: WriteBatchRawV2Request req) throws (1: WriteBatchRawErrors err)
-	void writeTaggedBatchRaw(1: WriteTaggedBatchRawRequest req) throws (1: WriteBatchRawErrors err)
-	void writeTaggedBatchRawV2(1: WriteTaggedBatchRawV2Request req) throws (1: WriteBatchRawErrors err)
-	void repair() throws (1: Error err)
-	TruncateResult truncate(1: TruncateRequest req) throws (1: Error err)
+	IndexChecksumResult            indexChecksum(1: IndexChecksumRequest req) throws (1: Error err)
+	void                           writeBatchRaw(1: WriteBatchRawRequest req) throws (1: WriteBatchRawErrors err)
+	void                           writeBatchRawV2(1: WriteBatchRawV2Request req) throws (1: WriteBatchRawErrors err)
+	void                           writeTaggedBatchRaw(1: WriteTaggedBatchRawRequest req) throws (1: WriteBatchRawErrors err)
+	void                           writeTaggedBatchRawV2(1: WriteTaggedBatchRawV2Request req) throws (1: WriteBatchRawErrors err)
+	void                           repair() throws (1: Error err)
+	TruncateResult                 truncate(1: TruncateRequest req) throws (1: Error err)
 
 	// Management endpoints
-	NodeHealthResult health() throws (1: Error err)
+	NodeHealthResult                               health() throws (1: Error err)
 	// NB: bootstrapped is for use with cluster management tools like k8s.
-	NodeBootstrappedResult bootstrapped() throws (1: Error err)
+	NodeBootstrappedResult                         bootstrapped() throws (1: Error err)
 	// NB: bootstrappedInPlacementOrNoPlacement is for use with cluster management tools like k8s.
 	NodeBootstrappedInPlacementOrNoPlacementResult bootstrappedInPlacementOrNoPlacement() throws (1: Error err)
-	NodePersistRateLimitResult getPersistRateLimit() throws (1: Error err)
-	NodePersistRateLimitResult setPersistRateLimit(1: NodeSetPersistRateLimitRequest req) throws (1: Error err)
-	NodeWriteNewSeriesAsyncResult getWriteNewSeriesAsync() throws (1: Error err)
-	NodeWriteNewSeriesAsyncResult setWriteNewSeriesAsync(1: NodeSetWriteNewSeriesAsyncRequest req) throws (1: Error err)
-	NodeWriteNewSeriesBackoffDurationResult getWriteNewSeriesBackoffDuration() throws (1: Error err)
-	NodeWriteNewSeriesBackoffDurationResult setWriteNewSeriesBackoffDuration(1: NodeSetWriteNewSeriesBackoffDurationRequest req) throws (1: Error err)
+	NodePersistRateLimitResult                     getPersistRateLimit() throws (1: Error err)
+	NodePersistRateLimitResult                     setPersistRateLimit(1: NodeSetPersistRateLimitRequest req) throws (1: Error err)
+	NodeWriteNewSeriesAsyncResult                  getWriteNewSeriesAsync() throws (1: Error err)
+	NodeWriteNewSeriesAsyncResult                  setWriteNewSeriesAsync(1: NodeSetWriteNewSeriesAsyncRequest req) throws (1: Error err)
+	NodeWriteNewSeriesBackoffDurationResult        getWriteNewSeriesBackoffDuration() throws (1: Error err)
+	NodeWriteNewSeriesBackoffDurationResult        setWriteNewSeriesBackoffDuration(1: NodeSetWriteNewSeriesBackoffDurationRequest req) throws (1: Error err)
 	NodeWriteNewSeriesLimitPerShardPerSecondResult getWriteNewSeriesLimitPerShardPerSecond() throws (1: Error err)
 	NodeWriteNewSeriesLimitPerShardPerSecondResult setWriteNewSeriesLimitPerShardPerSecond(1: NodeSetWriteNewSeriesLimitPerShardPerSecondRequest req) throws (1: Error err)
 
 	// Debug endpoints
-	DebugProfileStartResult debugProfileStart(1: DebugProfileStartRequest req) throws (1: Error err)
-	DebugProfileStopResult debugProfileStop(1: DebugProfileStopRequest req) throws (1: Error err)
+	DebugProfileStartResult        debugProfileStart(1: DebugProfileStartRequest req) throws (1: Error err)
+	DebugProfileStopResult         debugProfileStop(1: DebugProfileStopRequest req) throws (1: Error err)
 	DebugIndexMemorySegmentsResult debugIndexMemorySegments(1: DebugIndexMemorySegmentsRequest req) throws (1: Error err)
 }
 
@@ -429,6 +430,18 @@ struct AggregateQueryResultTagNameElement {
 
 struct AggregateQueryResultTagValueElement {
 	1: required string tagValue
+}
+
+struct IndexChecksumRequest {
+	1: required binary nameSpace
+	2: required binary query
+	3: required i64    blockStart
+	4: optional i64    batchSize
+}
+
+struct IndexChecksumResult {
+	1: optional list<i64> checksums
+	2: optional binary    marker
 }
 
 // Query wrapper types for simple non-optimized query use

--- a/src/dbnode/generated/thrift/rpc/rpc.go
+++ b/src/dbnode/generated/thrift/rpc/rpc.go
@@ -10971,6 +10971,396 @@ func (p *AggregateQueryResultTagValueElement) String() string {
 }
 
 // Attributes:
+//  - NameSpace
+//  - Query
+//  - BlockStart
+//  - BatchSize
+type IndexChecksumRequest struct {
+	NameSpace  []byte `thrift:"nameSpace,1,required" db:"nameSpace" json:"nameSpace"`
+	Query      []byte `thrift:"query,2,required" db:"query" json:"query"`
+	BlockStart int64  `thrift:"blockStart,3,required" db:"blockStart" json:"blockStart"`
+	BatchSize  *int64 `thrift:"batchSize,4" db:"batchSize" json:"batchSize,omitempty"`
+}
+
+func NewIndexChecksumRequest() *IndexChecksumRequest {
+	return &IndexChecksumRequest{}
+}
+
+func (p *IndexChecksumRequest) GetNameSpace() []byte {
+	return p.NameSpace
+}
+
+func (p *IndexChecksumRequest) GetQuery() []byte {
+	return p.Query
+}
+
+func (p *IndexChecksumRequest) GetBlockStart() int64 {
+	return p.BlockStart
+}
+
+var IndexChecksumRequest_BatchSize_DEFAULT int64
+
+func (p *IndexChecksumRequest) GetBatchSize() int64 {
+	if !p.IsSetBatchSize() {
+		return IndexChecksumRequest_BatchSize_DEFAULT
+	}
+	return *p.BatchSize
+}
+func (p *IndexChecksumRequest) IsSetBatchSize() bool {
+	return p.BatchSize != nil
+}
+
+func (p *IndexChecksumRequest) Read(iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	var issetNameSpace bool = false
+	var issetQuery bool = false
+	var issetBlockStart bool = false
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if err := p.ReadField1(iprot); err != nil {
+				return err
+			}
+			issetNameSpace = true
+		case 2:
+			if err := p.ReadField2(iprot); err != nil {
+				return err
+			}
+			issetQuery = true
+		case 3:
+			if err := p.ReadField3(iprot); err != nil {
+				return err
+			}
+			issetBlockStart = true
+		case 4:
+			if err := p.ReadField4(iprot); err != nil {
+				return err
+			}
+		default:
+			if err := iprot.Skip(fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	if !issetNameSpace {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field NameSpace is not set"))
+	}
+	if !issetQuery {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field Query is not set"))
+	}
+	if !issetBlockStart {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field BlockStart is not set"))
+	}
+	return nil
+}
+
+func (p *IndexChecksumRequest) ReadField1(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBinary(); err != nil {
+		return thrift.PrependError("error reading field 1: ", err)
+	} else {
+		p.NameSpace = v
+	}
+	return nil
+}
+
+func (p *IndexChecksumRequest) ReadField2(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBinary(); err != nil {
+		return thrift.PrependError("error reading field 2: ", err)
+	} else {
+		p.Query = v
+	}
+	return nil
+}
+
+func (p *IndexChecksumRequest) ReadField3(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI64(); err != nil {
+		return thrift.PrependError("error reading field 3: ", err)
+	} else {
+		p.BlockStart = v
+	}
+	return nil
+}
+
+func (p *IndexChecksumRequest) ReadField4(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI64(); err != nil {
+		return thrift.PrependError("error reading field 4: ", err)
+	} else {
+		p.BatchSize = &v
+	}
+	return nil
+}
+
+func (p *IndexChecksumRequest) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("IndexChecksumRequest"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField2(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField3(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField4(oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *IndexChecksumRequest) writeField1(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("nameSpace", thrift.STRING, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:nameSpace: ", p), err)
+	}
+	if err := oprot.WriteBinary(p.NameSpace); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.nameSpace (1) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:nameSpace: ", p), err)
+	}
+	return err
+}
+
+func (p *IndexChecksumRequest) writeField2(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("query", thrift.STRING, 2); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:query: ", p), err)
+	}
+	if err := oprot.WriteBinary(p.Query); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.query (2) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:query: ", p), err)
+	}
+	return err
+}
+
+func (p *IndexChecksumRequest) writeField3(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("blockStart", thrift.I64, 3); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:blockStart: ", p), err)
+	}
+	if err := oprot.WriteI64(int64(p.BlockStart)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.blockStart (3) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:blockStart: ", p), err)
+	}
+	return err
+}
+
+func (p *IndexChecksumRequest) writeField4(oprot thrift.TProtocol) (err error) {
+	if p.IsSetBatchSize() {
+		if err := oprot.WriteFieldBegin("batchSize", thrift.I64, 4); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:batchSize: ", p), err)
+		}
+		if err := oprot.WriteI64(int64(*p.BatchSize)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.batchSize (4) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 4:batchSize: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *IndexChecksumRequest) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("IndexChecksumRequest(%+v)", *p)
+}
+
+// Attributes:
+//  - Checksums
+//  - Marker
+type IndexChecksumResult_ struct {
+	Checksums []int64 `thrift:"checksums,1" db:"checksums" json:"checksums,omitempty"`
+	Marker    []byte  `thrift:"marker,2" db:"marker" json:"marker,omitempty"`
+}
+
+func NewIndexChecksumResult_() *IndexChecksumResult_ {
+	return &IndexChecksumResult_{}
+}
+
+var IndexChecksumResult__Checksums_DEFAULT []int64
+
+func (p *IndexChecksumResult_) GetChecksums() []int64 {
+	return p.Checksums
+}
+
+var IndexChecksumResult__Marker_DEFAULT []byte
+
+func (p *IndexChecksumResult_) GetMarker() []byte {
+	return p.Marker
+}
+func (p *IndexChecksumResult_) IsSetChecksums() bool {
+	return p.Checksums != nil
+}
+
+func (p *IndexChecksumResult_) IsSetMarker() bool {
+	return p.Marker != nil
+}
+
+func (p *IndexChecksumResult_) Read(iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if err := p.ReadField1(iprot); err != nil {
+				return err
+			}
+		case 2:
+			if err := p.ReadField2(iprot); err != nil {
+				return err
+			}
+		default:
+			if err := iprot.Skip(fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *IndexChecksumResult_) ReadField1(iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin()
+	if err != nil {
+		return thrift.PrependError("error reading list begin: ", err)
+	}
+	tSlice := make([]int64, 0, size)
+	p.Checksums = tSlice
+	for i := 0; i < size; i++ {
+		var _elem30 int64
+		if v, err := iprot.ReadI64(); err != nil {
+			return thrift.PrependError("error reading field 0: ", err)
+		} else {
+			_elem30 = v
+		}
+		p.Checksums = append(p.Checksums, _elem30)
+	}
+	if err := iprot.ReadListEnd(); err != nil {
+		return thrift.PrependError("error reading list end: ", err)
+	}
+	return nil
+}
+
+func (p *IndexChecksumResult_) ReadField2(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBinary(); err != nil {
+		return thrift.PrependError("error reading field 2: ", err)
+	} else {
+		p.Marker = v
+	}
+	return nil
+}
+
+func (p *IndexChecksumResult_) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("IndexChecksumResult"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField2(oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *IndexChecksumResult_) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetChecksums() {
+		if err := oprot.WriteFieldBegin("checksums", thrift.LIST, 1); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:checksums: ", p), err)
+		}
+		if err := oprot.WriteListBegin(thrift.I64, len(p.Checksums)); err != nil {
+			return thrift.PrependError("error writing list begin: ", err)
+		}
+		for _, v := range p.Checksums {
+			if err := oprot.WriteI64(int64(v)); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+			}
+		}
+		if err := oprot.WriteListEnd(); err != nil {
+			return thrift.PrependError("error writing list end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 1:checksums: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *IndexChecksumResult_) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetMarker() {
+		if err := oprot.WriteFieldBegin("marker", thrift.STRING, 2); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:marker: ", p), err)
+		}
+		if err := oprot.WriteBinary(p.Marker); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.marker (2) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 2:marker: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *IndexChecksumResult_) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("IndexChecksumResult_(%+v)", *p)
+}
+
+// Attributes:
 //  - Query
 //  - RangeStart
 //  - RangeEnd
@@ -11456,11 +11846,11 @@ func (p *QueryResult_) ReadField1(iprot thrift.TProtocol) error {
 	tSlice := make([]*QueryResultElement, 0, size)
 	p.Results = tSlice
 	for i := 0; i < size; i++ {
-		_elem30 := &QueryResultElement{}
-		if err := _elem30.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem30), err)
+		_elem31 := &QueryResultElement{}
+		if err := _elem31.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem31), err)
 		}
-		p.Results = append(p.Results, _elem30)
+		p.Results = append(p.Results, _elem31)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -11638,11 +12028,11 @@ func (p *QueryResultElement) ReadField2(iprot thrift.TProtocol) error {
 	tSlice := make([]*Tag, 0, size)
 	p.Tags = tSlice
 	for i := 0; i < size; i++ {
-		_elem31 := &Tag{}
-		if err := _elem31.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem31), err)
+		_elem32 := &Tag{}
+		if err := _elem32.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem32), err)
 		}
-		p.Tags = append(p.Tags, _elem31)
+		p.Tags = append(p.Tags, _elem32)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -11658,13 +12048,13 @@ func (p *QueryResultElement) ReadField3(iprot thrift.TProtocol) error {
 	tSlice := make([]*Datapoint, 0, size)
 	p.Datapoints = tSlice
 	for i := 0; i < size; i++ {
-		_elem32 := &Datapoint{
+		_elem33 := &Datapoint{
 			TimestampTimeType: 0,
 		}
-		if err := _elem32.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem32), err)
+		if err := _elem33.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem33), err)
 		}
-		p.Datapoints = append(p.Datapoints, _elem32)
+		p.Datapoints = append(p.Datapoints, _elem33)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -12203,11 +12593,11 @@ func (p *ConjunctionQuery) ReadField1(iprot thrift.TProtocol) error {
 	tSlice := make([]*Query, 0, size)
 	p.Queries = tSlice
 	for i := 0; i < size; i++ {
-		_elem33 := &Query{}
-		if err := _elem33.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem33), err)
+		_elem34 := &Query{}
+		if err := _elem34.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem34), err)
 		}
-		p.Queries = append(p.Queries, _elem33)
+		p.Queries = append(p.Queries, _elem34)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -12321,11 +12711,11 @@ func (p *DisjunctionQuery) ReadField1(iprot thrift.TProtocol) error {
 	tSlice := make([]*Query, 0, size)
 	p.Queries = tSlice
 	for i := 0; i < size; i++ {
-		_elem34 := &Query{}
-		if err := _elem34.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem34), err)
+		_elem35 := &Query{}
+		if err := _elem35.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", _elem35), err)
 		}
-		p.Queries = append(p.Queries, _elem34)
+		p.Queries = append(p.Queries, _elem35)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -13702,6 +14092,9 @@ type Node interface {
 	WriteTagged(req *WriteTaggedRequest) (err error)
 	// Parameters:
 	//  - Req
+	AggregateRaw(req *AggregateQueryRawRequest) (r *AggregateQueryRawResult_, err error)
+	// Parameters:
+	//  - Req
 	FetchBatchRaw(req *FetchBatchRawRequest) (r *FetchBatchRawResult_, err error)
 	// Parameters:
 	//  - Req
@@ -13714,10 +14107,10 @@ type Node interface {
 	FetchTagged(req *FetchTaggedRequest) (r *FetchTaggedResult_, err error)
 	// Parameters:
 	//  - Req
-	AggregateRaw(req *AggregateQueryRawRequest) (r *AggregateQueryRawResult_, err error)
+	FetchBlocksMetadataRawV2(req *FetchBlocksMetadataRawV2Request) (r *FetchBlocksMetadataRawV2Result_, err error)
 	// Parameters:
 	//  - Req
-	FetchBlocksMetadataRawV2(req *FetchBlocksMetadataRawV2Request) (r *FetchBlocksMetadataRawV2Result_, err error)
+	IndexChecksum(req *IndexChecksumRequest) (r *IndexChecksumResult_, err error)
 	// Parameters:
 	//  - Req
 	WriteBatchRaw(req *WriteBatchRawRequest) (err error)
@@ -13840,16 +14233,16 @@ func (p *NodeClient) recvQuery() (value *QueryResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error35 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error36 error
-		error36, err = error35.Read(iprot)
+		error36 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error37 error
+		error37, err = error36.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error36
+		err = error37
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -13921,16 +14314,16 @@ func (p *NodeClient) recvAggregate() (value *AggregateQueryResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error37 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error38 error
-		error38, err = error37.Read(iprot)
+		error38 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error39 error
+		error39, err = error38.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error38
+		err = error39
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14002,16 +14395,16 @@ func (p *NodeClient) recvFetch() (value *FetchResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error39 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error40 error
-		error40, err = error39.Read(iprot)
+		error40 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error41 error
+		error41, err = error40.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error40
+		err = error41
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14083,16 +14476,16 @@ func (p *NodeClient) recvWrite() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error41 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error42 error
-		error42, err = error41.Read(iprot)
+		error42 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error43 error
+		error43, err = error42.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error42
+		err = error43
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14163,16 +14556,16 @@ func (p *NodeClient) recvWriteTagged() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error43 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error44 error
-		error44, err = error43.Read(iprot)
+		error44 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error45 error
+		error45, err = error44.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error44
+		err = error45
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14190,6 +14583,87 @@ func (p *NodeClient) recvWriteTagged() (err error) {
 		err = result.Err
 		return
 	}
+	return
+}
+
+// Parameters:
+//  - Req
+func (p *NodeClient) AggregateRaw(req *AggregateQueryRawRequest) (r *AggregateQueryRawResult_, err error) {
+	if err = p.sendAggregateRaw(req); err != nil {
+		return
+	}
+	return p.recvAggregateRaw()
+}
+
+func (p *NodeClient) sendAggregateRaw(req *AggregateQueryRawRequest) (err error) {
+	oprot := p.OutputProtocol
+	if oprot == nil {
+		oprot = p.ProtocolFactory.GetProtocol(p.Transport)
+		p.OutputProtocol = oprot
+	}
+	p.SeqId++
+	if err = oprot.WriteMessageBegin("aggregateRaw", thrift.CALL, p.SeqId); err != nil {
+		return
+	}
+	args := NodeAggregateRawArgs{
+		Req: req,
+	}
+	if err = args.Write(oprot); err != nil {
+		return
+	}
+	if err = oprot.WriteMessageEnd(); err != nil {
+		return
+	}
+	return oprot.Flush()
+}
+
+func (p *NodeClient) recvAggregateRaw() (value *AggregateQueryRawResult_, err error) {
+	iprot := p.InputProtocol
+	if iprot == nil {
+		iprot = p.ProtocolFactory.GetProtocol(p.Transport)
+		p.InputProtocol = iprot
+	}
+	method, mTypeId, seqId, err := iprot.ReadMessageBegin()
+	if err != nil {
+		return
+	}
+	if method != "aggregateRaw" {
+		err = thrift.NewTApplicationException(thrift.WRONG_METHOD_NAME, "aggregateRaw failed: wrong method name")
+		return
+	}
+	if p.SeqId != seqId {
+		err = thrift.NewTApplicationException(thrift.BAD_SEQUENCE_ID, "aggregateRaw failed: out of sequence response")
+		return
+	}
+	if mTypeId == thrift.EXCEPTION {
+		error46 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error47 error
+		error47, err = error46.Read(iprot)
+		if err != nil {
+			return
+		}
+		if err = iprot.ReadMessageEnd(); err != nil {
+			return
+		}
+		err = error47
+		return
+	}
+	if mTypeId != thrift.REPLY {
+		err = thrift.NewTApplicationException(thrift.INVALID_MESSAGE_TYPE_EXCEPTION, "aggregateRaw failed: invalid message type")
+		return
+	}
+	result := NodeAggregateRawResult{}
+	if err = result.Read(iprot); err != nil {
+		return
+	}
+	if err = iprot.ReadMessageEnd(); err != nil {
+		return
+	}
+	if result.Err != nil {
+		err = result.Err
+		return
+	}
+	value = result.GetSuccess()
 	return
 }
 
@@ -14243,16 +14717,16 @@ func (p *NodeClient) recvFetchBatchRaw() (value *FetchBatchRawResult_, err error
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error45 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error46 error
-		error46, err = error45.Read(iprot)
+		error48 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error49 error
+		error49, err = error48.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error46
+		err = error49
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14324,16 +14798,16 @@ func (p *NodeClient) recvFetchBatchRawV2() (value *FetchBatchRawResult_, err err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error47 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error48 error
-		error48, err = error47.Read(iprot)
+		error50 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error51 error
+		error51, err = error50.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error48
+		err = error51
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14405,16 +14879,16 @@ func (p *NodeClient) recvFetchBlocksRaw() (value *FetchBlocksRawResult_, err err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error49 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error50 error
-		error50, err = error49.Read(iprot)
+		error52 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error53 error
+		error53, err = error52.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error50
+		err = error53
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14486,16 +14960,16 @@ func (p *NodeClient) recvFetchTagged() (value *FetchTaggedResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error51 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error52 error
-		error52, err = error51.Read(iprot)
+		error54 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error55 error
+		error55, err = error54.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error52
+		err = error55
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14503,87 +14977,6 @@ func (p *NodeClient) recvFetchTagged() (value *FetchTaggedResult_, err error) {
 		return
 	}
 	result := NodeFetchTaggedResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
-		return
-	}
-	if result.Err != nil {
-		err = result.Err
-		return
-	}
-	value = result.GetSuccess()
-	return
-}
-
-// Parameters:
-//  - Req
-func (p *NodeClient) AggregateRaw(req *AggregateQueryRawRequest) (r *AggregateQueryRawResult_, err error) {
-	if err = p.sendAggregateRaw(req); err != nil {
-		return
-	}
-	return p.recvAggregateRaw()
-}
-
-func (p *NodeClient) sendAggregateRaw(req *AggregateQueryRawRequest) (err error) {
-	oprot := p.OutputProtocol
-	if oprot == nil {
-		oprot = p.ProtocolFactory.GetProtocol(p.Transport)
-		p.OutputProtocol = oprot
-	}
-	p.SeqId++
-	if err = oprot.WriteMessageBegin("aggregateRaw", thrift.CALL, p.SeqId); err != nil {
-		return
-	}
-	args := NodeAggregateRawArgs{
-		Req: req,
-	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	return oprot.Flush()
-}
-
-func (p *NodeClient) recvAggregateRaw() (value *AggregateQueryRawResult_, err error) {
-	iprot := p.InputProtocol
-	if iprot == nil {
-		iprot = p.ProtocolFactory.GetProtocol(p.Transport)
-		p.InputProtocol = iprot
-	}
-	method, mTypeId, seqId, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "aggregateRaw" {
-		err = thrift.NewTApplicationException(thrift.WRONG_METHOD_NAME, "aggregateRaw failed: wrong method name")
-		return
-	}
-	if p.SeqId != seqId {
-		err = thrift.NewTApplicationException(thrift.BAD_SEQUENCE_ID, "aggregateRaw failed: out of sequence response")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error53 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error54 error
-		error54, err = error53.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		err = error54
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(thrift.INVALID_MESSAGE_TYPE_EXCEPTION, "aggregateRaw failed: invalid message type")
-		return
-	}
-	result := NodeAggregateRawResult{}
 	if err = result.Read(iprot); err != nil {
 		return
 	}
@@ -14648,16 +15041,16 @@ func (p *NodeClient) recvFetchBlocksMetadataRawV2() (value *FetchBlocksMetadataR
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error55 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error56 error
-		error56, err = error55.Read(iprot)
+		error56 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error57 error
+		error57, err = error56.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error56
+		err = error57
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14665,6 +15058,87 @@ func (p *NodeClient) recvFetchBlocksMetadataRawV2() (value *FetchBlocksMetadataR
 		return
 	}
 	result := NodeFetchBlocksMetadataRawV2Result{}
+	if err = result.Read(iprot); err != nil {
+		return
+	}
+	if err = iprot.ReadMessageEnd(); err != nil {
+		return
+	}
+	if result.Err != nil {
+		err = result.Err
+		return
+	}
+	value = result.GetSuccess()
+	return
+}
+
+// Parameters:
+//  - Req
+func (p *NodeClient) IndexChecksum(req *IndexChecksumRequest) (r *IndexChecksumResult_, err error) {
+	if err = p.sendIndexChecksum(req); err != nil {
+		return
+	}
+	return p.recvIndexChecksum()
+}
+
+func (p *NodeClient) sendIndexChecksum(req *IndexChecksumRequest) (err error) {
+	oprot := p.OutputProtocol
+	if oprot == nil {
+		oprot = p.ProtocolFactory.GetProtocol(p.Transport)
+		p.OutputProtocol = oprot
+	}
+	p.SeqId++
+	if err = oprot.WriteMessageBegin("indexChecksum", thrift.CALL, p.SeqId); err != nil {
+		return
+	}
+	args := NodeIndexChecksumArgs{
+		Req: req,
+	}
+	if err = args.Write(oprot); err != nil {
+		return
+	}
+	if err = oprot.WriteMessageEnd(); err != nil {
+		return
+	}
+	return oprot.Flush()
+}
+
+func (p *NodeClient) recvIndexChecksum() (value *IndexChecksumResult_, err error) {
+	iprot := p.InputProtocol
+	if iprot == nil {
+		iprot = p.ProtocolFactory.GetProtocol(p.Transport)
+		p.InputProtocol = iprot
+	}
+	method, mTypeId, seqId, err := iprot.ReadMessageBegin()
+	if err != nil {
+		return
+	}
+	if method != "indexChecksum" {
+		err = thrift.NewTApplicationException(thrift.WRONG_METHOD_NAME, "indexChecksum failed: wrong method name")
+		return
+	}
+	if p.SeqId != seqId {
+		err = thrift.NewTApplicationException(thrift.BAD_SEQUENCE_ID, "indexChecksum failed: out of sequence response")
+		return
+	}
+	if mTypeId == thrift.EXCEPTION {
+		error58 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error59 error
+		error59, err = error58.Read(iprot)
+		if err != nil {
+			return
+		}
+		if err = iprot.ReadMessageEnd(); err != nil {
+			return
+		}
+		err = error59
+		return
+	}
+	if mTypeId != thrift.REPLY {
+		err = thrift.NewTApplicationException(thrift.INVALID_MESSAGE_TYPE_EXCEPTION, "indexChecksum failed: invalid message type")
+		return
+	}
+	result := NodeIndexChecksumResult{}
 	if err = result.Read(iprot); err != nil {
 		return
 	}
@@ -14729,16 +15203,16 @@ func (p *NodeClient) recvWriteBatchRaw() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error57 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error58 error
-		error58, err = error57.Read(iprot)
+		error60 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error61 error
+		error61, err = error60.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error58
+		err = error61
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14809,16 +15283,16 @@ func (p *NodeClient) recvWriteBatchRawV2() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error59 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error60 error
-		error60, err = error59.Read(iprot)
+		error62 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error63 error
+		error63, err = error62.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error60
+		err = error63
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14889,16 +15363,16 @@ func (p *NodeClient) recvWriteTaggedBatchRaw() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error61 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error62 error
-		error62, err = error61.Read(iprot)
+		error64 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error65 error
+		error65, err = error64.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error62
+		err = error65
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -14969,16 +15443,16 @@ func (p *NodeClient) recvWriteTaggedBatchRawV2() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error63 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error64 error
-		error64, err = error63.Read(iprot)
+		error66 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error67 error
+		error67, err = error66.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error64
+		err = error67
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15045,16 +15519,16 @@ func (p *NodeClient) recvRepair() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error65 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error66 error
-		error66, err = error65.Read(iprot)
+		error68 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error69 error
+		error69, err = error68.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error66
+		err = error69
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15125,16 +15599,16 @@ func (p *NodeClient) recvTruncate() (value *TruncateResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error67 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error68 error
-		error68, err = error67.Read(iprot)
+		error70 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error71 error
+		error71, err = error70.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error68
+		err = error71
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15202,16 +15676,16 @@ func (p *NodeClient) recvHealth() (value *NodeHealthResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error69 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error70 error
-		error70, err = error69.Read(iprot)
+		error72 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error73 error
+		error73, err = error72.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error70
+		err = error73
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15279,16 +15753,16 @@ func (p *NodeClient) recvBootstrapped() (value *NodeBootstrappedResult_, err err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error71 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error72 error
-		error72, err = error71.Read(iprot)
+		error74 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error75 error
+		error75, err = error74.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error72
+		err = error75
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15356,16 +15830,16 @@ func (p *NodeClient) recvBootstrappedInPlacementOrNoPlacement() (value *NodeBoot
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error73 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error74 error
-		error74, err = error73.Read(iprot)
+		error76 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error77 error
+		error77, err = error76.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error74
+		err = error77
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15433,16 +15907,16 @@ func (p *NodeClient) recvGetPersistRateLimit() (value *NodePersistRateLimitResul
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error75 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error76 error
-		error76, err = error75.Read(iprot)
+		error78 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error79 error
+		error79, err = error78.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error76
+		err = error79
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15514,16 +15988,16 @@ func (p *NodeClient) recvSetPersistRateLimit() (value *NodePersistRateLimitResul
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error77 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error78 error
-		error78, err = error77.Read(iprot)
+		error80 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error81 error
+		error81, err = error80.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error78
+		err = error81
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15591,16 +16065,16 @@ func (p *NodeClient) recvGetWriteNewSeriesAsync() (value *NodeWriteNewSeriesAsyn
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error79 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error80 error
-		error80, err = error79.Read(iprot)
+		error82 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error83 error
+		error83, err = error82.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error80
+		err = error83
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15672,16 +16146,16 @@ func (p *NodeClient) recvSetWriteNewSeriesAsync() (value *NodeWriteNewSeriesAsyn
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error81 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error82 error
-		error82, err = error81.Read(iprot)
+		error84 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error85 error
+		error85, err = error84.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error82
+		err = error85
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15749,16 +16223,16 @@ func (p *NodeClient) recvGetWriteNewSeriesBackoffDuration() (value *NodeWriteNew
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error83 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error84 error
-		error84, err = error83.Read(iprot)
+		error86 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error87 error
+		error87, err = error86.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error84
+		err = error87
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15830,16 +16304,16 @@ func (p *NodeClient) recvSetWriteNewSeriesBackoffDuration() (value *NodeWriteNew
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error85 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error86 error
-		error86, err = error85.Read(iprot)
+		error88 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error89 error
+		error89, err = error88.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error86
+		err = error89
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15907,16 +16381,16 @@ func (p *NodeClient) recvGetWriteNewSeriesLimitPerShardPerSecond() (value *NodeW
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error87 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error88 error
-		error88, err = error87.Read(iprot)
+		error90 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error91 error
+		error91, err = error90.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error88
+		err = error91
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -15988,16 +16462,16 @@ func (p *NodeClient) recvSetWriteNewSeriesLimitPerShardPerSecond() (value *NodeW
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error89 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error90 error
-		error90, err = error89.Read(iprot)
+		error92 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error93 error
+		error93, err = error92.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error90
+		err = error93
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -16069,16 +16543,16 @@ func (p *NodeClient) recvDebugProfileStart() (value *DebugProfileStartResult_, e
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error91 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error92 error
-		error92, err = error91.Read(iprot)
+		error94 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error95 error
+		error95, err = error94.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error92
+		err = error95
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -16150,16 +16624,16 @@ func (p *NodeClient) recvDebugProfileStop() (value *DebugProfileStopResult_, err
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error93 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error94 error
-		error94, err = error93.Read(iprot)
+		error96 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error97 error
+		error97, err = error96.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error94
+		err = error97
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -16231,16 +16705,16 @@ func (p *NodeClient) recvDebugIndexMemorySegments() (value *DebugIndexMemorySegm
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error95 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error96 error
-		error96, err = error95.Read(iprot)
+		error98 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error99 error
+		error99, err = error98.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error96
+		err = error99
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -16282,39 +16756,40 @@ func (p *NodeProcessor) ProcessorMap() map[string]thrift.TProcessorFunction {
 
 func NewNodeProcessor(handler Node) *NodeProcessor {
 
-	self97 := &NodeProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
-	self97.processorMap["query"] = &nodeProcessorQuery{handler: handler}
-	self97.processorMap["aggregate"] = &nodeProcessorAggregate{handler: handler}
-	self97.processorMap["fetch"] = &nodeProcessorFetch{handler: handler}
-	self97.processorMap["write"] = &nodeProcessorWrite{handler: handler}
-	self97.processorMap["writeTagged"] = &nodeProcessorWriteTagged{handler: handler}
-	self97.processorMap["fetchBatchRaw"] = &nodeProcessorFetchBatchRaw{handler: handler}
-	self97.processorMap["fetchBatchRawV2"] = &nodeProcessorFetchBatchRawV2{handler: handler}
-	self97.processorMap["fetchBlocksRaw"] = &nodeProcessorFetchBlocksRaw{handler: handler}
-	self97.processorMap["fetchTagged"] = &nodeProcessorFetchTagged{handler: handler}
-	self97.processorMap["aggregateRaw"] = &nodeProcessorAggregateRaw{handler: handler}
-	self97.processorMap["fetchBlocksMetadataRawV2"] = &nodeProcessorFetchBlocksMetadataRawV2{handler: handler}
-	self97.processorMap["writeBatchRaw"] = &nodeProcessorWriteBatchRaw{handler: handler}
-	self97.processorMap["writeBatchRawV2"] = &nodeProcessorWriteBatchRawV2{handler: handler}
-	self97.processorMap["writeTaggedBatchRaw"] = &nodeProcessorWriteTaggedBatchRaw{handler: handler}
-	self97.processorMap["writeTaggedBatchRawV2"] = &nodeProcessorWriteTaggedBatchRawV2{handler: handler}
-	self97.processorMap["repair"] = &nodeProcessorRepair{handler: handler}
-	self97.processorMap["truncate"] = &nodeProcessorTruncate{handler: handler}
-	self97.processorMap["health"] = &nodeProcessorHealth{handler: handler}
-	self97.processorMap["bootstrapped"] = &nodeProcessorBootstrapped{handler: handler}
-	self97.processorMap["bootstrappedInPlacementOrNoPlacement"] = &nodeProcessorBootstrappedInPlacementOrNoPlacement{handler: handler}
-	self97.processorMap["getPersistRateLimit"] = &nodeProcessorGetPersistRateLimit{handler: handler}
-	self97.processorMap["setPersistRateLimit"] = &nodeProcessorSetPersistRateLimit{handler: handler}
-	self97.processorMap["getWriteNewSeriesAsync"] = &nodeProcessorGetWriteNewSeriesAsync{handler: handler}
-	self97.processorMap["setWriteNewSeriesAsync"] = &nodeProcessorSetWriteNewSeriesAsync{handler: handler}
-	self97.processorMap["getWriteNewSeriesBackoffDuration"] = &nodeProcessorGetWriteNewSeriesBackoffDuration{handler: handler}
-	self97.processorMap["setWriteNewSeriesBackoffDuration"] = &nodeProcessorSetWriteNewSeriesBackoffDuration{handler: handler}
-	self97.processorMap["getWriteNewSeriesLimitPerShardPerSecond"] = &nodeProcessorGetWriteNewSeriesLimitPerShardPerSecond{handler: handler}
-	self97.processorMap["setWriteNewSeriesLimitPerShardPerSecond"] = &nodeProcessorSetWriteNewSeriesLimitPerShardPerSecond{handler: handler}
-	self97.processorMap["debugProfileStart"] = &nodeProcessorDebugProfileStart{handler: handler}
-	self97.processorMap["debugProfileStop"] = &nodeProcessorDebugProfileStop{handler: handler}
-	self97.processorMap["debugIndexMemorySegments"] = &nodeProcessorDebugIndexMemorySegments{handler: handler}
-	return self97
+	self100 := &NodeProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
+	self100.processorMap["query"] = &nodeProcessorQuery{handler: handler}
+	self100.processorMap["aggregate"] = &nodeProcessorAggregate{handler: handler}
+	self100.processorMap["fetch"] = &nodeProcessorFetch{handler: handler}
+	self100.processorMap["write"] = &nodeProcessorWrite{handler: handler}
+	self100.processorMap["writeTagged"] = &nodeProcessorWriteTagged{handler: handler}
+	self100.processorMap["aggregateRaw"] = &nodeProcessorAggregateRaw{handler: handler}
+	self100.processorMap["fetchBatchRaw"] = &nodeProcessorFetchBatchRaw{handler: handler}
+	self100.processorMap["fetchBatchRawV2"] = &nodeProcessorFetchBatchRawV2{handler: handler}
+	self100.processorMap["fetchBlocksRaw"] = &nodeProcessorFetchBlocksRaw{handler: handler}
+	self100.processorMap["fetchTagged"] = &nodeProcessorFetchTagged{handler: handler}
+	self100.processorMap["fetchBlocksMetadataRawV2"] = &nodeProcessorFetchBlocksMetadataRawV2{handler: handler}
+	self100.processorMap["indexChecksum"] = &nodeProcessorIndexChecksum{handler: handler}
+	self100.processorMap["writeBatchRaw"] = &nodeProcessorWriteBatchRaw{handler: handler}
+	self100.processorMap["writeBatchRawV2"] = &nodeProcessorWriteBatchRawV2{handler: handler}
+	self100.processorMap["writeTaggedBatchRaw"] = &nodeProcessorWriteTaggedBatchRaw{handler: handler}
+	self100.processorMap["writeTaggedBatchRawV2"] = &nodeProcessorWriteTaggedBatchRawV2{handler: handler}
+	self100.processorMap["repair"] = &nodeProcessorRepair{handler: handler}
+	self100.processorMap["truncate"] = &nodeProcessorTruncate{handler: handler}
+	self100.processorMap["health"] = &nodeProcessorHealth{handler: handler}
+	self100.processorMap["bootstrapped"] = &nodeProcessorBootstrapped{handler: handler}
+	self100.processorMap["bootstrappedInPlacementOrNoPlacement"] = &nodeProcessorBootstrappedInPlacementOrNoPlacement{handler: handler}
+	self100.processorMap["getPersistRateLimit"] = &nodeProcessorGetPersistRateLimit{handler: handler}
+	self100.processorMap["setPersistRateLimit"] = &nodeProcessorSetPersistRateLimit{handler: handler}
+	self100.processorMap["getWriteNewSeriesAsync"] = &nodeProcessorGetWriteNewSeriesAsync{handler: handler}
+	self100.processorMap["setWriteNewSeriesAsync"] = &nodeProcessorSetWriteNewSeriesAsync{handler: handler}
+	self100.processorMap["getWriteNewSeriesBackoffDuration"] = &nodeProcessorGetWriteNewSeriesBackoffDuration{handler: handler}
+	self100.processorMap["setWriteNewSeriesBackoffDuration"] = &nodeProcessorSetWriteNewSeriesBackoffDuration{handler: handler}
+	self100.processorMap["getWriteNewSeriesLimitPerShardPerSecond"] = &nodeProcessorGetWriteNewSeriesLimitPerShardPerSecond{handler: handler}
+	self100.processorMap["setWriteNewSeriesLimitPerShardPerSecond"] = &nodeProcessorSetWriteNewSeriesLimitPerShardPerSecond{handler: handler}
+	self100.processorMap["debugProfileStart"] = &nodeProcessorDebugProfileStart{handler: handler}
+	self100.processorMap["debugProfileStop"] = &nodeProcessorDebugProfileStop{handler: handler}
+	self100.processorMap["debugIndexMemorySegments"] = &nodeProcessorDebugIndexMemorySegments{handler: handler}
+	return self100
 }
 
 func (p *NodeProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
@@ -16327,12 +16802,12 @@ func (p *NodeProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, er
 	}
 	iprot.Skip(thrift.STRUCT)
 	iprot.ReadMessageEnd()
-	x98 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
+	x101 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
 	oprot.WriteMessageBegin(name, thrift.EXCEPTION, seqId)
-	x98.Write(oprot)
+	x101.Write(oprot)
 	oprot.WriteMessageEnd()
 	oprot.Flush()
-	return false, x98
+	return false, x101
 
 }
 
@@ -16595,6 +17070,59 @@ func (p *nodeProcessorWriteTagged) Process(seqId int32, iprot, oprot thrift.TPro
 	return true, err
 }
 
+type nodeProcessorAggregateRaw struct {
+	handler Node
+}
+
+func (p *nodeProcessorAggregateRaw) Process(seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
+	args := NodeAggregateRawArgs{}
+	if err = args.Read(iprot); err != nil {
+		iprot.ReadMessageEnd()
+		x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err.Error())
+		oprot.WriteMessageBegin("aggregateRaw", thrift.EXCEPTION, seqId)
+		x.Write(oprot)
+		oprot.WriteMessageEnd()
+		oprot.Flush()
+		return false, err
+	}
+
+	iprot.ReadMessageEnd()
+	result := NodeAggregateRawResult{}
+	var retval *AggregateQueryRawResult_
+	var err2 error
+	if retval, err2 = p.handler.AggregateRaw(args.Req); err2 != nil {
+		switch v := err2.(type) {
+		case *Error:
+			result.Err = v
+		default:
+			x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing aggregateRaw: "+err2.Error())
+			oprot.WriteMessageBegin("aggregateRaw", thrift.EXCEPTION, seqId)
+			x.Write(oprot)
+			oprot.WriteMessageEnd()
+			oprot.Flush()
+			return true, err2
+		}
+	} else {
+		result.Success = retval
+	}
+	if err2 = oprot.WriteMessageBegin("aggregateRaw", thrift.REPLY, seqId); err2 != nil {
+		err = err2
+	}
+	if err2 = result.Write(oprot); err == nil && err2 != nil {
+		err = err2
+	}
+	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
+		err = err2
+	}
+	if err2 = oprot.Flush(); err == nil && err2 != nil {
+		err = err2
+	}
+	if err != nil {
+		return
+	}
+	return true, err
+}
+
 type nodeProcessorFetchBatchRaw struct {
 	handler Node
 }
@@ -16807,59 +17335,6 @@ func (p *nodeProcessorFetchTagged) Process(seqId int32, iprot, oprot thrift.TPro
 	return true, err
 }
 
-type nodeProcessorAggregateRaw struct {
-	handler Node
-}
-
-func (p *nodeProcessorAggregateRaw) Process(seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
-	args := NodeAggregateRawArgs{}
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err.Error())
-		oprot.WriteMessageBegin("aggregateRaw", thrift.EXCEPTION, seqId)
-		x.Write(oprot)
-		oprot.WriteMessageEnd()
-		oprot.Flush()
-		return false, err
-	}
-
-	iprot.ReadMessageEnd()
-	result := NodeAggregateRawResult{}
-	var retval *AggregateQueryRawResult_
-	var err2 error
-	if retval, err2 = p.handler.AggregateRaw(args.Req); err2 != nil {
-		switch v := err2.(type) {
-		case *Error:
-			result.Err = v
-		default:
-			x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing aggregateRaw: "+err2.Error())
-			oprot.WriteMessageBegin("aggregateRaw", thrift.EXCEPTION, seqId)
-			x.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			return true, err2
-		}
-	} else {
-		result.Success = retval
-	}
-	if err2 = oprot.WriteMessageBegin("aggregateRaw", thrift.REPLY, seqId); err2 != nil {
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		err = err2
-	}
-	if err != nil {
-		return
-	}
-	return true, err
-}
-
 type nodeProcessorFetchBlocksMetadataRawV2 struct {
 	handler Node
 }
@@ -16896,6 +17371,59 @@ func (p *nodeProcessorFetchBlocksMetadataRawV2) Process(seqId int32, iprot, opro
 		result.Success = retval
 	}
 	if err2 = oprot.WriteMessageBegin("fetchBlocksMetadataRawV2", thrift.REPLY, seqId); err2 != nil {
+		err = err2
+	}
+	if err2 = result.Write(oprot); err == nil && err2 != nil {
+		err = err2
+	}
+	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
+		err = err2
+	}
+	if err2 = oprot.Flush(); err == nil && err2 != nil {
+		err = err2
+	}
+	if err != nil {
+		return
+	}
+	return true, err
+}
+
+type nodeProcessorIndexChecksum struct {
+	handler Node
+}
+
+func (p *nodeProcessorIndexChecksum) Process(seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
+	args := NodeIndexChecksumArgs{}
+	if err = args.Read(iprot); err != nil {
+		iprot.ReadMessageEnd()
+		x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err.Error())
+		oprot.WriteMessageBegin("indexChecksum", thrift.EXCEPTION, seqId)
+		x.Write(oprot)
+		oprot.WriteMessageEnd()
+		oprot.Flush()
+		return false, err
+	}
+
+	iprot.ReadMessageEnd()
+	result := NodeIndexChecksumResult{}
+	var retval *IndexChecksumResult_
+	var err2 error
+	if retval, err2 = p.handler.IndexChecksum(args.Req); err2 != nil {
+		switch v := err2.(type) {
+		case *Error:
+			result.Err = v
+		default:
+			x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing indexChecksum: "+err2.Error())
+			oprot.WriteMessageBegin("indexChecksum", thrift.EXCEPTION, seqId)
+			x.Write(oprot)
+			oprot.WriteMessageEnd()
+			oprot.Flush()
+			return true, err2
+		}
+	} else {
+		result.Success = retval
+	}
+	if err2 = oprot.WriteMessageBegin("indexChecksum", thrift.REPLY, seqId); err2 != nil {
 		err = err2
 	}
 	if err2 = result.Write(oprot); err == nil && err2 != nil {
@@ -19139,6 +19667,261 @@ func (p *NodeWriteTaggedResult) String() string {
 
 // Attributes:
 //  - Req
+type NodeAggregateRawArgs struct {
+	Req *AggregateQueryRawRequest `thrift:"req,1" db:"req" json:"req"`
+}
+
+func NewNodeAggregateRawArgs() *NodeAggregateRawArgs {
+	return &NodeAggregateRawArgs{}
+}
+
+var NodeAggregateRawArgs_Req_DEFAULT *AggregateQueryRawRequest
+
+func (p *NodeAggregateRawArgs) GetReq() *AggregateQueryRawRequest {
+	if !p.IsSetReq() {
+		return NodeAggregateRawArgs_Req_DEFAULT
+	}
+	return p.Req
+}
+func (p *NodeAggregateRawArgs) IsSetReq() bool {
+	return p.Req != nil
+}
+
+func (p *NodeAggregateRawArgs) Read(iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if err := p.ReadField1(iprot); err != nil {
+				return err
+			}
+		default:
+			if err := iprot.Skip(fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *NodeAggregateRawArgs) ReadField1(iprot thrift.TProtocol) error {
+	p.Req = &AggregateQueryRawRequest{
+		AggregateQueryType: 1,
+
+		RangeType: 0,
+	}
+	if err := p.Req.Read(iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Req), err)
+	}
+	return nil
+}
+
+func (p *NodeAggregateRawArgs) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("aggregateRaw_args"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *NodeAggregateRawArgs) writeField1(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("req", thrift.STRUCT, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:req: ", p), err)
+	}
+	if err := p.Req.Write(oprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Req), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:req: ", p), err)
+	}
+	return err
+}
+
+func (p *NodeAggregateRawArgs) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("NodeAggregateRawArgs(%+v)", *p)
+}
+
+// Attributes:
+//  - Success
+//  - Err
+type NodeAggregateRawResult struct {
+	Success *AggregateQueryRawResult_ `thrift:"success,0" db:"success" json:"success,omitempty"`
+	Err     *Error                    `thrift:"err,1" db:"err" json:"err,omitempty"`
+}
+
+func NewNodeAggregateRawResult() *NodeAggregateRawResult {
+	return &NodeAggregateRawResult{}
+}
+
+var NodeAggregateRawResult_Success_DEFAULT *AggregateQueryRawResult_
+
+func (p *NodeAggregateRawResult) GetSuccess() *AggregateQueryRawResult_ {
+	if !p.IsSetSuccess() {
+		return NodeAggregateRawResult_Success_DEFAULT
+	}
+	return p.Success
+}
+
+var NodeAggregateRawResult_Err_DEFAULT *Error
+
+func (p *NodeAggregateRawResult) GetErr() *Error {
+	if !p.IsSetErr() {
+		return NodeAggregateRawResult_Err_DEFAULT
+	}
+	return p.Err
+}
+func (p *NodeAggregateRawResult) IsSetSuccess() bool {
+	return p.Success != nil
+}
+
+func (p *NodeAggregateRawResult) IsSetErr() bool {
+	return p.Err != nil
+}
+
+func (p *NodeAggregateRawResult) Read(iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 0:
+			if err := p.ReadField0(iprot); err != nil {
+				return err
+			}
+		case 1:
+			if err := p.ReadField1(iprot); err != nil {
+				return err
+			}
+		default:
+			if err := iprot.Skip(fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *NodeAggregateRawResult) ReadField0(iprot thrift.TProtocol) error {
+	p.Success = &AggregateQueryRawResult_{}
+	if err := p.Success.Read(iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Success), err)
+	}
+	return nil
+}
+
+func (p *NodeAggregateRawResult) ReadField1(iprot thrift.TProtocol) error {
+	p.Err = &Error{
+		Type: 0,
+	}
+	if err := p.Err.Read(iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Err), err)
+	}
+	return nil
+}
+
+func (p *NodeAggregateRawResult) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("aggregateRaw_result"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField0(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField1(oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *NodeAggregateRawResult) writeField0(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSuccess() {
+		if err := oprot.WriteFieldBegin("success", thrift.STRUCT, 0); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 0:success: ", p), err)
+		}
+		if err := p.Success.Write(oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Success), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 0:success: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *NodeAggregateRawResult) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetErr() {
+		if err := oprot.WriteFieldBegin("err", thrift.STRUCT, 1); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:err: ", p), err)
+		}
+		if err := p.Err.Write(oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Err), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 1:err: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *NodeAggregateRawResult) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("NodeAggregateRawResult(%+v)", *p)
+}
+
+// Attributes:
+//  - Req
 type NodeFetchBatchRawArgs struct {
 	Req *FetchBatchRawRequest `thrift:"req,1" db:"req" json:"req"`
 }
@@ -20147,261 +20930,6 @@ func (p *NodeFetchTaggedResult) String() string {
 
 // Attributes:
 //  - Req
-type NodeAggregateRawArgs struct {
-	Req *AggregateQueryRawRequest `thrift:"req,1" db:"req" json:"req"`
-}
-
-func NewNodeAggregateRawArgs() *NodeAggregateRawArgs {
-	return &NodeAggregateRawArgs{}
-}
-
-var NodeAggregateRawArgs_Req_DEFAULT *AggregateQueryRawRequest
-
-func (p *NodeAggregateRawArgs) GetReq() *AggregateQueryRawRequest {
-	if !p.IsSetReq() {
-		return NodeAggregateRawArgs_Req_DEFAULT
-	}
-	return p.Req
-}
-func (p *NodeAggregateRawArgs) IsSetReq() bool {
-	return p.Req != nil
-}
-
-func (p *NodeAggregateRawArgs) Read(iprot thrift.TProtocol) error {
-	if _, err := iprot.ReadStructBegin(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
-	}
-
-	for {
-		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
-		if err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
-		}
-		if fieldTypeId == thrift.STOP {
-			break
-		}
-		switch fieldId {
-		case 1:
-			if err := p.ReadField1(iprot); err != nil {
-				return err
-			}
-		default:
-			if err := iprot.Skip(fieldTypeId); err != nil {
-				return err
-			}
-		}
-		if err := iprot.ReadFieldEnd(); err != nil {
-			return err
-		}
-	}
-	if err := iprot.ReadStructEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
-	}
-	return nil
-}
-
-func (p *NodeAggregateRawArgs) ReadField1(iprot thrift.TProtocol) error {
-	p.Req = &AggregateQueryRawRequest{
-		AggregateQueryType: 1,
-
-		RangeType: 0,
-	}
-	if err := p.Req.Read(iprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Req), err)
-	}
-	return nil
-}
-
-func (p *NodeAggregateRawArgs) Write(oprot thrift.TProtocol) error {
-	if err := oprot.WriteStructBegin("aggregateRaw_args"); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
-	}
-	if p != nil {
-		if err := p.writeField1(oprot); err != nil {
-			return err
-		}
-	}
-	if err := oprot.WriteFieldStop(); err != nil {
-		return thrift.PrependError("write field stop error: ", err)
-	}
-	if err := oprot.WriteStructEnd(); err != nil {
-		return thrift.PrependError("write struct stop error: ", err)
-	}
-	return nil
-}
-
-func (p *NodeAggregateRawArgs) writeField1(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("req", thrift.STRUCT, 1); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:req: ", p), err)
-	}
-	if err := p.Req.Write(oprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Req), err)
-	}
-	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:req: ", p), err)
-	}
-	return err
-}
-
-func (p *NodeAggregateRawArgs) String() string {
-	if p == nil {
-		return "<nil>"
-	}
-	return fmt.Sprintf("NodeAggregateRawArgs(%+v)", *p)
-}
-
-// Attributes:
-//  - Success
-//  - Err
-type NodeAggregateRawResult struct {
-	Success *AggregateQueryRawResult_ `thrift:"success,0" db:"success" json:"success,omitempty"`
-	Err     *Error                    `thrift:"err,1" db:"err" json:"err,omitempty"`
-}
-
-func NewNodeAggregateRawResult() *NodeAggregateRawResult {
-	return &NodeAggregateRawResult{}
-}
-
-var NodeAggregateRawResult_Success_DEFAULT *AggregateQueryRawResult_
-
-func (p *NodeAggregateRawResult) GetSuccess() *AggregateQueryRawResult_ {
-	if !p.IsSetSuccess() {
-		return NodeAggregateRawResult_Success_DEFAULT
-	}
-	return p.Success
-}
-
-var NodeAggregateRawResult_Err_DEFAULT *Error
-
-func (p *NodeAggregateRawResult) GetErr() *Error {
-	if !p.IsSetErr() {
-		return NodeAggregateRawResult_Err_DEFAULT
-	}
-	return p.Err
-}
-func (p *NodeAggregateRawResult) IsSetSuccess() bool {
-	return p.Success != nil
-}
-
-func (p *NodeAggregateRawResult) IsSetErr() bool {
-	return p.Err != nil
-}
-
-func (p *NodeAggregateRawResult) Read(iprot thrift.TProtocol) error {
-	if _, err := iprot.ReadStructBegin(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
-	}
-
-	for {
-		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
-		if err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
-		}
-		if fieldTypeId == thrift.STOP {
-			break
-		}
-		switch fieldId {
-		case 0:
-			if err := p.ReadField0(iprot); err != nil {
-				return err
-			}
-		case 1:
-			if err := p.ReadField1(iprot); err != nil {
-				return err
-			}
-		default:
-			if err := iprot.Skip(fieldTypeId); err != nil {
-				return err
-			}
-		}
-		if err := iprot.ReadFieldEnd(); err != nil {
-			return err
-		}
-	}
-	if err := iprot.ReadStructEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
-	}
-	return nil
-}
-
-func (p *NodeAggregateRawResult) ReadField0(iprot thrift.TProtocol) error {
-	p.Success = &AggregateQueryRawResult_{}
-	if err := p.Success.Read(iprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Success), err)
-	}
-	return nil
-}
-
-func (p *NodeAggregateRawResult) ReadField1(iprot thrift.TProtocol) error {
-	p.Err = &Error{
-		Type: 0,
-	}
-	if err := p.Err.Read(iprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Err), err)
-	}
-	return nil
-}
-
-func (p *NodeAggregateRawResult) Write(oprot thrift.TProtocol) error {
-	if err := oprot.WriteStructBegin("aggregateRaw_result"); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
-	}
-	if p != nil {
-		if err := p.writeField0(oprot); err != nil {
-			return err
-		}
-		if err := p.writeField1(oprot); err != nil {
-			return err
-		}
-	}
-	if err := oprot.WriteFieldStop(); err != nil {
-		return thrift.PrependError("write field stop error: ", err)
-	}
-	if err := oprot.WriteStructEnd(); err != nil {
-		return thrift.PrependError("write struct stop error: ", err)
-	}
-	return nil
-}
-
-func (p *NodeAggregateRawResult) writeField0(oprot thrift.TProtocol) (err error) {
-	if p.IsSetSuccess() {
-		if err := oprot.WriteFieldBegin("success", thrift.STRUCT, 0); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field begin error 0:success: ", p), err)
-		}
-		if err := p.Success.Write(oprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Success), err)
-		}
-		if err := oprot.WriteFieldEnd(); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field end error 0:success: ", p), err)
-		}
-	}
-	return err
-}
-
-func (p *NodeAggregateRawResult) writeField1(oprot thrift.TProtocol) (err error) {
-	if p.IsSetErr() {
-		if err := oprot.WriteFieldBegin("err", thrift.STRUCT, 1); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:err: ", p), err)
-		}
-		if err := p.Err.Write(oprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Err), err)
-		}
-		if err := oprot.WriteFieldEnd(); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field end error 1:err: ", p), err)
-		}
-	}
-	return err
-}
-
-func (p *NodeAggregateRawResult) String() string {
-	if p == nil {
-		return "<nil>"
-	}
-	return fmt.Sprintf("NodeAggregateRawResult(%+v)", *p)
-}
-
-// Attributes:
-//  - Req
 type NodeFetchBlocksMetadataRawV2Args struct {
 	Req *FetchBlocksMetadataRawV2Request `thrift:"req,1" db:"req" json:"req"`
 }
@@ -20649,6 +21177,257 @@ func (p *NodeFetchBlocksMetadataRawV2Result) String() string {
 		return "<nil>"
 	}
 	return fmt.Sprintf("NodeFetchBlocksMetadataRawV2Result(%+v)", *p)
+}
+
+// Attributes:
+//  - Req
+type NodeIndexChecksumArgs struct {
+	Req *IndexChecksumRequest `thrift:"req,1" db:"req" json:"req"`
+}
+
+func NewNodeIndexChecksumArgs() *NodeIndexChecksumArgs {
+	return &NodeIndexChecksumArgs{}
+}
+
+var NodeIndexChecksumArgs_Req_DEFAULT *IndexChecksumRequest
+
+func (p *NodeIndexChecksumArgs) GetReq() *IndexChecksumRequest {
+	if !p.IsSetReq() {
+		return NodeIndexChecksumArgs_Req_DEFAULT
+	}
+	return p.Req
+}
+func (p *NodeIndexChecksumArgs) IsSetReq() bool {
+	return p.Req != nil
+}
+
+func (p *NodeIndexChecksumArgs) Read(iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if err := p.ReadField1(iprot); err != nil {
+				return err
+			}
+		default:
+			if err := iprot.Skip(fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *NodeIndexChecksumArgs) ReadField1(iprot thrift.TProtocol) error {
+	p.Req = &IndexChecksumRequest{}
+	if err := p.Req.Read(iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Req), err)
+	}
+	return nil
+}
+
+func (p *NodeIndexChecksumArgs) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("indexChecksum_args"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *NodeIndexChecksumArgs) writeField1(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("req", thrift.STRUCT, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:req: ", p), err)
+	}
+	if err := p.Req.Write(oprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Req), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:req: ", p), err)
+	}
+	return err
+}
+
+func (p *NodeIndexChecksumArgs) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("NodeIndexChecksumArgs(%+v)", *p)
+}
+
+// Attributes:
+//  - Success
+//  - Err
+type NodeIndexChecksumResult struct {
+	Success *IndexChecksumResult_ `thrift:"success,0" db:"success" json:"success,omitempty"`
+	Err     *Error                `thrift:"err,1" db:"err" json:"err,omitempty"`
+}
+
+func NewNodeIndexChecksumResult() *NodeIndexChecksumResult {
+	return &NodeIndexChecksumResult{}
+}
+
+var NodeIndexChecksumResult_Success_DEFAULT *IndexChecksumResult_
+
+func (p *NodeIndexChecksumResult) GetSuccess() *IndexChecksumResult_ {
+	if !p.IsSetSuccess() {
+		return NodeIndexChecksumResult_Success_DEFAULT
+	}
+	return p.Success
+}
+
+var NodeIndexChecksumResult_Err_DEFAULT *Error
+
+func (p *NodeIndexChecksumResult) GetErr() *Error {
+	if !p.IsSetErr() {
+		return NodeIndexChecksumResult_Err_DEFAULT
+	}
+	return p.Err
+}
+func (p *NodeIndexChecksumResult) IsSetSuccess() bool {
+	return p.Success != nil
+}
+
+func (p *NodeIndexChecksumResult) IsSetErr() bool {
+	return p.Err != nil
+}
+
+func (p *NodeIndexChecksumResult) Read(iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 0:
+			if err := p.ReadField0(iprot); err != nil {
+				return err
+			}
+		case 1:
+			if err := p.ReadField1(iprot); err != nil {
+				return err
+			}
+		default:
+			if err := iprot.Skip(fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *NodeIndexChecksumResult) ReadField0(iprot thrift.TProtocol) error {
+	p.Success = &IndexChecksumResult_{}
+	if err := p.Success.Read(iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Success), err)
+	}
+	return nil
+}
+
+func (p *NodeIndexChecksumResult) ReadField1(iprot thrift.TProtocol) error {
+	p.Err = &Error{
+		Type: 0,
+	}
+	if err := p.Err.Read(iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Err), err)
+	}
+	return nil
+}
+
+func (p *NodeIndexChecksumResult) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("indexChecksum_result"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField0(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField1(oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *NodeIndexChecksumResult) writeField0(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSuccess() {
+		if err := oprot.WriteFieldBegin("success", thrift.STRUCT, 0); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 0:success: ", p), err)
+		}
+		if err := p.Success.Write(oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Success), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 0:success: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *NodeIndexChecksumResult) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetErr() {
+		if err := oprot.WriteFieldBegin("err", thrift.STRUCT, 1); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:err: ", p), err)
+		}
+		if err := p.Err.Write(oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Err), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 1:err: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *NodeIndexChecksumResult) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("NodeIndexChecksumResult(%+v)", *p)
 }
 
 // Attributes:
@@ -25166,16 +25945,16 @@ func (p *ClusterClient) recvHealth() (value *HealthResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error237 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error238 error
-		error238, err = error237.Read(iprot)
+		error246 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error247 error
+		error247, err = error246.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error238
+		err = error247
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -25247,16 +26026,16 @@ func (p *ClusterClient) recvWrite() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error239 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error240 error
-		error240, err = error239.Read(iprot)
+		error248 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error249 error
+		error249, err = error248.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error240
+		err = error249
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -25327,16 +26106,16 @@ func (p *ClusterClient) recvWriteTagged() (err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error241 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error242 error
-		error242, err = error241.Read(iprot)
+		error250 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error251 error
+		error251, err = error250.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error242
+		err = error251
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -25407,16 +26186,16 @@ func (p *ClusterClient) recvQuery() (value *QueryResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error243 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error244 error
-		error244, err = error243.Read(iprot)
+		error252 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error253 error
+		error253, err = error252.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error244
+		err = error253
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -25488,16 +26267,16 @@ func (p *ClusterClient) recvAggregate() (value *AggregateQueryResult_, err error
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error245 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error246 error
-		error246, err = error245.Read(iprot)
+		error254 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error255 error
+		error255, err = error254.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error246
+		err = error255
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -25569,16 +26348,16 @@ func (p *ClusterClient) recvFetch() (value *FetchResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error247 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error248 error
-		error248, err = error247.Read(iprot)
+		error256 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error257 error
+		error257, err = error256.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error248
+		err = error257
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -25650,16 +26429,16 @@ func (p *ClusterClient) recvTruncate() (value *TruncateResult_, err error) {
 		return
 	}
 	if mTypeId == thrift.EXCEPTION {
-		error249 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
-		var error250 error
-		error250, err = error249.Read(iprot)
+		error258 := thrift.NewTApplicationException(thrift.UNKNOWN_APPLICATION_EXCEPTION, "Unknown Exception")
+		var error259 error
+		error259, err = error258.Read(iprot)
 		if err != nil {
 			return
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return
 		}
-		err = error250
+		err = error259
 		return
 	}
 	if mTypeId != thrift.REPLY {
@@ -25701,15 +26480,15 @@ func (p *ClusterProcessor) ProcessorMap() map[string]thrift.TProcessorFunction {
 
 func NewClusterProcessor(handler Cluster) *ClusterProcessor {
 
-	self251 := &ClusterProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
-	self251.processorMap["health"] = &clusterProcessorHealth{handler: handler}
-	self251.processorMap["write"] = &clusterProcessorWrite{handler: handler}
-	self251.processorMap["writeTagged"] = &clusterProcessorWriteTagged{handler: handler}
-	self251.processorMap["query"] = &clusterProcessorQuery{handler: handler}
-	self251.processorMap["aggregate"] = &clusterProcessorAggregate{handler: handler}
-	self251.processorMap["fetch"] = &clusterProcessorFetch{handler: handler}
-	self251.processorMap["truncate"] = &clusterProcessorTruncate{handler: handler}
-	return self251
+	self260 := &ClusterProcessor{handler: handler, processorMap: make(map[string]thrift.TProcessorFunction)}
+	self260.processorMap["health"] = &clusterProcessorHealth{handler: handler}
+	self260.processorMap["write"] = &clusterProcessorWrite{handler: handler}
+	self260.processorMap["writeTagged"] = &clusterProcessorWriteTagged{handler: handler}
+	self260.processorMap["query"] = &clusterProcessorQuery{handler: handler}
+	self260.processorMap["aggregate"] = &clusterProcessorAggregate{handler: handler}
+	self260.processorMap["fetch"] = &clusterProcessorFetch{handler: handler}
+	self260.processorMap["truncate"] = &clusterProcessorTruncate{handler: handler}
+	return self260
 }
 
 func (p *ClusterProcessor) Process(iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
@@ -25722,12 +26501,12 @@ func (p *ClusterProcessor) Process(iprot, oprot thrift.TProtocol) (success bool,
 	}
 	iprot.Skip(thrift.STRUCT)
 	iprot.ReadMessageEnd()
-	x252 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
+	x261 := thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "Unknown function "+name)
 	oprot.WriteMessageBegin(name, thrift.EXCEPTION, seqId)
-	x252.Write(oprot)
+	x261.Write(oprot)
 	oprot.WriteMessageEnd()
 	oprot.Flush()
-	return false, x252
+	return false, x261
 
 }
 

--- a/src/dbnode/generated/thrift/rpc/rpc_mock.go
+++ b/src/dbnode/generated/thrift/rpc/rpc_mock.go
@@ -450,6 +450,21 @@ func (mr *MockTChanNodeMockRecorder) Health(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Health", reflect.TypeOf((*MockTChanNode)(nil).Health), ctx)
 }
 
+// IndexChecksum mocks base method
+func (m *MockTChanNode) IndexChecksum(ctx thrift.Context, req *IndexChecksumRequest) (*IndexChecksumResult_, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexChecksum", ctx, req)
+	ret0, _ := ret[0].(*IndexChecksumResult_)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexChecksum indicates an expected call of IndexChecksum
+func (mr *MockTChanNodeMockRecorder) IndexChecksum(ctx, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexChecksum", reflect.TypeOf((*MockTChanNode)(nil).IndexChecksum), ctx, req)
+}
+
 // Query mocks base method
 func (m *MockTChanNode) Query(ctx thrift.Context, req *QueryRequest) (*QueryResult_, error) {
 	m.ctrl.T.Helper()

--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -21,6 +21,7 @@
 package node
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"runtime"
@@ -104,6 +105,7 @@ var (
 type serviceMetrics struct {
 	fetch                   instrument.MethodMetrics
 	fetchTagged             instrument.MethodMetrics
+	indexChecksum           instrument.MethodMetrics
 	aggregate               instrument.MethodMetrics
 	write                   instrument.MethodMetrics
 	writeTagged             instrument.MethodMetrics
@@ -124,6 +126,7 @@ func newServiceMetrics(scope tally.Scope, opts instrument.TimerOptions) serviceM
 	return serviceMetrics{
 		fetch:                   instrument.NewMethodMetrics(scope, "fetch", opts),
 		fetchTagged:             instrument.NewMethodMetrics(scope, "fetchTagged", opts),
+		indexChecksum:           instrument.NewMethodMetrics(scope, "indexChecksum", opts),
 		aggregate:               instrument.NewMethodMetrics(scope, "aggregate", opts),
 		write:                   instrument.NewMethodMetrics(scope, "write", opts),
 		writeTagged:             instrument.NewMethodMetrics(scope, "writeTagged", opts),
@@ -865,6 +868,111 @@ func (s *service) AggregateRaw(tctx thrift.Context, req *rpc.AggregateQueryRawRe
 	}
 	s.metrics.aggregate.ReportSuccess(s.nowFn().Sub(callStart))
 	return response, nil
+}
+
+func (s *service) IndexChecksum(tctx thrift.Context, req *rpc.IndexChecksumRequest) (*rpc.IndexChecksumResult_, error) {
+	db, err := s.startReadRPCWithDB()
+	if err != nil {
+		return nil, err
+	}
+	defer s.readRPCCompleted()
+
+	ctx, sp, sampled := tchannelthrift.Context(tctx).StartSampledTraceSpan(tracepoint.IndexChecksum)
+	if sampled {
+		sp.LogFields(
+			opentracinglog.String("query", string(req.Query)),
+			opentracinglog.String("namespace", string(req.NameSpace)),
+			xopentracing.Time("start", time.Unix(0, req.BlockStart)),
+		)
+	}
+
+	result, err := s.indexChecksum(ctx, db, req)
+	if sampled && err != nil {
+		sp.LogFields(opentracinglog.Error(err))
+	}
+	sp.Finish()
+
+	return result, err
+}
+
+func (s *service) indexChecksum(
+	ctx context.Context,
+	db storage.Database,
+	req *rpc.IndexChecksumRequest,
+) (*rpc.IndexChecksumResult_, error) {
+	callStart := s.nowFn()
+	ns, query, opts, err := convert.FromRPCIndexChecksumRequest(req, s.opts.BatchSize(), s.pools)
+	if err != nil {
+		s.metrics.indexChecksum.ReportError(s.nowFn().Sub(callStart))
+		return nil, tterrors.NewBadRequestError(err)
+	}
+
+	queryResult, err := db.QueryIDs(ctx, ns, query, opts)
+	if err != nil {
+		s.metrics.indexChecksum.ReportError(s.nowFn().Sub(callStart))
+		return nil, convert.ToRPCError(err)
+	}
+
+	results := queryResult.Results
+	response := &rpc.IndexChecksumResult_{
+		Checksums: make([]int64, 0, s.opts.BatchSize()),
+	}
+
+	// TODO: this should open a stream.
+	if err := s.indexHashSingle(ctx, db, response, results, opts); err != nil {
+		s.metrics.indexChecksum.ReportError(s.nowFn().Sub(callStart))
+		return nil, err
+	}
+
+	s.metrics.indexChecksum.ReportSuccess(s.nowFn().Sub(callStart))
+	return response, nil
+}
+
+func (s *service) indexHashSingle(ctx context.Context,
+	db storage.Database,
+	response *rpc.IndexChecksumResult_,
+	results index.QueryResults,
+	opts index.QueryOptions,
+) error {
+	nsID := results.Namespace()
+	ctx, sp, sampled := ctx.StartSampledTraceSpan(tracepoint.IndexChecksumSingleResult)
+	if sampled {
+		sp.LogFields(
+			opentracinglog.String("id", nsID.String()),
+		)
+	}
+	defer sp.Finish()
+
+	i := 0
+	count := results.Map().Len()
+	// TODO: have an ordered representation generated into the result instead.
+	orderedIDs := make([]ident.ID, 0, count)
+	for _, entry := range results.Map().Iter() {
+		orderedIDs = append(orderedIDs, entry.Key())
+	}
+	// Sort counters for comparison purposes.
+	sort.Slice(orderedIDs, func(i, j int) bool {
+		return bytes.Compare(orderedIDs[i].Bytes(), orderedIDs[j].Bytes()) == -1
+	})
+
+	for _, tsID := range orderedIDs {
+		i++
+
+		// if last element of the batch or last element in the result set,
+		// include ID as a batch marker.
+		useID := i%opts.BatchSize == 0 || i == count
+		checksum, err := db.IndexChecksum(ctx, nsID, tsID, useID,
+			opts.StartInclusive)
+		if err != nil {
+			continue
+		}
+
+		response.Checksums = append(response.Checksums, int64(checksum.Checksum))
+		if useID {
+			response.Marker = checksum.ID
+		}
+	}
+	return nil
 }
 
 func (s *service) encodeTags(

--- a/src/dbnode/network/server/tchannelthrift/options.go
+++ b/src/dbnode/network/server/tchannelthrift/options.go
@@ -30,6 +30,8 @@ import (
 	"github.com/m3db/m3/src/x/serialize"
 )
 
+const defaultBatchSize = 1024
+
 type options struct {
 	clockOpts                   clock.Options
 	instrumentOpts              instrument.Options
@@ -42,9 +44,10 @@ type options struct {
 	checkedBytesWrapperPool     xpool.CheckedBytesWrapperPool
 	maxOutstandingWriteRequests int
 	maxOutstandingReadRequests  int
+	batchSize                   int
 }
 
-// NewOptions creates new options
+// NewOptions creates new options.
 func NewOptions() Options {
 	// Use a zero size pool by default, override from config.
 	poolOptions := pool.NewObjectPoolOptions().
@@ -83,6 +86,7 @@ func NewOptions() Options {
 		tagEncoderPool:           tagEncoderPool,
 		tagDecoderPool:           tagDecoderPool,
 		checkedBytesWrapperPool:  bytesWrapperPool,
+		batchSize:                defaultBatchSize,
 	}
 }
 
@@ -194,4 +198,14 @@ func (o *options) SetMaxOutstandingReadRequests(value int) Options {
 
 func (o *options) MaxOutstandingReadRequests() int {
 	return o.maxOutstandingReadRequests
+}
+
+func (o *options) SetBatchSize(value int) Options {
+	opts := *o
+	opts.batchSize = value
+	return &opts
+}
+
+func (o *options) BatchSize() int {
+	return o.batchSize
 }

--- a/src/dbnode/network/server/tchannelthrift/types.go
+++ b/src/dbnode/network/server/tchannelthrift/types.go
@@ -100,4 +100,10 @@ type Options interface {
 	// MaxOutstandingReadRequests returns the maxinum number of allowed
 	// outstanding read requests.
 	MaxOutstandingReadRequests() int
+
+	// SetBatchSize sets batch size for wide operations.
+	SetBatchSize(value int) Options
+
+	// BatchSize returns batch size for wide operations.
+	BatchSize() int
 }

--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -489,6 +489,21 @@ func (mr *MockDataFileSetSeekerMockRecorder) SeekIndexEntry(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekIndexEntry", reflect.TypeOf((*MockDataFileSetSeeker)(nil).SeekIndexEntry), arg0, arg1)
 }
 
+// SeekIndexEntryToIndexChecksum mocks base method
+func (m *MockDataFileSetSeeker) SeekIndexEntryToIndexChecksum(arg0 ident.ID, arg1 bool, arg2 ReusableSeekerResources) (ident.IndexChecksum, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SeekIndexEntryToIndexChecksum", arg0, arg1, arg2)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SeekIndexEntryToIndexChecksum indicates an expected call of SeekIndexEntryToIndexChecksum
+func (mr *MockDataFileSetSeekerMockRecorder) SeekIndexEntryToIndexChecksum(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekIndexEntryToIndexChecksum", reflect.TypeOf((*MockDataFileSetSeeker)(nil).SeekIndexEntryToIndexChecksum), arg0, arg1, arg2)
+}
+
 // MockIndexFileSetWriter is a mock of IndexFileSetWriter interface
 type MockIndexFileSetWriter struct {
 	ctrl     *gomock.Controller
@@ -1208,6 +1223,21 @@ func (m *MockConcurrentDataFileSetSeeker) SeekIndexEntry(arg0 ident.ID, arg1 Reu
 func (mr *MockConcurrentDataFileSetSeekerMockRecorder) SeekIndexEntry(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekIndexEntry", reflect.TypeOf((*MockConcurrentDataFileSetSeeker)(nil).SeekIndexEntry), arg0, arg1)
+}
+
+// SeekIndexEntryToIndexChecksum mocks base method
+func (m *MockConcurrentDataFileSetSeeker) SeekIndexEntryToIndexChecksum(arg0 ident.ID, arg1 bool, arg2 ReusableSeekerResources) (ident.IndexChecksum, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SeekIndexEntryToIndexChecksum", arg0, arg1, arg2)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SeekIndexEntryToIndexChecksum indicates an expected call of SeekIndexEntryToIndexChecksum
+func (mr *MockConcurrentDataFileSetSeekerMockRecorder) SeekIndexEntryToIndexChecksum(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekIndexEntryToIndexChecksum", reflect.TypeOf((*MockConcurrentDataFileSetSeeker)(nil).SeekIndexEntryToIndexChecksum), arg0, arg1, arg2)
 }
 
 // MockMergeWith is a mock of MergeWith interface

--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -489,21 +489,6 @@ func (mr *MockDataFileSetSeekerMockRecorder) SeekIndexEntry(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekIndexEntry", reflect.TypeOf((*MockDataFileSetSeeker)(nil).SeekIndexEntry), arg0, arg1)
 }
 
-// SeekIndexEntryToIndexChecksum mocks base method
-func (m *MockDataFileSetSeeker) SeekIndexEntryToIndexChecksum(arg0 ident.ID, arg1 bool, arg2 ReusableSeekerResources) (ident.IndexChecksum, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SeekIndexEntryToIndexChecksum", arg0, arg1, arg2)
-	ret0, _ := ret[0].(ident.IndexChecksum)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SeekIndexEntryToIndexChecksum indicates an expected call of SeekIndexEntryToIndexChecksum
-func (mr *MockDataFileSetSeekerMockRecorder) SeekIndexEntryToIndexChecksum(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekIndexEntryToIndexChecksum", reflect.TypeOf((*MockDataFileSetSeeker)(nil).SeekIndexEntryToIndexChecksum), arg0, arg1, arg2)
-}
-
 // MockIndexFileSetWriter is a mock of IndexFileSetWriter interface
 type MockIndexFileSetWriter struct {
 	ctrl     *gomock.Controller
@@ -1223,21 +1208,6 @@ func (m *MockConcurrentDataFileSetSeeker) SeekIndexEntry(arg0 ident.ID, arg1 Reu
 func (mr *MockConcurrentDataFileSetSeekerMockRecorder) SeekIndexEntry(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekIndexEntry", reflect.TypeOf((*MockConcurrentDataFileSetSeeker)(nil).SeekIndexEntry), arg0, arg1)
-}
-
-// SeekIndexEntryToIndexChecksum mocks base method
-func (m *MockConcurrentDataFileSetSeeker) SeekIndexEntryToIndexChecksum(arg0 ident.ID, arg1 bool, arg2 ReusableSeekerResources) (ident.IndexChecksum, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SeekIndexEntryToIndexChecksum", arg0, arg1, arg2)
-	ret0, _ := ret[0].(ident.IndexChecksum)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SeekIndexEntryToIndexChecksum indicates an expected call of SeekIndexEntryToIndexChecksum
-func (mr *MockConcurrentDataFileSetSeekerMockRecorder) SeekIndexEntryToIndexChecksum(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekIndexEntryToIndexChecksum", reflect.TypeOf((*MockConcurrentDataFileSetSeeker)(nil).SeekIndexEntryToIndexChecksum), arg0, arg1, arg2)
 }
 
 // MockMergeWith is a mock of MergeWith interface

--- a/src/dbnode/persist/fs/merger_test.go
+++ b/src/dbnode/persist/fs/merger_test.go
@@ -449,13 +449,13 @@ func TestCleanup(t *testing.T) {
 
 	blockStart := time.Now()
 	var shard uint32 = 1
-	fsId := FileSetFileIdentifier{
+	fsID := FileSetFileIdentifier{
 		Namespace:   md.ID(),
 		Shard:       shard,
 		BlockStart:  blockStart,
 		VolumeIndex: 0,
 	}
-	writeFilesetToDisk(t, fsId, fsOpts)
+	writeFilesetToDisk(t, fsID, fsOpts)
 
 	// Verify fileset exists
 	exists, err := DataFileSetExists(filePathPrefix, md.ID(), shard, blockStart, 0)
@@ -476,7 +476,7 @@ func TestCleanup(t *testing.T) {
 	preparer, err := pm.StartFlushPersist()
 	require.NoError(t, err)
 
-	err = merger.MergeAndCleanup(fsId, NewNoopMergeWith(), fsId.VolumeIndex+1, preparer,
+	err = merger.MergeAndCleanup(fsID, NewNoopMergeWith(), fsID.VolumeIndex+1, preparer,
 		namespace.NewContextFrom(md), &persist.NoOpColdFlushNamespace{}, false)
 	require.NoError(t, err)
 
@@ -504,12 +504,12 @@ func TestCleanupOnceBootstrapped(t *testing.T) {
 	require.Error(t, err)
 }
 
-func writeFilesetToDisk(t *testing.T, fsId FileSetFileIdentifier, fsOpts Options) {
+func writeFilesetToDisk(t *testing.T, fsID FileSetFileIdentifier, fsOpts Options) {
 	w, err := NewWriter(fsOpts)
 	require.NoError(t, err)
 
 	writerOpts := DataWriterOpenOptions{
-		Identifier: fsId,
+		Identifier: fsID,
 		BlockSize:  2 * time.Hour,
 	}
 	err = w.Open(writerOpts)

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -462,6 +462,16 @@ func (r *blockRetriever) Stream(
 	// read the data.
 	return req.toBlock(), nil
 }
+func (r *blockRetriever) StreamIndexChecksum(
+	ctx context.Context,
+	shard uint32,
+	id ident.ID,
+	useID bool,
+	startTime time.Time,
+	nsCtx namespace.Context,
+) (ident.IndexChecksum, bool, error) {
+	return ident.IndexChecksum{}, false, nil // TODO: implement.
+}
 
 func (req *retrieveRequest) toBlock() xio.BlockReader {
 	return xio.BlockReader{

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -635,6 +635,10 @@ func Run(runOpts RunOptions) {
 		SetMaxOutstandingWriteRequests(cfg.Limits.MaxOutstandingWriteRequests).
 		SetMaxOutstandingReadRequests(cfg.Limits.MaxOutstandingReadRequests)
 
+	if cfg.TChannel != nil && cfg.TChannel.BatchSize > 0 {
+		ttopts = ttopts.SetBatchSize(cfg.TChannel.BatchSize)
+	}
+
 	// Start servers before constructing the DB so orchestration tools can check health endpoints
 	// before topology is set.
 	var (

--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -884,6 +884,22 @@ func (mr *MockDatabaseBlockRetrieverMockRecorder) Stream(ctx, shard, id, blockSt
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stream", reflect.TypeOf((*MockDatabaseBlockRetriever)(nil).Stream), ctx, shard, id, blockStart, onRetrieve, nsCtx)
 }
 
+// StreamIndexChecksum mocks base method
+func (m *MockDatabaseBlockRetriever) StreamIndexChecksum(ctx context.Context, shard uint32, id ident.ID, useID bool, startTime time.Time, nsCtx namespace.Context) (ident.IndexChecksum, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamIndexChecksum", ctx, shard, id, useID, startTime, nsCtx)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// StreamIndexChecksum indicates an expected call of StreamIndexChecksum
+func (mr *MockDatabaseBlockRetrieverMockRecorder) StreamIndexChecksum(ctx, shard, id, useID, startTime, nsCtx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamIndexChecksum", reflect.TypeOf((*MockDatabaseBlockRetriever)(nil).StreamIndexChecksum), ctx, shard, id, useID, startTime, nsCtx)
+}
+
 // AssignShardSet mocks base method
 func (m *MockDatabaseBlockRetriever) AssignShardSet(shardSet sharding.ShardSet) {
 	m.ctrl.T.Helper()
@@ -932,6 +948,22 @@ func (m *MockDatabaseShardBlockRetriever) Stream(ctx context.Context, id ident.I
 func (mr *MockDatabaseShardBlockRetrieverMockRecorder) Stream(ctx, id, blockStart, onRetrieve, nsCtx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stream", reflect.TypeOf((*MockDatabaseShardBlockRetriever)(nil).Stream), ctx, id, blockStart, onRetrieve, nsCtx)
+}
+
+// StreamIndexChecksum mocks base method
+func (m *MockDatabaseShardBlockRetriever) StreamIndexChecksum(ctx context.Context, id ident.ID, useID bool, blockStart time.Time, nsCtx namespace.Context) (ident.IndexChecksum, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamIndexChecksum", ctx, id, useID, blockStart, nsCtx)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// StreamIndexChecksum indicates an expected call of StreamIndexChecksum
+func (mr *MockDatabaseShardBlockRetrieverMockRecorder) StreamIndexChecksum(ctx, id, useID, blockStart, nsCtx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamIndexChecksum", reflect.TypeOf((*MockDatabaseShardBlockRetriever)(nil).StreamIndexChecksum), ctx, id, useID, blockStart, nsCtx)
 }
 
 // MockDatabaseBlockRetrieverManager is a mock of DatabaseBlockRetrieverManager interface

--- a/src/dbnode/storage/block/retriever_manager.go
+++ b/src/dbnode/storage/block/retriever_manager.go
@@ -112,6 +112,17 @@ func (r *shardBlockRetriever) Stream(
 		blockStart, onRetrieve, nsCtx)
 }
 
+func (r *shardBlockRetriever) StreamIndexChecksum(
+	ctx context.Context,
+	id ident.ID,
+	useID bool,
+	blockStart time.Time,
+	nsCtx namespace.Context,
+) (ident.IndexChecksum, bool, error) {
+	return r.DatabaseBlockRetriever.StreamIndexChecksum(ctx, r.shard, id, useID,
+		blockStart, nsCtx)
+}
+
 type shardBlockRetrieverManager struct {
 	sync.RWMutex
 	retriever       DatabaseBlockRetriever

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -283,6 +283,18 @@ type DatabaseBlockRetriever interface {
 		nsCtx namespace.Context,
 	) (xio.BlockReader, error)
 
+	// StreamIndexChecksum will stream block index checksums for a given id and
+	// start, yielding an index checksum if available, a boolean indicating if it
+	// was found, and any errors encountered.
+	StreamIndexChecksum(
+		ctx context.Context,
+		shard uint32,
+		id ident.ID,
+		useID bool,
+		startTime time.Time,
+		nsCtx namespace.Context,
+	) (ident.IndexChecksum, bool, error)
+
 	AssignShardSet(shardSet sharding.ShardSet)
 }
 
@@ -296,6 +308,17 @@ type DatabaseShardBlockRetriever interface {
 		onRetrieve OnRetrieveBlock,
 		nsCtx namespace.Context,
 	) (xio.BlockReader, error)
+
+	// StreamIndexChecksum will stream block index checksums for a given id and
+	// start, yielding an index checksum if available, a boolean indicating if
+	// it was found, and any errors encountered.
+	StreamIndexChecksum(
+		ctx context.Context,
+		id ident.ID,
+		useID bool,
+		blockStart time.Time,
+		nsCtx namespace.Context,
+	) (ident.IndexChecksum, bool, error)
 }
 
 // DatabaseBlockRetrieverManager creates and holds block retrievers

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1312,7 +1312,7 @@ func (i *nsIndex) Query(
 		xopentracing.Time("queryEnd", opts.EndExclusive),
 	}
 
-	ctx, sp := ctx.StartTraceSpan(tracepoint.NSIdxQuery)
+	ctx, sp := ctx.StartTraceSpan(opts.NSIdxTracepoint())
 	sp.LogFields(logFields...)
 	defer sp.Finish()
 

--- a/src/dbnode/storage/index/query_options.go
+++ b/src/dbnode/storage/index/query_options.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package index
+
+import (
+	"github.com/m3db/m3/src/dbnode/tracepoint"
+)
+
+// SeriesLimitExceeded returns whether a given size exceeds the
+// series limit the query options imposes, if it is enabled.
+func (o QueryOptions) SeriesLimitExceeded(size int) bool {
+	return o.SeriesLimit > 0 && size >= o.SeriesLimit
+}
+
+// DocsLimitExceeded returns whether a given size exceeds the
+// docs limit the query options imposes, if it is enabled.
+func (o QueryOptions) DocsLimitExceeded(size int) bool {
+	return o.DocsLimit > 0 && size >= o.DocsLimit
+}
+
+// LimitsExceeded returns whether a given size exceeds the given limits.
+func (o QueryOptions) LimitsExceeded(seriesCount, docsCount int) bool {
+	if o.IndexChecksumQuery {
+		return false
+	}
+
+	return o.SeriesLimitExceeded(seriesCount) || o.DocsLimitExceeded(docsCount)
+}
+
+func (o QueryOptions) exhaustive(seriesCount, docsCount int) bool {
+	return !o.SeriesLimitExceeded(seriesCount) && !o.DocsLimitExceeded(docsCount)
+}
+
+func (o QueryOptions) tracepoint(idxHash, query string) string {
+	if o.IndexChecksumQuery {
+		return idxHash
+	}
+
+	return query
+}
+
+func (o QueryOptions) queryTracepoint() string {
+	return o.tracepoint(tracepoint.IndexChecksumQuery, tracepoint.BlockQuery)
+}
+
+// NSTracepoint yields the appropriate tracepoint for namespace tchannelthrift path.
+func (o QueryOptions) NSTracepoint() string {
+	return o.tracepoint(tracepoint.NSIndexChecksum, tracepoint.NSQueryIDs)
+}
+
+// DBTracepoint yields the appropriate tracepoint for database tchannelthrift path.
+func (o QueryOptions) DBTracepoint() string {
+	return o.tracepoint(tracepoint.DBQueryIDsIndexChecksum, tracepoint.DBQueryIDs)
+}
+
+// NSIdxTracepoint yields the appropriate tracepoint for index namespace tchannelthrift path.
+func (o QueryOptions) NSIdxTracepoint() string {
+	return o.tracepoint(tracepoint.NSIndexChecksumQuery, tracepoint.NSIdxQuery)
+}

--- a/src/dbnode/storage/index/query_options_test.go
+++ b/src/dbnode/storage/index/query_options_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryOptions(t *testing.T) {
+	opts := QueryOptions{
+		DocsLimit:          10,
+		SeriesLimit:        20,
+		IndexChecksumQuery: false,
+	}
+
+	assert.False(t, opts.SeriesLimitExceeded(19))
+	assert.True(t, opts.SeriesLimitExceeded(20))
+
+	assert.False(t, opts.DocsLimitExceeded(9))
+	assert.True(t, opts.DocsLimitExceeded(10))
+
+	assert.True(t, opts.LimitsExceeded(19, 10))
+	assert.True(t, opts.LimitsExceeded(20, 9))
+	assert.False(t, opts.LimitsExceeded(19, 9))
+
+	assert.False(t, opts.exhaustive(19, 10))
+	assert.False(t, opts.exhaustive(20, 9))
+	assert.True(t, opts.exhaustive(19, 9))
+
+	assert.Equal(t, "storage/index.block.Query", opts.queryTracepoint())
+	assert.Equal(t, "storage.dbNamespace.QueryIDs", opts.NSTracepoint())
+	assert.Equal(t, "storage.db.QueryIDs", opts.DBTracepoint())
+	assert.Equal(t, "storage.nsIndex.Query", opts.NSIdxTracepoint())
+}
+
+func TestIndexChecksumQueryOptions(t *testing.T) {
+	opts := QueryOptions{
+		IndexChecksumQuery: true,
+	}
+
+	assert.False(t, opts.SeriesLimitExceeded(19))
+	assert.False(t, opts.SeriesLimitExceeded(20))
+
+	assert.False(t, opts.DocsLimitExceeded(9))
+	assert.False(t, opts.DocsLimitExceeded(10))
+
+	assert.False(t, opts.LimitsExceeded(19, 10))
+	assert.False(t, opts.LimitsExceeded(20, 9))
+	assert.False(t, opts.LimitsExceeded(19, 9))
+
+	assert.True(t, opts.exhaustive(19, 10))
+	assert.True(t, opts.exhaustive(20, 9))
+	assert.True(t, opts.exhaustive(19, 9))
+
+	assert.Equal(t, "storage/index.block.IndexChecksum", opts.queryTracepoint())
+	assert.Equal(t, "storage.dbNamespace.IndexChecksum", opts.NSTracepoint())
+	assert.Equal(t, "storage.db.QueryIDsIndexChecksum", opts.DBTracepoint())
+	assert.Equal(t, "storage.nsIndex.IndexChecksum", opts.NSIdxTracepoint())
+}

--- a/src/dbnode/storage/series/reader.go
+++ b/src/dbnode/storage/series/reader.go
@@ -203,6 +203,16 @@ func (r Reader) readersWithBlocksMapAndBuffer(
 	return results, nil
 }
 
+// IndexChecksum reads index checksum blocks using just a block retriever.
+func (r Reader) IndexChecksum(
+	ctx context.Context,
+	start time.Time,
+	useID bool,
+	nsCtx namespace.Context,
+) (ident.IndexChecksum, error) {
+	return ident.IndexChecksum{}, nil // TODO: add logic.
+}
+
 // FetchBlocks returns data blocks given a list of block start times using
 // just a block retriever.
 func (r Reader) FetchBlocks(

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -402,6 +402,19 @@ func (s *dbSeries) ReadEncoded(
 	return r, err
 }
 
+func (s *dbSeries) IndexChecksum(
+	ctx context.Context,
+	start time.Time,
+	useID bool,
+	nsCtx namespace.Context,
+) (ident.IndexChecksum, error) {
+	s.RLock()
+	reader := NewReaderUsingRetriever(s.id, s.blockRetriever, s.onRetrieveBlock, s, s.opts)
+	r, err := reader.indexChecksum(ctx, start, useID, nsCtx)
+	s.RUnlock()
+	return r, err
+}
+
 func (s *dbSeries) FetchBlocksForColdFlush(
 	ctx context.Context,
 	start time.Time,

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -410,7 +410,7 @@ func (s *dbSeries) IndexChecksum(
 ) (ident.IndexChecksum, error) {
 	s.RLock()
 	reader := NewReaderUsingRetriever(s.id, s.blockRetriever, s.onRetrieveBlock, s, s.opts)
-	r, err := reader.indexChecksum(ctx, start, useID, nsCtx)
+	r, err := reader.IndexChecksum(ctx, start, useID, nsCtx)
 	s.RUnlock()
 	return r, err
 }

--- a/src/dbnode/storage/series/series_mock.go
+++ b/src/dbnode/storage/series/series_mock.go
@@ -163,6 +163,21 @@ func (mr *MockDatabaseSeriesMockRecorder) ID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ID", reflect.TypeOf((*MockDatabaseSeries)(nil).ID))
 }
 
+// IndexChecksum mocks base method
+func (m *MockDatabaseSeries) IndexChecksum(arg0 context.Context, arg1 time.Time, arg2 bool, arg3 namespace.Context) (ident.IndexChecksum, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexChecksum", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexChecksum indicates an expected call of IndexChecksum
+func (mr *MockDatabaseSeriesMockRecorder) IndexChecksum(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexChecksum", reflect.TypeOf((*MockDatabaseSeries)(nil).IndexChecksum), arg0, arg1, arg2, arg3)
+}
+
 // IsBufferEmptyAtBlockStart mocks base method
 func (m *MockDatabaseSeries) IsBufferEmptyAtBlockStart(arg0 time.Time) bool {
 	m.ctrl.T.Helper()
@@ -439,4 +454,20 @@ func (m *MockQueryableBlockRetriever) Stream(arg0 context.Context, arg1 ident.ID
 func (mr *MockQueryableBlockRetrieverMockRecorder) Stream(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stream", reflect.TypeOf((*MockQueryableBlockRetriever)(nil).Stream), arg0, arg1, arg2, arg3, arg4)
+}
+
+// StreamIndexChecksum mocks base method
+func (m *MockQueryableBlockRetriever) StreamIndexChecksum(arg0 context.Context, arg1 ident.ID, arg2 bool, arg3 time.Time, arg4 namespace.Context) (ident.IndexChecksum, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StreamIndexChecksum", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// StreamIndexChecksum indicates an expected call of StreamIndexChecksum
+func (mr *MockQueryableBlockRetrieverMockRecorder) StreamIndexChecksum(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamIndexChecksum", reflect.TypeOf((*MockQueryableBlockRetriever)(nil).StreamIndexChecksum), arg0, arg1, arg2, arg3, arg4)
 }

--- a/src/dbnode/storage/series/types.go
+++ b/src/dbnode/storage/series/types.go
@@ -86,6 +86,14 @@ type DatabaseSeries interface {
 		nsCtx namespace.Context,
 	) ([][]xio.BlockReader, error)
 
+	// IndexChecksum reads checksums from encoded blocks.
+	IndexChecksum(
+		ctx context.Context,
+		start time.Time,
+		useID bool,
+		nsCtx namespace.Context,
+	) (ident.IndexChecksum, error)
+
 	// FetchBlocks returns data blocks given a list of block start times.
 	FetchBlocks(
 		ctx context.Context,

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -182,7 +182,7 @@ func TestShardBootstrapWithFlushVersion(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	var (
@@ -260,7 +260,7 @@ func TestShardBootstrapWithFlushVersionNoCleanUp(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	var (
@@ -318,7 +318,7 @@ func TestShardBootstrapWithCacheShardIndices(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	var (
@@ -406,7 +406,7 @@ func testShardLoadLimit(t *testing.T, limit int64, shouldReturnError bool) {
 }
 
 func TestShardFlushSeriesFlushError(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	blockStart := time.Unix(21600, 0)
@@ -478,7 +478,7 @@ func TestShardFlushSeriesFlushError(t *testing.T) {
 }
 
 func TestShardFlushSeriesFlushSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	blockStart := time.Unix(21600, 0)
@@ -662,7 +662,7 @@ func TestShardColdFlush(t *testing.T) {
 }
 
 func TestShardColdFlushNoMergeIfNothingDirty(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 	now := time.Now()
 	nowFn := func() time.Time {
@@ -774,7 +774,7 @@ func newFSMergeWithMemTestFn(
 }
 
 func TestShardSnapshotShardNotBootstrapped(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	blockStart := time.Unix(21600, 0)
@@ -789,7 +789,7 @@ func TestShardSnapshotShardNotBootstrapped(t *testing.T) {
 }
 
 func TestShardSnapshotSeriesSnapshotSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	blockStart := time.Unix(21600, 0)
@@ -896,7 +896,7 @@ func TestShardTick(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	now := time.Now()
@@ -1038,7 +1038,7 @@ func testShardWriteAsync(t *testing.T, writes []testWrite) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	testReporter := xmetrics.NewTestStatsReporter(xmetrics.NewTestStatsReporterOptions())
@@ -1220,7 +1220,7 @@ func TestShardReturnsErrorForConcurrentTicks(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	opts := DefaultTestOptions()
@@ -1278,7 +1278,7 @@ func TestShardReturnsErrorForConcurrentTicks(t *testing.T) {
 // This tests ensures the resources held in series contained in the shard are released
 // when closing the shard.
 func TestShardTicksWhenClosed(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	opts := DefaultTestOptions()
@@ -1294,7 +1294,7 @@ func TestShardTicksWhenClosed(t *testing.T) {
 
 // This tests ensures the shard terminates Ticks when closing.
 func TestShardTicksStopWhenClosing(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	opts := DefaultTestOptions()
@@ -1360,7 +1360,7 @@ func TestPurgeExpiredSeriesEmptySeries(t *testing.T) {
 
 // This tests the scenario where a non-empty series is not expired.
 func TestPurgeExpiredSeriesNonEmptySeries(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	opts := DefaultTestOptions()
@@ -1382,7 +1382,7 @@ func TestPurgeExpiredSeriesNonEmptySeries(t *testing.T) {
 // but receives writes after tickForEachSeries finishes but before purgeExpiredSeries
 // starts. The expected behavior is not to expire series in this case.
 func TestPurgeExpiredSeriesWriteAfterTicking(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	opts := DefaultTestOptions()
@@ -1411,7 +1411,7 @@ func TestPurgeExpiredSeriesWriteAfterTicking(t *testing.T) {
 // starts, we receive a write for a series, then purgeExpiredSeries runs, then we write to
 // the series. The expected behavior is not to expire series in this case.
 func TestPurgeExpiredSeriesWriteAfterPurging(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	var entry *lookup.Entry
@@ -1486,7 +1486,7 @@ func TestShardFetchBlocksIDNotExists(t *testing.T) {
 }
 
 func TestShardFetchBlocksIDExists(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	opts := DefaultTestOptions()
@@ -1531,7 +1531,7 @@ func (c *testCloser) Close() {
 }
 
 func TestShardRegisterRuntimeOptionsListeners(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	callRegisterListenerOnShard := 0
@@ -1568,12 +1568,72 @@ func TestShardRegisterRuntimeOptionsListeners(t *testing.T) {
 	assert.Equal(t, 2, closer.called)
 }
 
+func TestShardStreamIndexChecksum(t *testing.T) {
+	dir, err := ioutil.TempDir("", "testdir")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	opts := DefaultTestOptions().
+		SetSeriesCachePolicy(series.CacheRecentlyRead)
+	fsOpts := opts.CommitLogOptions().FilesystemOptions().
+		SetFilePathPrefix(dir)
+	opts = opts.
+		SetCommitLogOptions(opts.CommitLogOptions().
+			SetFilesystemOptions(fsOpts))
+
+	shard := testDatabaseShard(t, opts)
+	defer shard.Close()
+
+	ctx := context.NewContext()
+	defer ctx.Close()
+
+	nsCtx := namespace.Context{ID: ident.StringID("foo")}
+	require.NoError(t, shard.Bootstrap(ctx, nsCtx))
+
+	ropts := shard.seriesOpts.RetentionOptions()
+	end := opts.ClockOptions().NowFn()().Truncate(ropts.BlockSize())
+	start := end.Add(-2 * ropts.BlockSize())
+	shard.markWarmFlushStateSuccess(start)
+	shard.markWarmFlushStateSuccess(start.Add(ropts.BlockSize()))
+
+	retriever := block.NewMockDatabaseBlockRetriever(ctrl)
+	shard.setBlockRetriever(retriever)
+
+	indexChecksum := ident.IndexChecksum{
+		Checksum: 5,
+		ID:       []byte("foo"),
+	}
+
+	retriever.EXPECT().
+		StreamIndexChecksum(ctx, shard.shard, ident.NewIDMatcher("foo"), true,
+			start, gomock.Any()).Return(indexChecksum, true, nil)
+
+	// Check reads as expected
+	r, err := shard.IndexChecksum(ctx, ident.StringID("foo"), true, start, namespace.Context{})
+	require.NoError(t, err)
+
+	// Check that nothing has been cached. Should be cached after a second.
+	time.Sleep(time.Second)
+
+	shard.RLock()
+	entry, _, err := shard.lookupEntryWithLock(ident.StringID("foo"))
+	shard.RUnlock()
+
+	require.Equal(t, err, errShardEntryNotFound)
+	require.Nil(t, entry)
+
+	assert.Equal(t, indexChecksum, r)
+}
+
 func TestShardReadEncodedCachesSeriesWithRecentlyReadPolicy(t *testing.T) {
 	dir, err := ioutil.TempDir("", "testdir")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	opts := DefaultTestOptions().
@@ -1691,7 +1751,7 @@ func TestShardNewInvalidShardEntry(t *testing.T) {
 }
 
 func TestShardNewValidShardEntry(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
 	shard := testDatabaseShard(t, DefaultTestOptions())

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -1569,6 +1569,9 @@ func TestShardRegisterRuntimeOptionsListeners(t *testing.T) {
 }
 
 func TestShardStreamIndexChecksum(t *testing.T) {
+	// TODO: re-enable test when retriever logic is hooked up.
+	t.SkipNow()
+
 	dir, err := ioutil.TempDir("", "testdir")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -343,6 +343,21 @@ func (mr *MockDatabaseMockRecorder) ReadEncoded(ctx, namespace, id, start, end i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadEncoded", reflect.TypeOf((*MockDatabase)(nil).ReadEncoded), ctx, namespace, id, start, end)
 }
 
+// IndexChecksum mocks base method
+func (m *MockDatabase) IndexChecksum(ctx context.Context, namespace, id ident.ID, useID bool, start time.Time) (ident.IndexChecksum, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexChecksum", ctx, namespace, id, useID, start)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexChecksum indicates an expected call of IndexChecksum
+func (mr *MockDatabaseMockRecorder) IndexChecksum(ctx, namespace, id, useID, start interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexChecksum", reflect.TypeOf((*MockDatabase)(nil).IndexChecksum), ctx, namespace, id, useID, start)
+}
+
 // FetchBlocks mocks base method
 func (m *MockDatabase) FetchBlocks(ctx context.Context, namespace ident.ID, shard uint32, id ident.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	m.ctrl.T.Helper()
@@ -736,6 +751,21 @@ func (m *Mockdatabase) ReadEncoded(ctx context.Context, namespace, id ident.ID, 
 func (mr *MockdatabaseMockRecorder) ReadEncoded(ctx, namespace, id, start, end interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadEncoded", reflect.TypeOf((*Mockdatabase)(nil).ReadEncoded), ctx, namespace, id, start, end)
+}
+
+// IndexChecksum mocks base method
+func (m *Mockdatabase) IndexChecksum(ctx context.Context, namespace, id ident.ID, useID bool, start time.Time) (ident.IndexChecksum, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexChecksum", ctx, namespace, id, useID, start)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexChecksum indicates an expected call of IndexChecksum
+func (mr *MockdatabaseMockRecorder) IndexChecksum(ctx, namespace, id, useID, start interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexChecksum", reflect.TypeOf((*Mockdatabase)(nil).IndexChecksum), ctx, namespace, id, useID, start)
 }
 
 // FetchBlocks mocks base method
@@ -1313,6 +1343,21 @@ func (mr *MockdatabaseNamespaceMockRecorder) ReadEncoded(ctx, id, start, end int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadEncoded", reflect.TypeOf((*MockdatabaseNamespace)(nil).ReadEncoded), ctx, id, start, end)
 }
 
+// IndexChecksum mocks base method
+func (m *MockdatabaseNamespace) IndexChecksum(ctx context.Context, id ident.ID, useID bool, start time.Time) (ident.IndexChecksum, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexChecksum", ctx, id, useID, start)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexChecksum indicates an expected call of IndexChecksum
+func (mr *MockdatabaseNamespaceMockRecorder) IndexChecksum(ctx, id, useID, start interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexChecksum", reflect.TypeOf((*MockdatabaseNamespace)(nil).IndexChecksum), ctx, id, useID, start)
+}
+
 // FetchBlocks mocks base method
 func (m *MockdatabaseNamespace) FetchBlocks(ctx context.Context, shardID uint32, id ident.ID, starts []time.Time) ([]block.FetchBlockResult, error) {
 	m.ctrl.T.Helper()
@@ -1774,6 +1819,21 @@ func (m *MockdatabaseShard) ReadEncoded(ctx context.Context, id ident.ID, start,
 func (mr *MockdatabaseShardMockRecorder) ReadEncoded(ctx, id, start, end, nsCtx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadEncoded", reflect.TypeOf((*MockdatabaseShard)(nil).ReadEncoded), ctx, id, start, end, nsCtx)
+}
+
+// IndexChecksum mocks base method
+func (m *MockdatabaseShard) IndexChecksum(ctx context.Context, id ident.ID, useID bool, start time.Time, nsCtx namespace.Context) (ident.IndexChecksum, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexChecksum", ctx, id, useID, start, nsCtx)
+	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexChecksum indicates an expected call of IndexChecksum
+func (mr *MockdatabaseShardMockRecorder) IndexChecksum(ctx, id, useID, start, nsCtx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexChecksum", reflect.TypeOf((*MockdatabaseShard)(nil).IndexChecksum), ctx, id, useID, start, nsCtx)
 }
 
 // FetchBlocks mocks base method

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -162,13 +162,22 @@ type Database interface {
 		opts index.AggregationOptions,
 	) (index.AggregateQueryResult, error)
 
-	// ReadEncoded retrieves encoded segments for an ID
+	// ReadEncoded retrieves encoded segments for an ID.
 	ReadEncoded(
 		ctx context.Context,
 		namespace ident.ID,
 		id ident.ID,
 		start, end time.Time,
 	) ([][]xio.BlockReader, error)
+
+	// IndexChecksum retrieves index checksum for an ID.
+	IndexChecksum(
+		ctx context.Context,
+		namespace ident.ID,
+		id ident.ID,
+		useID bool,
+		start time.Time,
+	) (ident.IndexChecksum, error)
 
 	// FetchBlocks retrieves data blocks for a given id and a list of block
 	// start times.
@@ -333,6 +342,15 @@ type databaseNamespace interface {
 		start, end time.Time,
 	) ([][]xio.BlockReader, error)
 
+	// IndexChecksum retrieves the index checksum for an ID for the block
+	// at time start.
+	IndexChecksum(
+		ctx context.Context,
+		id ident.ID,
+		useID bool,
+		start time.Time,
+	) (ident.IndexChecksum, error)
+
 	// FetchBlocks retrieves data blocks for a given id and a list of block
 	// start times.
 	FetchBlocks(
@@ -480,6 +498,15 @@ type databaseShard interface {
 		start, end time.Time,
 		nsCtx namespace.Context,
 	) ([][]xio.BlockReader, error)
+
+	// IndexChecksum retrieves the index checksum for an ID.
+	IndexChecksum(
+		ctx context.Context,
+		id ident.ID,
+		useID bool,
+		start time.Time,
+		nsCtx namespace.Context,
+	) (ident.IndexChecksum, error)
 
 	// FetchBlocks retrieves data blocks for a given id and a list of block
 	// start times.

--- a/src/dbnode/tracepoint/tracepoint.go
+++ b/src/dbnode/tracepoint/tracepoint.go
@@ -46,8 +46,17 @@ const (
 	// FetchReadSegment is the operation name for the tchannelthrift FetchReadSegment path.
 	FetchReadSegment = "tchannelthrift/node.service.FetchReadSegment"
 
+	// IndexChecksum is the operation name for the tchannelthrift IndexChecksum path.
+	IndexChecksum = "tchannelthrift/node.service.IndexChecksum"
+
+	// IndexChecksumSingleResult is the operation name for the tchannelthrift IndexChecksumSingleResult path.
+	IndexChecksumSingleResult = "tchannelthrift/node.service.IndexChecksumSingleResult"
+
 	// DBQueryIDs is the operation name for the db QueryIDs path.
 	DBQueryIDs = "storage.db.QueryIDs"
+
+	// DBQueryIDsIndexChecksum is the operation name for the db QueryIDs IndexChecksum path.
+	DBQueryIDsIndexChecksum = "storage.db.QueryIDsIndexChecksum"
 
 	// DBAggregateQuery is the operation name for the db AggregateQuery path.
 	DBAggregateQuery = "storage.db.AggregateQuery"
@@ -64,14 +73,23 @@ const (
 	// DBWriteBatch is the operation name for the db WriteBatch path.
 	DBWriteBatch = "storage.db.WriteBatch"
 
+	// DBIndexChecksum is the operation name for the tchannelthrift IndexChecksum path.
+	DBIndexChecksum = "storage.db.IndexChecksum"
+
 	// NSQueryIDs is the operation name for the dbNamespace QueryIDs path.
 	NSQueryIDs = "storage.dbNamespace.QueryIDs"
+
+	// NSIndexChecksumQuery is the operation name for the dbNamespace QueryIDs path when fetching index checksums.
+	NSIndexChecksumQuery = "storage.nsIndex.IndexChecksum"
 
 	// NSPrepareBootstrap is the operation name for the dbNamespace PrepareBootstrap path.
 	NSPrepareBootstrap = "storage.dbNamespace.PrepareBootstrap"
 
 	// NSBootstrap is the operation name for the dbNamespace Bootstrap path.
 	NSBootstrap = "storage.dbNamespace.Bootstrap"
+
+	// NSIndexChecksum is the operation name for the tchannelthrift IndexChecksum path.
+	NSIndexChecksum = "storage.dbNamespace.IndexChecksum"
 
 	// ShardPrepareBootstrap is the operation name for the dbShard PrepareBootstrap path.
 	ShardPrepareBootstrap = "storage.dbShard.PrepareBootstrap"
@@ -99,6 +117,9 @@ const (
 
 	// BlockAggregate is the operation name for the index block aggregate path.
 	BlockAggregate = "storage/index.block.Aggregate"
+
+	// IndexChecksumQuery is the operation name for the IndexChecksum query path.
+	IndexChecksumQuery = "storage/index.block.IndexChecksum"
 
 	// BootstrapProcessRun is the operation name for the bootstrap process Run path.
 	BootstrapProcessRun = "bootstrap.bootstrapProcess.Run"

--- a/src/x/ident/types.go
+++ b/src/x/ident/types.go
@@ -310,3 +310,19 @@ func (t Tags) Equal(other Tags) bool {
 	}
 	return true
 }
+
+// IndexChecksumBlock represents a set of index checksums within a series block.
+type IndexChecksumBlock struct {
+	// Checksums is the list of index checksums.
+	Checksums []uint32
+	// Marker is a batch marker, signifying the ID of the last element in the batch.
+	Marker []byte
+}
+
+// IndexChecksum represents an index checksums within a series block.
+type IndexChecksum struct {
+	// Checksum is the index checksum.
+	Checksum uint32
+	// ID is an optional ID for this series, set only when explicitly requested.
+	ID []byte
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides RPC plumbing for performing index checksum queries. The implementation of index checksumming will be added in a further PR; this is largely RPC plumbing.