### PR TITLE
[dbnode] Cache the results of the commitlog bootstapper between runs

### DIFF
--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -87,66 +87,6 @@ func TestReadEmpty(t *testing.T) {
 	tester.EnsureNoWrites()
 }
 
-func TestCachedResults(t *testing.T) {
-	opts := testDefaultOpts
-	md := testNsMetadata(t)
-
-	nsCtx := namespace.NewContextFrom(md)
-
-	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)
-
-	blockSize := md.Options().RetentionOptions().BlockSize()
-	now := time.Now()
-	start := now.Truncate(blockSize).Add(-blockSize)
-	end := now.Truncate(blockSize)
-
-	ranges := xtime.NewRanges(xtime.Range{Start: start, End: end})
-
-	foo := ts.Series{Namespace: nsCtx.ID, Shard: 0, ID: ident.StringID("foo")}
-	bar := ts.Series{Namespace: nsCtx.ID, Shard: 1, ID: ident.StringID("bar")}
-	baz := ts.Series{Namespace: nsCtx.ID, Shard: 2, ID: ident.StringID("baz")}
-
-	values := testValues{
-		{foo, start, 1.0, xtime.Second, nil},
-		{foo, start.Add(1 * time.Minute), 2.0, xtime.Second, nil},
-		{bar, start.Add(2 * time.Minute), 1.0, xtime.Second, nil},
-		{bar, start.Add(3 * time.Minute), 2.0, xtime.Second, nil},
-		// "baz" is in shard 2 and should not be returned
-		{baz, start.Add(4 * time.Minute), 1.0, xtime.Second, nil},
-	}
-
-	iterated := false
-	src.newIteratorFn = func(
-		_ commitlog.IteratorOpts,
-	) (commitlog.Iterator, []commitlog.ErrorWithPath, error) {
-		if iterated == true {
-			return nil, nil, errors.New("expected results to be cached")
-		}
-		iterated = true
-		return newTestCommitLogIterator(values, nil), nil, nil
-	}
-
-	targetRanges := result.NewShardTimeRanges().Set(0, ranges).Set(1, ranges)
-	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, targetRanges, md)
-	defer tester.Finish()
-
-	tester.TestReadWith(src)
-	tester.TestUnfulfilledForNamespaceIsEmpty(md)
-
-	read := tester.EnsureDumpWritesForNamespace(md)
-	require.Equal(t, 2, len(read))
-	enforceValuesAreCorrect(t, values[:4], read)
-	tester.EnsureNoLoadedBlocks()
-
-	tester.TestReadWith(src)
-	tester.TestUnfulfilledForNamespaceIsEmpty(md)
-
-	read = tester.EnsureDumpWritesForNamespace(md)
-	require.Equal(t, 2, len(read))
-	enforceValuesAreCorrect(t, values[:4], read)
-	tester.EnsureNoLoadedBlocks()
-}
-
 func TestReadErrorOnNewIteratorError(t *testing.T) {
 	opts := testDefaultOpts
 	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source_data_test.go
@@ -87,6 +87,66 @@ func TestReadEmpty(t *testing.T) {
 	tester.EnsureNoWrites()
 }
 
+func TestCachedResults(t *testing.T) {
+	opts := testDefaultOpts
+	md := testNsMetadata(t)
+
+	nsCtx := namespace.NewContextFrom(md)
+
+	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)
+
+	blockSize := md.Options().RetentionOptions().BlockSize()
+	now := time.Now()
+	start := now.Truncate(blockSize).Add(-blockSize)
+	end := now.Truncate(blockSize)
+
+	ranges := xtime.NewRanges(xtime.Range{Start: start, End: end})
+
+	foo := ts.Series{Namespace: nsCtx.ID, Shard: 0, ID: ident.StringID("foo")}
+	bar := ts.Series{Namespace: nsCtx.ID, Shard: 1, ID: ident.StringID("bar")}
+	baz := ts.Series{Namespace: nsCtx.ID, Shard: 2, ID: ident.StringID("baz")}
+
+	values := testValues{
+		{foo, start, 1.0, xtime.Second, nil},
+		{foo, start.Add(1 * time.Minute), 2.0, xtime.Second, nil},
+		{bar, start.Add(2 * time.Minute), 1.0, xtime.Second, nil},
+		{bar, start.Add(3 * time.Minute), 2.0, xtime.Second, nil},
+		// "baz" is in shard 2 and should not be returned
+		{baz, start.Add(4 * time.Minute), 1.0, xtime.Second, nil},
+	}
+
+	iterated := false
+	src.newIteratorFn = func(
+		_ commitlog.IteratorOpts,
+	) (commitlog.Iterator, []commitlog.ErrorWithPath, error) {
+		if iterated == true {
+			return nil, nil, errors.New("expected results to be cached")
+		}
+		iterated = true
+		return newTestCommitLogIterator(values, nil), nil, nil
+	}
+
+	targetRanges := result.NewShardTimeRanges().Set(0, ranges).Set(1, ranges)
+	tester := bootstrap.BuildNamespacesTester(t, testDefaultRunOpts, targetRanges, md)
+	defer tester.Finish()
+
+	tester.TestReadWith(src)
+	tester.TestUnfulfilledForNamespaceIsEmpty(md)
+
+	read := tester.EnsureDumpWritesForNamespace(md)
+	require.Equal(t, 2, len(read))
+	enforceValuesAreCorrect(t, values[:4], read)
+	tester.EnsureNoLoadedBlocks()
+
+	tester.TestReadWith(src)
+	tester.TestUnfulfilledForNamespaceIsEmpty(md)
+
+	read = tester.EnsureDumpWritesForNamespace(md)
+	require.Equal(t, 2, len(read))
+	enforceValuesAreCorrect(t, values[:4], read)
+	tester.EnsureNoLoadedBlocks()
+}
+
 func TestReadErrorOnNewIteratorError(t *testing.T) {
 	opts := testDefaultOpts
 	src := newCommitLogSource(opts, fs.Inspection{}).(*commitLogSource)

--- a/src/dbnode/storage/bootstrap/process.go
+++ b/src/dbnode/storage/bootstrap/process.go
@@ -173,6 +173,10 @@ func (b bootstrapProcess) Run(
 			dataRanges.firstRangeWithPersistTrue.Range,
 			namespace.Shards,
 		)
+		secondRanges := b.newShardTimeRanges(
+			dataRanges.secondRangeWithPersistFalse.Range, namespace.Shards)
+		allRanges := firstRanges.Copy()
+		allRanges.AddRanges(secondRanges)
 		namespacesRunFirst.Namespaces.Set(namespace.Metadata.ID(), Namespace{
 			Metadata:         namespace.Metadata,
 			Shards:           namespace.Shards,
@@ -181,18 +185,16 @@ func (b bootstrapProcess) Run(
 			DataTargetRange:  dataRanges.firstRangeWithPersistTrue,
 			IndexTargetRange: indexRanges.firstRangeWithPersistTrue,
 			DataRunOptions: NamespaceRunOptions{
-				ShardTimeRanges:       firstRanges.Copy(),
-				TargetShardTimeRanges: firstRanges.Copy(),
-				RunOptions:            dataRanges.firstRangeWithPersistTrue.RunOptions,
+				ShardTimeRanges:    firstRanges.Copy(),
+				AllShardTimeRanges: allRanges.Copy(),
+				RunOptions:         dataRanges.firstRangeWithPersistTrue.RunOptions,
 			},
 			IndexRunOptions: NamespaceRunOptions{
-				ShardTimeRanges:       firstRanges.Copy(),
-				TargetShardTimeRanges: firstRanges.Copy(),
-				RunOptions:            indexRanges.firstRangeWithPersistTrue.RunOptions,
+				ShardTimeRanges:    firstRanges.Copy(),
+				AllShardTimeRanges: allRanges.Copy(),
+				RunOptions:         indexRanges.firstRangeWithPersistTrue.RunOptions,
 			},
 		})
-		secondRanges := b.newShardTimeRanges(
-			dataRanges.secondRangeWithPersistFalse.Range, namespace.Shards)
 		namespacesRunSecond.Namespaces.Set(namespace.Metadata.ID(), Namespace{
 			Metadata:         namespace.Metadata,
 			Shards:           namespace.Shards,
@@ -201,14 +203,14 @@ func (b bootstrapProcess) Run(
 			DataTargetRange:  dataRanges.secondRangeWithPersistFalse,
 			IndexTargetRange: indexRanges.secondRangeWithPersistFalse,
 			DataRunOptions: NamespaceRunOptions{
-				ShardTimeRanges:       secondRanges.Copy(),
-				TargetShardTimeRanges: secondRanges.Copy(),
-				RunOptions:            dataRanges.secondRangeWithPersistFalse.RunOptions,
+				ShardTimeRanges:    secondRanges.Copy(),
+				AllShardTimeRanges: allRanges.Copy(),
+				RunOptions:         dataRanges.secondRangeWithPersistFalse.RunOptions,
 			},
 			IndexRunOptions: NamespaceRunOptions{
-				ShardTimeRanges:       secondRanges.Copy(),
-				TargetShardTimeRanges: secondRanges.Copy(),
-				RunOptions:            indexRanges.secondRangeWithPersistFalse.RunOptions,
+				ShardTimeRanges:    secondRanges.Copy(),
+				AllShardTimeRanges: allRanges.Copy(),
+				RunOptions:         indexRanges.secondRangeWithPersistFalse.RunOptions,
 			},
 		})
 	}

--- a/src/dbnode/storage/bootstrap/types.go
+++ b/src/dbnode/storage/bootstrap/types.go
@@ -226,11 +226,10 @@ type NamespaceRunOptions struct {
 	// ShardTimeRanges are the time ranges for the shards that should be fulfilled
 	// by the bootstrapper. This changes each bootstrapper pass as time ranges are fulfilled.
 	ShardTimeRanges result.ShardTimeRanges
-	// TargetShardTimeRanges are the original target time ranges for shards and does not change
-	// each bootstrapper pass.
-	// NB(bodu): This is used by the commit log bootstrapper as it needs to run for the entire original
-	// target shard time ranges.
-	TargetShardTimeRanges result.ShardTimeRanges
+	// AllShardTimeRanges covers the entire retention period and does not change each bootstrapper pass.
+	// NB(rhall): This is used by the commit log bootstrapper since it only runs during a single pass of the bootstrapper.
+	// See the commit log bootstrapper for more details.
+	AllShardTimeRanges result.ShardTimeRanges
 	// RunOptions are the run options for the bootstrap run.
 	RunOptions RunOptions
 }

--- a/src/dbnode/storage/bootstrap/util.go
+++ b/src/dbnode/storage/bootstrap/util.go
@@ -378,14 +378,14 @@ func BuildNamespacesTesterWithReaderIteratorPool(
 			Shards:          shards,
 			DataAccumulator: acc,
 			DataRunOptions: NamespaceRunOptions{
-				ShardTimeRanges:       ranges.Copy(),
-				TargetShardTimeRanges: ranges.Copy(),
-				RunOptions:            runOpts,
+				ShardTimeRanges:    ranges.Copy(),
+				AllShardTimeRanges: ranges.Copy(),
+				RunOptions:         runOpts,
 			},
 			IndexRunOptions: NamespaceRunOptions{
-				ShardTimeRanges:       ranges.Copy(),
-				TargetShardTimeRanges: ranges.Copy(),
-				RunOptions:            runOpts,
+				ShardTimeRanges:    ranges.Copy(),
+				AllShardTimeRanges: ranges.Copy(),
+				RunOptions:         runOpts,
 			},
 		})
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
A recent refactoring of cold writes ( https://github.com/m3db/m3/pull/2508/) introduced a regression
that results in the commit log being read twice while bootstrapping. The referenced PR changed the
commitlog source to read all time ranges, not just the requested time ranges. This was necessary since
the commitlog may have cold writes that were never commmited to a fileset. Another bootstrapper (filesystem or peer)
might report a ShardTimeRange as fulfilled, but it could be missing recent cold writes from a commit log.

The bootstrapper is split into 2 runs, one for the cold time ranges and one for the recent warm time range. Since the commitlog source
now reads the full time range for both runs, it resulted in 2 full reads of the commit log/snapshots.

This commit introduces a simple fix that caches the results of the commitlog source between runs. Other options
were considered, such as adding an option to disable a specific bootstrapper. This change seemed the most ideal since it
isolates the special logic of the commitlog bootstrapper to a single file.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
