### PR TITLE
[dbnode] Fix setting of Head/Tail finalize flags for Segment

### DIFF
--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -3341,7 +3341,7 @@ func (b *baseBlocksResult) segmentForBlock(seg *rpc.Segment) ts.Segment {
 		checksum = uint32(*seg.Checksum)
 	}
 
-	return ts.NewSegment(head, tail, checksum, ts.FinalizeHead&ts.FinalizeTail)
+	return ts.NewSegment(head, tail, checksum, ts.FinalizeHead|ts.FinalizeTail)
 }
 
 func (b *baseBlocksResult) mergeReaders(start time.Time, blockSize time.Duration, readers []xio.SegmentReader) (encoding.Encoder, error) {

--- a/src/dbnode/ts/segment.go
+++ b/src/dbnode/ts/segment.go
@@ -184,5 +184,5 @@ func (s *Segment) Clone(pool pool.CheckedBytesPool) Segment {
 
 	// NB: new segment is always finalizeable.
 	return NewSegment(checkedHead, checkedTail,
-		s.CalculateChecksum(), FinalizeHead&FinalizeTail)
+		s.CalculateChecksum(), FinalizeHead|FinalizeTail)
 }

--- a/src/dbnode/ts/segment_test.go
+++ b/src/dbnode/ts/segment_test.go
@@ -69,8 +69,8 @@ func testSegmentCloneWithPools(
 
 	assert.False(t, seg.Equal(&cloned))
 	assert.Equal(t, len(expected), cloned.Len())
-	assert.True(t, cloned.Flags|FinalizeHead > 0)
-	assert.True(t, cloned.Flags|FinalizeTail > 0)
+	assert.True(t, cloned.Flags&FinalizeHead > 0)
+	assert.True(t, cloned.Flags&FinalizeTail > 0)
 	assert.Equal(t, testChecksum, cloned.checksum)
 
 	cloned.Finalize()


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases `Segment.Flags` was being set to `FinalizeHead&FinalizeTail` which was clearly not intended because this expression results in 0 with the consequence of neither `Head` nor `Tail` being finalized during `Segment.Finalize()`. Fixed by changing the expression to `FinalizeHead|FinalizeTail` which results in finalizing both `Head` and `Tail`.

**Special notes for your reviewer**:
Somewhat worried that introducing finalization where it belongs might cause a double finalize in case there was some other code finalizing `Segment.Head` or `Segment.Tail`. Inspecting via IDE did not reveal any such cases directly.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE