### PR TITLE
[dbnode] Better defaults for block retriever config

### DIFF
--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -260,7 +260,7 @@ type TickConfiguration struct {
 type BlockRetrievePolicy struct {
 	// FetchConcurrency is the concurrency to fetch blocks from disk. For
 	// spinning disks it is highly recommended to set this value to 1.
-	FetchConcurrency int `yaml:"fetchConcurrency" validate:"min=0"`
+	FetchConcurrency *int `yaml:"fetchConcurrency" validate:"min=1"`
 
 	// CacheBlocksOnRetrieve globally enables/disables callbacks used to cache blocks fetched
 	// from disk.

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -554,10 +554,11 @@ func Run(runOpts RunOptions) {
 			SetBlockLeaseManager(blockLeaseManager).
 			SetQueryLimits(queryLimits)
 		if blockRetrieveCfg := cfg.BlockRetrieve; blockRetrieveCfg != nil {
-			retrieverOpts = retrieverOpts.
-				SetFetchConcurrency(blockRetrieveCfg.FetchConcurrency)
-			if blockRetrieveCfg.CacheBlocksOnRetrieve != nil {
-				retrieverOpts = retrieverOpts.SetCacheBlocksOnRetrieve(*blockRetrieveCfg.CacheBlocksOnRetrieve)
+			if v := blockRetrieveCfg.FetchConcurrency; v != nil {
+				retrieverOpts = retrieverOpts.SetFetchConcurrency(*v)
+			}
+			if v := blockRetrieveCfg.CacheBlocksOnRetrieve; v != nil {
+				retrieverOpts = retrieverOpts.SetCacheBlocksOnRetrieve(*v)
 			}
 		}
 		blockRetrieverMgr := block.NewDatabaseBlockRetrieverManager(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
When you just set `cacheBlocksOnRetrieve: false` it was default the `fetchConcurrency` to zero as a default value, then also setting to validate the min to be 1 since below 1 will break queries (as no fetch concurrency exists and no fetch loops are spun up).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
