### PR TITLE
[dbnode] No empty TSDB snapshots

### DIFF
--- a/src/dbnode/integration/disk_snapshot_test.go
+++ b/src/dbnode/integration/disk_snapshot_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	xtime "github.com/m3db/m3/src/x/time"
-	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestDiskSnapshotSimple(t *testing.T) {

--- a/src/dbnode/integration/disk_snapshot_test.go
+++ b/src/dbnode/integration/disk_snapshot_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	xtime "github.com/m3db/m3/src/x/time"
+	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/require"
 )
@@ -99,9 +100,9 @@ func TestDiskSnapshotSimple(t *testing.T) {
 			// Writes in the previous block which should be mutable due to bufferPast
 			{IDs: []string{"foo", "bar", "baz"}, NumPoints: 5, Start: currBlock.Add(-10 * time.Minute)},
 			// Writes in the current block
-			{IDs: []string{"a", "b", "c"}, NumPoints: 30, Start: currBlock},
+			{IDs: []string{"a", "b", "c"}, NumPoints: 5, Start: currBlock},
 			// Writes in the next block which should be mutable due to bufferFuture
-			{IDs: []string{"1", "2", "3"}, NumPoints: 30, Start: currBlock.Add(blockSize)},
+			{IDs: []string{"1", "2", "3"}, NumPoints: 5, Start: currBlock.Add(blockSize)},
 		}
 	)
 	for _, input := range inputData {
@@ -120,27 +121,26 @@ func TestDiskSnapshotSimple(t *testing.T) {
 	// the measured volume index + 1.
 	var (
 		snapshotsToWaitForByNS = make([][]snapshotID, 0, len(testSetup.Namespaces()))
-		filePathPrefix         = testSetup.StorageOpts().
+		fsOpts                 = testSetup.StorageOpts().
 					CommitLogOptions().
-					FilesystemOptions().
-					FilePathPrefix()
+					FilesystemOptions()
 	)
 	for _, ns := range testSetup.Namespaces() {
 		snapshotsToWaitForByNS = append(snapshotsToWaitForByNS, []snapshotID{
 			{
 				blockStart: currBlock.Add(-blockSize),
 				minVolume: getLatestSnapshotVolumeIndex(
-					filePathPrefix, shardSet, ns.ID(), currBlock.Add(-blockSize)) + 1,
+					fsOpts, shardSet, ns.ID(), currBlock.Add(-blockSize)),
 			},
 			{
 				blockStart: currBlock,
 				minVolume: getLatestSnapshotVolumeIndex(
-					filePathPrefix, shardSet, ns.ID(), currBlock) + 1,
+					fsOpts, shardSet, ns.ID(), currBlock),
 			},
 			{
 				blockStart: currBlock.Add(blockSize),
 				minVolume: getLatestSnapshotVolumeIndex(
-					filePathPrefix, shardSet, ns.ID(), currBlock.Add(blockSize)) + 1,
+					fsOpts, shardSet, ns.ID(), currBlock.Add(blockSize)),
 			},
 		})
 	}
@@ -151,35 +151,49 @@ func TestDiskSnapshotSimple(t *testing.T) {
 
 	maxWaitTime := time.Minute
 	for i, ns := range testSetup.Namespaces() {
-		log.Info("waiting for snapshot files to flush")
-		_, err := waitUntilSnapshotFilesFlushed(filePathPrefix, shardSet, ns.ID(), snapshotsToWaitForByNS[i], maxWaitTime)
+		log.Info("waiting for snapshot files to flush",
+			zap.Any("ns", ns.ID()))
+		_, err := waitUntilSnapshotFilesFlushed(fsOpts, shardSet, ns.ID(), snapshotsToWaitForByNS[i], maxWaitTime)
 		require.NoError(t, err)
-		log.Info("verifying snapshot files")
+		log.Info("verifying snapshot files",
+			zap.Any("ns", ns.ID()))
 		verifySnapshottedDataFiles(t, shardSet, testSetup.StorageOpts(), ns.ID(), seriesMaps)
 	}
 
 	var (
-		oldTime = testSetup.NowFn()()
-		newTime = oldTime.Add(blockSize * 2)
+		newTime = testSetup.NowFn()().Add(blockSize * 2)
 	)
 	testSetup.SetNowFn(newTime)
 
 	for _, ns := range testSetup.Namespaces() {
-		log.Info("waiting for new snapshot files to be written out")
-		snapshotsToWaitFor := []snapshotID{{blockStart: newTime.Truncate(blockSize)}}
+		log.Info("waiting for new snapshot files to be written out",
+			zap.Any("ns", ns.ID()))
+		snapshotsToWaitFor := []snapshotID{{blockStart: currBlock.Add(blockSize)}}
 		// NB(bodu): We need to check if a specific snapshot ID was deleted since snapshotting logic now changed
 		// to always snapshotting every block start w/in retention.
-		snapshotID, err := waitUntilSnapshotFilesFlushed(filePathPrefix, shardSet, ns.ID(), snapshotsToWaitFor, maxWaitTime)
+		snapshotID, err := waitUntilSnapshotFilesFlushed(fsOpts, shardSet, ns.ID(), snapshotsToWaitFor, maxWaitTime)
 		require.NoError(t, err)
-		log.Info("waiting for old snapshot files to be deleted")
+		log.Info("waiting for old snapshot files to be deleted",
+			zap.Any("ns", ns.ID()))
+		// These should be flushed to disk and snapshots should have been cleaned up.
+		flushedBlockStarts := []time.Time{
+			currBlock.Add(-blockSize),
+			currBlock,
+		}
 		for _, shard := range shardSet.All() {
 			waitUntil(func() bool {
 				// Increase the time each check to ensure that the filesystem processes are able to progress (some
 				// of them throttle themselves based on time elapsed since the previous time.)
 				testSetup.SetNowFn(testSetup.NowFn()().Add(10 * time.Second))
-				exists, err := fs.SnapshotFileSetExistsAt(filePathPrefix, ns.ID(), snapshotID, shard.ID(), oldTime.Truncate(blockSize))
-				require.NoError(t, err)
-				return !exists
+				// Ensure that snapshots for flushed data blocks no longer exist.
+				for _, blockStart := range flushedBlockStarts {
+					exists, err := fs.SnapshotFileSetExistsAt(fsOpts.FilePathPrefix(), ns.ID(), snapshotID, shard.ID(), blockStart)
+					require.NoError(t, err)
+					if exists {
+						return false
+					}
+				}
+				return true
 			}, maxWaitTime)
 		}
 	}

--- a/src/dbnode/integration/fs_commitlog_snapshot_mixed_mode_read_write_prop_test.go
+++ b/src/dbnode/integration/fs_commitlog_snapshot_mixed_mode_read_write_prop_test.go
@@ -170,7 +170,10 @@ func TestFsCommitLogMixedModeReadWriteProp(t *testing.T) {
 					defer ctx.Close()
 
 					log.Info("writing datapoints")
-					var i int
+					var (
+						i              int
+						snapshotBlocks = map[xtime.UnixNano]struct{}{}
+					)
 					for i = lastDatapointsIdx; i < len(datapoints); i++ {
 						var (
 							dp = datapoints[i]
@@ -187,6 +190,7 @@ func TestFsCommitLogMixedModeReadWriteProp(t *testing.T) {
 							log.Warn("error writing series datapoint", zap.Error(err))
 							return false, err
 						}
+						snapshotBlocks[xtime.ToUnixNano(ts.Truncate(ns1BlockSize))] = struct{}{}
 					}
 					lastDatapointsIdx = i
 					log.Info("wrote datapoints")
@@ -220,20 +224,22 @@ func TestFsCommitLogMixedModeReadWriteProp(t *testing.T) {
 						}
 					}
 
-					if input.waitForSnapshotFiles {
+					// We've written data if we've advanced the datapoints index.
+					dpsWritten := i > 0
+					if input.waitForSnapshotFiles && dpsWritten {
 						log.Info("waiting for snapshot files to be written")
-						now := setup.NowFn()()
-						var snapshotBlock time.Time
-						if now.Add(-bufferPast).Truncate(ns1BlockSize).Equal(now.Truncate(ns1BlockSize)) {
-							snapshotBlock = now.Truncate(ns1BlockSize)
-						} else {
-							snapshotBlock = now.Truncate(ns1BlockSize).Add(-ns1BlockSize)
+						// We only snapshot TSDB blocks that have data in them.
+						expectedSnapshotBlocks := make([]snapshotID, 0, len(snapshotBlocks))
+						for snapshotBlock := range snapshotBlocks {
+							expectedSnapshotBlocks = append(expectedSnapshotBlocks, snapshotID{
+								blockStart: snapshotBlock.ToTime(),
+							})
 						}
 						_, err := waitUntilSnapshotFilesFlushed(
 							fsOpts,
 							setup.ShardSet(),
 							nsID,
-							[]snapshotID{{blockStart: snapshotBlock}},
+							expectedSnapshotBlocks,
 							maxFlushWaitTime,
 						)
 						if err != nil {

--- a/src/dbnode/integration/fs_commitlog_snapshot_mixed_mode_read_write_prop_test.go
+++ b/src/dbnode/integration/fs_commitlog_snapshot_mixed_mode_read_write_prop_test.go
@@ -148,7 +148,8 @@ func TestFsCommitLogMixedModeReadWriteProp(t *testing.T) {
 					latestToCheck     = datapoints[len(datapoints)-1].time.Add(ns1BlockSize)
 					timesToRestart    = []time.Time{}
 					start             = earliestToCheck
-					filePathPrefix    = setup.StorageOpts().CommitLogOptions().FilesystemOptions().FilePathPrefix()
+					fsOpts            = setup.StorageOpts().CommitLogOptions().FilesystemOptions()
+					filePathPrefix    = fsOpts.FilePathPrefix()
 				)
 
 				// Generate randomly selected times during which the node will restart
@@ -229,7 +230,7 @@ func TestFsCommitLogMixedModeReadWriteProp(t *testing.T) {
 							snapshotBlock = now.Truncate(ns1BlockSize).Add(-ns1BlockSize)
 						}
 						_, err := waitUntilSnapshotFilesFlushed(
-							filePathPrefix,
+							fsOpts,
 							setup.ShardSet(),
 							nsID,
 							[]snapshotID{{blockStart: snapshotBlock}},

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -1196,9 +1196,9 @@ func NewAggregateTilesOptions(
 	}
 
 	return AggregateTilesOptions{
-		Start: start,
-		End: end,
-		Step: step,
+		Start:               start,
+		End:                 end,
+		Step:                step,
 		HandleCounterResets: handleCounterResets,
 	}, nil
 }

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -277,16 +277,11 @@ type shardFlushState struct {
 	sync.RWMutex
 	statesByTime map[xtime.UnixNano]fileOpState
 	initialized  bool
-
-	// NB(bodu): Cache state on whether we snapshotted last or not to avoid
-	// going to disk to see if filesets are empty.
-	emptySnapshotOnDiskByTime map[xtime.UnixNano]bool
 }
 
 func newShardFlushState() shardFlushState {
 	return shardFlushState{
-		statesByTime:              make(map[xtime.UnixNano]fileOpState),
-		emptySnapshotOnDiskByTime: make(map[xtime.UnixNano]bool),
+		statesByTime: make(map[xtime.UnixNano]fileOpState),
 	}
 }
 
@@ -2421,15 +2416,7 @@ func (s *dbShard) Snapshot(
 	})
 	checkNeedsSnapshotTimer.Stop()
 
-	// Only terminate early when we would be over-writing an empty snapshot fileset on disk.
-	// TODO(bodu): We could bootstrap empty snapshot state in the bs path to avoid doing extra
-	// snapshotting work after a bootstrap since this cached state gets cleared.
-	s.flushState.RLock()
-	// NB(bodu): This always defaults to false if the record does not exist.
-	emptySnapshotOnDisk := s.flushState.emptySnapshotOnDiskByTime[xtime.ToUnixNano(blockStart)]
-	s.flushState.RUnlock()
-
-	if !needsSnapshot && emptySnapshotOnDisk {
+	if !needsSnapshot {
 		return ShardSnapshotResult{}, nil
 	}
 
@@ -2499,19 +2486,6 @@ func (s *dbShard) Snapshot(
 	if err := multiErr.FinalError(); err != nil {
 		return ShardSnapshotResult{}, err
 	}
-
-	// Only update cached snapshot state if we successfully flushed data to disk.
-	s.flushState.Lock()
-	if needsSnapshot {
-		s.flushState.emptySnapshotOnDiskByTime[xtime.ToUnixNano(blockStart)] = false
-	} else {
-		// NB(bodu): If we flushed an empty snapshot to disk, it means that the previous
-		// snapshot on disk was not empty (or we just bootstrapped and cached state was lost).
-		// The snapshot we just flushed may or may not have data, although whatever data we flushed
-		// would be recoverable from the rotate commit log as well.
-		s.flushState.emptySnapshotOnDiskByTime[xtime.ToUnixNano(blockStart)] = true
-	}
-	s.flushState.Unlock()
 
 	return ShardSnapshotResult{
 		SeriesPersist: persist,


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Both writing empty TSDB snapshots and tracking of empty snapshots on disk is unnecessary. Each snapshot run is tagged w/ a unique UUID and a snapshot run will complete and write the UUID to a metadata file on disk regardless of whether in-mem TSDB data exists or not. The cleanup manager will remove all but the latest snapshot UUID meaning that it will cleanup stale snapshots without the need for writing an empty TSDB snapshot to disk. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
