### PR TITLE
Add a configurable write timeout for consumer ACKs

### DIFF
--- a/src/msg/consumer/config.go
+++ b/src/msg/consumer/config.go
@@ -37,6 +37,7 @@ type Configuration struct {
 	AckBufferSize             *int                      `yaml:"ackBufferSize"`
 	ConnectionWriteBufferSize *int                      `yaml:"connectionWriteBufferSize"`
 	ConnectionReadBufferSize  *int                      `yaml:"connectionReadBufferSize"`
+	ConnectionWriteTimeout    *time.Duration            `yaml:"connectionWriteTimeout"`
 }
 
 // MessagePoolConfiguration is the message pool configuration
@@ -91,6 +92,9 @@ func (c *Configuration) NewOptions(iOpts instrument.Options) Options {
 	}
 	if c.ConnectionReadBufferSize != nil {
 		opts = opts.SetConnectionReadBufferSize(*c.ConnectionReadBufferSize)
+	}
+	if c.ConnectionWriteTimeout != nil {
+		opts = opts.SetConnectionWriteTimeout(*c.ConnectionWriteTimeout)
 	}
 	return opts
 }

--- a/src/msg/consumer/options.go
+++ b/src/msg/consumer/options.go
@@ -33,6 +33,8 @@ var (
 	defaultAckBufferSize        = 1048576
 	defaultAckFlushInterval     = 200 * time.Millisecond
 	defaultConnectionBufferSize = 1048576
+	// TODO(ryanhall07): set this to 5s once we verify this works.
+	defaultWriteTimeout         = 0 * time.Second
 )
 
 type options struct {
@@ -43,6 +45,7 @@ type options struct {
 	ackBufferSize    int
 	writeBufferSize  int
 	readBufferSize   int
+	writeTimeout     time.Duration
 	iOpts            instrument.Options
 	rwOpts           xio.Options
 }
@@ -57,6 +60,7 @@ func NewOptions() Options {
 		ackBufferSize:    defaultAckBufferSize,
 		writeBufferSize:  defaultConnectionBufferSize,
 		readBufferSize:   defaultConnectionBufferSize,
+		writeTimeout:     defaultWriteTimeout,
 		iOpts:            instrument.NewOptions(),
 		rwOpts:           xio.NewOptions(),
 	}
@@ -129,6 +133,16 @@ func (opts *options) ConnectionReadBufferSize() int {
 func (opts *options) SetConnectionReadBufferSize(value int) Options {
 	o := *opts
 	o.readBufferSize = value
+	return &o
+}
+
+func (opts *options) ConnectionWriteTimeout() time.Duration {
+	return opts.writeTimeout
+}
+
+func (opts *options) SetConnectionWriteTimeout(value time.Duration) Options {
+	o := *opts
+	o.writeTimeout = value
 	return &o
 }
 

--- a/src/msg/consumer/types.go
+++ b/src/msg/consumer/types.go
@@ -106,6 +106,12 @@ type Options interface {
 	// SetConnectionWriteBufferSize sets the buffer size.
 	SetConnectionReadBufferSize(value int) Options
 
+	// ConnectionWriteTimeout returns the timeout for writing to the connection.
+	ConnectionWriteTimeout() time.Duration
+
+	// SetConnectionWriteTimeout sets the write timeout for the connection.
+	SetConnectionWriteTimeout(value time.Duration) Options
+
 	// InstrumentOptions returns the instrument options.
 	InstrumentOptions() instrument.Options
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Without a timeout this can potentially block forever.

The producer and consumer can potentially dead lock trying to send/receive messages:

Producer -> msg -> Consumer. Consumer is not attempting to read since it's trying to ACK.
Consumer -> ack -> Producer. Producer is not attempting to read since it might be stuck trying to get a lock on the connection.

For backwards compatibility this defaults to 0. We should set it to a sane default (5s) in the future.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE. timeout is off by default.
```

**Does this PR require updating code package or user-facing documentation?**:
NONE
```
