### PR TITLE
[coordinator] Configurable writes to leaving shards count towards consistency, add read level unstrict all

### DIFF
--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -411,6 +411,7 @@ func TestConfiguration(t *testing.T) {
     fetchSeriesBlocksBatchConcurrency: null
     fetchSeriesBlocksBatchSize: null
     writeShardsInitializing: null
+    shardsLeavingCountTowardsConsistency: null
   gcPercentage: 100
   writeNewSeriesLimitPerSecond: 1048576
   writeNewSeriesBackoffDuration: 2ms

--- a/src/dbnode/client/aggregate_results_accumulator_consistency_test.go
+++ b/src/dbnode/client/aggregate_results_accumulator_consistency_test.go
@@ -154,6 +154,71 @@ func TestAggregateResultsAccumulatorShardAvailabilityIsEnforced(t *testing.T) {
 		},
 	}.run()
 
+	// for consistency level unstrict all
+	testFetchStateWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictAll,
+		steps: []testFetchStateWorklowStep{
+			testFetchStateWorklowStep{
+				hostname:        "testhost1",
+				aggregateResult: &testAggregateSuccessResponse,
+			},
+			testFetchStateWorklowStep{
+				hostname:        "testhost2",
+				aggregateResult: &testAggregateSuccessResponse,
+			},
+			testFetchStateWorklowStep{
+				hostname:     "testhost0",
+				aggregateErr: errTestAggregate,
+				expectedDone: true,
+				expectedErr:  false,
+			},
+		},
+	}.run()
+	testFetchStateWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictAll,
+		steps: []testFetchStateWorklowStep{
+			testFetchStateWorklowStep{
+				hostname:     "testhost1",
+				aggregateErr: errTestAggregate,
+			},
+			testFetchStateWorklowStep{
+				hostname:        "testhost2",
+				aggregateResult: &testAggregateSuccessResponse,
+			},
+			testFetchStateWorklowStep{
+				hostname:     "testhost0",
+				aggregateErr: errTestAggregate,
+				expectedDone: true,
+				expectedErr:  false,
+			},
+		},
+	}.run()
+	testFetchStateWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictAll,
+		steps: []testFetchStateWorklowStep{
+			testFetchStateWorklowStep{
+				hostname:     "testhost1",
+				aggregateErr: errTestAggregate,
+			},
+			testFetchStateWorklowStep{
+				hostname:     "testhost2",
+				aggregateErr: errTestAggregate,
+			},
+			testFetchStateWorklowStep{
+				hostname:     "testhost0",
+				aggregateErr: errTestAggregate,
+				expectedDone: true,
+				expectedErr:  true,
+			},
+		},
+	}.run()
+
 	// for consistency level all
 	testFetchStateWorkflow{
 		t:       t,

--- a/src/dbnode/client/client_mock.go
+++ b/src/dbnode/client/client_mock.go
@@ -1804,6 +1804,34 @@ func (mr *MockOptionsMockRecorder) WriteShardsInitializing() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteShardsInitializing", reflect.TypeOf((*MockOptions)(nil).WriteShardsInitializing))
 }
 
+// SetShardsLeavingCountTowardsConsistency mocks base method
+func (m *MockOptions) SetShardsLeavingCountTowardsConsistency(value bool) Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetShardsLeavingCountTowardsConsistency", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+// SetShardsLeavingCountTowardsConsistency indicates an expected call of SetShardsLeavingCountTowardsConsistency
+func (mr *MockOptionsMockRecorder) SetShardsLeavingCountTowardsConsistency(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShardsLeavingCountTowardsConsistency", reflect.TypeOf((*MockOptions)(nil).SetShardsLeavingCountTowardsConsistency), value)
+}
+
+// ShardsLeavingCountTowardsConsistency mocks base method
+func (m *MockOptions) ShardsLeavingCountTowardsConsistency() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShardsLeavingCountTowardsConsistency")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShardsLeavingCountTowardsConsistency indicates an expected call of ShardsLeavingCountTowardsConsistency
+func (mr *MockOptionsMockRecorder) ShardsLeavingCountTowardsConsistency() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShardsLeavingCountTowardsConsistency", reflect.TypeOf((*MockOptions)(nil).ShardsLeavingCountTowardsConsistency))
+}
+
 // SetTagEncoderOptions mocks base method
 func (m *MockOptions) SetTagEncoderOptions(value serialize.TagEncoderOptions) Options {
 	m.ctrl.T.Helper()
@@ -3337,6 +3365,34 @@ func (m *MockAdminOptions) WriteShardsInitializing() bool {
 func (mr *MockAdminOptionsMockRecorder) WriteShardsInitializing() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteShardsInitializing", reflect.TypeOf((*MockAdminOptions)(nil).WriteShardsInitializing))
+}
+
+// SetShardsLeavingCountTowardsConsistency mocks base method
+func (m *MockAdminOptions) SetShardsLeavingCountTowardsConsistency(value bool) Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetShardsLeavingCountTowardsConsistency", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+// SetShardsLeavingCountTowardsConsistency indicates an expected call of SetShardsLeavingCountTowardsConsistency
+func (mr *MockAdminOptionsMockRecorder) SetShardsLeavingCountTowardsConsistency(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShardsLeavingCountTowardsConsistency", reflect.TypeOf((*MockAdminOptions)(nil).SetShardsLeavingCountTowardsConsistency), value)
+}
+
+// ShardsLeavingCountTowardsConsistency mocks base method
+func (m *MockAdminOptions) ShardsLeavingCountTowardsConsistency() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShardsLeavingCountTowardsConsistency")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShardsLeavingCountTowardsConsistency indicates an expected call of ShardsLeavingCountTowardsConsistency
+func (mr *MockAdminOptionsMockRecorder) ShardsLeavingCountTowardsConsistency() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShardsLeavingCountTowardsConsistency", reflect.TypeOf((*MockAdminOptions)(nil).ShardsLeavingCountTowardsConsistency))
 }
 
 // SetTagEncoderOptions mocks base method

--- a/src/dbnode/client/config.go
+++ b/src/dbnode/client/config.go
@@ -117,6 +117,10 @@ type Configuration struct {
 
 	// WriteShardsInitializing sets whether or not to write to nodes that are initializing.
 	WriteShardsInitializing *bool `yaml:"writeShardsInitializing"`
+
+	// ShardsLeavingCountTowardsConsistency sets whether or not to write to leaving shards
+	// count towards consistency, by default they do not.
+	ShardsLeavingCountTowardsConsistency *bool `yaml:"shardsLeavingCountTowardsConsistency"`
 }
 
 // ProtoConfiguration is the configuration for running with ProtoDataMode enabled.
@@ -424,6 +428,9 @@ func (c Configuration) NewAdminClient(
 
 	if c.WriteShardsInitializing != nil {
 		v = v.SetWriteShardsInitializing(*c.WriteShardsInitializing)
+	}
+	if c.ShardsLeavingCountTowardsConsistency != nil {
+		v = v.SetShardsLeavingCountTowardsConsistency(*c.ShardsLeavingCountTowardsConsistency)
 	}
 
 	// Cast to admin options to apply admin config options.

--- a/src/dbnode/client/config.go
+++ b/src/dbnode/client/config.go
@@ -115,10 +115,11 @@ type Configuration struct {
 	// from the remote peer. Defaults to 4096.
 	FetchSeriesBlocksBatchSize *int `yaml:"fetchSeriesBlocksBatchSize"`
 
-	// WriteShardsInitializing sets whether or not to write to nodes that are initializing.
+	// WriteShardsInitializing sets whether or not writes to leaving shards
+	// count towards consistency, by default they do not.
 	WriteShardsInitializing *bool `yaml:"writeShardsInitializing"`
 
-	// ShardsLeavingCountTowardsConsistency sets whether or not to write to leaving shards
+	// ShardsLeavingCountTowardsConsistency sets whether or not writes to leaving shards
 	// count towards consistency, by default they do not.
 	ShardsLeavingCountTowardsConsistency *bool `yaml:"shardsLeavingCountTowardsConsistency"`
 }

--- a/src/dbnode/client/fetch_tagged_results_accumulator_consistency_prop_test.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator_consistency_prop_test.go
@@ -112,6 +112,7 @@ func TestFetchTaggedResultsAccumulatorGenerativeConsistencyCheck(t *testing.T) {
 			topology.ReadConsistencyLevelMajority,
 			topology.ReadConsistencyLevelOne,
 			topology.ReadConsistencyLevelUnstrictMajority,
+			topology.ReadConsistencyLevelUnstrictAll,
 		),
 	))
 
@@ -189,6 +190,7 @@ func TestAggregateResultsAccumulatorGenerativeConsistencyCheck(t *testing.T) {
 			topology.ReadConsistencyLevelMajority,
 			topology.ReadConsistencyLevelOne,
 			topology.ReadConsistencyLevelUnstrictMajority,
+			topology.ReadConsistencyLevelUnstrictAll,
 		),
 	))
 
@@ -218,6 +220,8 @@ func (res topoAndHostResponses) meetsConsistencyCheckForLevel(
 	case topology.ReadConsistencyLevelMajority:
 		requiredNumSuccessResponsePerShard = majority
 	case topology.ReadConsistencyLevelUnstrictMajority:
+		fallthrough
+	case topology.ReadConsistencyLevelUnstrictAll:
 		fallthrough
 	case topology.ReadConsistencyLevelOne:
 		requiredNumSuccessResponsePerShard = 1

--- a/src/dbnode/client/fetch_tagged_results_accumulator_consistency_test.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator_consistency_test.go
@@ -152,6 +152,71 @@ func TestFetchTaggedResultsAccumulatorShardAvailabilityIsEnforced(t *testing.T) 
 		},
 	}.run()
 
+	// for consistency level unstrict all
+	testFetchStateWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictAll,
+		steps: []testFetchStateWorklowStep{
+			testFetchStateWorklowStep{
+				hostname:          "testhost1",
+				fetchTaggedResult: &testFetchTaggedSuccessResponse,
+			},
+			testFetchStateWorklowStep{
+				hostname:          "testhost2",
+				fetchTaggedResult: &testFetchTaggedSuccessResponse,
+			},
+			testFetchStateWorklowStep{
+				hostname:       "testhost0",
+				fetchTaggedErr: errTestFetchTagged,
+				expectedDone:   true,
+				expectedErr:    false,
+			},
+		},
+	}.run()
+	testFetchStateWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictAll,
+		steps: []testFetchStateWorklowStep{
+			testFetchStateWorklowStep{
+				hostname:       "testhost1",
+				fetchTaggedErr: errTestFetchTagged,
+			},
+			testFetchStateWorklowStep{
+				hostname:          "testhost2",
+				fetchTaggedResult: &testFetchTaggedSuccessResponse,
+			},
+			testFetchStateWorklowStep{
+				hostname:       "testhost0",
+				fetchTaggedErr: errTestFetchTagged,
+				expectedDone:   true,
+				expectedErr:    false,
+			},
+		},
+	}.run()
+	testFetchStateWorkflow{
+		t:       t,
+		topoMap: topoMap,
+		level:   topology.ReadConsistencyLevelUnstrictAll,
+		steps: []testFetchStateWorklowStep{
+			testFetchStateWorklowStep{
+				hostname:       "testhost1",
+				fetchTaggedErr: errTestFetchTagged,
+			},
+			testFetchStateWorklowStep{
+				hostname:       "testhost2",
+				fetchTaggedErr: errTestFetchTagged,
+			},
+			testFetchStateWorklowStep{
+				hostname:       "testhost0",
+				fetchTaggedErr: errTestFetchTagged,
+				expectedDone:   true,
+				expectedErr:    true,
+			},
+		},
+	}.run()
+
 	// for consistency level all
 	testFetchStateWorkflow{
 		t:       t,

--- a/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
@@ -320,7 +320,7 @@ func (tm testFetchStateWorkflow) run() fetchTaggedResultAccumulator {
 	accum = newFetchTaggedResultAccumulator()
 	accum.Clear()
 	accum.Reset(tm.startTime, tm.endTime, tm.topoMap, majority, tm.level)
-	for _, s := range tm.steps {
+	for i, s := range tm.steps {
 		var (
 			done bool
 			err  error
@@ -341,8 +341,8 @@ func (tm testFetchStateWorkflow) run() fetchTaggedResultAccumulator {
 		default:
 			assert.FailNow(tm.t, "unexpected workflow step", fmt.Sprintf("%+v", s))
 		}
-		assert.Equal(tm.t, s.expectedDone, done, fmt.Sprintf("%+v", s))
-		assert.Equal(tm.t, s.expectedErr, err != nil, fmt.Sprintf("%+v", s))
+		assert.Equal(tm.t, s.expectedDone, done, fmt.Sprintf("i=%d, step=%+v", i, s))
+		assert.Equal(tm.t, s.expectedErr, err != nil, fmt.Sprintf("i=%d, step=%+v, err=%v", i, s, err))
 	}
 	return accum
 }

--- a/src/dbnode/client/options.go
+++ b/src/dbnode/client/options.go
@@ -92,6 +92,9 @@ const (
 	// defaultWriteShardsInitializing is the default write to shards intializing value
 	defaultWriteShardsInitializing = true
 
+	// defaultShardsLeavingCountTowardsConsistency is the default shards leaving count towards consistency
+	defaultShardsLeavingCountTowardsConsistency = false
+
 	// defaultIdentifierPoolSize is the default identifier pool size
 	defaultIdentifierPoolSize = 8192
 
@@ -253,6 +256,7 @@ type options struct {
 	fetchRetrier                            xretry.Retrier
 	streamBlocksRetrier                     xretry.Retrier
 	writeShardsInitializing                 bool
+	shardsLeavingCountTowardsConsistency    bool
 	newConnectionFn                         NewConnectionFn
 	readerIteratorAllocate                  encoding.ReaderIteratorAllocate
 	writeOperationPoolSize                  int
@@ -370,6 +374,7 @@ func newOptions() *options {
 		writeRetrier:                            defaultWriteRetrier,
 		fetchRetrier:                            defaultFetchRetrier,
 		writeShardsInitializing:                 defaultWriteShardsInitializing,
+		shardsLeavingCountTowardsConsistency:    defaultShardsLeavingCountTowardsConsistency,
 		tagEncoderPoolSize:                      defaultTagEncoderPoolSize,
 		tagEncoderOpts:                          serialize.NewTagEncoderOptions(),
 		tagDecoderPoolSize:                      defaultTagDecoderPoolSize,
@@ -717,6 +722,16 @@ func (o *options) SetWriteShardsInitializing(value bool) Options {
 
 func (o *options) WriteShardsInitializing() bool {
 	return o.writeShardsInitializing
+}
+
+func (o *options) SetShardsLeavingCountTowardsConsistency(value bool) Options {
+	opts := *o
+	opts.shardsLeavingCountTowardsConsistency = value
+	return &opts
+}
+
+func (o *options) ShardsLeavingCountTowardsConsistency() bool {
+	return o.shardsLeavingCountTowardsConsistency
 }
 
 func (o *options) SetTagEncoderOptions(value serialize.TagEncoderOptions) Options {

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -136,31 +136,32 @@ type sessionState struct {
 }
 
 type session struct {
-	state                            sessionState
-	opts                             Options
-	runtimeOptsListenerCloser        xclose.Closer
-	scope                            tally.Scope
-	nowFn                            clock.NowFn
-	log                              *zap.Logger
-	logWriteErrorSampler             *sampler.Sampler
-	logFetchErrorSampler             *sampler.Sampler
-	newHostQueueFn                   newHostQueueFn
-	writeRetrier                     xretry.Retrier
-	fetchRetrier                     xretry.Retrier
-	streamBlocksRetrier              xretry.Retrier
-	pools                            sessionPools
-	fetchBatchSize                   int
-	newPeerBlocksQueueFn             newPeerBlocksQueueFn
-	reattemptStreamBlocksFromPeersFn reattemptStreamBlocksFromPeersFn
-	pickBestPeerFn                   pickBestPeerFn
-	origin                           topology.Host
-	streamBlocksMaxBlockRetries      int
-	streamBlocksWorkers              xsync.WorkerPool
-	streamBlocksBatchSize            int
-	streamBlocksMetadataBatchTimeout time.Duration
-	streamBlocksBatchTimeout         time.Duration
-	writeShardsInitializing          bool
-	metrics                          sessionMetrics
+	state                                sessionState
+	opts                                 Options
+	runtimeOptsListenerCloser            xclose.Closer
+	scope                                tally.Scope
+	nowFn                                clock.NowFn
+	log                                  *zap.Logger
+	logWriteErrorSampler                 *sampler.Sampler
+	logFetchErrorSampler                 *sampler.Sampler
+	newHostQueueFn                       newHostQueueFn
+	writeRetrier                         xretry.Retrier
+	fetchRetrier                         xretry.Retrier
+	streamBlocksRetrier                  xretry.Retrier
+	pools                                sessionPools
+	fetchBatchSize                       int
+	newPeerBlocksQueueFn                 newPeerBlocksQueueFn
+	reattemptStreamBlocksFromPeersFn     reattemptStreamBlocksFromPeersFn
+	pickBestPeerFn                       pickBestPeerFn
+	origin                               topology.Host
+	streamBlocksMaxBlockRetries          int
+	streamBlocksWorkers                  xsync.WorkerPool
+	streamBlocksBatchSize                int
+	streamBlocksMetadataBatchTimeout     time.Duration
+	streamBlocksBatchTimeout             time.Duration
+	writeShardsInitializing              bool
+	shardsLeavingCountTowardsConsistency bool
+	metrics                              sessionMetrics
 }
 
 type shardMetricsKey struct {
@@ -289,8 +290,9 @@ func newSession(opts Options) (clientSession, error) {
 			context: opts.ContextPool(),
 			id:      opts.IdentifierPool(),
 		},
-		writeShardsInitializing: opts.WriteShardsInitializing(),
-		metrics:                 newSessionMetrics(scope),
+		writeShardsInitializing:              opts.WriteShardsInitializing(),
+		shardsLeavingCountTowardsConsistency: opts.ShardsLeavingCountTowardsConsistency(),
+		metrics:                              newSessionMetrics(scope),
 	}
 	s.reattemptStreamBlocksFromPeersFn = s.streamBlocksReattemptFromPeers
 	s.pickBestPeerFn = s.streamBlocksPickBestPeer

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -1138,6 +1138,7 @@ func (s *session) writeAttemptWithRLock(
 
 	state := s.pools.writeState.Get()
 	state.consistencyLevel = s.state.writeLevel
+	state.shardsLeavingCountTowardsConsistency = s.shardsLeavingCountTowardsConsistency
 	state.topoMap = s.state.topoMap
 	state.incRef()
 

--- a/src/dbnode/client/session_fetch_test.go
+++ b/src/dbnode/client/session_fetch_test.go
@@ -316,6 +316,16 @@ func TestSessionFetchReadConsistencyLevelAll(t *testing.T) {
 	}
 }
 
+func TestSessionFetchReadConsistencyLevelUnstrictAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for i := 0; i <= 2; i++ {
+		testFetchConsistencyLevel(t, ctrl, topology.ReadConsistencyLevelUnstrictAll, i, outcomeSuccess)
+	}
+	testFetchConsistencyLevel(t, ctrl, topology.ReadConsistencyLevelUnstrictAll, 3, outcomeFail)
+}
+
 func TestSessionFetchReadConsistencyLevelMajority(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -419,6 +419,14 @@ type Options interface {
 	// initializing or not.
 	WriteShardsInitializing() bool
 
+	// SetShardsLeavingCountTowardsConsistency sets whether to count shards
+	// that are leaving or not towards consistency level calculations.
+	SetShardsLeavingCountTowardsConsistency(value bool) Options
+
+	// ShardsLeavingCountTowardsConsistency returns whether to count shards
+	// that are leaving or not towards consistency level calculations.
+	ShardsLeavingCountTowardsConsistency() bool
+
 	// SetTagEncoderOptions sets the TagEncoderOptions.
 	SetTagEncoderOptions(value serialize.TagEncoderOptions) Options
 

--- a/src/dbnode/client/write_test.go
+++ b/src/dbnode/client/write_test.go
@@ -123,6 +123,17 @@ func TestShardNotAvailable(t *testing.T) {
 	writeTestTeardown(wState, &writeWg)
 }
 
+func TestShardLeavingWithShardsLeavingCountTowardsConsistency(t *testing.T) {
+	var writeWg sync.WaitGroup
+
+	wState, s, host := writeTestSetup(t, &writeWg)
+	wState.shardsLeavingCountTowardsConsistency = true
+	setShardStates(t, s, host, shard.Leaving)
+	wState.completionFn(host, nil)
+	assert.Equal(t, int32(1), wState.success)
+	writeTestTeardown(wState, &writeWg)
+}
+
 // utils
 
 func getWriteState(s *session, w writeStub) *writeState {

--- a/src/dbnode/integration/fetch_tagged_quorum_test.go
+++ b/src/dbnode/integration/fetch_tagged_quorum_test.go
@@ -64,7 +64,7 @@ func TestFetchTaggedQuorumNormalOnlyOneUp(t *testing.T) {
 	writeTagged(t, nodes[0])
 
 	testFetch.assertContainsTaggedResult(t,
-		topology.ReadConsistencyLevelOne, topology.ReadConsistencyLevelUnstrictMajority)
+		topology.ReadConsistencyLevelOne, topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelUnstrictAll)
 	testFetch.assertFailsTaggedResult(t,
 		topology.ReadConsistencyLevelAll, topology.ReadConsistencyLevelMajority)
 }
@@ -92,7 +92,7 @@ func TestFetchTaggedQuorumNormalOnlyTwoUp(t *testing.T) {
 
 	// succeed to two nodes
 	testFetch.assertContainsTaggedResult(t, topology.ReadConsistencyLevelOne,
-		topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelMajority)
+		topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelMajority, topology.ReadConsistencyLevelUnstrictAll)
 	testFetch.assertFailsTaggedResult(t, topology.ReadConsistencyLevelAll)
 }
 
@@ -120,8 +120,9 @@ func TestFetchTaggedQuorumNormalAllUp(t *testing.T) {
 
 	// succeed to all nodes
 	testFetch.assertContainsTaggedResult(t,
-		topology.ReadConsistencyLevelOne, topology.ReadConsistencyLevelUnstrictMajority,
-		topology.ReadConsistencyLevelMajority, topology.ReadConsistencyLevelAll)
+		topology.ReadConsistencyLevelOne,
+		topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelMajority,
+		topology.ReadConsistencyLevelUnstrictAll, topology.ReadConsistencyLevelAll)
 }
 
 func TestFetchTaggedQuorumAddNodeOnlyLeavingInitializingUp(t *testing.T) {
@@ -148,8 +149,9 @@ func TestFetchTaggedQuorumAddNodeOnlyLeavingInitializingUp(t *testing.T) {
 
 	// No fetches succeed to available nodes
 	testFetch.assertFailsTaggedResult(t,
-		topology.ReadConsistencyLevelOne, topology.ReadConsistencyLevelUnstrictMajority,
-		topology.ReadConsistencyLevelMajority, topology.ReadConsistencyLevelAll)
+		topology.ReadConsistencyLevelOne,
+		topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelMajority,
+		topology.ReadConsistencyLevelUnstrictAll, topology.ReadConsistencyLevelAll)
 }
 
 func TestFetchTaggedQuorumAddNodeOnlyOneNormalAndLeavingInitializingUp(t *testing.T) {
@@ -177,7 +179,7 @@ func TestFetchTaggedQuorumAddNodeOnlyOneNormalAndLeavingInitializingUp(t *testin
 
 	// fetches succeed to one available node
 	testFetch.assertContainsTaggedResult(t,
-		topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelOne)
+		topology.ReadConsistencyLevelOne, topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelUnstrictAll)
 
 	testFetch.assertFailsTaggedResult(t,
 		topology.ReadConsistencyLevelMajority, topology.ReadConsistencyLevelAll)
@@ -209,7 +211,8 @@ func TestFetchTaggedQuorumAddNodeAllUp(t *testing.T) {
 	writeTagged(t, nodes...)
 
 	testFetch.assertContainsTaggedResult(t, topology.ReadConsistencyLevelOne,
-		topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelMajority)
+		topology.ReadConsistencyLevelUnstrictMajority, topology.ReadConsistencyLevelMajority,
+		topology.ReadConsistencyLevelUnstrictAll)
 
 	testFetch.assertFailsTaggedResult(t, topology.ReadConsistencyLevelAll)
 }

--- a/src/dbnode/integration/index_multiple_node_high_concurrency_test.go
+++ b/src/dbnode/integration/index_multiple_node_high_concurrency_test.go
@@ -55,6 +55,7 @@ func TestIndexMultipleNodeHighConcurrency(t *testing.T) {
 		topology.ReadConsistencyLevelOne,
 		topology.ReadConsistencyLevelUnstrictMajority,
 		topology.ReadConsistencyLevelMajority,
+		topology.ReadConsistencyLevelUnstrictAll,
 		topology.ReadConsistencyLevelAll,
 	}
 	for _, lvl := range levels {

--- a/src/x/sync/pooled_worker_pool_test.go
+++ b/src/x/sync/pooled_worker_pool_test.go
@@ -51,8 +51,15 @@ func TestPooledWorkerPoolGo(t *testing.T) {
 
 func TestPooledWorkerPoolGoWithTimeout(t *testing.T) {
 	var (
-		workers = 2
+		workers         = 2
+		channelCapacity = 1
 	)
+	// So we can control how empty the worker pool chanel is we
+	// set capacity to be same as num workers.
+	pooledWorkerPoolGoroutinesCapacity = &channelCapacity
+	defer func() {
+		pooledWorkerPoolGoroutinesCapacity = nil
+	}()
 
 	p, err := NewPooledWorkerPool(workers, NewPooledWorkerPoolOptions())
 	require.NoError(t, err)

--- a/src/x/sync/pooled_worker_pool_test.go
+++ b/src/x/sync/pooled_worker_pool_test.go
@@ -84,8 +84,7 @@ func TestPooledWorkerPoolGoWithTimeout(t *testing.T) {
 
 	wg.Done()
 
-	require.Equal(t, workers, resultsTrue)
-	require.Equal(t, workers, resultsFalse)
+	require.True(t, resultsFalse > 0)
 }
 
 func TestPooledWorkerPoolGrowOnDemand(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Allows for writes to leaving shards to count towards consistency and adds read consistency level unstrict all. Combined these settings allow for clusters under stress to perform a node join without removing the availability of the leaving node. Since this can cause issues where writes made to unavailable nodes count towards consistency the read unstrict all consistency level is made available so you can attempt always to try to read from all replicas. This means you won't optimistically short-circuit once reading from majority of nodes (with unstrict majority) and will always give the cluster a chance to read from all replicas (so if a write during a node join with write to a leaving shard that count towards consistency leaves a write on two nodes but the shard that is given up after leaving drops the data and the joining node didn't persist it, you are most likely to always read it from the single shard that still has the data).

Only advised to use this when the cluster is under stress, and also advised to be using repairs in this situation.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
