### PR TITLE
[dbnode] Fix granularity of LeaseManager.UpdateOpenLeases

### DIFF
--- a/src/dbnode/storage/block/lease.go
+++ b/src/dbnode/storage/block/lease.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 )
 
 var (
@@ -36,7 +37,7 @@ var (
 
 type leaseManager struct {
 	sync.Mutex
-	updateOpenLeasesInProgress bool
+	updateOpenLeasesInProgress sync.Map
 	leasers                    []Leaser
 	verifier                   LeaseVerifier
 }
@@ -139,19 +140,6 @@ func (m *leaseManager) UpdateOpenLeases(
 		m.Unlock()
 		return UpdateLeasesResult{}, errUpdateOpenLeasesVerifierNotSet
 	}
-	if m.updateOpenLeasesInProgress {
-		// Prevent UpdateOpenLeases() calls from happening concurrently (since the lock
-		// is not held for the duration) to ensure that Leaser's receive all updates
-		// and in the correct order.
-		//
-		// NB(rartoul): In the future this could be made more granular by preventing
-		// concurrent calls for a given descriptor, but for now this is simpler since
-		// there is no existing code path that calls this method concurrently.
-		m.Unlock()
-		return UpdateLeasesResult{}, errConcurrentUpdateOpenLeases
-	}
-
-	m.updateOpenLeasesInProgress = true
 	// NB(rartoul): Release lock while calling UpdateOpenLease() so that
 	// calls to OpenLease() and OpenLatestLease() are not blocked which
 	// would blocks reads and could cause deadlocks if those calls were
@@ -159,11 +147,15 @@ func (m *leaseManager) UpdateOpenLeases(
 	// return before being released.
 	m.Unlock()
 
-	defer func() {
-		m.Lock()
-		m.updateOpenLeasesInProgress = false
-		m.Unlock()
-	}()
+	hashableDescriptor := newHashableLeaseDescriptor(descriptor)
+	if _, ok := m.updateOpenLeasesInProgress.LoadOrStore(hashableDescriptor, struct{}{}); ok {
+		// Prevent UpdateOpenLeases() calls from happening concurrently (since the lock
+		// is not held for the duration) to ensure that Leaser's receive all updates
+		// and in the correct order.
+		return UpdateLeasesResult{}, errConcurrentUpdateOpenLeases
+	}
+
+	defer m.updateOpenLeasesInProgress.Delete(hashableDescriptor)
 
 	var result UpdateLeasesResult
 	for _, l := range m.leasers {
@@ -199,4 +191,22 @@ func (m *leaseManager) isRegistered(leaser Leaser) bool {
 		}
 	}
 	return false
+}
+
+type hashableLeaseDescriptor struct {
+	namespace  string
+	shard      uint32
+	blockStart time.Time
+}
+
+func newHashableLeaseDescriptor(descriptor LeaseDescriptor) hashableLeaseDescriptor {
+	ns := ""
+	if descriptor.Namespace != nil {
+		ns = descriptor.Namespace.String()
+	}
+	return hashableLeaseDescriptor{
+		namespace:  ns,
+		shard:      descriptor.Shard,
+		blockStart: descriptor.BlockStart,
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`LeaseManager.UpdateOpenLeases(...)` was preventing concurrent calls at global granularity (see the NB in the removed comment). This changes it to the smallest granularity possible (namespace + shard + block start) to allow concurrent operations.
Such change would prevent possible collisions between `shard.AggregateTiles()` background running and manual invocations, and `shardColdFlush.Done()`.
Also, this would open up the possibility of concurrent aggregation in `shard.AggregateTiles()` in future.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
