### PR TITLE
[dbnode] GetNamespaceFn returns public Namespace interface

### DIFF
--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -412,13 +412,17 @@ func (d *db) addNamespacesWithLock(namespaces []namespace.Metadata) error {
 
 	hooks := d.Options().NamespaceHooks()
 	for _, ns := range createdNamespaces {
-		err := hooks.OnCreatedNamespace(ns, d.namespaces.Get)
+		err := hooks.OnCreatedNamespace(ns, d.getNamespaceWithLock)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (d *db) getNamespaceWithLock(id ident.ID) (Namespace, bool) {
+	return d.namespaces.Get(id)
 }
 
 func (d *db) newDatabaseNamespaceWithLock(

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -1316,4 +1316,4 @@ type NamespaceHooks interface {
 	OnCreatedNamespace(Namespace, GetNamespaceFn) error
 }
 
-type GetNamespaceFn func (k ident.ID) (databaseNamespace, bool)
+type GetNamespaceFn func (id ident.ID) (Namespace, bool)


### PR DESCRIPTION
**What this PR does / why we need it**:
I had by mistake declared `GetNamespaceFn` to return the private `databaseNamespace` which makes using it form other packages problematic. Replacing return type with the public `storage.Namespace`interface.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
