### PR TITLE
[query] Add implementation for dynamically fetching ClusterNamespaces

### DIFF
--- a/src/query/storage/m3/dynamic_cluster.go
+++ b/src/query/storage/m3/dynamic_cluster.go
@@ -22,18 +22,415 @@ package m3
 
 import (
 	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
+	xerrors "github.com/m3db/m3/src/x/errors"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/instrument"
+
+	"go.uber.org/zap"
 )
 
 var (
 	errDynamicClusterNamespaceConfigurationNotSet = errors.New("dynamicClusterNamespaceConfiguration not set")
 	errInstrumentOptionsNotSet                    = errors.New("instrumentOptions not set")
+	errNsWatchAlreadyClosed                       = errors.New("namespace watch already closed")
 )
 
 type dynamicCluster struct {
+	clusterCfgs []DynamicClusterNamespaceConfiguration
+	logger      *zap.Logger
+	iOpts       instrument.Options
+
+	sync.RWMutex
+
+	namespaces              ClusterNamespaces
+	unaggregatedNamespace   ClusterNamespace
+	aggregatedNamespaces    map[RetentionResolution]ClusterNamespace
+	namespacesByEtcdCluster map[int]clusterNamespaceLookup
+
+	nsWatches []namespace.NamespaceWatch
+	closed    bool
 }
 
 // NewDynamicClusters creates an implementation of the Clusters interface
 // supports dynamic updating of cluster namespaces.
 func NewDynamicClusters(_ DynamicClusterOptions) (Clusters, error) {
 	return nil, errors.New("dynamic cluster configuration not yet supported")
+}
+
+// TODO(nate): Replace constructor above with this method
+// once namespace staging is complete.
+//
+// newDynamicClusters creates an implementation of the Clusters interface
+// supports dynamic updating of cluster namespaces.
+func newDynamicClusters(opts DynamicClusterOptions) (Clusters, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+
+	cluster := dynamicCluster{
+		clusterCfgs:             opts.DynamicClusterNamespaceConfiguration(),
+		logger:                  opts.InstrumentOptions().Logger(),
+		iOpts:                   opts.InstrumentOptions(),
+		namespacesByEtcdCluster: make(map[int]clusterNamespaceLookup),
+	}
+
+	if err := cluster.init(); err != nil {
+		if cErr := cluster.Close(); cErr != nil {
+			return nil, cErr
+		}
+
+		return nil, err
+	}
+
+	return &cluster, nil
+}
+
+func (d *dynamicCluster) init() error {
+	d.logger.Info("creating namespaces watches", zap.Int("clusters", len(d.clusterCfgs)))
+
+	var (
+		wg       sync.WaitGroup
+		multiErr xerrors.MultiError
+		errLock  sync.Mutex
+	)
+	// Configure watch for each cluster provided
+	for i, cfg := range d.clusterCfgs {
+		i := i
+		cfg := cfg
+
+		wg.Add(1)
+		go func() {
+			if err := d.initNamespaceWatch(i, cfg); err != nil {
+				errLock.Lock()
+				multiErr = multiErr.Add(err)
+				errLock.Unlock()
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+	if !multiErr.Empty() {
+		return multiErr.FinalError()
+	}
+
+	return nil
+}
+
+func (d *dynamicCluster) initNamespaceWatch(etcdClusterId int, cfg DynamicClusterNamespaceConfiguration) error {
+	registry, err := cfg.nsInitializer.Init()
+	if err != nil {
+		return err
+	}
+
+	// Get a namespace watch
+	watch, err := registry.Watch()
+	if err != nil {
+		return err
+	}
+
+	// Wait till first namespaces value is received and set the value.
+	d.logger.Info("resolving namespaces with namespace watch", zap.Int("cluster", etcdClusterId))
+	<-watch.C()
+
+	updater := func(namespaces namespace.Map) error {
+		d.updateNamespaces(etcdClusterId, cfg, namespaces)
+		return nil
+	}
+	nsWatch := namespace.NewNamespaceWatch(updater, watch, d.iOpts)
+	if err = nsWatch.Start(); err != nil {
+		return err
+	}
+
+	nsMap := watch.Get()
+	d.updateNamespaces(etcdClusterId, cfg, nsMap)
+
+	d.Lock()
+	d.nsWatches = append(d.nsWatches, nsWatch)
+	d.Unlock()
+
+	return nil
+}
+
+func (d *dynamicCluster) updateNamespaces(
+	etcdClusterId int,
+	clusterCfg DynamicClusterNamespaceConfiguration,
+	newNamespaces namespace.Map,
+) {
+	if newNamespaces == nil {
+		d.logger.Debug("received empty namespace map. ignoring", zap.Int("cluster", etcdClusterId))
+		return
+	}
+
+	d.Lock()
+	defer d.Unlock()
+
+	d.updateNamespacesByEtcdClusterWithLock(etcdClusterId, clusterCfg, newNamespaces)
+	d.updateClusterNamespacesWithLock()
+}
+
+func (d *dynamicCluster) updateNamespacesByEtcdClusterWithLock(
+	etcdClusterId int,
+	clusterCfg DynamicClusterNamespaceConfiguration,
+	newNamespaces namespace.Map,
+) {
+	// TODO(nate): incorporate checking if new namespace is ready once staging state has landed.
+
+	// Check if existing namespaces still exist or need to be updated.
+	if _, ok := d.namespacesByEtcdCluster[etcdClusterId]; !ok {
+		d.namespacesByEtcdCluster[etcdClusterId] = newClusterNamespaceLookup(len(newNamespaces.IDs()))
+	}
+	existing := d.namespacesByEtcdCluster[etcdClusterId]
+	var (
+		sz      = len(newNamespaces.Metadatas())
+		added   = make([]string, 0, sz)
+		updated = make([]string, 0, sz)
+		removed = make([]string, 0, sz)
+	)
+	for nsId, nsMd := range existing.idToMetadata {
+		newNsMd, err := newNamespaces.Get(ident.StringID(nsId))
+		// non-nil error here means namespace is not present (i.e. namespace has been removed)
+		if err != nil {
+			existing.remove(nsId)
+			removed = append(removed, nsId)
+		}
+
+		// Namespace options have been updated; regenerate cluster namespaces.
+		if !nsMd.Equal(newNsMd) {
+			// Replace with new metadata and cluster namespaces.
+			newClusterNamespaces, err := toClusterNamespaces(clusterCfg, newNsMd)
+			if err != nil {
+				// Log error, but don't allow singular failed namespace update to fail all namespace updates.
+				d.logger.Error("failed to update namespace", zap.String("namespace", nsId),
+					zap.Error(err))
+				continue
+			}
+			existing.update(nsId, newNsMd, newClusterNamespaces)
+			updated = append(updated, nsId)
+		}
+	}
+
+	// Check for new namespaces to add.
+	for _, newNsMd := range newNamespaces.Metadatas() {
+		// Namespace has been added.
+		if !existing.exists(newNsMd.ID().String()) {
+			newClusterNamespaces, err := toClusterNamespaces(clusterCfg, newNsMd)
+			if err != nil {
+				// Log error, but don't allow singular failed namespace update to fail all namespace updates.
+				d.logger.Error("failed to update namespace", zap.String("namespace", newNsMd.ID().String()),
+					zap.Error(err))
+				continue
+			}
+			existing.add(newNsMd.ID().String(), newNsMd, newClusterNamespaces)
+			added = append(added, newNsMd.ID().String())
+		}
+	}
+
+	if len(added) > 0 {
+		d.logger.Info("added cluster namespaces", zap.Strings("namespaces", added))
+	}
+
+	if len(updated) > 0 {
+		d.logger.Info("updated cluster namespaces", zap.Strings("namespaces", updated))
+	}
+
+	if len(removed) > 0 {
+		d.logger.Info("removed cluster namespaces", zap.Strings("namespaces", removed))
+	}
+}
+
+func toClusterNamespaces(clusterCfg DynamicClusterNamespaceConfiguration, md namespace.Metadata) (ClusterNamespaces, error) {
+	aggOpts := md.Options().AggregationOptions()
+	if aggOpts == nil {
+		return nil, fmt.Errorf("no aggregationOptions present for namespace %v", md.ID().String())
+	}
+
+	if len(aggOpts.Aggregations()) == 0 {
+		return nil, fmt.Errorf("no aggregations present for namespace %v", md.ID().String())
+	}
+
+	retOpts := md.Options().RetentionOptions()
+	if retOpts == nil {
+		return nil, fmt.Errorf("no retentionOptions present for namespace %v", md.ID().String())
+	}
+
+	clusterNamespaces := make(ClusterNamespaces, 0, len(aggOpts.Aggregations()))
+	for _, agg := range aggOpts.Aggregations() {
+		var (
+			clusterNamespace ClusterNamespace
+			err              error
+		)
+		if agg.Aggregated {
+			clusterNamespace, err = newAggregatedClusterNamespace(AggregatedClusterNamespaceDefinition{
+				NamespaceID: md.ID(),
+				Session:     clusterCfg.session,
+				Retention:   retOpts.RetentionPeriod(),
+				Resolution:  agg.Attributes.Resolution,
+				Downsample: &ClusterNamespaceDownsampleOptions{
+					All: agg.Attributes.DownsampleOptions.All,
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			clusterNamespace, err = newUnaggregatedClusterNamespace(UnaggregatedClusterNamespaceDefinition{
+				NamespaceID: md.ID(),
+				Session:     clusterCfg.session,
+				Retention:   retOpts.RetentionPeriod(),
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+		clusterNamespaces = append(clusterNamespaces, clusterNamespace)
+	}
+
+	return clusterNamespaces, nil
+}
+
+func (d *dynamicCluster) updateClusterNamespacesWithLock() {
+	nsCount := 0
+	for _, nsMap := range d.namespacesByEtcdCluster {
+		for _, clusterNamespaces := range nsMap.metadataToClusterNamespaces {
+			nsCount += len(clusterNamespaces)
+		}
+	}
+
+	var (
+		newNamespaces            = make(ClusterNamespaces, 0, nsCount)
+		newAggregatedNamespaces  = make(map[RetentionResolution]ClusterNamespace)
+		newUnaggregatedNamespace ClusterNamespace
+	)
+
+	for _, nsMap := range d.namespacesByEtcdCluster {
+		for _, clusterNamespaces := range nsMap.metadataToClusterNamespaces {
+			for _, clusterNamespace := range clusterNamespaces {
+				attrs := clusterNamespace.Options().Attributes()
+				if attrs.MetricsType == storagemetadata.UnaggregatedMetricsType {
+					if newUnaggregatedNamespace != nil {
+						d.logger.Warn("more than one unaggregated namespace found. using most recently "+
+							"discovered unaggregated namespace",
+							zap.String("existing", newUnaggregatedNamespace.NamespaceID().String()),
+							zap.String("new", clusterNamespace.NamespaceID().String()))
+					}
+					newUnaggregatedNamespace = clusterNamespace
+				} else {
+					retRes := RetentionResolution{
+						Retention:  attrs.Retention,
+						Resolution: attrs.Resolution,
+					}
+					existing, ok := newAggregatedNamespaces[retRes]
+					if ok {
+						d.logger.Warn("more than one aggregated namespace found for retention and resolution. "+
+							"using most recently discovered aggregated namespace",
+							zap.String("retention", retRes.Retention.String()),
+							zap.String("resolution", retRes.Resolution.String()),
+							zap.String("existing", existing.NamespaceID().String()),
+							zap.String("new", clusterNamespace.NamespaceID().String()))
+					}
+					newAggregatedNamespaces[retRes] = clusterNamespace
+				}
+			}
+		}
+	}
+
+	newNamespaces = append(newNamespaces, newUnaggregatedNamespace)
+	for _, ns := range newAggregatedNamespaces {
+		newNamespaces = append(newNamespaces, ns)
+	}
+
+	d.unaggregatedNamespace = newUnaggregatedNamespace
+	d.aggregatedNamespaces = newAggregatedNamespaces
+	d.namespaces = newNamespaces
+}
+
+func (d *dynamicCluster) Close() error {
+	d.Lock()
+	defer d.Unlock()
+
+	if d.closed {
+		return errNsWatchAlreadyClosed
+	}
+
+	d.closed = true
+
+	var multiErr xerrors.MultiError
+	for _, watch := range d.nsWatches {
+		if err := watch.Close(); err != nil {
+			multiErr = multiErr.Add(err)
+		}
+	}
+
+	if !multiErr.Empty() {
+		return multiErr.FinalError()
+	}
+
+	return nil
+}
+
+func (d *dynamicCluster) ClusterNamespaces() ClusterNamespaces {
+	d.RLock()
+	defer d.RUnlock()
+
+	return d.namespaces
+}
+
+func (d *dynamicCluster) UnaggregatedClusterNamespace() ClusterNamespace {
+	d.RLock()
+	defer d.RUnlock()
+
+	return d.unaggregatedNamespace
+}
+
+func (d *dynamicCluster) AggregatedClusterNamespace(attrs RetentionResolution) (ClusterNamespace, bool) {
+	d.RLock()
+	defer d.RUnlock()
+
+	namespace, ok := d.aggregatedNamespaces[attrs]
+	return namespace, ok
+}
+
+// clusterNamespaceLookup is a helper to track namespace changes. Two maps are necessary
+// to handle the update case which causes the metadata for a previously seen namespaces to change.
+// idToMetadata map allows us to find the previous metadata to detect changes. metadataToClusterNamespaces
+// map allows us to find ClusterNamespaces generated from the metadata's AggregationOptions.
+type clusterNamespaceLookup struct {
+	idToMetadata                map[string]namespace.Metadata
+	metadataToClusterNamespaces map[namespace.Metadata]ClusterNamespaces
+}
+
+func newClusterNamespaceLookup(size int) clusterNamespaceLookup {
+	return clusterNamespaceLookup{
+		idToMetadata:                make(map[string]namespace.Metadata, size),
+		metadataToClusterNamespaces: make(map[namespace.Metadata]ClusterNamespaces, size),
+	}
+}
+
+func (c *clusterNamespaceLookup) exists(nsId string) bool {
+	_, ok := c.idToMetadata[nsId]
+	return ok
+}
+
+func (c *clusterNamespaceLookup) add(nsId string, nsMd namespace.Metadata, clusterNamespaces ClusterNamespaces) {
+	c.idToMetadata[nsId] = nsMd
+	c.metadataToClusterNamespaces[nsMd] = clusterNamespaces
+}
+
+func (c *clusterNamespaceLookup) update(nsId string, nsMd namespace.Metadata, clusterNamespaces ClusterNamespaces) {
+	existingMd := c.idToMetadata[nsId]
+	c.idToMetadata[nsId] = nsMd
+	delete(c.metadataToClusterNamespaces, existingMd)
+	c.metadataToClusterNamespaces[nsMd] = clusterNamespaces
+}
+
+func (c *clusterNamespaceLookup) remove(nsId string) {
+	existingMd := c.idToMetadata[nsId]
+	delete(c.metadataToClusterNamespaces, existingMd)
+	delete(c.idToMetadata, nsId)
 }

--- a/src/query/storage/m3/dynamic_cluster_test.go
+++ b/src/query/storage/m3/dynamic_cluster_test.go
@@ -1,0 +1,416 @@
+// Copyright (c) 2020  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package m3
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/retention"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/instrument"
+	xtest "github.com/m3db/m3/src/x/test"
+	xwatch "github.com/m3db/m3/src/x/watch"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	defaultTestNs1ID         = ident.StringID("testns1")
+	defaultTestNs2ID         = ident.StringID("testns2")
+	defaultTestRetentionOpts = retention.NewOptions().
+					SetBufferFuture(10 * time.Minute).
+					SetBufferPast(10 * time.Minute).
+					SetBlockSize(2 * time.Hour).
+					SetRetentionPeriod(48 * time.Hour)
+	defaultTestNs2RetentionOpts = retention.NewOptions().
+					SetBufferFuture(10 * time.Minute).
+					SetBufferPast(10 * time.Minute).
+					SetBlockSize(4 * time.Hour).
+					SetRetentionPeriod(48 * time.Hour)
+	defaultTestAggregationOpts = namespace.NewAggregationOptions().
+					SetAggregations([]namespace.Aggregation{namespace.NewUnaggregatedAggregation()})
+	defaultTestNs2AggregationOpts = namespace.NewAggregationOptions().
+					SetAggregations([]namespace.Aggregation{namespace.NewAggregatedAggregation(
+			namespace.AggregatedAttributes{
+				Resolution:        1 * time.Minute,
+				DownsampleOptions: namespace.NewDownsampleOptions(true),
+			}),
+		})
+	defaultTestNs1Opts = namespace.NewOptions().SetRetentionOptions(defaultTestRetentionOpts).
+				SetAggregationOptions(defaultTestAggregationOpts)
+	defaultTestNs2Opts = namespace.NewOptions().SetRetentionOptions(defaultTestNs2RetentionOpts).
+				SetAggregationOptions(defaultTestNs2AggregationOpts)
+)
+
+func TestDynamicClustersInitialization(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	mockSession := client.NewMockSession(ctrl)
+
+	mapCh := make(nsMapCh, 10)
+	mapCh <- testNamespaceMap(t, []mapParams{
+		{nsID: defaultTestNs1ID, nsOpts: defaultTestNs1Opts},
+		{nsID: defaultTestNs2ID, nsOpts: defaultTestNs2Opts},
+	})
+	mockInitializer := newMockNsInitializer(t, ctrl, mapCh)
+
+	cfg := DynamicClusterNamespaceConfiguration{
+		session:       mockSession,
+		nsInitializer: mockInitializer,
+	}
+
+	opts := NewDynamicClusterOptions().
+		SetDynamicClusterNamespaceConfiguration([]DynamicClusterNamespaceConfiguration{cfg}).
+		SetInstrumentOptions(instrument.NewOptions())
+
+	clusters, err := newDynamicClusters(opts)
+	require.NoError(t, err)
+
+	defer cleanup(clusters)
+
+	requireClusterNamespace(t, clusters, defaultTestNs2ID, ClusterNamespaceOptions{
+		attributes: storagemetadata.Attributes{
+			MetricsType: storagemetadata.AggregatedMetricsType,
+			Retention:   48 * time.Hour,
+			Resolution:  1 * time.Minute,
+		},
+		downsample: &ClusterNamespaceDownsampleOptions{All: true},
+	})
+
+	requireClusterNamespace(t, clusters, defaultTestNs1ID, ClusterNamespaceOptions{
+		attributes: storagemetadata.Attributes{
+			MetricsType: storagemetadata.UnaggregatedMetricsType,
+			Retention:   48 * time.Hour,
+		}})
+
+	requireClusterNamespaceIDs(t, clusters, []ident.ID{defaultTestNs1ID, defaultTestNs2ID})
+}
+
+func TestDynamicClustersWithUpdates(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	mockSession := client.NewMockSession(ctrl)
+
+	mapCh := make(nsMapCh, 10)
+	nsMap := testNamespaceMap(t, []mapParams{
+		{nsID: defaultTestNs1ID, nsOpts: defaultTestNs1Opts},
+		{nsID: defaultTestNs2ID, nsOpts: defaultTestNs2Opts},
+	})
+	mapCh <- nsMap
+	mockInitializer := newMockNsInitializer(t, ctrl, mapCh)
+
+	cfg := DynamicClusterNamespaceConfiguration{
+		session:       mockSession,
+		nsInitializer: mockInitializer,
+	}
+
+	opts := NewDynamicClusterOptions().
+		SetDynamicClusterNamespaceConfiguration([]DynamicClusterNamespaceConfiguration{cfg}).
+		SetInstrumentOptions(instrument.NewOptions())
+
+	clusters, err := newDynamicClusters(opts)
+	require.NoError(t, err)
+
+	defer cleanup(clusters)
+
+	// Update resolution of aggregated namespace
+	newOpts := defaultTestNs2Opts.
+		SetAggregationOptions(defaultTestNs2AggregationOpts.
+			SetAggregations([]namespace.Aggregation{namespace.NewAggregatedAggregation(
+				namespace.AggregatedAttributes{
+					Resolution:        2 * time.Minute,
+					DownsampleOptions: namespace.NewDownsampleOptions(true),
+				}),
+			}))
+	nsMap = testNamespaceMap(t, []mapParams{
+		{nsID: defaultTestNs1ID, nsOpts: defaultTestNs1Opts},
+		{nsID: defaultTestNs2ID, nsOpts: newOpts},
+	})
+
+	// Send update to trigger watch
+	mapCh <- nsMap
+
+done:
+	for {
+		select {
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "failed to receive namespace watch update")
+		default:
+			if _, ok := clusters.AggregatedClusterNamespace(RetentionResolution{
+				Retention:  48 * time.Hour,
+				Resolution: 2 * time.Minute,
+			}); ok {
+				requireClusterNamespace(t, clusters, defaultTestNs2ID, ClusterNamespaceOptions{
+					attributes: storagemetadata.Attributes{
+						MetricsType: storagemetadata.AggregatedMetricsType,
+						Retention:   48 * time.Hour,
+						Resolution:  2 * time.Minute,
+					},
+					downsample: &ClusterNamespaceDownsampleOptions{All: true},
+				})
+
+				requireClusterNamespaceIDs(t, clusters, []ident.ID{defaultTestNs1ID, defaultTestNs2ID})
+
+				break done
+			}
+		}
+	}
+}
+
+func TestDynamicClustersWithMultipleInitializers(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	mockSession := client.NewMockSession(ctrl)
+	mockSession2 := client.NewMockSession(ctrl)
+
+	mapCh := make(nsMapCh, 10)
+	mapCh <- testNamespaceMap(t, []mapParams{
+		{nsID: defaultTestNs1ID, nsOpts: defaultTestNs1Opts},
+		{nsID: defaultTestNs2ID, nsOpts: defaultTestNs2Opts},
+	})
+	mockInitializer := newMockNsInitializer(t, ctrl, mapCh)
+
+	fooOpts := defaultTestNs1Opts.
+		SetAggregationOptions(namespace.NewAggregationOptions().
+			SetAggregations([]namespace.Aggregation{namespace.NewAggregatedAggregation(
+				namespace.AggregatedAttributes{
+					Resolution:        2 * time.Minute,
+					DownsampleOptions: namespace.NewDownsampleOptions(true),
+				}),
+			}))
+	barOpts := defaultTestNs1Opts.
+		SetAggregationOptions(namespace.NewAggregationOptions().
+			SetAggregations([]namespace.Aggregation{namespace.NewAggregatedAggregation(
+				namespace.AggregatedAttributes{
+					Resolution:        5 * time.Minute,
+					DownsampleOptions: namespace.NewDownsampleOptions(false),
+				}),
+			}))
+	var (
+		fooNsID = ident.StringID("foo")
+		barNsID = ident.StringID("bar")
+	)
+	nsMap := testNamespaceMap(t, []mapParams{
+		{nsID: fooNsID, nsOpts: fooOpts},
+		{nsID: barNsID, nsOpts: barOpts},
+	})
+
+	mapCh2 := make(nsMapCh, 10)
+	mapCh2 <- nsMap
+	mockInitializer2 := newMockNsInitializer(t, ctrl, mapCh2)
+
+	cfg := DynamicClusterNamespaceConfiguration{
+		session:       mockSession,
+		nsInitializer: mockInitializer,
+	}
+	cfg2 := DynamicClusterNamespaceConfiguration{
+		session:       mockSession2,
+		nsInitializer: mockInitializer2,
+	}
+
+	opts := NewDynamicClusterOptions().
+		SetDynamicClusterNamespaceConfiguration([]DynamicClusterNamespaceConfiguration{cfg, cfg2}).
+		SetInstrumentOptions(instrument.NewOptions())
+
+	clusters, err := newDynamicClusters(opts)
+	require.NoError(t, err)
+
+	defer cleanup(clusters)
+
+	requireClusterNamespace(t, clusters, defaultTestNs2ID, ClusterNamespaceOptions{
+		attributes: storagemetadata.Attributes{
+			MetricsType: storagemetadata.AggregatedMetricsType,
+			Retention:   48 * time.Hour,
+			Resolution:  1 * time.Minute,
+		},
+		downsample: &ClusterNamespaceDownsampleOptions{All: true},
+	})
+
+	requireClusterNamespace(t, clusters, fooNsID, ClusterNamespaceOptions{
+		attributes: storagemetadata.Attributes{
+			MetricsType: storagemetadata.AggregatedMetricsType,
+			Retention:   48 * time.Hour,
+			Resolution:  2 * time.Minute,
+		},
+		downsample: &ClusterNamespaceDownsampleOptions{All: true},
+	})
+
+	requireClusterNamespace(t, clusters, barNsID, ClusterNamespaceOptions{
+		attributes: storagemetadata.Attributes{
+			MetricsType: storagemetadata.AggregatedMetricsType,
+			Retention:   48 * time.Hour,
+			Resolution:  5 * time.Minute,
+		},
+		downsample: &ClusterNamespaceDownsampleOptions{All: false},
+	})
+
+	requireClusterNamespace(t, clusters, defaultTestNs1ID, ClusterNamespaceOptions{
+		attributes: storagemetadata.Attributes{
+			MetricsType: storagemetadata.UnaggregatedMetricsType,
+			Retention:   48 * time.Hour,
+		}})
+
+	requireClusterNamespaceIDs(t, clusters, []ident.ID{defaultTestNs1ID, defaultTestNs2ID,
+		fooNsID, barNsID})
+}
+
+func TestDynamicClustersInitFailures(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	mockSession := client.NewMockSession(ctrl)
+
+	updateCh := make(chan struct{}, 10)
+	reg := namespace.NewMockRegistry(ctrl)
+	reg.EXPECT().Watch().Return(nil, errors.New("failed to init")).AnyTimes()
+
+	cfg := DynamicClusterNamespaceConfiguration{
+		session: mockSession,
+		nsInitializer: &mockNsInitializer{
+			registry: reg,
+			updateCh: updateCh,
+		},
+	}
+
+	opts := NewDynamicClusterOptions().
+		SetDynamicClusterNamespaceConfiguration([]DynamicClusterNamespaceConfiguration{cfg}).
+		SetInstrumentOptions(instrument.NewOptions())
+
+	_, err := newDynamicClusters(opts)
+	require.Error(t, err)
+}
+
+func cleanup(clusters Clusters) {
+	// Give test a chance to schedule pending goroutines (i.e. goroutine watching for updates)
+	// If this is not done, test may complete and Close() will be called before startWatch goroutine
+	// is invoked which causes a deadlock.
+	time.Sleep(100 * time.Millisecond)
+
+	clusters.Close()
+}
+
+func requireClusterNamespace(t *testing.T, clusters Clusters, expectedID ident.ID, expectedOpts ClusterNamespaceOptions) {
+	var (
+		ns ClusterNamespace
+		ok bool
+	)
+	if expectedOpts.Attributes().MetricsType == storagemetadata.AggregatedMetricsType {
+		ns, ok = clusters.AggregatedClusterNamespace(RetentionResolution{
+			Retention:  expectedOpts.Attributes().Retention,
+			Resolution: expectedOpts.Attributes().Resolution,
+		})
+		if !ok {
+			require.Fail(t, fmt.Sprintf("aggregated namespace not found for resolution=%v retention=%v",
+				expectedOpts.Attributes().Resolution, expectedOpts.Attributes().Retention))
+		}
+	} else {
+		ns = clusters.UnaggregatedClusterNamespace()
+	}
+	require.Equal(t, expectedID.String(), ns.NamespaceID().String())
+	require.Equal(t, expectedOpts, ns.Options())
+}
+
+type mapParams struct {
+	nsID   ident.ID
+	nsOpts namespace.Options
+}
+
+func requireClusterNamespaceIDs(t *testing.T, clusters Clusters, ids []ident.ID) {
+	var (
+		nsIds       = make([]string, 0, len(ids))
+		expectedIds = make([]string, 0, len(ids))
+	)
+	for _, ns := range clusters.ClusterNamespaces() {
+		nsIds = append(nsIds, ns.NamespaceID().String())
+	}
+	for _, id := range ids {
+		expectedIds = append(expectedIds, id.String())
+	}
+	sort.Strings(nsIds)
+	sort.Strings(expectedIds)
+	require.Equal(t, expectedIds, nsIds)
+}
+
+func testNamespaceMap(t *testing.T, params []mapParams) namespace.Map {
+	var mds []namespace.Metadata
+	for _, param := range params {
+		md, err := namespace.NewMetadata(param.nsID, param.nsOpts)
+		require.NoError(t, err)
+		mds = append(mds, md)
+	}
+	nsMap, err := namespace.NewMap(mds)
+	require.NoError(t, err)
+	return nsMap
+}
+
+type nsMapCh chan namespace.Map
+
+type mockNsInitializer struct {
+	registry *namespace.MockRegistry
+	updateCh chan struct{}
+}
+
+func (m *mockNsInitializer) Init() (namespace.Registry, error) {
+	return m.registry, nil
+}
+
+func newMockNsInitializer(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	nsMapCh nsMapCh,
+) namespace.Initializer {
+	updateCh := make(chan struct{}, 10)
+	watch := xwatch.NewWatchable()
+	go func() {
+		for {
+			v, ok := <-nsMapCh
+			if !ok { // closed channel
+				return
+			}
+
+			watch.Update(v)
+			updateCh <- struct{}{}
+		}
+	}()
+
+	_, w, err := watch.Watch()
+	require.NoError(t, err)
+
+	nsWatch := namespace.NewWatch(w)
+	reg := namespace.NewMockRegistry(ctrl)
+	reg.EXPECT().Watch().Return(nsWatch, nil).AnyTimes()
+
+	return &mockNsInitializer{
+		registry: reg,
+		updateCh: updateCh,
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR implements dynamicCluster to support fetching ClusterNamespaces
from etcd dynamically instead of pulling from static config. Notably,
this does not wire up the implementation for use in the coordinator yet.
That change is pending the addition of a flag to namespace metadata
to notify the coordinator that the namespace is ready for use.

**Special notes for your reviewer**:
Builds off https://github.com/m3db/m3/pull/2701

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
