### PR TITLE
[coordinator] Extract tag value from encoded tags without pooling required

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -972,8 +972,7 @@ func (o DownsamplerOptions) newAggregatorRulesOptions(pools aggPools) rules.Opti
 	tagsFilterOpts := filters.TagsFilterOptions{
 		NameTagKey: nameTag,
 		NameAndTagsFn: func(id []byte) ([]byte, []byte, error) {
-			name, err := resolveEncodedTagsNameTag(id, pools.metricTagsIteratorPool,
-				nameTag)
+			name, err := resolveEncodedTagsNameTag(id, nameTag)
 			if err != nil && err != errNoMetricNameTag {
 				return nil, nil, err
 			}

--- a/src/x/serialize/decoder_fast.go
+++ b/src/x/serialize/decoder_fast.go
@@ -51,6 +51,9 @@ func TagValueFromEncodedTagsFast(
 			return nil, false, fmt.Errorf("missing size for tag name: index=%d", i)
 		}
 		numBytesName := int(byteOrder.Uint16(encodedTags[:2]))
+		if numBytesName <= 0 {
+			return nil, false, errEmptyTagNameLiteral
+		}
 		encodedTags = encodedTags[2:]
 
 		bytesName := encodedTags[:numBytesName]

--- a/src/x/serialize/decoder_fast.go
+++ b/src/x/serialize/decoder_fast.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package serialize
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// TagValueFromEncodedTagsFast returns a tag from a set of encoded tags without
+// any pooling required.
+func TagValueFromEncodedTagsFast(
+	encodedTags []byte,
+	tagName []byte,
+) ([]byte, bool, error) {
+	total := len(encodedTags)
+	if total < 4 {
+		return nil, false, fmt.Errorf(
+			"encoded tags too short: size=%d, need=%d", total, 4)
+	}
+
+	header := byteOrder.Uint16(encodedTags[:2])
+	encodedTags = encodedTags[2:]
+	if header != headerMagicNumber {
+		return nil, false, errIncorrectHeader
+	}
+
+	length := int(byteOrder.Uint16(encodedTags[:2]))
+	encodedTags = encodedTags[2:]
+
+	for i := 0; i < length; i++ {
+		if len(encodedTags) < 2 {
+			return nil, false, fmt.Errorf("missing size for tag name: index=%d", i)
+		}
+		numBytesName := int(byteOrder.Uint16(encodedTags[:2]))
+		encodedTags = encodedTags[2:]
+
+		bytesName := encodedTags[:numBytesName]
+		encodedTags = encodedTags[numBytesName:]
+
+		if len(encodedTags) < 2 {
+			return nil, false, fmt.Errorf("missing size for tag value: index=%d", i)
+		}
+
+		numBytesValue := int(byteOrder.Uint16(encodedTags[:2]))
+		encodedTags = encodedTags[2:]
+
+		bytesValue := encodedTags[:numBytesValue]
+		encodedTags = encodedTags[numBytesValue:]
+
+		if bytes.Compare(bytesName, tagName) == 0 {
+			return bytesValue, true, nil
+		}
+	}
+
+	return nil, false, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds a faster path for extracting a single tag from encoded tags that does not require pooling overhead.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
