### PR TITLE
[dbnode] Reduce allocations in AggregateTiles

### DIFF
--- a/src/dbnode/encoding/tile/series_block_iterator.go
+++ b/src/dbnode/encoding/tile/series_block_iterator.go
@@ -41,7 +41,7 @@ type seriesBlockIter struct {
 	iter        SeriesFrameIterator
 	blockIter   fs.CrossBlockIterator
 	encodedTags ts.EncodedTags
-	id          ident.ID
+	id          ident.BytesID
 }
 
 // NewSeriesBlockIterator creates a new SeriesBlockIterator.
@@ -78,7 +78,7 @@ func (b *seriesBlockIter) Next() bool {
 	return true
 }
 
-func (b *seriesBlockIter) Current() (SeriesFrameIterator, ident.ID, ts.EncodedTags) {
+func (b *seriesBlockIter) Current() (SeriesFrameIterator, ident.BytesID, ts.EncodedTags) {
 	return b.iter, b.id, b.encodedTags
 }
 

--- a/src/dbnode/encoding/tile/types.go
+++ b/src/dbnode/encoding/tile/types.go
@@ -70,7 +70,7 @@ type SeriesBlockIterator interface {
 	// Close closes the iterator.
 	Close() error
 	// Current returns the next set of series frame iterators.
-	Current() (SeriesFrameIterator, ident.ID, ts.EncodedTags)
+	Current() (SeriesFrameIterator, ident.BytesID, ts.EncodedTags)
 }
 
 // Options are series block iterator options.

--- a/src/dbnode/persist/fs/cross_block_reader.go
+++ b/src/dbnode/persist/fs/cross_block_reader.go
@@ -41,6 +41,7 @@ var (
 type crossBlockReader struct {
 	dataFileSetReaders   []DataFileSetReader
 	pendingReaderIndices []int
+	preAllocatedEntries  []*minHeapEntry
 	minHeap              minHeap
 
 	iOpts instrument.Options
@@ -69,14 +70,17 @@ func NewCrossBlockReader(dataFileSetReaders []DataFileSetReader, iOpts instrumen
 	}
 
 	pendingReaderIndices := make([]int, len(dataFileSetReaders))
+	preAllocatedEntries := make([]*minHeapEntry, len(dataFileSetReaders))
 	for i := range dataFileSetReaders {
 		pendingReaderIndices[i] = i
+		preAllocatedEntries[i] = &minHeapEntry{}
 	}
 
 	return &crossBlockReader{
 		dataFileSetReaders:   dataFileSetReaders,
 		pendingReaderIndices: pendingReaderIndices,
-		minHeap:              make([]minHeapEntry, 0, len(dataFileSetReaders)),
+		minHeap:              make([]*minHeapEntry, 0, len(dataFileSetReaders)),
+		preAllocatedEntries:  preAllocatedEntries,
 		records:              make([]BlockRecord, 0, len(dataFileSetReaders)),
 		iOpts:                iOpts,
 	}, nil
@@ -99,8 +103,9 @@ func (r *crossBlockReader) Next() bool {
 		return false
 	}
 
+	var err error
 	for _, readerIndex := range r.pendingReaderIndices {
-		entry, err := r.readFromDataFileSet(readerIndex)
+		*r.preAllocatedEntries[readerIndex], err = r.readFromDataFileSet(readerIndex)
 		if err == io.EOF {
 			// Will no longer read from this one.
 			continue
@@ -108,7 +113,7 @@ func (r *crossBlockReader) Next() bool {
 			r.err = err
 			return false
 		} else {
-			heap.Push(&r.minHeap, entry)
+			heap.Push(&r.minHeap, r.preAllocatedEntries[readerIndex])
 		}
 	}
 
@@ -118,7 +123,7 @@ func (r *crossBlockReader) Next() bool {
 		return false
 	}
 
-	firstEntry := heap.Pop(&r.minHeap).(minHeapEntry)
+	firstEntry := heap.Pop(&r.minHeap).(*minHeapEntry)
 
 	r.id = firstEntry.id
 	r.encodedTags = firstEntry.encodedTags
@@ -130,7 +135,7 @@ func (r *crossBlockReader) Next() bool {
 
 	// As long as id stays the same across the blocks, accumulate records for this id/tags.
 	for len(r.minHeap) > 0 && bytes.Equal(r.minHeap[0].id.Bytes(), firstEntry.id.Bytes()) {
-		nextEntry := heap.Pop(&r.minHeap).(minHeapEntry)
+		nextEntry := heap.Pop(&r.minHeap).(*minHeapEntry)
 
 		r.records = append(r.records, BlockRecord{nextEntry.data, nextEntry.checksum})
 
@@ -179,9 +184,8 @@ func (r *crossBlockReader) Close() error {
 	}
 	r.records = r.records[:0]
 
-	var emptyEntry minHeapEntry
 	for i := range r.minHeap {
-		r.minHeap[i] = emptyEntry
+		r.minHeap[i] = nil
 	}
 	r.minHeap = r.minHeap[:0]
 
@@ -198,7 +202,7 @@ type minHeapEntry struct {
 
 var _ heap.Interface = (*minHeap)(nil)
 
-type minHeap []minHeapEntry
+type minHeap []*minHeapEntry
 
 func (h minHeap) Len() int {
 	return len(h)
@@ -217,14 +221,14 @@ func (h minHeap) Swap(i, j int) {
 }
 
 func (h *minHeap) Push(x interface{}) {
-	*h = append(*h, x.(minHeapEntry))
+	*h = append(*h, x.(*minHeapEntry))
 }
 
 func (h *minHeap) Pop() interface{} {
 	old := *h
 	n := len(old)
 	x := old[n-1]
-	old[n-1] = minHeapEntry{}
+	old[n-1] = nil
 	*h = old[0 : n-1]
 	return x
 }

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -2700,7 +2700,6 @@ func (s *dbShard) AggregateTiles(
 		ReaderIteratorPool: s.opts.ReaderIteratorPool(),
 	}
 
-	// TODO: these should probably be pooled
 	readerIter, err := tile.NewSeriesBlockIterator(crossBlockReader, tileOpts)
 	if err != nil {
 		s.logger.Error("error when creating new series block iterator", zap.Error(err))
@@ -2776,14 +2775,13 @@ func (s *dbShard) AggregateTiles(
 		writerData[1] = segment.Tail.Bytes()
 		checksum := segment.CalculateChecksum()
 
-		if err := writer.WriteAll(id.Bytes(), encodedTags, writerData, checksum); err != nil {
+		if err := writer.WriteAll(id, encodedTags, writerData, checksum); err != nil {
 			s.metrics.largeTilesWriteErrors.Inc(1)
 			multiErr = multiErr.Add(err)
 		} else {
 			s.metrics.largeTilesWrites.Inc(1)
 		}
 
-		id.Finalize()
 		segment.Finalize()
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the reasons behind 99% of allocations incurred during `AggregateTiles`:
- boxing of minHeap entries to `interface {}` when going through `heap` API
- leftover unnecessary conversion of `ident.BytesID` to `ident.ID` 

**Special notes for your reviewer**:
<img width="458" alt="Screenshot 2020-10-13 at 13 27 58" src="https://user-images.githubusercontent.com/5231884/95864193-b8535f00-0d6d-11eb-934a-bc93e4fd628a.png">

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE