### PR TITLE
[test] Fix TestPooledWorkerPoolGoWithTimeout flaking

### DIFF
--- a/src/x/sync/pooled_worker_pool.go
+++ b/src/x/sync/pooled_worker_pool.go
@@ -35,10 +35,6 @@ const (
 	numGoroutinesGaugeSampleRate = 1000
 )
 
-var (
-	pooledWorkerPoolGoroutinesCapacity *int
-)
-
 type pooledWorkerPool struct {
 	sync.Mutex
 	numRoutinesAtomic        int64
@@ -65,15 +61,7 @@ func NewPooledWorkerPool(size int, opts PooledWorkerPoolOptions) (PooledWorkerPo
 
 	workChs := make([]chan Work, numShards)
 	for i := range workChs {
-		if c := pooledWorkerPoolGoroutinesCapacity; c != nil {
-			if *c == 0 {
-				workChs[i] = make(chan Work)
-			} else {
-				workChs[i] = make(chan Work, *c)
-			}
-		} else {
-			workChs[i] = make(chan Work, int64(size)/numShards)
-		}
+		workChs[i] = make(chan Work, int64(size)/numShards)
 	}
 
 	return &pooledWorkerPool{

--- a/src/x/sync/pooled_worker_pool_test.go
+++ b/src/x/sync/pooled_worker_pool_test.go
@@ -70,13 +70,14 @@ func TestPooledWorkerPoolGoWithTimeout(t *testing.T) {
 	// (which is 1, since 2 / 2 = 1) which means we need to enqueue two times
 	// the workers.
 	totalEnqueue := workers * 2
+	now := time.Now()
 	for i := 0; i < totalEnqueue; i++ {
 		// Set now in such a way that independent shards are selected.
-		now := time.Now().
+		shardNowSelect := now.
 			Truncate(time.Duration(totalEnqueue) * time.Nanosecond).
 			Add(time.Duration(i) * time.Nanosecond)
 		pooledWorkerPool.nowFn = func() time.Time {
-			return now
+			return shardNowSelect
 		}
 
 		result := p.GoWithTimeout(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The underlying buffered pools and queue selection (shards) weren't deterministic in this test, this changes it to be deterministic and make sure that the enqueues that are meant to timeout always will.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
