### PR TITLE
[dbnode] Only extend reverse index retention up

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -2181,7 +2181,9 @@ func (i *nsIndex) SetExtendedRetentionPeriod(period time.Duration) {
 	i.state.Lock()
 	defer i.state.Unlock()
 
-	i.extendedRetentionPeriod = period
+	if period > i.extendedRetentionPeriod {
+		i.extendedRetentionPeriod = period
+	}
 }
 
 func (i *nsIndex) effectiveRetentionPeriodWithLock() time.Duration {

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -391,9 +391,9 @@ func TestNamespaceIndexSetExtendedRetentionPeriod(t *testing.T) {
 	idx.SetExtendedRetentionPeriod(longerRetention)
 	assert.Equal(t, longerRetention, idx.effectiveRetentionPeriodWithLock())
 
-	shorterRetention := originalRetention - time.Minute
+	shorterRetention := longerRetention - time.Second
 	idx.SetExtendedRetentionPeriod(shorterRetention)
-	assert.Equal(t, originalRetention, idx.effectiveRetentionPeriodWithLock())
+	assert.Equal(t, longerRetention, idx.effectiveRetentionPeriodWithLock())
 }
 
 func verifyFlushForShards(


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows to extend reverse index retention only up, so that if there are multiple calls to `nsIndex.SetExtendedRetentionPeriod`, the one with the longest period will win.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE