### PR TITLE
Enable runtime profiles inside server run methods

### DIFF
--- a/src/aggregator/server/server.go
+++ b/src/aggregator/server/server.go
@@ -70,6 +70,8 @@ func Run(opts RunOptions) {
 	}
 	defer logger.Sync()
 
+	cfg.Debug.SetRuntimeValues(logger)
+
 	xconfig.WarnOnDeprecation(cfg, logger)
 
 	scope, closer, err := cfg.Metrics.NewRootScope()

--- a/src/cmd/services/m3aggregator/main/main.go
+++ b/src/cmd/services/m3aggregator/main/main.go
@@ -50,8 +50,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	cfg.Debug.SetMutexProfileFraction()
-
 	server.Run(server.RunOptions{
 		Config: cfg,
 	})

--- a/src/cmd/services/m3coordinator/main/main.go
+++ b/src/cmd/services/m3coordinator/main/main.go
@@ -50,8 +50,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	cfg.Debug.SetMutexProfileFraction()
-
 	server.Run(server.RunOptions{
 		Config: cfg,
 	})

--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -59,9 +59,6 @@ type Configuration struct {
 
 	// Coordinator is the configuration for the coordinator to run (optional).
 	Coordinator *coordinatorcfg.Configuration `yaml:"coordinator"`
-
-	// Debug configuration.
-	Debug config.DebugConfiguration `yaml:"debug"`
 }
 
 // InitDefaultsAndValidate initializes all default values and validates the Configuration.
@@ -169,6 +166,9 @@ type DBConfiguration struct {
 
 	// TChannel exposes TChannel config options.
 	TChannel *TChannelConfiguration `yaml:"tchannel"`
+
+	// Debug configuration.
+	Debug config.DebugConfiguration `yaml:"debug"`
 }
 
 // InitDefaultsAndValidate initializes all default values and validates the Configuration.

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -727,9 +727,10 @@ func TestConfiguration(t *testing.T) {
     maxEncodersPerBlock: 0
   wide: null
   tchannel: null
+  debug:
+    mutexProfileFraction: 0
+    blockProfileRate: 0
 coordinator: null
-debug:
-  mutexProfileFraction: 0
 `
 
 	actual := string(data)

--- a/src/cmd/services/m3dbnode/main/main.go
+++ b/src/cmd/services/m3dbnode/main/main.go
@@ -56,8 +56,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	cfg.Debug.SetMutexProfileFraction()
-
 	if err := cfg.InitDefaultsAndValidate(); err != nil {
 		// NB(r): Use fmt.Fprintf(os.Stderr, ...) to avoid etcd.SetGlobals()
 		// sending stdlib "log" to black hole. Don't remove unless with good reason.

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -184,6 +184,8 @@ func Run(runOpts RunOptions) {
 	}
 	defer logger.Sync()
 
+	cfg.Debug.SetRuntimeValues(logger)
+
 	xconfig.WarnOnDeprecation(cfg, logger)
 
 	// By default attempt to raise process limits, which is a benign operation.

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -203,6 +203,8 @@ func Run(runOpts RunOptions) {
 
 	defer logger.Sync()
 
+	cfg.Debug.SetRuntimeValues(logger)
+
 	xconfig.WarnOnDeprecation(cfg, logger)
 
 	if cfg.MultiProcess.Enabled {

--- a/src/x/debug/config/config.go
+++ b/src/x/debug/config/config.go
@@ -20,17 +20,29 @@
 
 package config
 
-import "runtime"
+import (
+	"fmt"
+	"runtime"
+
+	"go.uber.org/zap"
+)
 
 // DebugConfiguration for the debug package.
 type DebugConfiguration struct {
 
-	// MutexProfileFraction is used to set the runtime.SetMutexProfileFraction to report mutex convention events.
-	// See https://tip.golang.org/pkg/runtime/#SetMutexProfileFraction for more details about the values.
+	// MutexProfileFraction is used to set the runtime.SetMutexProfileFraction to report mutex contention events.
+	// See https://tip.golang.org/pkg/runtime/#SetMutexProfileFraction for more details about the value.
 	MutexProfileFraction int `yaml:"mutexProfileFraction"`
+
+	// BlockProfileRate is used to set the runtime.BlockProfileRate to report blocking events
+	// See https://golang.org/pkg/runtime/#SetBlockProfileRate for more details about the value.
+	BlockProfileRate int `yaml:"blockProfileRate"`
 }
 
-// SetMutexProfileFraction sets the configured mutex profile fraction for the runtime.
-func (c DebugConfiguration) SetMutexProfileFraction() {
+// SetRuntimeValues sets the configured pprof runtime values.
+func (c DebugConfiguration) SetRuntimeValues(logger *zap.Logger) {
+	logger.Info(fmt.Sprintf("setting MutexProfileFraction: %v", c.MutexProfileFraction))
 	runtime.SetMutexProfileFraction(c.MutexProfileFraction)
+	logger.Info(fmt.Sprintf("setting BlockProfileRate: %v", c.BlockProfileRate))
+	runtime.SetBlockProfileRate(c.BlockProfileRate)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This allows users with a different main method to still enable the
runtime profiles.

Also adding the blocking profile.
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
NONE
