### PR TITLE
[coordinator] Add config option to control storing of metrics type

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -128,7 +128,7 @@ type Configuration struct {
 	// WriteForwarding is the write forwarding options.
 	WriteForwarding WriteForwardingConfiguration `yaml:"writeForwarding"`
 
-	// Downsample configurates how the metrics should be downsampled.
+	// Downsample configures how the metrics should be downsampled.
 	Downsample downsample.Configuration `yaml:"downsample"`
 
 	// Ingest is the ingest server.
@@ -151,6 +151,9 @@ type Configuration struct {
 
 	// Experimental is the configuration for the experimental API group.
 	Experimental ExperimentalAPIConfiguration `yaml:"experimental"`
+
+	// StoreMetricsType controls if metrics type is stored or not.
+	StoreMetricsType *bool `yaml:"storeMetricsType"`
 
 	// Cache configurations.
 	//

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -617,22 +617,24 @@ func (i *promTSIter) Next() bool {
 		return false
 	}
 
-	if i.storeMetricsType {
-		annotationPayload, err := storage.SeriesAttributesToAnnotationPayload(i.attributes[i.idx])
-		if err != nil {
-			i.err = err
-			return false
-		}
+	if !i.storeMetricsType {
+		return true
+	}
 
-		i.annotation, err = annotationPayload.Marshal()
-		if err != nil {
-			i.err = err
-			return false
-		}
+	annotationPayload, err := storage.SeriesAttributesToAnnotationPayload(i.attributes[i.idx])
+	if err != nil {
+		i.err = err
+		return false
+	}
 
-		if len(i.annotation) == 0 {
-			i.annotation = nil
-		}
+	i.annotation, err = annotationPayload.Marshal()
+	if err != nil {
+		i.err = err
+		return false
+	}
+
+	if len(i.annotation) == 0 {
+		i.annotation = nil
 	}
 
 	return true

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -99,6 +99,7 @@ var (
 type PromWriteHandler struct {
 	downsamplerAndWriter   ingest.DownsamplerAndWriter
 	tagOptions             models.TagOptions
+	storeMetricsType       bool
 	forwarding             handleroptions.PromWriteHandlerForwardingOptions
 	forwardTimeout         time.Duration
 	forwardHTTPClient      *http.Client
@@ -168,6 +169,7 @@ func NewPromWriteHandler(options options.HandlerOptions) (http.Handler, error) {
 	return &PromWriteHandler{
 		downsamplerAndWriter:   downsamplerAndWriter,
 		tagOptions:             tagOptions,
+		storeMetricsType:       options.StoreMetricsType(),
 		forwarding:             forwarding,
 		forwardTimeout:         forwardTimeout,
 		forwardHTTPClient:      xhttp.NewHTTPClient(forwardHTTPOpts),
@@ -491,7 +493,7 @@ func (h *PromWriteHandler) write(
 	r *prompb.WriteRequest,
 	opts ingest.WriteOptions,
 ) ingest.BatchError {
-	iter, err := newPromTSIter(r.Timeseries, h.tagOptions)
+	iter, err := newPromTSIter(r.Timeseries, h.tagOptions, h.storeMetricsType)
 	if err != nil {
 		var errs xerrors.MultiError
 		return errs.Add(err)
@@ -553,7 +555,11 @@ func (h *PromWriteHandler) forward(
 	return nil
 }
 
-func newPromTSIter(timeseries []prompb.TimeSeries, tagOpts models.TagOptions) (*promTSIter, error) {
+func newPromTSIter(
+	timeseries []prompb.TimeSeries,
+	tagOpts models.TagOptions,
+	storeMetricsType bool,
+) (*promTSIter, error) {
 	// Construct the tags and datapoints upfront so that if the iterator
 	// is reset, we don't have to generate them twice.
 	var (
@@ -581,10 +587,11 @@ func newPromTSIter(timeseries []prompb.TimeSeries, tagOpts models.TagOptions) (*
 	}
 
 	return &promTSIter{
-		attributes: seriesAttributes,
-		idx:        -1,
-		tags:       tags,
-		datapoints: datapoints,
+		attributes:       seriesAttributes,
+		idx:              -1,
+		tags:             tags,
+		datapoints:       datapoints,
+		storeMetricsType: storeMetricsType,
 	}, nil
 }
 
@@ -596,6 +603,8 @@ type promTSIter struct {
 	datapoints []ts.Datapoints
 	metadatas  []ts.Metadata
 	annotation []byte
+
+	storeMetricsType bool
 }
 
 func (i *promTSIter) Next() bool {
@@ -608,20 +617,22 @@ func (i *promTSIter) Next() bool {
 		return false
 	}
 
-	annotationPayload, err := storage.SeriesAttributesToAnnotationPayload(i.attributes[i.idx])
-	if err != nil {
-		i.err = err
-		return false
-	}
+	if i.storeMetricsType {
+		annotationPayload, err := storage.SeriesAttributesToAnnotationPayload(i.attributes[i.idx])
+		if err != nil {
+			i.err = err
+			return false
+		}
 
-	i.annotation, err = annotationPayload.Marshal()
-	if err != nil {
-		i.err = err
-		return false
-	}
+		i.annotation, err = annotationPayload.Marshal()
+		if err != nil {
+			i.err = err
+			return false
+		}
 
-	if len(i.annotation) == 0 {
-		i.annotation = nil
+		if len(i.annotation) == 0 {
+			i.annotation = nil
+		}
 	}
 
 	return true

--- a/src/query/api/v1/options/handler.go
+++ b/src/query/api/v1/options/handler.go
@@ -42,6 +42,7 @@ import (
 	"github.com/m3db/m3/src/query/ts/m3db"
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/instrument"
+
 	"github.com/prometheus/prometheus/promql"
 )
 
@@ -212,6 +213,12 @@ type HandlerOptions interface {
 	SetM3DBOptions(value m3db.Options) HandlerOptions
 	// M3DBOptions returns the M3DB options.
 	M3DBOptions() m3db.Options
+
+	// SetStoreMetricsType enables/disables storing of metrics type.
+	SetStoreMetricsType(value bool) HandlerOptions
+
+	// StoreMetricsType returns true if storing of metrics type is enabled.
+	StoreMetricsType() bool
 }
 
 // HandlerOptions represents handler options.
@@ -240,6 +247,7 @@ type handlerOptions struct {
 	instantQueryRouter    QueryRouter
 	graphiteStorageOpts   graphite.M3WrappedStorageOptions
 	m3dbOpts              m3db.Options
+	storeMetricsType      bool
 }
 
 // EmptyHandlerOptions returns  default handler options.
@@ -280,6 +288,11 @@ func NewHandlerOptions(
 		timeout = *embeddedDbCfg.Client.FetchTimeout
 	}
 
+	storeMetricsType := false
+	if cfg.StoreMetricsType != nil {
+		storeMetricsType = *cfg.StoreMetricsType
+	}
+
 	return &handlerOptions{
 		storage:               downsamplerAndWriter.Storage(),
 		downsamplerAndWriter:  downsamplerAndWriter,
@@ -307,6 +320,7 @@ func NewHandlerOptions(
 		instantQueryRouter:  instantQueryRouter,
 		graphiteStorageOpts: graphiteStorageOpts,
 		m3dbOpts:            m3dbOpts,
+		storeMetricsType:    storeMetricsType,
 	}, nil
 }
 
@@ -567,4 +581,14 @@ func (o *handlerOptions) SetM3DBOptions(value m3db.Options) HandlerOptions {
 
 func (o *handlerOptions) M3DBOptions() m3db.Options {
 	return o.m3dbOpts
+}
+
+func (o *handlerOptions) SetStoreMetricsType(value bool) HandlerOptions {
+	opts := *o
+	opts.storeMetricsType = value
+	return &opts
+}
+
+func (o *handlerOptions) StoreMetricsType() bool {
+	return o.storeMetricsType
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a configuration option `storeMetricsType` to allow enabling/disabling store of metrics type into the annotation.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
