### PR TITLE
[m3ninx] Remove dead code from FST segment

### DIFF
--- a/src/m3ninx/index/segment/fst/fst_mock.go
+++ b/src/m3ninx/index/segment/fst/fst_mock.go
@@ -28,10 +28,7 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/m3db/m3/src/m3ninx/doc"
-	"github.com/m3db/m3/src/m3ninx/index"
 	"github.com/m3db/m3/src/m3ninx/index/segment"
-	"github.com/m3db/m3/src/m3ninx/postings"
 	"github.com/m3db/m3/src/x/context"
 
 	"github.com/golang/mock/gomock"
@@ -209,21 +206,6 @@ func (m *MockSegment) EXPECT() *MockSegmentMockRecorder {
 	return m.recorder
 }
 
-// AllDocs mocks base method
-func (m *MockSegment) AllDocs() (index.IDDocIterator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllDocs")
-	ret0, _ := ret[0].(index.IDDocIterator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllDocs indicates an expected call of AllDocs
-func (mr *MockSegmentMockRecorder) AllDocs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllDocs", reflect.TypeOf((*MockSegment)(nil).AllDocs))
-}
-
 // Close mocks base method
 func (m *MockSegment) Close() error {
 	m.ctrl.T.Helper()
@@ -268,36 +250,6 @@ func (mr *MockSegmentMockRecorder) ContainsID(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsID", reflect.TypeOf((*MockSegment)(nil).ContainsID), arg0)
 }
 
-// Doc mocks base method
-func (m *MockSegment) Doc(arg0 postings.ID) (doc.Document, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Doc", arg0)
-	ret0, _ := ret[0].(doc.Document)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Doc indicates an expected call of Doc
-func (mr *MockSegmentMockRecorder) Doc(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Doc", reflect.TypeOf((*MockSegment)(nil).Doc), arg0)
-}
-
-// Docs mocks base method
-func (m *MockSegment) Docs(arg0 postings.List) (doc.Iterator, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Docs", arg0)
-	ret0, _ := ret[0].(doc.Iterator)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Docs indicates an expected call of Docs
-func (mr *MockSegmentMockRecorder) Docs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Docs", reflect.TypeOf((*MockSegment)(nil).Docs), arg0)
-}
-
 // FieldsIterable mocks base method
 func (m *MockSegment) FieldsIterable() segment.FieldsIterable {
 	m.ctrl.T.Helper()
@@ -324,66 +276,6 @@ func (m *MockSegment) FreeMmap() error {
 func (mr *MockSegmentMockRecorder) FreeMmap() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FreeMmap", reflect.TypeOf((*MockSegment)(nil).FreeMmap))
-}
-
-// MatchAll mocks base method
-func (m *MockSegment) MatchAll() (postings.MutableList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MatchAll")
-	ret0, _ := ret[0].(postings.MutableList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MatchAll indicates an expected call of MatchAll
-func (mr *MockSegmentMockRecorder) MatchAll() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchAll", reflect.TypeOf((*MockSegment)(nil).MatchAll))
-}
-
-// MatchField mocks base method
-func (m *MockSegment) MatchField(arg0 []byte) (postings.List, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MatchField", arg0)
-	ret0, _ := ret[0].(postings.List)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MatchField indicates an expected call of MatchField
-func (mr *MockSegmentMockRecorder) MatchField(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchField", reflect.TypeOf((*MockSegment)(nil).MatchField), arg0)
-}
-
-// MatchRegexp mocks base method
-func (m *MockSegment) MatchRegexp(arg0 []byte, arg1 index.CompiledRegex) (postings.List, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MatchRegexp", arg0, arg1)
-	ret0, _ := ret[0].(postings.List)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MatchRegexp indicates an expected call of MatchRegexp
-func (mr *MockSegmentMockRecorder) MatchRegexp(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchRegexp", reflect.TypeOf((*MockSegment)(nil).MatchRegexp), arg0, arg1)
-}
-
-// MatchTerm mocks base method
-func (m *MockSegment) MatchTerm(arg0, arg1 []byte) (postings.List, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MatchTerm", arg0, arg1)
-	ret0, _ := ret[0].(postings.List)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MatchTerm indicates an expected call of MatchTerm
-func (mr *MockSegmentMockRecorder) MatchTerm(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchTerm", reflect.TypeOf((*MockSegment)(nil).MatchTerm), arg0, arg1)
 }
 
 // Reader mocks base method

--- a/src/m3ninx/index/segment/fst/segment.go
+++ b/src/m3ninx/index/segment/fst/segment.go
@@ -411,15 +411,6 @@ func (r *fsSegment) unmarshalPostingsListBitmapNotClosedMaybeFinalizedWithLock(b
 	return b.UnmarshalBinary(postingsBytes)
 }
 
-func (r *fsSegment) MatchField(field []byte) (postings.List, error) {
-	r.RLock()
-	defer r.RUnlock()
-	if r.closed {
-		return nil, errReaderClosed
-	}
-	return r.matchFieldNotClosedMaybeFinalizedWithRLock(field)
-}
-
 func (r *fsSegment) matchFieldNotClosedMaybeFinalizedWithRLock(
 	field []byte,
 ) (postings.List, error) {
@@ -455,15 +446,6 @@ func (r *fsSegment) matchFieldNotClosedMaybeFinalizedWithRLock(
 
 	postingsOffset := fieldData.FieldPostingsListOffset
 	return r.retrievePostingsListWithRLock(postingsOffset)
-}
-
-func (r *fsSegment) MatchTerm(field []byte, term []byte) (postings.List, error) {
-	r.RLock()
-	defer r.RUnlock()
-	if r.closed {
-		return nil, errReaderClosed
-	}
-	return r.matchTermNotClosedMaybeFinalizedWithRLock(field, term)
 }
 
 func (r *fsSegment) matchTermNotClosedMaybeFinalizedWithRLock(
@@ -508,18 +490,6 @@ func (r *fsSegment) matchTermNotClosedMaybeFinalizedWithRLock(
 	}
 
 	return pl, nil
-}
-
-func (r *fsSegment) MatchRegexp(
-	field []byte,
-	compiled index.CompiledRegex,
-) (postings.List, error) {
-	r.RLock()
-	defer r.Unlock()
-	if r.closed {
-		return nil, errReaderClosed
-	}
-	return r.matchRegexpNotClosedMaybeFinalizedWithRLock(field, compiled)
 }
 
 func (r *fsSegment) matchRegexpNotClosedMaybeFinalizedWithRLock(
@@ -593,15 +563,6 @@ func (r *fsSegment) matchRegexpNotClosedMaybeFinalizedWithRLock(
 	return pl, nil
 }
 
-func (r *fsSegment) MatchAll() (postings.MutableList, error) {
-	r.RLock()
-	defer r.RUnlock()
-	if r.closed {
-		return nil, errReaderClosed
-	}
-	return r.matchAllNotClosedMaybeFinalizedWithRLock()
-}
-
 func (r *fsSegment) matchAllNotClosedMaybeFinalizedWithRLock() (postings.MutableList, error) {
 	// NB(r): Not closed, but could be finalized (i.e. closed segment reader)
 	// calling match field after this segment is finalized.
@@ -616,15 +577,6 @@ func (r *fsSegment) matchAllNotClosedMaybeFinalizedWithRLock() (postings.Mutable
 	}
 
 	return pl, nil
-}
-
-func (r *fsSegment) Doc(id postings.ID) (doc.Document, error) {
-	r.RLock()
-	defer r.RUnlock()
-	if r.closed {
-		return doc.Document{}, errReaderClosed
-	}
-	return r.docNotClosedMaybeFinalizedWithRLock(id)
 }
 
 func (r *fsSegment) docNotClosedMaybeFinalizedWithRLock(id postings.ID) (doc.Document, error) {
@@ -647,15 +599,6 @@ func (r *fsSegment) docNotClosedMaybeFinalizedWithRLock(id postings.ID) (doc.Doc
 	return r.docsDataReader.Read(offset)
 }
 
-func (r *fsSegment) Docs(pl postings.List) (doc.Iterator, error) {
-	r.RLock()
-	defer r.RUnlock()
-	if r.closed {
-		return nil, errReaderClosed
-	}
-	return r.docsNotClosedMaybeFinalizedWithRLock(r, pl)
-}
-
 func (r *fsSegment) docsNotClosedMaybeFinalizedWithRLock(
 	retriever index.DocRetriever,
 	pl postings.List,
@@ -667,15 +610,6 @@ func (r *fsSegment) docsNotClosedMaybeFinalizedWithRLock(
 	}
 
 	return index.NewIDDocIterator(retriever, pl.Iterator()), nil
-}
-
-func (r *fsSegment) AllDocs() (index.IDDocIterator, error) {
-	r.RLock()
-	defer r.RUnlock()
-	if r.closed {
-		return nil, errReaderClosed
-	}
-	return r.allDocsNotClosedMaybeFinalizedWithRLock(r)
 }
 
 func (r *fsSegment) allDocsNotClosedMaybeFinalizedWithRLock(

--- a/src/m3ninx/index/segment/fst/types.go
+++ b/src/m3ninx/index/segment/fst/types.go
@@ -53,7 +53,7 @@ var (
 	}
 )
 
-// Segment represents a FST segment.
+// Segment is an FST segment.
 type Segment interface {
 	sgmt.ImmutableSegment
 

--- a/src/m3ninx/index/segment/fst/types.go
+++ b/src/m3ninx/index/segment/fst/types.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/m3db/m3/src/m3ninx/index"
 	sgmt "github.com/m3db/m3/src/m3ninx/index/segment"
 	"github.com/m3db/m3/src/x/context"
 )
@@ -57,7 +56,6 @@ var (
 // Segment represents a FST segment.
 type Segment interface {
 	sgmt.ImmutableSegment
-	index.Readable
 
 	// SegmentData returns the segment data used to create the segment.
 	// Note: Must close context when done with the data


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Removing dead code from FST segment that was no longer used. All reads should be through segment reader.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
