### PR TITLE
[dbnode] Adds additional fields to IndexChecksum

### DIFF
--- a/src/dbnode/integration/index_single_node_high_concurrency_test.go
+++ b/src/dbnode/integration/index_single_node_high_concurrency_test.go
@@ -258,6 +258,7 @@ func testIndexSingleNodeHighConcurrency(
 			zap.Int("concurrency", opts.concurrencyQueryDuringWrites))
 		checkNumTotalQueryMatches = true
 		for i := 0; i < opts.concurrencyQueryDuringWrites; i++ {
+			i := i
 			go func() {
 				src := rand.NewSource(int64(i))
 				rng := rand.New(src)

--- a/src/dbnode/integration/wide_query_test.go
+++ b/src/dbnode/integration/wide_query_test.go
@@ -33,14 +33,18 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/m3ninx/idx"
+	"github.com/m3db/m3/src/x/checked"
 	xclock "github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/context"
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
 	xhash "github.com/m3db/m3/src/x/test/hash"
 
 	"github.com/stretchr/testify/assert"
@@ -48,9 +52,14 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	wideTagName   = "tag"
+	wideTagValFmt = "val-%05d"
+)
+
 type shardedIndexChecksum struct {
 	shard     uint32
-	checksums []ident.IndexChecksum
+	checksums []schema.IndexChecksum
 }
 
 // buildExpectedChecksumsByShard sorts the given IDs into ascending shard order,
@@ -60,12 +69,17 @@ func buildExpectedChecksumsByShard(
 	allowedShards []uint32,
 	shardSet sharding.ShardSet,
 	batchSize int,
-) []ident.IndexChecksum {
+) []schema.IndexChecksum {
 	shardedChecksums := make([]shardedIndexChecksum, 0, len(ids))
 	for i, id := range ids {
-		checksum := ident.IndexChecksum{ID: []byte(id), Checksum: int64(i)}
-		shard := shardSet.Lookup(ident.StringID(id))
+		checksum := schema.IndexChecksum{
+			IndexEntry: schema.IndexEntry{
+				ID: []byte(id),
+			},
+			MetadataChecksum: int64(i),
+		}
 
+		shard := shardSet.Lookup(ident.StringID(id))
 		if len(allowedShards) > 0 {
 			shardInUse := false
 			for _, allowed := range allowedShards {
@@ -97,7 +111,7 @@ func buildExpectedChecksumsByShard(
 
 		shardedChecksums = append(shardedChecksums, shardedIndexChecksum{
 			shard:     shard,
-			checksums: []ident.IndexChecksum{checksum},
+			checksums: []schema.IndexChecksum{checksum},
 		})
 	}
 
@@ -105,7 +119,7 @@ func buildExpectedChecksumsByShard(
 		return shardedChecksums[i].shard < shardedChecksums[j].shard
 	})
 
-	var checksums []ident.IndexChecksum
+	var checksums []schema.IndexChecksum
 	for _, sharded := range shardedChecksums {
 		checksums = append(checksums, sharded.checksums...)
 	}
@@ -125,6 +139,22 @@ func buildExpectedChecksumsByShard(
 	}
 
 	return checksums
+}
+
+func assertTags(
+	t *testing.T,
+	encoded []byte,
+	decoder serialize.TagDecoder,
+	expected int64,
+) {
+	decoder.Reset(checked.NewBytes(encoded, nil))
+	assert.Equal(t, 1, decoder.Len())
+	assert.True(t, decoder.Next())
+	tag := decoder.Current()
+	assert.Equal(t, wideTagName, tag.Name.String())
+	assert.Equal(t, fmt.Sprintf(wideTagValFmt, expected), tag.Value.String())
+	assert.False(t, decoder.Next())
+	require.NoError(t, decoder.Err())
 }
 
 func TestWideFetch(t *testing.T) {
@@ -190,11 +220,11 @@ func TestWideFetch(t *testing.T) {
 	indexWrites := make(TestIndexWrites, 0, seriesCount)
 	ids := make([]string, 0, seriesCount)
 	for i := 0; i < seriesCount; i++ {
-		id := fmt.Sprintf("foo-%05d", i)
+		id := fmt.Sprintf("id-%05d", i)
 		ids = append(ids, id)
 		indexWrites = append(indexWrites, testIndexWrite{
 			id:    ident.StringID(id),
-			tags:  ident.MustNewTagStringsIterator("abc", fmt.Sprintf("def%d", i)),
+			tags:  ident.MustNewTagStringsIterator(wideTagName, fmt.Sprintf(wideTagValFmt, i)),
 			ts:    now,
 			value: float64(i),
 		})
@@ -232,7 +262,7 @@ func TestWideFetch(t *testing.T) {
 	log.Info("filesets found on disk")
 
 	var (
-		query    = index.Query{Query: idx.MustCreateRegexpQuery([]byte("abc"), []byte("def.*"))}
+		query    = index.Query{Query: idx.MustCreateRegexpQuery([]byte(wideTagName), []byte("val.*"))}
 		iterOpts = index.IterationOptions{}
 	)
 
@@ -246,6 +276,16 @@ func TestWideFetch(t *testing.T) {
 		{name: "all shards filter", shards: testSetup.ShardSet().AllIDs()},
 	}
 
+	tagDecoderPool := serialize.NewTagDecoderPool(
+		serialize.NewTagDecoderOptions(
+			serialize.TagDecoderOptionsConfig{}),
+		pool.NewObjectPoolOptions(),
+	)
+
+	tagDecoderPool.Init()
+	decoder := tagDecoderPool.Get()
+	defer decoder.Close()
+
 	for _, tt := range shardFilterTests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.NewContext()
@@ -257,7 +297,10 @@ func TestWideFetch(t *testing.T) {
 				testSetup.ShardSet(), batchSize)
 			require.Equal(t, len(expected), len(chk))
 			for i, checksum := range chk {
-				assert.Equal(t, expected[i], checksum)
+				assert.Equal(t, expected[i].MetadataChecksum, checksum.MetadataChecksum)
+				assert.Equal(t, expected[i].ID, checksum.ID)
+				assertTags(t, checksum.EncodedTags, decoder, checksum.MetadataChecksum)
+				checksum.Finalize()
 			}
 
 			ctx.Close()
@@ -266,7 +309,7 @@ func TestWideFetch(t *testing.T) {
 
 	var (
 		exactID    = ids[1]
-		exactQuery = index.Query{Query: idx.NewTermQuery([]byte("abc"), []byte("def1"))}
+		exactQuery = index.Query{Query: idx.NewTermQuery([]byte(wideTagName), []byte("val-00001"))}
 		exactShard = testSetup.ShardSet().Lookup(ident.StringID(exactID))
 	)
 
@@ -297,8 +340,11 @@ func TestWideFetch(t *testing.T) {
 				assert.Equal(t, 0, len(chk))
 			} else {
 				require.Equal(t, 1, len(chk))
-				assert.Equal(t, int64(1), chk[0].Checksum)
-				assert.Equal(t, []byte(exactID), chk[0].ID)
+				checksum := chk[0]
+				assert.Equal(t, int64(1), checksum.MetadataChecksum)
+				assert.Equal(t, []byte(exactID), checksum.ID)
+				assertTags(t, checksum.EncodedTags, decoder, checksum.MetadataChecksum)
+				checksum.Finalize()
 			}
 
 			ctx.Close()
@@ -333,12 +379,14 @@ func TestWideFetch(t *testing.T) {
 					break
 				}
 
-				for i, c := range chk {
-					if expected[i].Checksum != c.Checksum {
+				for i, checksum := range chk {
+					if expected[i].MetadataChecksum != checksum.MetadataChecksum {
 						runError = fmt.Errorf("expected %d checksum, got %d",
-							expected[i].Checksum, c.Checksum)
+							expected[i].MetadataChecksum, checksum.MetadataChecksum)
 						break
 					}
+
+					checksum.Finalize()
 				}
 
 				ctx.Close()

--- a/src/dbnode/persist/fs/fs_mock.go
+++ b/src/dbnode/persist/fs/fs_mock.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/namespace"
 	persist "github.com/m3db/m3/src/dbnode/persist"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"
@@ -523,10 +524,10 @@ func (mr *MockDataFileSetSeekerMockRecorder) SeekIndexEntry(arg0, arg1 interface
 }
 
 // SeekIndexEntryToIndexChecksum mocks base method
-func (m *MockDataFileSetSeeker) SeekIndexEntryToIndexChecksum(arg0 ident.ID, arg1 ReusableSeekerResources) (ident.IndexChecksum, error) {
+func (m *MockDataFileSetSeeker) SeekIndexEntryToIndexChecksum(arg0 ident.ID, arg1 ReusableSeekerResources) (schema.IndexChecksum, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SeekIndexEntryToIndexChecksum", arg0, arg1)
-	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret0, _ := ret[0].(schema.IndexChecksum)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1259,10 +1260,10 @@ func (mr *MockConcurrentDataFileSetSeekerMockRecorder) SeekIndexEntry(arg0, arg1
 }
 
 // SeekIndexEntryToIndexChecksum mocks base method
-func (m *MockConcurrentDataFileSetSeeker) SeekIndexEntryToIndexChecksum(arg0 ident.ID, arg1 ReusableSeekerResources) (ident.IndexChecksum, error) {
+func (m *MockConcurrentDataFileSetSeeker) SeekIndexEntryToIndexChecksum(arg0 ident.ID, arg1 ReusableSeekerResources) (schema.IndexChecksum, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SeekIndexEntryToIndexChecksum", arg0, arg1)
-	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret0, _ := ret[0].(schema.IndexChecksum)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/src/dbnode/persist/fs/msgpack/decoder_test.go
+++ b/src/dbnode/persist/fs/msgpack/decoder_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/dbnode/digest"
+	"github.com/m3db/m3/src/x/pool"
+	xtest "github.com/m3db/m3/src/x/test"
 	xhash "github.com/m3db/m3/src/x/test/hash"
 
 	"github.com/stretchr/testify/require"
@@ -283,32 +285,84 @@ func TestDecodeIndexEntryInvalidChecksum(t *testing.T) {
 	require.Error(t, err)
 }
 
+var decodeIndexChecksumTests = []struct {
+	id         string
+	exStatus   IndexChecksumLookupStatus
+	exChecksum int64
+}{
+	{id: "aaa", exStatus: NotFoundLookupStatus},
+	{id: "test100", exStatus: MatchedLookupStatus, exChecksum: testMetadataChecksum},
+	{id: "zzz", exStatus: MismatchLookupStatus},
+}
+
 func TestDecodeIndexEntryToIndexChecksum(t *testing.T) {
 	var (
 		enc = NewEncoder()
 		dec = NewDecoder(NewDecodingOptions().SetIndexEntryHasher(xhash.NewParsedIndexHasher(t)))
 	)
 
-	require.NoError(t, enc.EncodeIndexEntry(testIndexCheksumEntry))
+	require.NoError(t, enc.EncodeIndexEntry(testIndexCheksumEntry.IndexEntry))
 	data := enc.Bytes()
 
-	tests := []struct {
-		id         string
-		exStatus   IndexChecksumLookupStatus
-		exChecksum int64
-	}{
-		{id: "aaa", exStatus: NotFound},
-		{id: "test100", exStatus: Match, exChecksum: testIndexHashValue},
-		{id: "zzz", exStatus: Mismatch},
+	for _, tt := range decodeIndexChecksumTests {
+		t.Run(tt.id, func(t *testing.T) {
+			dec.Reset(NewByteDecoderStream(data))
+			res, status, err := dec.DecodeIndexEntryToIndexChecksum([]byte(tt.id), nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.exStatus, status)
+			if tt.exStatus == MatchedLookupStatus {
+				require.Equal(t, tt.exChecksum, res.MetadataChecksum)
+			}
+		})
 	}
+}
 
-	for _, tt := range tests {
-		dec.Reset(NewByteDecoderStream(data))
-		res, status, err := dec.DecodeIndexEntryToIndexChecksum([]byte(tt.id), nil)
-		require.NoError(t, err)
-		require.Equal(t, tt.exStatus, status)
-		if tt.exStatus == Match {
-			require.Equal(t, tt.exChecksum, res)
-		}
+func TestDecodeIndexEntryToIndexChecksumPooled(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		enc = NewEncoder()
+		dec = NewDecoder(NewDecodingOptions().SetIndexEntryHasher(xhash.NewParsedIndexHasher(t)))
+	)
+
+	require.NoError(t, enc.EncodeIndexEntry(testIndexCheksumEntry.IndexEntry))
+	data := enc.Bytes()
+
+	for _, tt := range decodeIndexChecksumTests {
+		t.Run(tt.id+"_pooled", func(t *testing.T) {
+			dec.Reset(NewByteDecoderStream(data))
+
+			bytePool := pool.NewMockBytesPool(ctrl)
+			idLength := len(testIndexCheksumEntry.ID)
+			idBytes := make([]byte, idLength)
+			bytePool.EXPECT().Get(idLength).Return(idBytes)
+
+			finishCalled := false
+			if tt.exStatus != MatchedLookupStatus {
+				bytePool.EXPECT().Put(idBytes)
+			} else {
+				tagLength := len(testIndexCheksumEntry.EncodedTags)
+				tagBytes := make([]byte, tagLength)
+				bytePool.EXPECT().Get(tagLength).Return(tagBytes)
+
+				bytePool.EXPECT().Put(idBytes).Do(func(_ []byte) {
+					require.True(t, finishCalled)
+				})
+
+				bytePool.EXPECT().Put(tagBytes).Do(func(_ []byte) {
+					require.True(t, finishCalled)
+				})
+			}
+
+			res, status, err := dec.DecodeIndexEntryToIndexChecksum([]byte(tt.id), bytePool)
+			require.NoError(t, err)
+			require.Equal(t, tt.exStatus, status)
+			if tt.exStatus == MatchedLookupStatus {
+				require.Equal(t, tt.exChecksum, res.MetadataChecksum)
+				finishCalled = true
+				res.Finalize()
+			}
+		})
 	}
 }

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/storage/limits"
@@ -707,7 +708,7 @@ type retrieveRequest struct {
 
 	streamReqType streamReqType
 	indexEntry    IndexEntry
-	indexChecksum ident.IndexChecksum
+	indexChecksum schema.IndexChecksum
 	reader        xio.SegmentReader
 
 	err error
@@ -722,7 +723,7 @@ type retrieveRequest struct {
 }
 
 func (req *retrieveRequest) onIndexChecksumCompleted(
-	indexChecksum ident.IndexChecksum) {
+	indexChecksum schema.IndexChecksum) {
 	if req.err == nil {
 		req.indexChecksum = indexChecksum
 		// If there was an error, we've already called done.
@@ -730,10 +731,10 @@ func (req *retrieveRequest) onIndexChecksumCompleted(
 	}
 }
 
-func (req *retrieveRequest) RetrieveIndexChecksum() (ident.IndexChecksum, error) {
+func (req *retrieveRequest) RetrieveIndexChecksum() (schema.IndexChecksum, error) {
 	req.resultWg.Wait()
 	if req.err != nil {
-		return ident.IndexChecksum{}, req.err
+		return schema.IndexChecksum{}, req.err
 	}
 	return req.indexChecksum, nil
 }
@@ -840,7 +841,7 @@ func (req *retrieveRequest) resetForReuse() {
 	req.onRetrieve = nil
 	req.streamReqType = streamInvalidReq
 	req.indexEntry = IndexEntry{}
-	req.indexChecksum = ident.IndexChecksum{}
+	req.indexChecksum = schema.IndexChecksum{}
 	req.reader = nil
 	req.err = nil
 	req.notFound = false

--- a/src/dbnode/persist/fs/seek.go
+++ b/src/dbnode/persist/fs/seek.go
@@ -474,12 +474,12 @@ func (s *seeker) SeekIndexEntry(
 func (s *seeker) SeekIndexEntryToIndexChecksum(
 	id ident.ID,
 	resources ReusableSeekerResources,
-) (ident.IndexChecksum, error) {
+) (schema.IndexChecksum, error) {
 	offset, err := s.indexLookup.getNearestIndexFileOffset(id, resources)
 	// Should never happen, either something is really wrong with the code or
 	// the file on disk was corrupted.
 	if err != nil {
-		return ident.IndexChecksum{}, err
+		return schema.IndexChecksum{}, err
 	}
 
 	resources.offsetFileReader.reset(s.indexFd, offset)
@@ -493,31 +493,28 @@ func (s *seeker) SeekIndexEntryToIndexChecksum(
 		if err != nil {
 			if err == io.EOF {
 				// Reached the end of the file without finding the ID.
-				return ident.IndexChecksum{}, errSeekIDNotFound
+				return schema.IndexChecksum{}, errSeekIDNotFound
 			}
 			// Should never happen, either something is really wrong with the code or
 			// the file on disk was corrupted.
-			return ident.IndexChecksum{}, instrument.InvariantErrorf(err.Error())
+			return schema.IndexChecksum{}, instrument.InvariantErrorf(err.Error())
 		}
 
-		if status == xmsgpack.NotFound {
+		if status == xmsgpack.NotFoundLookupStatus {
 			// a `NotFound` status for the index checksum decode indicates that the
 			// current seek has passed the point in the file where this ID could have
 			// appeared; short-circuit here as the ID does not exist in the file.
-			return ident.IndexChecksum{}, errSeekIDNotFound
-		} else if status == xmsgpack.Mismatch {
+			return schema.IndexChecksum{}, errSeekIDNotFound
+		} else if status == xmsgpack.MismatchLookupStatus {
 			// a `Mismatch` status for the index checksum decode indicates that the
 			// current seek does not match the ID, but that it may still appear in
 			// the file.
 			continue
+		} else if status == xmsgpack.ErrorLookupStatus {
+			return schema.IndexChecksum{}, errors.New("unknown index lookup error")
 		}
 
-		indexChecksum := ident.IndexChecksum{
-			Checksum: checksum,
-		}
-
-		indexChecksum.ID = idBytes
-		return indexChecksum, nil
+		return checksum, nil
 	}
 }
 

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs/msgpack"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage/block"
@@ -221,7 +222,7 @@ type DataFileSetSeeker interface {
 
 	// SeekIndexEntryToIndexChecksum seeks in a manner similar to SeekIndexEntry, but
 	// instead yields a minimal structure describing a checksum of the series.
-	SeekIndexEntryToIndexChecksum(id ident.ID, resources ReusableSeekerResources) (ident.IndexChecksum, error)
+	SeekIndexEntryToIndexChecksum(id ident.ID, resources ReusableSeekerResources) (schema.IndexChecksum, error)
 
 	// Range returns the time range associated with data in the volume
 	Range() xtime.Range
@@ -259,7 +260,7 @@ type ConcurrentDataFileSetSeeker interface {
 	SeekIndexEntry(id ident.ID, resources ReusableSeekerResources) (IndexEntry, error)
 
 	// SeekIndexEntryToIndexChecksum is the same as in DataFileSetSeeker.
-	SeekIndexEntryToIndexChecksum(id ident.ID, resources ReusableSeekerResources) (ident.IndexChecksum, error)
+	SeekIndexEntryToIndexChecksum(id ident.ID, resources ReusableSeekerResources) (schema.IndexChecksum, error)
 
 	// ConcurrentIDBloomFilter is the same as in DataFileSetSeeker.
 	ConcurrentIDBloomFilter() *ManagedConcurrentBloomFilter

--- a/src/dbnode/persist/fs/wide/entry_checksum_mismatch_checker.go
+++ b/src/dbnode/persist/fs/wide/entry_checksum_mismatch_checker.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/persist/fs/msgpack"
 	"github.com/m3db/m3/src/dbnode/persist/schema"
-	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 
 	"go.uber.org/zap"
@@ -107,12 +106,12 @@ func (c *entryChecksumMismatchChecker) emitInvariantViolation(
 	return err
 }
 
-func (c *entryChecksumMismatchChecker) readNextBatch() ident.IndexChecksumBlockBatch {
+func (c *entryChecksumMismatchChecker) readNextBatch() IndexChecksumBlockBatch {
 	if !c.blockReader.Next() {
 		c.exhausted = true
 		// NB: set exhausted to true and return an empty since there are no
 		// more available checksum blocks.
-		return ident.IndexChecksumBlockBatch{}
+		return IndexChecksumBlockBatch{}
 	}
 
 	c.batchIdx = 0

--- a/src/dbnode/persist/fs/wide/entry_checksum_mismatch_checker_test.go
+++ b/src/dbnode/persist/fs/wide/entry_checksum_mismatch_checker_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/persist/fs/msgpack"
 	"github.com/m3db/m3/src/dbnode/persist/schema"
-	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 	xtest "github.com/m3db/m3/src/x/test"
 	xhash "github.com/m3db/m3/src/x/test/hash"
@@ -35,8 +34,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildTestReader(bls ...ident.IndexChecksumBlockBatch) IndexChecksumBlockBatchReader {
-	ch := make(chan ident.IndexChecksumBlockBatch)
+func buildTestReader(bls ...IndexChecksumBlockBatch) IndexChecksumBlockBatchReader {
+	ch := make(chan IndexChecksumBlockBatch)
 	reader := NewIndexChecksumBlockBatchReader(ch)
 	go func() {
 		for _, bl := range bls {
@@ -126,7 +125,7 @@ func TestEmitMismatches(t *testing.T) {
 }
 
 func TestComputeMismatchInvariant(t *testing.T) {
-	reader := buildTestReader(ident.IndexChecksumBlockBatch{
+	reader := buildTestReader(IndexChecksumBlockBatch{
 		Checksums: []int64{1},
 		EndMarker: []byte("foo1"),
 	})
@@ -137,7 +136,7 @@ func TestComputeMismatchInvariant(t *testing.T) {
 }
 
 func TestComputeMismatchInvariantEndOfBlock(t *testing.T) {
-	reader := buildTestReader(ident.IndexChecksumBlockBatch{
+	reader := buildTestReader(IndexChecksumBlockBatch{
 		Checksums: []int64{1, 2},
 		EndMarker: []byte("foo2"),
 	})
@@ -158,18 +157,18 @@ func assertNoMismatch(
 }
 
 func TestComputeMismatchWithDelayedReader(t *testing.T) {
-	ch := make(chan ident.IndexChecksumBlockBatch)
+	ch := make(chan IndexChecksumBlockBatch)
 	reader := NewIndexChecksumBlockBatchReader(ch)
 	chk := NewEntryChecksumMismatchChecker(reader, buildOpts(t))
 
 	go func() {
 		time.Sleep(time.Millisecond * 100)
-		ch <- ident.IndexChecksumBlockBatch{
+		ch <- IndexChecksumBlockBatch{
 			Checksums: []int64{1},
 			EndMarker: []byte("foo1"),
 		}
 		time.Sleep(time.Millisecond * 200)
-		ch <- ident.IndexChecksumBlockBatch{
+		ch <- IndexChecksumBlockBatch{
 			Checksums: []int64{10},
 			EndMarker: []byte("qux10"),
 		}
@@ -182,10 +181,10 @@ func TestComputeMismatchWithDelayedReader(t *testing.T) {
 }
 
 func TestComputeMismatchNoMismatch(t *testing.T) {
-	reader := buildTestReader(ident.IndexChecksumBlockBatch{
+	reader := buildTestReader(IndexChecksumBlockBatch{
 		Checksums: []int64{1, 2, 3},
 		EndMarker: []byte("foo3"),
-	}, ident.IndexChecksumBlockBatch{
+	}, IndexChecksumBlockBatch{
 		Checksums: []int64{100, 5},
 		EndMarker: []byte("zoo5"),
 	})
@@ -200,16 +199,16 @@ func TestComputeMismatchNoMismatch(t *testing.T) {
 }
 
 func TestComputeMismatchMismatchesIndexMismatch(t *testing.T) {
-	reader := buildTestReader(ident.IndexChecksumBlockBatch{
+	reader := buildTestReader(IndexChecksumBlockBatch{
 		Checksums: []int64{1, 2, 3},
 		EndMarker: []byte("foo3"),
-	}, ident.IndexChecksumBlockBatch{
+	}, IndexChecksumBlockBatch{
 		Checksums: []int64{4, 5},
 		EndMarker: []byte("moo5"),
-	}, ident.IndexChecksumBlockBatch{
+	}, IndexChecksumBlockBatch{
 		Checksums: []int64{6, 7, 8},
 		EndMarker: []byte("qux8"),
-	}, ident.IndexChecksumBlockBatch{
+	}, IndexChecksumBlockBatch{
 		Checksums: []int64{9, 10},
 		EndMarker: []byte("zzz9"),
 	})
@@ -244,16 +243,16 @@ func TestComputeMismatchMismatchesIndexMismatch(t *testing.T) {
 }
 
 func TestComputeMismatchMismatchesEntryMismatches(t *testing.T) {
-	reader := buildTestReader(ident.IndexChecksumBlockBatch{
+	reader := buildTestReader(IndexChecksumBlockBatch{
 		Checksums: []int64{4},
 		EndMarker: []byte("foo3"),
-	}, ident.IndexChecksumBlockBatch{
+	}, IndexChecksumBlockBatch{
 		Checksums: []int64{5},
 		EndMarker: []byte("goo5"),
-	}, ident.IndexChecksumBlockBatch{
+	}, IndexChecksumBlockBatch{
 		Checksums: []int64{6},
 		EndMarker: []byte("moo6"),
-	}, ident.IndexChecksumBlockBatch{
+	}, IndexChecksumBlockBatch{
 		Checksums: []int64{7},
 		EndMarker: []byte("qux7"),
 	})
@@ -304,10 +303,10 @@ func TestComputeMismatchMismatchesEntryMismatches(t *testing.T) {
 }
 
 func TestComputeMismatchMismatchesOvershoot(t *testing.T) {
-	reader := buildTestReader(ident.IndexChecksumBlockBatch{
+	reader := buildTestReader(IndexChecksumBlockBatch{
 		Checksums: []int64{1, 2, 3},
 		EndMarker: []byte("foo3"),
-	}, ident.IndexChecksumBlockBatch{
+	}, IndexChecksumBlockBatch{
 		Checksums: []int64{4, 5, 10},
 		EndMarker: []byte("goo10"),
 	})
@@ -339,7 +338,7 @@ func TestComputeMismatchMismatchesOvershoot(t *testing.T) {
 }
 
 func TestComputeMismatchMismatchesEntryMismatchSkipsFirst(t *testing.T) {
-	reader := buildTestReader(ident.IndexChecksumBlockBatch{
+	reader := buildTestReader(IndexChecksumBlockBatch{
 		Checksums: []int64{4},
 		EndMarker: []byte("foo3"),
 	})
@@ -357,7 +356,7 @@ func TestComputeMismatchMismatchesEntryMismatchSkipsFirst(t *testing.T) {
 }
 
 func TestComputeMismatchMismatchesEntryMismatchMatchesLast(t *testing.T) {
-	reader := buildTestReader(ident.IndexChecksumBlockBatch{
+	reader := buildTestReader(IndexChecksumBlockBatch{
 		Checksums: []int64{1, 2, 3},
 		EndMarker: []byte("foo3"),
 	})

--- a/src/dbnode/persist/fs/wide/index_checksum_block_batch_reader.go
+++ b/src/dbnode/persist/fs/wide/index_checksum_block_batch_reader.go
@@ -21,20 +21,18 @@
 package wide
 
 import (
-	"github.com/m3db/m3/src/x/ident"
-
 	"go.uber.org/atomic"
 )
 
 type indexChecksumBlockReader struct {
 	closed       *atomic.Bool
-	currentBlock ident.IndexChecksumBlockBatch
-	blocks       chan ident.IndexChecksumBlockBatch
+	currentBlock IndexChecksumBlockBatch
+	blocks       chan IndexChecksumBlockBatch
 }
 
 // NewIndexChecksumBlockBatchReader creates a new IndexChecksumBlockBatchReader.
 func NewIndexChecksumBlockBatchReader(
-	blockInput chan ident.IndexChecksumBlockBatch,
+	blockInput chan IndexChecksumBlockBatch,
 ) IndexChecksumBlockBatchReader {
 	return &indexChecksumBlockReader{
 		closed: atomic.NewBool(false),
@@ -42,7 +40,7 @@ func NewIndexChecksumBlockBatchReader(
 	}
 }
 
-func (b *indexChecksumBlockReader) Current() ident.IndexChecksumBlockBatch {
+func (b *indexChecksumBlockReader) Current() IndexChecksumBlockBatch {
 	return b.currentBlock
 }
 

--- a/src/dbnode/persist/fs/wide/index_checksum_block_batch_reader_test.go
+++ b/src/dbnode/persist/fs/wide/index_checksum_block_batch_reader_test.go
@@ -23,16 +23,14 @@ package wide
 import (
 	"testing"
 
-	"github.com/m3db/m3/src/x/ident"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIndexChecksumBlockBatchReader(t *testing.T) {
-	ch := make(chan ident.IndexChecksumBlockBatch)
+	ch := make(chan IndexChecksumBlockBatch)
 	buf := NewIndexChecksumBlockBatchReader(ch)
-	bl := ident.IndexChecksumBlockBatch{EndMarker: []byte("foo")}
-	bl2 := ident.IndexChecksumBlockBatch{
+	bl := IndexChecksumBlockBatch{EndMarker: []byte("foo")}
+	bl2 := IndexChecksumBlockBatch{
 		Checksums: []int64{1, 2, 3},
 		EndMarker: []byte("bar"),
 	}

--- a/src/dbnode/persist/fs/wide/types.go
+++ b/src/dbnode/persist/fs/wide/types.go
@@ -23,7 +23,6 @@ package wide
 import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/msgpack"
 	"github.com/m3db/m3/src/dbnode/persist/schema"
-	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 )
 
@@ -73,7 +72,7 @@ type IndexChecksumBlockBatchReader interface {
 	// Next moves to the next IndexChecksumBlockBatch element.
 	Next() bool
 	// Current yields the current IndexChecksumBlockBatch.
-	Current() ident.IndexChecksumBlockBatch
+	Current() IndexChecksumBlockBatch
 }
 
 // EntryChecksumMismatchChecker checks if a given entry should yield a mismatch.
@@ -106,3 +105,13 @@ func (emptyStreamedMismatchBatch) RetrieveMismatchBatch() (ReadMismatchBatch, er
 
 // EmptyStreamedMismatchBatch is an empty streamed mismatch batch.
 var EmptyStreamedMismatchBatch StreamedMismatchBatch = emptyStreamedMismatchBatch{}
+
+// IndexChecksumBlockBatch represents a batch of index checksums originating
+// from a single series block.
+type IndexChecksumBlockBatch struct {
+	// Checksums is the list of index checksums.
+	Checksums []int64
+	// EndMarker is a batch marker, signifying the ID of the
+	// last element in the batch.
+	EndMarker []byte
+}

--- a/src/dbnode/persist/fs/wide/wide_mock.go
+++ b/src/dbnode/persist/fs/wide/wide_mock.go
@@ -27,8 +27,6 @@ package wide
 import (
 	"reflect"
 
-	"github.com/m3db/m3/src/x/ident"
-
 	"github.com/golang/mock/gomock"
 )
 
@@ -56,10 +54,10 @@ func (m *MockIndexChecksumBlockBatchReader) EXPECT() *MockIndexChecksumBlockBatc
 }
 
 // Current mocks base method
-func (m *MockIndexChecksumBlockBatchReader) Current() ident.IndexChecksumBlockBatch {
+func (m *MockIndexChecksumBlockBatchReader) Current() IndexChecksumBlockBatch {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Current")
-	ret0, _ := ret[0].(ident.IndexChecksumBlockBatch)
+	ret0, _ := ret[0].(IndexChecksumBlockBatch)
 	return ret0
 }
 

--- a/src/dbnode/persist/schema/types.go
+++ b/src/dbnode/persist/schema/types.go
@@ -75,6 +75,30 @@ type IndexEntry struct {
 	IndexChecksum int64
 }
 
+// IndexChecksum extends IndexEntry for use with queries, by providing
+// an additional metadata checksum field.
+type IndexChecksum struct {
+	// IndexChecksum embeds IndexEntry.
+	IndexEntry
+	// MetadataChecksum is the computed index metadata checksum.
+	// NB: built from ID, DataChecksum, and tags.
+	MetadataChecksum int64
+	// finalizeFn is any specific cleanup for the IndexChecksum.
+	finalizeFn func()
+}
+
+// Finalize finalizes the index checksum, releasing any held resources.
+func (c *IndexChecksum) Finalize() {
+	if c.finalizeFn != nil {
+		c.finalizeFn()
+	}
+}
+
+// SetFinalizer sets the finalizer for this index checksum.
+func (c *IndexChecksum) SetFinalizer(fn func()) {
+	c.finalizeFn = fn
+}
+
 // IndexEntryHasher hashes an index entry.
 type IndexEntryHasher interface {
 	// HashIndexEntry computes a hash value for this IndexEntry using its ID, tags,

--- a/src/dbnode/storage/block/block_mock.go
+++ b/src/dbnode/storage/block/block_mock.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/x/xio"
@@ -856,10 +857,10 @@ func (m *MockStreamedChecksum) EXPECT() *MockStreamedChecksumMockRecorder {
 }
 
 // RetrieveIndexChecksum mocks base method
-func (m *MockStreamedChecksum) RetrieveIndexChecksum() (ident.IndexChecksum, error) {
+func (m *MockStreamedChecksum) RetrieveIndexChecksum() (schema.IndexChecksum, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveIndexChecksum")
-	ret0, _ := ret[0].(ident.IndexChecksum)
+	ret0, _ := ret[0].(schema.IndexChecksum)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/src/dbnode/storage/block/types.go
+++ b/src/dbnode/storage/block/types.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/ts"
@@ -267,17 +268,17 @@ type RetrievableBlockMetadata struct {
 	Checksum uint32
 }
 
-// StreamedChecksum yields an ident.IndexChecksum value asynchronously,
+// StreamedChecksum yields a schema.IndexChecksum value asynchronously,
 // and any errors encountered during execution.
 type StreamedChecksum interface {
 	// RetrieveIndexChecksum retrieves the index checksum.
-	RetrieveIndexChecksum() (ident.IndexChecksum, error)
+	RetrieveIndexChecksum() (schema.IndexChecksum, error)
 }
 
 type emptyStreamedChecksum struct{}
 
-func (emptyStreamedChecksum) RetrieveIndexChecksum() (ident.IndexChecksum, error) {
-	return ident.IndexChecksum{}, nil
+func (emptyStreamedChecksum) RetrieveIndexChecksum() (schema.IndexChecksum, error) {
+	return schema.IndexChecksum{}, nil
 }
 
 // EmptyStreamedChecksum is an empty streamed checksum.

--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/persist/fs/wide"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	dberrors "github.com/m3db/m3/src/dbnode/storage/errors"
@@ -992,7 +993,7 @@ func (d *db) WideQuery(
 	queryStart time.Time,
 	shards []uint32,
 	iterOpts index.IterationOptions,
-) ([]ident.IndexChecksum, error) { // FIXME: change when exact type known.
+) ([]schema.IndexChecksum, error) { // FIXME: change when exact type known.
 	n, err := d.namespaceFor(namespace)
 	if err != nil {
 		d.metrics.unknownNamespaceRead.Inc(1)
@@ -1003,7 +1004,7 @@ func (d *db) WideQuery(
 		batchSize = d.opts.WideBatchSize()
 		blockSize = n.Options().IndexOptions().BlockSize()
 
-		collectedChecksums = make([]ident.IndexChecksum, 0, 10)
+		collectedChecksums = make([]schema.IndexChecksum, 0, 10)
 	)
 
 	opts, err := index.NewWideQueryOptions(queryStart, batchSize, blockSize, shards, iterOpts)

--- a/src/dbnode/storage/database_test.go
+++ b/src/dbnode/storage/database_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/persist/fs/wide"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage/block"
@@ -328,14 +329,17 @@ func TestDatabaseIndexChecksum(t *testing.T) {
 
 	indexChecksumWithID := block.NewMockStreamedChecksum(ctrl)
 	indexChecksumWithID.EXPECT().RetrieveIndexChecksum().
-		Return(ident.IndexChecksum{ID: []byte("foo"), Checksum: 5}, nil)
+		Return(schema.IndexChecksum{
+			IndexEntry:       schema.IndexEntry{ID: []byte("foo")},
+			MetadataChecksum: 5},
+			nil)
 	mockNamespace := NewMockdatabaseNamespace(ctrl)
 	mockNamespace.EXPECT().FetchIndexChecksum(ctx, seriesID, start).
 		Return(indexChecksumWithID, nil)
 
 	indexChecksumWithoutID := block.NewMockStreamedChecksum(ctrl)
 	indexChecksumWithoutID.EXPECT().RetrieveIndexChecksum().
-		Return(ident.IndexChecksum{Checksum: 7}, nil)
+		Return(schema.IndexChecksum{MetadataChecksum: 7}, nil)
 	mockNamespace.EXPECT().FetchIndexChecksum(ctx, seriesID, start).
 		Return(indexChecksumWithoutID, nil)
 	d.namespaces.Set(nsID, mockNamespace)
@@ -345,14 +349,14 @@ func TestDatabaseIndexChecksum(t *testing.T) {
 	checksum, err := res.RetrieveIndexChecksum()
 	require.NoError(t, err)
 	assert.Equal(t, "foo", string(checksum.ID))
-	assert.Equal(t, 5, int(checksum.Checksum))
+	assert.Equal(t, 5, int(checksum.MetadataChecksum))
 
 	res, err = d.fetchIndexChecksum(ctx, mockNamespace, seriesID, start)
 	checksum, err = res.RetrieveIndexChecksum()
 	require.NoError(t, err)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(checksum.ID))
-	assert.Equal(t, 7, int(checksum.Checksum))
+	assert.Equal(t, 7, int(checksum.MetadataChecksum))
 }
 
 func TestDatabaseFetchBlocksNamespaceNonExistent(t *testing.T) {

--- a/src/dbnode/storage/index/wide_query_results.go
+++ b/src/dbnode/storage/index/wide_query_results.go
@@ -181,9 +181,6 @@ func (r *wideResults) addDocumentWithLock(d doc.Document) error {
 
 	r.size++
 	r.totalDocsCount++
-
-	// Pool IDs after filter is passed.
-	tsID = r.idPool.Clone(tsID)
 	if len(r.batch.IDs) < r.batchSize {
 		r.batch.IDs = append(r.batch.IDs, tsID)
 	} else {

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/wide"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/storage/block"
@@ -1609,9 +1610,11 @@ func TestShardFetchIndexChecksum(t *testing.T) {
 	retriever := block.NewMockDatabaseBlockRetriever(ctrl)
 	shard.setBlockRetriever(retriever)
 
-	checksum := ident.IndexChecksum{
-		Checksum: 5,
-		ID:       []byte("foo"),
+	checksum := schema.IndexChecksum{
+		IndexEntry: schema.IndexEntry{
+			ID: []byte("foo"),
+		},
+		MetadataChecksum: 5,
 	}
 
 	indexChecksum := block.NewMockStreamedChecksum(ctrl)
@@ -1621,7 +1624,7 @@ func TestShardFetchIndexChecksum(t *testing.T) {
 
 	// First call to RetrieveIndexChecksum is expected to error on retrieval
 	indexChecksum.EXPECT().RetrieveIndexChecksum().
-		Return(ident.IndexChecksum{}, errors.New("err"))
+		Return(schema.IndexChecksum{}, errors.New("err"))
 	r, err := shard.FetchIndexChecksum(ctx, ident.StringID("foo"), start, namespace.Context{})
 	require.NoError(t, err)
 	_, err = r.RetrieveIndexChecksum()

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -37,6 +37,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/persist/fs/wide"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage/block"
@@ -346,10 +347,10 @@ func (mr *MockDatabaseMockRecorder) ReadEncoded(ctx, namespace, id, start, end i
 }
 
 // WideQuery mocks base method
-func (m *MockDatabase) WideQuery(ctx context.Context, namespace ident.ID, query index.Query, start time.Time, shards []uint32, iterOpts index.IterationOptions) ([]ident.IndexChecksum, error) {
+func (m *MockDatabase) WideQuery(ctx context.Context, namespace ident.ID, query index.Query, start time.Time, shards []uint32, iterOpts index.IterationOptions) ([]schema.IndexChecksum, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WideQuery", ctx, namespace, query, start, shards, iterOpts)
-	ret0, _ := ret[0].([]ident.IndexChecksum)
+	ret0, _ := ret[0].([]schema.IndexChecksum)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -786,10 +787,10 @@ func (mr *MockdatabaseMockRecorder) ReadEncoded(ctx, namespace, id, start, end i
 }
 
 // WideQuery mocks base method
-func (m *Mockdatabase) WideQuery(ctx context.Context, namespace ident.ID, query index.Query, start time.Time, shards []uint32, iterOpts index.IterationOptions) ([]ident.IndexChecksum, error) {
+func (m *Mockdatabase) WideQuery(ctx context.Context, namespace ident.ID, query index.Query, start time.Time, shards []uint32, iterOpts index.IterationOptions) ([]schema.IndexChecksum, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WideQuery", ctx, namespace, query, start, shards, iterOpts)
-	ret0, _ := ret[0].([]ident.IndexChecksum)
+	ret0, _ := ret[0].([]schema.IndexChecksum)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -33,6 +33,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/persist/fs/wide"
+	"github.com/m3db/m3/src/dbnode/persist/schema"
 	"github.com/m3db/m3/src/dbnode/runtime"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage/block"
@@ -184,7 +185,7 @@ type Database interface {
 		start time.Time,
 		shards []uint32,
 		iterOpts index.IterationOptions,
-	) ([]ident.IndexChecksum, error) // FIXME: change when exact type known.
+	) ([]schema.IndexChecksum, error) // FIXME: change when exact type known.
 
 	// ReadMismatches performs a wide blockwise query that applies a received
 	// index checksum block batch.

--- a/src/x/ident/types.go
+++ b/src/x/ident/types.go
@@ -318,21 +318,3 @@ type IDBatch struct {
 	// IDs are the IDs for the batch.
 	IDs []ID
 }
-
-// IndexChecksum represents an index checksums within a series block.
-type IndexChecksum struct {
-	// Checksum is the index checksum.
-	Checksum int64
-	// ID is an optional ID for this series, set only when explicitly requested.
-	ID []byte
-}
-
-// IndexChecksumBlockBatch represents a batch of index checksums originating
-// from a single series block.
-type IndexChecksumBlockBatch struct {
-	// Checksums is the list of index checksums.
-	Checksums []int64
-	// EndMarker is a batch marker, signifying the ID of the
-	// last element in the batch.
-	EndMarker []byte
-}


### PR DESCRIPTION
Moves `ident.IndexChecksum` to `schema` package, and greatly expands its fields. This ensures the wide index query result retains the `schema.IndexEntry` fields returned by reverse index lookup, enabling seeker data retrieval with no additional index lookups.

Also moves `ident.IndexChecksumBlockBatch` to `wide`