### PR TITLE
Remove RestartSec from m3dbnode.service example

### DIFF
--- a/integrations/systemd/m3dbnode.service
+++ b/integrations/systemd/m3dbnode.service
@@ -7,7 +7,6 @@ After=network.target
 Type=simple
 ExecStart=/usr/bin/m3dbnode -f /etc/m3db/m3dbnode.yaml
 Restart=on-failure
-RestartSec=10s
 SuccessExitStatus=0
 
 # May not be honored if higher than kernel limit (sysctl fs.file-max) or process


### PR DESCRIPTION
Having `RestartSec=10s` makes systemd wait for 10s before starting the
service back up after it already exited. This does not appear to be the
original intention of it. As we want m3dbnode started as soon as
possible once it stopped on error.

This was intended to be `TimeoutStopSec` which would have waited for 10s
before forcibly SIGKILLing the process. Without it specified the
default is given by `DefaultTimeoutStopSec` which is usually `90s`.

Remove the RestartSec, which would mean it would only wait 100ms before
starting the process after it exited with non-zero status. Do not add
`TimeoutStopSec` so the kill behavior is not changed. If someone wants
it, they can add that option.

<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
NONE