### PR TITLE
[dbnode] Improve error messages on corrupt files

### DIFF
--- a/src/dbnode/encoding/types.go
+++ b/src/dbnode/encoding/types.go
@@ -216,7 +216,7 @@ type MultiReaderIterator interface {
 	// for this MultiReaderIterator.
 	Readers() xio.ReaderSliceOfSlicesIterator
 
-	// Schema exposes the underlying SchemaDescr for this MutliReaderIterator.
+	// Schema exposes the underlying SchemaDescr for this MultiReaderIterator.
 	Schema() namespace.SchemaDescr
 }
 

--- a/src/dbnode/persist/fs/mmap_util.go
+++ b/src/dbnode/persist/fs/mmap_util.go
@@ -85,8 +85,8 @@ func validateAndMmapFile(
 
 	if calculatedDigest := digest.Checksum(mmapDescriptor.Bytes); calculatedDigest != expectedDigest {
 		mmap.Munmap(mmapDescriptor)
-		return mmap.Descriptor{}, fmt.Errorf("expected summaries file digest was: %d, but got: %d",
-			expectedDigest, calculatedDigest)
+		return mmap.Descriptor{}, fmt.Errorf("expected file %s digest was: %d, but got: %d",
+			fd.Name(), expectedDigest, calculatedDigest)
 	}
 
 	return mmapDescriptor, nil

--- a/src/dbnode/persist/fs/mmap_util.go
+++ b/src/dbnode/persist/fs/mmap_util.go
@@ -85,7 +85,7 @@ func validateAndMmapFile(
 
 	if calculatedDigest := digest.Checksum(mmapDescriptor.Bytes); calculatedDigest != expectedDigest {
 		mmap.Munmap(mmapDescriptor)
-		return mmap.Descriptor{}, fmt.Errorf("expected file %s digest was: %d, but got: %d",
+		return mmap.Descriptor{}, fmt.Errorf("expected %s file digest was: %d, but got: %d",
 			fd.Name(), expectedDigest, calculatedDigest)
 	}
 

--- a/src/dbnode/persist/fs/msgpack/decoder_test.go
+++ b/src/dbnode/persist/fs/msgpack/decoder_test.go
@@ -282,7 +282,21 @@ func TestDecodeIndexEntryInvalidChecksum(t *testing.T) {
 
 	dec.Reset(NewByteDecoderStream(enc.Bytes()))
 	_, err := dec.DecodeIndexEntry(nil)
-	require.Error(t, err)
+	require.EqualError(t, err, errorIndexEntryChecksumMismatch.Error())
+}
+
+func TestDecodeIndexEntryIncompleteFile(t *testing.T) {
+	var (
+		enc = NewEncoder()
+		dec = NewDecoder(nil)
+	)
+	require.NoError(t, enc.EncodeIndexEntry(testIndexEntry))
+
+	enc.buf.Truncate(len(enc.Bytes()) - 4)
+
+	dec.Reset(NewByteDecoderStream(enc.Bytes()))
+	_, err := dec.DecodeIndexEntry(nil)
+	require.EqualError(t, err, "decode index entry encountered error: EOF")
 }
 
 var decodeIndexChecksumTests = []struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
1. On incomplete data index file, it fixes error message from potentially misleading `decode index entry encountered checksum mismatch` to a more accurate `decode index entry encountered error: EOF` (or any other actual error encountered while reading/decoding the file).

2. On whole file checksum mismatch, it includes the file name (which helps to see both file type and block) into the error message and removes the misleading word `summaries` from it (this is generic code not related to summaries, and it is also used eg. for bloom filter checksumming).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
