### PR TITLE
[large-tiles] fix incorrect namespace after querying reverse index

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1336,7 +1336,13 @@ func (i *nsIndex) Query(
 
 	// Get results and set the namespace ID and size limit.
 	results := i.resultsPool.Get()
-	results.Reset(i.nsMetadata.ID(), index.QueryResultsOptions{
+
+	nsID := i.nsMetadata.ID()
+	// Override result namespace if it's provided.
+	if opts.Namespace != nil {
+		nsID = opts.Namespace
+	}
+	results.Reset(nsID, index.QueryResultsOptions{
 		SizeLimit: opts.SeriesLimit,
 		FilterID:  i.shardsFilterID(),
 	})

--- a/src/dbnode/storage/index/types.go
+++ b/src/dbnode/storage/index/types.go
@@ -92,6 +92,8 @@ type QueryOptions struct {
 	RequireExhaustive bool
 	// IterationOptions controls additional iteration methods.
 	IterationOptions IterationOptions
+	// Optional. Force work with provided namespace
+	Namespace ident.ID
 }
 
 // WideQueryOptions enables users to specify constraints and

--- a/src/dbnode/storage/readonly_index_proxy.go
+++ b/src/dbnode/storage/readonly_index_proxy.go
@@ -37,6 +37,7 @@ import (
 var errNamespaceIndexReadOnly = errors.New("write operation on read only namespace index")
 
 type readOnlyIndexProxy struct {
+	sourceNs   ident.ID
 	underlying NamespaceIndex
 }
 
@@ -63,6 +64,7 @@ func (r readOnlyIndexProxy) Query(
 	query index.Query,
 	opts index.QueryOptions,
 ) (index.QueryResult, error) {
+	opts.Namespace = r.sourceNs
 	return r.underlying.Query(ctx, query, opts)
 }
 
@@ -125,8 +127,11 @@ func (r readOnlyIndexProxy) Close() error {
 
 // NewReadOnlyIndexProxy builds a new NamespaceIndex that proxies only read
 // operations, and no-ops on write operations.
-func NewReadOnlyIndexProxy(underlying NamespaceIndex) NamespaceIndex {
-	return readOnlyIndexProxy{underlying: underlying}
+func NewReadOnlyIndexProxy(sourceNs ident.ID, underlying NamespaceIndex) NamespaceIndex {
+	return readOnlyIndexProxy{
+		sourceNs:   sourceNs,
+		underlying: underlying,
+	}
 }
 
 func noopOnColdFlushDone() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
When querying computed namespace data from default namespace is returned in place of the computed namespace. This PR fixes it.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
