### PR TITLE
[dbnode] Bump default filesystem persist rate limit

### DIFF
--- a/src/cmd/services/m3dbnode/config/fs.go
+++ b/src/cmd/services/m3dbnode/config/fs.go
@@ -36,7 +36,7 @@ const (
 	defaultDataReadBufferSize              = 65536
 	defaultInfoReadBufferSize              = 128
 	defaultSeekReadBufferSize              = 4096
-	defaultThroughputLimitMbps             = 100.0
+	defaultThroughputLimitMbps             = 1000.0
 	defaultThroughputCheckEvery            = 128
 	defaultForceIndexSummariesMmapMemory   = false
 	defaultForceBloomFilterMmapMemory      = false

--- a/src/dbnode/config/m3dbnode-all-config.yml
+++ b/src/dbnode/config/m3dbnode-all-config.yml
@@ -147,7 +147,7 @@ db:
     # and snapshotting to prevent them from interfering with the commitlog. Increasing
     # this value can make node adds significantly faster if the underlyign disk can
     # support the throughput.
-    throughputLimitMbps: 100.0
+    throughputLimitMbps: 1000.0
     throughputCheckEvery: 128
 
   # This feature is currently not working, do not enable.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR brings flush ratelimit into 2020. The existing config is far too conservative and might actually cause harm - any decently-powered machine could potentially OOM before it can write out a snapshot @ 12MiB/s.
1000 mbps is still only 125mb/s, but a much more reasonable baseline for modern VMs/machines.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
