### PR TITLE
[aggregator] Handle follower canLead() for not yet flushed windows

### DIFF
--- a/src/aggregator/aggregator/follower_flush_mgr.go
+++ b/src/aggregator/aggregator/follower_flush_mgr.go
@@ -284,7 +284,7 @@ func (mgr *followerFlushManager) CanLead() bool {
 			for _, lastFlushedNanos := range fbr.ByNumForwardedTimes {
 				if lastFlushedNanos == 0 {
 					mgr.logger.Warn("Encountered zero lastFlushedNanos",
-						zap.Int64("windowNanos", windowNanos),
+						zap.Duration("windowNanos", windowSize),
 						zap.String("flusherType", "forwarded"),
 						zap.Int("shardID", int(shardID)))
 					mgr.metrics.forwarded.zeroLastFlushTime.Inc(1)
@@ -308,15 +308,15 @@ func (mgr *followerFlushManager) canLead(
 	metrics standardFollowerFlusherMetrics,
 ) bool {
 	for windowNanos, lastFlushedNanos := range flushTimes {
+		windowSize := time.Duration(windowNanos)
 		if lastFlushedNanos == 0 {
 			mgr.logger.Warn("Encountered zero lastFlushedNanos",
-				zap.Int64("windowNanos", windowNanos),
+				zap.Duration("windowNanos", windowSize),
 				zap.String("flusherType", flusherType),
 				zap.Int("shardID", shardID))
 			metrics.zeroLastFlushTime.Inc(1)
 		}
 
-		windowSize := time.Duration(windowNanos)
 		windowEndAt := mgr.openedAt.Truncate(windowSize)
 		if windowEndAt.Before(mgr.openedAt) {
 			windowEndAt = windowEndAt.Add(windowSize)


### PR DESCRIPTION
### Problem

Recently we started using status endpoint to track health of aggregator leaders and followers.
We noticed that some followers are occasionally in a state of `canLead == false` when the last flush time recorded by leader is zero. Specifically, it was noticed for forwarded metrics at 10 minute resolution.

According to the leader flush manager code, this is possible when a new metric at some resolution appears for the very first time for a given shard (a new list is created). But since leader persists flush times for all resolution widows in the same batch, if some resolution window is brand new, its last flush time in etcd is zero.

Follower does not handle the zero value of last flush time and reports `canLead == false` even when it can legitimately takeover leadership.

### Solution

When follower encounters a resolution window with last flush time equal zero, it should report `canLead == true` if it has been up for amount of time greater than that resolution window. 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE