### PR TITLE
Add non-ready namespaces to Clusters interface and use in /namespace/ready endpoint

### DIFF
--- a/src/dbnode/namespace/staging.go
+++ b/src/dbnode/namespace/staging.go
@@ -33,12 +33,12 @@ type StagingState struct {
 }
 
 // Status returns the StagingStatus for a namespace.
-func (s *StagingState) Status() StagingStatus {
+func (s StagingState) Status() StagingStatus {
 	return s.status
 }
 
 // Validate validates the StagingState object.
-func (s *StagingState) Validate() error {
+func (s StagingState) Validate() error {
 	var validStatus bool
 	for _, status := range validStagingStatuses {
 		if status == s.Status() {
@@ -64,4 +64,15 @@ func NewStagingState(status nsproto.StagingStatus) (StagingState, error) {
 		return StagingState{status: ReadyStagingStatus}, nil
 	}
 	return StagingState{}, fmt.Errorf("invalid namespace status: %v", status)
+}
+
+func (s StagingStatus) String() string {
+	switch s {
+	case ReadyStagingStatus:
+		return "ready"
+	case InitializingStagingStatus:
+		return "initializing"
+	default:
+		return "unknown"
+	}
 }

--- a/src/query/api/v1/handler/namespace/ready_test.go
+++ b/src/query/api/v1/handler/namespace/ready_test.go
@@ -57,7 +57,7 @@ func TestNamespaceReadyHandler(t *testing.T) {
 		options: m3.ClusterNamespaceOptions{},
 	}
 	testClusters := testClusters{
-		namespaces: []m3.ClusterNamespace{&testClusterNs},
+		nonReadyNamespaces: []m3.ClusterNamespace{&testClusterNs},
 	}
 	mockSession.EXPECT().FetchTaggedIDs(testClusterNs.NamespaceID(), index.Query{Query: idx.NewAllQuery()},
 		index.QueryOptions{SeriesLimit: 1, DocsLimit: 1}).Return(nil, client.FetchResponseMetadata{}, nil)
@@ -70,7 +70,7 @@ func TestNamespaceReadyHandler(t *testing.T) {
 		"name": "testNamespace",
 	}
 
-	req := httptest.NewRequest("POST", "/namespace/mark_ready",
+	req := httptest.NewRequest("POST", "/namespace/ready",
 		xjson.MustNewTestReader(t, jsonInput))
 	require.NotNil(t, req)
 
@@ -105,7 +105,7 @@ func TestNamespaceReadyHandlerWithForce(t *testing.T) {
 		"force": true,
 	}
 
-	req := httptest.NewRequest("POST", "/namespace/mark_ready",
+	req := httptest.NewRequest("POST", "/namespace/ready",
 		xjson.MustNewTestReader(t, jsonInput))
 	require.NotNil(t, req)
 
@@ -138,7 +138,7 @@ func TestNamespaceReadyFailIfNoClusters(t *testing.T) {
 		"name": "testNamespace",
 	}
 
-	req := httptest.NewRequest("POST", "/namespace/mark_ready",
+	req := httptest.NewRequest("POST", "/namespace/ready",
 		xjson.MustNewTestReader(t, jsonInput))
 	require.NotNil(t, req)
 
@@ -163,7 +163,7 @@ func TestNamespaceReadyFailIfNamespaceMissing(t *testing.T) {
 		"name": "missingNamespace",
 	}
 
-	req := httptest.NewRequest("POST", "/namespace/mark_ready",
+	req := httptest.NewRequest("POST", "/namespace/ready",
 		xjson.MustNewTestReader(t, jsonInput))
 	require.NotNil(t, req)
 
@@ -220,11 +220,15 @@ func (t *testClusterNamespace) Session() client.Session {
 }
 
 type testClusters struct {
-	namespaces m3.ClusterNamespaces
+	nonReadyNamespaces m3.ClusterNamespaces
 }
 
 func (t *testClusters) ClusterNamespaces() m3.ClusterNamespaces {
-	return t.namespaces
+	panic("implement me")
+}
+
+func (t *testClusters) NonReadyClusterNamespaces() m3.ClusterNamespaces {
+	return t.nonReadyNamespaces
 }
 
 func (t *testClusters) Close() error {

--- a/src/query/storage/m3/cluster.go
+++ b/src/query/storage/m3/cluster.go
@@ -48,8 +48,11 @@ var (
 type Clusters interface {
 	io.Closer
 
-	// ClusterNamespaces returns all known cluster namespaces.
+	// ClusterNamespaces returns all known and ready cluster namespaces.
 	ClusterNamespaces() ClusterNamespaces
+
+	// NonReadyClusterNamespaces returns all cluster namespaces not in the ready state.
+	NonReadyClusterNamespaces() ClusterNamespaces
 
 	// UnaggregatedClusterNamespace returns the valid unaggregated
 	// cluster namespace.
@@ -248,6 +251,11 @@ func NewClusters(
 
 func (c *clusters) ClusterNamespaces() ClusterNamespaces {
 	return c.namespaces
+}
+
+func (c *clusters) NonReadyClusterNamespaces() ClusterNamespaces {
+	// statically configured cluster namespaces are always considered ready.
+	return nil
 }
 
 func (c *clusters) UnaggregatedClusterNamespace() ClusterNamespace {

--- a/src/query/storage/m3/cluster_test.go
+++ b/src/query/storage/m3/cluster_test.go
@@ -205,6 +205,10 @@ func (n *noopCluster) ClusterNamespaces() ClusterNamespaces {
 	panic("implement me")
 }
 
+func (n *noopCluster) NonReadyClusterNamespaces() ClusterNamespaces {
+	panic("implement me")
+}
+
 func (n *noopCluster) UnaggregatedClusterNamespace() ClusterNamespace {
 	panic("implement me")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Previously, non-ready namespaces could not be marked as ready without using the `force` flag due to the coordinator ignoring the non-ready namespace when it was initially discovered. This PR ensures that non-ready namespaces are not discarded on discovery so that the coordinator can associate the appropriate dbnode session with the namespace. With the session in place, the coordinator can gracefully check the dbnode for the namespace availablility and set the namespace as ready for writes if the dbnode check is successful.
 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
