### PR TITLE
Draft: support concurrent replaces within the mirrored placement code

### DIFF
--- a/src/cluster/placement/algo/mirrored_test.go
+++ b/src/cluster/placement/algo/mirrored_test.go
@@ -21,13 +21,11 @@
 package algo
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/m3db/m3/src/cluster/placement"
 	"github.com/m3db/m3/src/cluster/shard"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -89,8 +87,8 @@ func TestMirrorWorkflow(t *testing.T) {
 		SetShardCutoverNanosFn(timeNanosGen(2)).
 		SetShardCutoffNanosFn(timeNanosGen(3)))
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.True(t, p.IsMirrored())
 	assert.Equal(t, 2, p.ReplicaFactor())
 	assert.Equal(t, int64(1), p.CutoverNanos())
@@ -100,8 +98,8 @@ func TestMirrorWorkflow(t *testing.T) {
 	assert.Error(t, err)
 
 	p, err = a.AddInstances(p, []placement.Instance{})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 
 	i7 := placement.NewInstance().
 		SetID("i7").
@@ -118,7 +116,7 @@ func TestMirrorWorkflow(t *testing.T) {
 		SetWeight(4).
 		SetMetadata(placement.InstanceMetadata{DebugPort: 8})
 	p, err = a.AddInstances(p, []placement.Instance{i7, i8})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(4), p.MaxShardSetID())
 	validateDistribution(t, p, 1.01)
 
@@ -158,12 +156,10 @@ func TestMirrorWorkflow(t *testing.T) {
 	assert.Equal(t, uint32(4), p.MaxShardSetID())
 
 	p, err = a.RemoveInstances(p, []string{i7.ID(), i8.ID()})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(4), p.MaxShardSetID())
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, placement.Validate(p))
 
-	fmt.Println("before first replace")
-	printPlacement(p)
 	p, err = a.ReplaceInstances(p, []string{"i6"}, []placement.Instance{
 		placement.NewInstance().
 			SetID("i16").
@@ -172,9 +168,9 @@ func TestMirrorWorkflow(t *testing.T) {
 			SetShardSetID(3).
 			SetWeight(3),
 	})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(4), p.MaxShardSetID())
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, placement.Validate(p))
 
 	i9 := placement.NewInstance().
 		SetID("i9").
@@ -189,7 +185,7 @@ func TestMirrorWorkflow(t *testing.T) {
 		SetShardSetID(5).
 		SetWeight(1)
 	p, err = a.AddInstances(p, []placement.Instance{i9, i10})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(5), p.MaxShardSetID())
 	validateDistribution(t, p, 1.01)
 
@@ -201,14 +197,14 @@ func TestMirrorWorkflow(t *testing.T) {
 			SetShardSetID(5).
 			SetWeight(1),
 	})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(5), p.MaxShardSetID())
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, placement.Validate(p))
 
 	p, err = a.RemoveInstances(p, []string{"i19", "i10"})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(5), p.MaxShardSetID())
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, placement.Validate(p))
 }
 
 func TestMirrorAddAndRevertBeforeCutover(t *testing.T) {
@@ -266,29 +262,29 @@ func TestMirrorAddAndRevertBeforeCutover(t *testing.T) {
 		SetShardCutoffNanosFn(func() int64 { return shardCutoverTime })
 	a := NewAlgorithm(opts)
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, placement.Validate(p))
 
 	p, _, err = a.MarkAllShardsAvailable(p)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	p1, err := a.AddInstances(p, []placement.Instance{i5, i6})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(3), p1.MaxShardSetID())
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, placement.Validate(p1))
 	assert.True(t, allInitializing(p1, []string{"i5", "i6"}, nowNanos))
 
 	p2, err := a.RemoveInstances(p1, []string{"i5", "i6"})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(3), p2.MaxShardSetID())
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, placement.Validate(p2))
 	_, ok := p2.Instance("i5")
 	assert.False(t, ok)
 	_, ok = p2.Instance("i6")
 	assert.False(t, ok)
 
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, p.SetMaxShardSetID(3), p2)
 }
 
@@ -359,17 +355,17 @@ func TestMirrorAddMultiplePairs(t *testing.T) {
 		SetShardCutoffNanosFn(func() int64 { return shardCutoverTime })
 	a := NewAlgorithm(opts)
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, placement.Validate(p))
 
 	p, _, err = a.MarkAllShardsAvailable(p)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	p1, err := a.AddInstances(p, []placement.Instance{i5, i6, i7, i8})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(4), p1.MaxShardSetID())
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, placement.Validate(p1))
 	assert.True(t, allInitializing(p1, []string{"i5", "i6", "i7", "i8"}, nowNanos))
 	i5, ok := p1.Instance("i5")
 	assert.True(t, ok)
@@ -386,30 +382,30 @@ func TestMirrorAddMultiplePairs(t *testing.T) {
 
 	// Removing all initializing nodes will trigger the revert path.
 	p2, err := a.RemoveInstances(p1.Clone(), []string{"i5", "i6", "i7", "i8"})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(4), p2.MaxShardSetID())
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, placement.Validate(p2))
 	_, ok = p2.Instance("i5")
 	assert.False(t, ok)
 	_, ok = p2.Instance("i7")
 	assert.False(t, ok)
 
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, p.SetMaxShardSetID(4), p2)
 
 	// Removing part of the initializing nodes will not trigger the revert path
 	// and will only do a normal revert.
 	p3, err := a.RemoveInstances(p1.Clone(), []string{"i7", "i8"})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(4), p3.MaxShardSetID())
-	require.NoError(t, placement.Validate(p3))
+	assert.NoError(t, placement.Validate(p3))
 	_, ok = p3.Instance("i5")
 	assert.True(t, ok)
 	newI7, ok := p3.Instance("i7")
 	assert.True(t, ok)
 	assert.True(t, newI7.IsLeaving())
 
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, p.SetMaxShardSetID(4), p2)
 }
 
@@ -468,19 +464,19 @@ func TestMirrorAddAndRevertAfterCutover(t *testing.T) {
 		SetShardCutoffNanosFn(func() int64 { return shardCutoverTime }))
 	p, err := a.InitialPlacement(instances, ids, 2)
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 
 	p1, err := a.AddInstances(p, []placement.Instance{i5, i6})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(3), p1.MaxShardSetID())
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, placement.Validate(p1))
 	assert.False(t, allInitializing(p1, []string{"i5", "i6"}, nowNanos))
 
 	p2, err := a.RemoveInstances(p1, []string{"i5", "i6"})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(3), p2.MaxShardSetID())
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, placement.Validate(p2))
 	i5, ok := p2.Instance("i5")
 	assert.True(t, ok)
 	assert.True(t, i5.IsLeaving())
@@ -544,23 +540,23 @@ func TestMirrorRemoveAndRevertBeforeCutover(t *testing.T) {
 		SetShardCutoffNanosFn(func() int64 { return shardCutoverTime })
 	a := NewAlgorithm(opts)
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(3), p.MaxShardSetID())
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, placement.Validate(p))
 
 	p, _, err = a.MarkAllShardsAvailable(p)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	p1, err := a.RemoveInstances(p, []string{"i5", "i6"})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(3), p1.MaxShardSetID())
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, placement.Validate(p1))
 	assert.True(t, allLeaving(p1, []placement.Instance{i5, i6}, nowNanos))
 
 	p2, err := a.AddInstances(p1, []placement.Instance{i5, i6})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(3), p2.MaxShardSetID())
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, placement.Validate(p2))
 	i5, ok := p2.Instance("i5")
 	assert.True(t, ok)
 	assert.Equal(t, i5.Shards().NumShards(), i5.Shards().NumShardsForState(shard.Available))
@@ -568,7 +564,7 @@ func TestMirrorRemoveAndRevertBeforeCutover(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, i6.Shards().NumShards(), i6.Shards().NumShardsForState(shard.Available))
 
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, p, p2)
 }
 
@@ -626,19 +622,19 @@ func TestMirrorRemoveAndRevertAfterCutover(t *testing.T) {
 		SetShardCutoverNanosFn(func() int64 { return shardCutoverTime }).
 		SetShardCutoffNanosFn(func() int64 { return shardCutoverTime }))
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, uint32(3), p.MaxShardSetID())
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, placement.Validate(p))
 
 	p1, err := a.RemoveInstances(p, []string{"i5", "i6"})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p1))
 	assert.Equal(t, uint32(3), p1.MaxShardSetID())
 	assert.False(t, allLeaving(p1, []placement.Instance{i5, i6}, nowNanos))
 
 	p2, err := a.AddInstances(p1, []placement.Instance{i5.SetShards(shard.NewShards(nil)), i6.SetShards(shard.NewShards(nil))})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p2))
 	assert.Equal(t, uint32(3), p2.MaxShardSetID())
 
 	i5, ok := p2.Instance("i5")
@@ -697,58 +693,26 @@ func TestMirrorReplaceAndRevertBeforeCutover(t *testing.T) {
 		SetShardCutoverNanosFn(func() int64 { return shardCutoverTime }).
 		SetShardCutoffNanosFn(func() int64 { return shardCutoverTime }))
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
 
-	fmt.Println("initial placement")
-	printPlacement(p)
 	p1, err := a.ReplaceInstances(p, []string{"i4"}, []placement.Instance{i5})
-	require.NoError(t, err)
-
-	fmt.Println("after first replace")
-	printPlacement(p1)
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p1))
 	assert.Equal(t, uint32(2), p1.MaxShardSetID())
 	assert.True(t, allLeaving(p1, []placement.Instance{i4}, nowNanos))
-
-	assertAllInitializing(t, p1, []string{"i5"}, nowNanos)
-	// assert.True(t, allInitializing(p1, []string{"i5"}, nowNanos))
+	assert.True(t, allInitializing(p1, []string{"i5"}, nowNanos))
 
 	p2, err := a.ReplaceInstances(p1, []string{"i5"}, []placement.Instance{i4})
-	require.NoError(t, err)
-
-	fmt.Println("after second replace")
-	printPlacement(p2)
-
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p2))
 	assert.Equal(t, uint32(2), p2.MaxShardSetID())
 	i4, ok := p2.Instance("i4")
 	assert.True(t, ok)
 	assert.Equal(t, i4.Shards().NumShards(), i4.Shards().NumShardsForState(shard.Available))
 	_, ok = p2.Instance("i5")
 	assert.False(t, ok)
-}
-
-func assertAllInitializing(t *testing.T, p placement.Placement, instances []string, nowNanos int64) {
-	// assert.True(t, allInitializing(p, instances, nowNanos))
-
-	for _, instID := range instances {
-		inst, ok := p.Instance(instID)
-		require.True(t, ok)
-		assert.Equal(t, len(inst.Shards().ShardsForState(shard.Initializing)), inst.Shards().NumShards(), "instance %s", instID)
-		for _, s := range inst.Shards().All() {
-			require.True(
-				t,
-				s.CutoverNanos() > nowNanos,
-				"shard %d instance %s cutover %d now %d",
-				s.ID(),
-				instID,
-				s.CutoverNanos(),
-				nowNanos,
-			)
-		}
-	}
 }
 
 func TestMirrorReplaceAndRevertAfterCutover(t *testing.T) {
@@ -799,13 +763,13 @@ func TestMirrorReplaceAndRevertAfterCutover(t *testing.T) {
 		SetShardCutoverNanosFn(func() int64 { return shardCutoverTime }).
 		SetShardCutoffNanosFn(func() int64 { return shardCutoverTime }))
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
 
 	p1, err := a.ReplaceInstances(p, []string{"i4"}, []placement.Instance{i5})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p1))
 	assert.Equal(t, uint32(2), p1.MaxShardSetID())
 	assert.False(t, allLeaving(p1, []placement.Instance{i4}, nowNanos))
 	assert.False(t, allInitializing(p1, []string{"i5"}, nowNanos))
@@ -820,10 +784,9 @@ func TestMirrorReplaceAndRevertAfterCutover(t *testing.T) {
 	ssI5 := i5.Shards()
 
 	p2, err := a.ReplaceInstances(p1, []string{"i5"}, []placement.Instance{i4})
-	require.NoError(t, err)
 	assert.Equal(t, uint32(2), p2.MaxShardSetID())
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p2))
 
 	i4, ok = p2.Instance("i4")
 	assert.True(t, ok)
@@ -919,8 +882,8 @@ func TestMirrorAddInstancesError(t *testing.T) {
 
 	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true))
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
 
 	_, err = a.AddInstances(p.Clone().SetIsMirrored(false), []placement.Instance{i5, i6})
@@ -933,8 +896,8 @@ func TestMirrorAddInstancesError(t *testing.T) {
 
 	// Allow adding back leaving instances.
 	p, err = a.RemoveInstances(p, []string{i3.ID(), i4.ID()})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
 
 	p, err = a.AddInstances(p, []placement.Instance{
@@ -951,8 +914,8 @@ func TestMirrorAddInstancesError(t *testing.T) {
 			SetShardSetID(2).
 			SetWeight(2),
 	})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
 
 	// Duplicated shardset id.
@@ -1010,8 +973,8 @@ func TestMirrorRemoveInstancesError(t *testing.T) {
 
 	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true))
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
 
 	_, err = a.RemoveInstances(p.SetIsMirrored(false), []string{"i1", "i2"})
@@ -1067,8 +1030,8 @@ func TestMirrorReplaceInstancesError(t *testing.T) {
 
 	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true))
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.Equal(t, uint32(2), p.MaxShardSetID())
 
 	_, err = a.ReplaceInstances(p.SetIsMirrored(false), []string{"i1"}, []placement.Instance{
@@ -1177,13 +1140,9 @@ func TestMirrorReplaceWithLeavingShards(t *testing.T) {
 		SetShardSetID(2).
 		SetWeight(2)
 
-	fmt.Println("initial")
-	printPlacement(p)
 	p2, err := a.ReplaceInstances(p, []string{"i1", "i4"}, []placement.Instance{replaceI1, replaceI4})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
-	fmt.Println("after replace")
-	printPlacement(p2)
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	assert.Equal(t, uint32(2), p2.MaxShardSetID())
 
 	_, ok := p2.Instance("i1")
@@ -1205,12 +1164,8 @@ func TestMirrorReplaceWithLeavingShards(t *testing.T) {
 			shard.NewShard(2).SetState(shard.Initializing).SetSourceID("i4"),
 		}),
 	), newI4)
-
-	fmt.Println("after tweaks")
-	printPlacement(p2)
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, placement.Validate(p2))
 }
-
 
 func TestIncompatibleWithMirroredAlgo(t *testing.T) {
 	a := newMirroredAlgorithm(placement.NewOptions())
@@ -1249,7 +1204,7 @@ func TestGroupInstanceByShardSetID(t *testing.T) {
 		}))
 
 	res, err := groupInstancesByShardSetID([]placement.Instance{i1, i2}, 2)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(res))
 	assert.Equal(t, placement.NewInstance().
 		SetID("1").
@@ -1311,14 +1266,14 @@ func TestReturnInitializingShards(t *testing.T) {
 
 	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true)).(mirroredAlgorithm)
 	p1, err := a.returnInitializingShards(p.Clone(), []string{i3.ID(), i4.ID()})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, p1.NumInstances())
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, placement.Validate(p1))
 	assert.Equal(t, uint32(1), p1.MaxShardSetID())
 	p2, err := a.returnInitializingShards(p.Clone(), []string{i4.ID(), i3.ID()})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, p2.NumInstances())
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, placement.Validate(p2))
 	assert.Equal(t, uint32(1), p2.MaxShardSetID())
 }
 
@@ -1364,14 +1319,14 @@ func TestReclaimLeavingShards(t *testing.T) {
 
 	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true)).(mirroredAlgorithm)
 	p1, err := a.reclaimLeavingShards(p.Clone(), []placement.Instance{i2, i1})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, p1.NumInstances())
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, placement.Validate(p1))
 	assert.Equal(t, uint32(1), p1.MaxShardSetID())
 	p2, err := a.reclaimLeavingShards(p.Clone(), []placement.Instance{i1, i2})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, p2.NumInstances())
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, placement.Validate(p2))
 	assert.Equal(t, uint32(1), p2.MaxShardSetID())
 }
 
@@ -1419,14 +1374,14 @@ func TestReclaimLeavingShardsWithAvailable(t *testing.T) {
 
 	a := NewAlgorithm(placement.NewOptions().SetIsMirrored(true)).(mirroredAlgorithm)
 	p1, err := a.reclaimLeavingShards(p.Clone(), []placement.Instance{i2, i1})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 4, p1.NumInstances())
-	require.NoError(t, placement.Validate(p1))
+	assert.NoError(t, placement.Validate(p1))
 	assert.Equal(t, uint32(2), p1.MaxShardSetID())
 	p2, err := a.reclaimLeavingShards(p.Clone(), []placement.Instance{i1, i2})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 4, p2.NumInstances())
-	require.NoError(t, placement.Validate(p2))
+	assert.NoError(t, placement.Validate(p2))
 	assert.Equal(t, uint32(2), p2.MaxShardSetID())
 }
 
@@ -1468,8 +1423,8 @@ func TestMarkShardAsAvailableWithMirroredAlgo(t *testing.T) {
 		SetIsShardCutoverFn(genShardCutoverFn(oneHourInTheFuture)).
 		SetIsShardCutoffFn(genShardCutoffFn(oneHourInTheFuture, time.Hour)))
 	p, err = a.MarkShardsAvailable(p, "i2", 0)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 }
 
 func TestMarkShardAsAvailableBulkWithMirroredAlgo(t *testing.T) {
@@ -1498,8 +1453,8 @@ func TestMarkShardAsAvailableBulkWithMirroredAlgo(t *testing.T) {
 		SetIsShardCutoverFn(genShardCutoverFn(oneHourInTheFuture)).
 		SetIsShardCutoffFn(genShardCutoffFn(oneHourInTheFuture, time.Hour)))
 	p, err := a.MarkShardsAvailable(p, "i2", 0, 1)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 
 	mi2, ok := p.Instance("i2")
 	assert.True(t, ok)
@@ -1560,8 +1515,8 @@ func TestMirrorAlgoWithSimpleShardStateType(t *testing.T) {
 		SetPlacementCutoverNanosFn(timeNanosGen(1)).
 		SetShardStateMode(placement.StableShardStateOnly))
 	p, err := a.InitialPlacement(instances, ids, 2)
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	verifyAllShardsInAvailableState(t, p)
 
 	i7 := placement.NewInstance().
@@ -1577,13 +1532,13 @@ func TestMirrorAlgoWithSimpleShardStateType(t *testing.T) {
 		SetShardSetID(4).
 		SetWeight(4)
 	p, err = a.AddInstances(p, []placement.Instance{i7, i8})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	verifyAllShardsInAvailableState(t, p)
 
 	p, err = a.RemoveInstances(p, []string{i7.ID(), i8.ID()})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	verifyAllShardsInAvailableState(t, p)
 
 	p, err = a.ReplaceInstances(p, []string{"i6"}, []placement.Instance{
@@ -1594,8 +1549,8 @@ func TestMirrorAlgoWithSimpleShardStateType(t *testing.T) {
 			SetShardSetID(3).
 			SetWeight(3),
 	})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	verifyAllShardsInAvailableState(t, p)
 
 	i9 := placement.NewInstance().
@@ -1611,8 +1566,8 @@ func TestMirrorAlgoWithSimpleShardStateType(t *testing.T) {
 		SetShardSetID(5).
 		SetWeight(1)
 	p, err = a.AddInstances(p, []placement.Instance{i9, i10})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	verifyAllShardsInAvailableState(t, p)
 
 	p, err = a.ReplaceInstances(p, []string{"i9"}, []placement.Instance{
@@ -1623,12 +1578,12 @@ func TestMirrorAlgoWithSimpleShardStateType(t *testing.T) {
 			SetShardSetID(5).
 			SetWeight(1),
 	})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	verifyAllShardsInAvailableState(t, p)
 
 	p, err = a.RemoveInstances(p, []string{"i19", "i10"})
-	require.NoError(t, err)
-	require.NoError(t, placement.Validate(p))
+	assert.NoError(t, err)
+	assert.NoError(t, placement.Validate(p))
 	verifyAllShardsInAvailableState(t, p)
 }


### PR DESCRIPTION
This is very WIP; I'm putting it up for @abliqo and potentially @prateek to look at it, but it's otherwise too messy to really consider (and importantly, mostly untested ;)).

This implements a fix for https://github.com/m3db/m3/issues/2850. 

The high level approach:
> [Limit] the instances we mark available to those affected by the replace, i.e. the leaving (replaced) instances. This will allow replaces that operate on independent shardsets to proceed concurrently.

What this means in practice is that we:

- Lookup the shard set pair for the node being replaced
- for each node in that shard set, try to mark shards available on it

Marking shards available on a node means:

- for each initializing shard, find the corresponding leaving shard. If past cutoff, remove the leaving shard and mark the initializing shard available
- for each leaving shard, find the corresponding initializing shard. Proceed as above.

One other bit of nuance here:

The mirrored algorithm has special casing around reclaiming shards--any case where a node left the cluster, and then was added back before cutovers/cutoffs have passed. This case also ended up needing a bit of changing here. 

The reclaim code goes through the entire placement, and pulls back shards whenever they have sourceID == the readding node. For instance:

```
nodeA: {id = 1, state = INIT, source = nodeB}
nodeB: {1 LEAVING}
```

If nodeB is readded to the placement, it will reclaim shard 1. 

Previous code for replace relies on the nodes being operated on being the only ones in flux. That is, if you have:

```
nodeA: {id = 1, state= INIT, source = nodeB}
nodeB: {1 LEAVING}
nodeC: {2 INIT source = nodeD}
nodeD: {2 LEAVING }
```
it will refuse to reclaim nodeB's shards, even though it theoretically could. I think the current check is overly conservative; a node A should be able to reclaim shards from a node B if:

```
// The leaving instances were a replacement for the adding instances iff:
//  - all shards on the leaving node are initializing and came from the adding node
//  - all shards on the adding node are leaving (and implicitly, they should be going to the adding node--I could add a defensive check there too, come to think of it)
//  - every leaving node has a unique adding node and every adding node has a unique leaving node (i.e. there is a bijection between them).
```