### PR TITLE
[aggregator] Process campaign state without waiting for first campaign check interval

### DIFF
--- a/src/aggregator/aggregator/election_mgr.go
+++ b/src/aggregator/aggregator/election_mgr.go
@@ -588,6 +588,7 @@ func (mgr *electionManager) checkCampaignStateLoop() {
 		enabled, err := mgr.campaignIsEnabledFn()
 		if err != nil {
 			mgr.metrics.campaignCheckErrors.Inc(1)
+
 			continue
 		}
 		newState := newCampaignState(enabled)

--- a/src/aggregator/aggregator/election_mgr.go
+++ b/src/aggregator/aggregator/election_mgr.go
@@ -580,18 +580,26 @@ func (mgr *electionManager) checkCampaignStateLoop() {
 
 	for {
 		select {
+		case <-mgr.doneCh:
+			return
+		default:
+		}
+
+		enabled, err := mgr.campaignIsEnabledFn()
+		if err != nil {
+			mgr.metrics.campaignCheckErrors.Inc(1)
+			continue
+		}
+		newState := newCampaignState(enabled)
+		currState := mgr.campaignState()
+		if currState == newState {
+			continue
+		}
+		mgr.processCampaignStateChange(newState)
+
+		// block on ticker or exit signal
+		select {
 		case <-ticker.C:
-			enabled, err := mgr.campaignIsEnabledFn()
-			if err != nil {
-				mgr.metrics.campaignCheckErrors.Inc(1)
-				continue
-			}
-			newState := newCampaignState(enabled)
-			currState := mgr.campaignState()
-			if currState == newState {
-				continue
-			}
-			mgr.processCampaignStateChange(newState)
 		case <-mgr.doneCh:
 			return
 		}

--- a/src/aggregator/aggregator/election_mgr_test.go
+++ b/src/aggregator/aggregator/election_mgr_test.go
@@ -134,6 +134,9 @@ func TestElectionManagerOpenSuccess(t *testing.T) {
 			return make(chan campaign.Status), nil
 		}).
 		AnyTimes()
+	leaderService.EXPECT().
+		Resign(gomock.Any()).
+		AnyTimes()
 
 	opts := testElectionManagerOptions(t, ctrl).SetLeaderService(leaderService)
 	mgr := NewElectionManager(opts).(*electionManager)
@@ -245,6 +248,7 @@ func TestElectionManagerResignLeaderServiceResignError(t *testing.T) {
 }
 
 func TestElectionManagerResignTimeout(t *testing.T) {
+	t.Parallel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -272,14 +276,16 @@ func TestElectionManagerResignTimeout(t *testing.T) {
 }
 
 func TestElectionManagerResignSuccess(t *testing.T) {
+	t.Parallel()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	var (
-		statusCh = make(chan campaign.Status, 2)
+		statusCh = make(chan campaign.Status, 1)
 		mgr      *electionManager
 	)
 
@@ -290,7 +296,10 @@ func TestElectionManagerResignSuccess(t *testing.T) {
 	leaderService.EXPECT().
 		Resign(gomock.Any()).
 		DoAndReturn(func(string) error {
-			statusCh <- campaign.Status{State: campaign.Follower}
+			select {
+			case statusCh <- campaign.Status{State: campaign.Follower}:
+			default:
+			}
 			return nil
 		}).
 		AnyTimes()
@@ -300,6 +309,7 @@ func TestElectionManagerResignSuccess(t *testing.T) {
 	campaignOpts = campaignOpts.SetLeaderValue(leaderValue)
 	opts := testElectionManagerOptions(t, ctrl).
 		SetCampaignOptions(campaignOpts).
+		// SetCampaignStateCheckInterval(1 * time.Second).
 		SetLeaderService(leaderService)
 	i := placement.NewInstance().SetID("myself")
 	opts.PlacementManager().(*MockPlacementManager).
@@ -319,9 +329,20 @@ func TestElectionManagerResignSuccess(t *testing.T) {
 	require.NoError(t, mgr.Open(testShardSetID))
 
 	require.NoError(t, mgr.Resign(ctx))
-	time.Sleep(time.Second)
+
+	var mgrState electionManagerState
+	for i := 0; i < 10; i++ {
+		mgr.RLock()
+		mgrState = mgr.state
+		mgr.RUnlock()
+		if mgr.ElectionState() == FollowerState && mgrState == electionManagerOpen {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
 	require.Equal(t, FollowerState, mgr.ElectionState())
-	require.Equal(t, electionManagerOpen, mgr.state)
+	require.Equal(t, electionManagerOpen, mgrState)
 	require.NoError(t, mgr.Close())
 }
 
@@ -346,6 +367,8 @@ func TestElectionManagerCloseSuccess(t *testing.T) {
 }
 
 func TestElectionManagerCampaignLoop(t *testing.T) {
+	t.Parallel()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -380,6 +403,7 @@ func TestElectionManagerCampaignLoop(t *testing.T) {
 	campaignOpts = campaignOpts.SetLeaderValue(leaderValue)
 	opts := testElectionManagerOptions(t, ctrl).
 		SetCampaignOptions(campaignOpts).
+		SetCampaignStateCheckInterval(100 * time.Millisecond).
 		SetLeaderService(leaderService)
 	i := placement.NewInstance().SetID("myself")
 	opts.PlacementManager().(*MockPlacementManager).
@@ -479,6 +503,8 @@ func TestElectionManagerCampaignLoop(t *testing.T) {
 }
 
 func TestElectionManagerVerifyLeaderDelayWithValidLeader(t *testing.T) {
+	t.Parallel()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -544,6 +570,8 @@ func TestElectionManagerVerifyLeaderDelayWithValidLeader(t *testing.T) {
 }
 
 func TestElectionManagerVerifyLeaderDelayWithLeaderNotInPlacement(t *testing.T) {
+	t.Parallel()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -603,6 +631,8 @@ func TestElectionManagerVerifyLeaderDelayWithLeaderNotInPlacement(t *testing.T) 
 }
 
 func TestElectionManagerVerifyLeaderDelayWithLeaderOwningDifferentShardSet(t *testing.T) {
+	t.Parallel()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -667,6 +697,8 @@ func TestElectionManagerVerifyLeaderDelayWithLeaderOwningDifferentShardSet(t *te
 }
 
 func TestElectionManagerVerifyWithLeaderErrors(t *testing.T) {
+	t.Parallel()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -815,6 +847,8 @@ func TestElectionManagerVerifyCampaignDisabled(t *testing.T) {
 }
 
 func TestElectionManagerCheckCampaignStateLoop(t *testing.T) {
+	t.Parallel()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -834,6 +868,7 @@ func TestElectionManagerCheckCampaignStateLoop(t *testing.T) {
 	campaignOpts = campaignOpts.SetLeaderValue(leaderValue)
 	opts := testElectionManagerOptions(t, ctrl).
 		SetCampaignOptions(campaignOpts).
+		SetCampaignStateCheckInterval(100 * time.Millisecond).
 		SetLeaderService(leaderService)
 	mgr := NewElectionManager(opts).(*electionManager)
 	iterCh := make(chan enabledRes)


### PR DESCRIPTION
This fixes an annoying behavior, where campaign manager will always have a delay of $campaignCheckInterval, even if the process has crashed/restarted and lease hasn't expired yet. It also makes other tests that rely on non-mocked-out campaign manager much slower than they need to be.

The initialization delay also exposed some racy behavior in campaign manager tests. Fixing everything and reducing sleeps sped them up by quite a bit:
```
~# go test  github.com/m3db/m3/src/aggregator/aggregator  -tags integration  -count 1
ok  	github.com/m3db/m3/src/aggregator/aggregator	12.460s
```
vs
```
ok  	github.com/m3db/m3/src/aggregator/aggregator	34.935s
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
