### PR TITLE
Fix typo

### DIFF
--- a/kube/bundle.yaml
+++ b/kube/bundle.yaml
@@ -172,7 +172,7 @@ data:
           calculationType: fixed
           size: 2097152
 
-      filesystem:
+      fs:
         filePathPrefix: /var/lib/m3db
 
       config:


### PR DESCRIPTION
https://www.m3db.io/docs/how_to/kubernetes/ does not work, should be `fs` instead of `filesystem`.