### PR TITLE
[lint] Disable nlreturn linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -212,6 +212,9 @@ linters:
     # We allow cuddling assignment following conditions because there are valid 
     # logical groupings for this use-case (e.g. when evaluating config values).
     - wsl
+    # New line required before return would require a large fraction of the
+    # code base to need updating, it's not worth the perceived benefit.
+    - nlreturn
   disable-all: false
   presets:
     # bodyclose, errcheck, gosec, govet, scopelint, staticcheck, typecheck


### PR DESCRIPTION
Keeping the new line required before a return linter would require a large fraction of the code base to need updating. 

The perceived benefit of always an empty line does not seem worth the changes required to each file. Also it is purely stylistic and doesn't seem to avoid types of errors.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
