### PR TITLE
[dbnode] Resurrect flaky test skip

### DIFF
--- a/src/dbnode/integration/large_tiles_test.go
+++ b/src/dbnode/integration/large_tiles_test.go
@@ -54,7 +54,7 @@ var (
 )
 
 func TestReadAggregateWrite(t *testing.T) {
-//	t.Skip("flaky")
+	t.Skip("flaky")
 	var (
 		start                   = time.Now()
 		testSetup, srcNs, trgNs = setupServer(t)


### PR DESCRIPTION
**What this PR does / why we need it**:
Had accidentally uncommented a `Skip` on a flaky test while checking it locally. Reverting.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
