### PR TITLE
[dbnode] Default HostID and Discovery config for minimal config

### DIFF
--- a/src/cmd/services/m3dbnode/main/main_index_test.go
+++ b/src/cmd/services/m3dbnode/main/main_index_test.go
@@ -111,7 +111,8 @@ func TestIndexEnabledServer(t *testing.T) {
 	err = xconfig.LoadFile(&cfg, configFd.Name(), xconfig.Options{})
 	require.NoError(t, err)
 
-	envCfg, err := cfg.DB.DiscoveryConfig.EnvironmentConfig(hostID)
+	discoveryCfg := cfg.DB.DiscoveryOrDefault()
+	envCfg, err := discoveryCfg.EnvironmentConfig(hostID)
 	require.NoError(t, err)
 
 	syncCluster, err := envCfg.Services.SyncCluster()

--- a/src/cmd/services/m3dbnode/main/main_test.go
+++ b/src/cmd/services/m3dbnode/main/main_test.go
@@ -103,7 +103,8 @@ func TestConfig(t *testing.T) {
 	err = xconfig.LoadFile(&cfg, configFd.Name(), xconfig.Options{})
 	require.NoError(t, err)
 
-	envCfg, err := cfg.DB.DiscoveryConfig.EnvironmentConfig(hostID)
+	discoveryCfg := cfg.DB.DiscoveryOrDefault()
+	envCfg, err := discoveryCfg.EnvironmentConfig(hostID)
 	require.NoError(t, err)
 
 	syncCluster, err := envCfg.Services.SyncCluster()
@@ -337,7 +338,8 @@ func TestEmbeddedConfig(t *testing.T) {
 	err = xconfig.LoadFile(&cfg, configFd.Name(), xconfig.Options{})
 	require.NoError(t, err)
 
-	envCfg, err := cfg.DB.DiscoveryConfig.EnvironmentConfig(hostID)
+	discoveryCfg := cfg.DB.DiscoveryOrDefault()
+	envCfg, err := discoveryCfg.EnvironmentConfig(hostID)
 	require.NoError(t, err)
 
 	syncCluster, err := envCfg.Services.SyncCluster()

--- a/src/dbnode/config/m3dbnode-local-etcd-proto.yml
+++ b/src/dbnode/config/m3dbnode-local-etcd-proto.yml
@@ -1,13 +1,6 @@
 coordinator: {}
 
 db:
-  hostID:
-    resolver: config
-    value: m3db_local
-
-  discovery:
-    type: m3db_single_node
-
   proto:
     enabled: true
     schema_registry:

--- a/src/dbnode/config/m3dbnode-local-etcd.yml
+++ b/src/dbnode/config/m3dbnode-local-etcd.yml
@@ -1,15 +1,2 @@
 coordinator: {}
-
-db:
-  hostID:
-    resolver: config
-    value: m3db_local
-
-  discovery:
-    type: m3db_single_node
-
-  # un-comment the lines below to enable Jaeger tracing. See https://www.jaegertracing.io/docs/1.9/getting-started/
-  # for quick local setup (which this config will send data to).
-
-  # tracing:
-  #  backend: jaeger
+db: {}

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -237,7 +237,7 @@ func Run(runOpts RunOptions) {
 		logger.Fatal("could not connect to metrics", zap.Error(err))
 	}
 
-	hostID, err := cfg.HostID.Resolve()
+	hostID, err := cfg.HostIDOrDefault().Resolve()
 	if err != nil {
 		logger.Fatal("could not resolve local host ID", zap.Error(err))
 	}
@@ -268,7 +268,8 @@ func Run(runOpts RunOptions) {
 	}
 
 	// Presence of KV server config indicates embedded etcd cluster
-	envConfig, err := cfg.DiscoveryConfig.EnvironmentConfig(hostID)
+	discoveryConfig := cfg.DiscoveryOrDefault()
+	envConfig, err := discoveryConfig.EnvironmentConfig(hostID)
 	if err != nil {
 		logger.Fatal("could not get env config from discovery config", zap.Error(err))
 	}

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -436,13 +436,14 @@ func Run(runOpts RunOptions) {
 
 	var serviceOptionDefaults []handleroptions.ServiceOptionsDefault
 	if dbCfg := runOpts.DBConfig; dbCfg != nil {
-		hostID, err := dbCfg.HostID.Resolve()
+		hostID, err := dbCfg.HostIDOrDefault().Resolve()
 		if err != nil {
 			logger.Fatal("could not resolve hostID",
 				zap.Error(err))
 		}
 
-		envCfg, err := dbCfg.DiscoveryConfig.EnvironmentConfig(hostID)
+		discoveryCfg := dbCfg.DiscoveryOrDefault()
+		envCfg, err := discoveryCfg.EnvironmentConfig(hostID)
 		if err != nil {
 			logger.Fatal("could not get env config from discovery config",
 				zap.Error(err))
@@ -826,13 +827,14 @@ func initClusters(
 				return nil, nil, nil, errors.New("environment config required when dynamically fetching namespaces")
 			}
 
-			hostID, err := dbCfg.HostID.Resolve()
+			hostID, err := dbCfg.HostIDOrDefault().Resolve()
 			if err != nil {
 				logger.Fatal("could not resolve hostID",
 					zap.Error(err))
 			}
 
-			envCfg, err := dbCfg.DiscoveryConfig.EnvironmentConfig(hostID)
+			discoveryCfg := dbCfg.DiscoveryOrDefault()
+			envCfg, err := discoveryCfg.EnvironmentConfig(hostID)
 			if err != nil {
 				logger.Fatal("could not get env config from discovery config",
 					zap.Error(err))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Default HostID and Discovery config for a minimal configuration file for default DB node which ends up being:
```
coordinator: {}
db: {}
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
