### PR TITLE
Improve some slow tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200824191128-ae9734ed278b
 	go.uber.org/atomic v1.6.0
 	go.uber.org/config v1.4.0
+	go.uber.org/goleak v1.1.10
 	go.uber.org/zap v1.13.0
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208

--- a/go.sum
+++ b/go.sum
@@ -922,6 +922,8 @@ go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/config v1.4.0 h1:upnMPpMm6WlbZtXoasNkK4f0FhxwS+W4Iqz5oNznehQ=
 go.uber.org/config v1.4.0/go.mod h1:aCyrMHmUAc/s2h9sv1koP84M9ZF/4K+g2oleyESO/Ig=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0 h1:f3WCSC2KzAcBXGATIxAB1E2XuCpNU255wNKZ505qi3E=
@@ -1069,6 +1071,7 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191104232314-dc038396d1f0/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191203134012-c197fd4bf371/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/src/cluster/kv/etcd/store_test.go
+++ b/src/cluster/kv/etcd/store_test.go
@@ -31,13 +31,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/pkg/capnslog"
-	"github.com/golang/protobuf/proto"
 	"github.com/m3db/m3/src/cluster/generated/proto/kvtest"
 	"github.com/m3db/m3/src/cluster/kv"
 	"github.com/m3db/m3/src/cluster/mocks"
 	xclock "github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/retry"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/integration"

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -76,6 +76,8 @@ const (
 )
 
 func TestDownsamplerAggregationWithAutoMappingRulesFromNamespacesWatcher(t *testing.T) {
+	t.Parallel()
+
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
@@ -123,6 +125,8 @@ func TestDownsamplerAggregationWithAutoMappingRulesFromNamespacesWatcher(t *test
 }
 
 func TestDownsamplerAggregationToggleEnabled(t *testing.T) {
+	t.Parallel()
+
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
@@ -158,6 +162,8 @@ func TestDownsamplerAggregationToggleEnabled(t *testing.T) {
 }
 
 func TestDownsamplerAggregationWithRulesStore(t *testing.T) {
+	t.Parallel()
+
 	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{})
 	rulesStore := testDownsampler.rulesStore
 
@@ -207,6 +213,8 @@ func TestDownsamplerAggregationWithRulesStore(t *testing.T) {
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRules(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			nameTag: "foo_metric",
@@ -224,7 +232,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRules(t *testing.T) {
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -241,7 +249,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRules(t *testing.T) {
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -254,6 +262,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRules(t *testing.T) {
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesPartialReplaceAutoMappingRuleFromNamespacesWatcher(t *testing.T) {
+	t.Parallel()
+
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
@@ -263,7 +273,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesPartialReplaceAutoMapp
 			"app":   "nginx_edge",
 		},
 		timedSamples: []testGaugeMetricTimedSample{
-			{value: 15}, {value: 10}, {value: 30}, {value: 5}, {value: 0},
+			{value: 15}, {value: 10}, {value: 30}, {value: 5}, {value: 0, offset: 1 * time.Millisecond},
 		},
 	}
 	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
@@ -337,6 +347,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesPartialReplaceAutoMapp
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesReplaceAutoMappingRuleFromNamespacesWatcher(t *testing.T) {
+	t.Parallel()
+
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
@@ -401,6 +413,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesReplaceAutoMappingRule
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesNoNameTag(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"app":      "nginx_edge",
@@ -419,7 +433,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesNoNameTag(t *testing.T
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -436,7 +450,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesNoNameTag(t *testing.T
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -449,6 +463,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesNoNameTag(t *testing.T
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesTypeFilter(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"app":      "nginx_edge",
@@ -467,7 +483,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesTypeFilter(t *testing.
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -490,7 +506,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesTypeFilter(t *testing.
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -503,6 +519,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesTypeFilter(t *testing.
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesTypeFilterNoMatch(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"app":      "nginx_edge",
@@ -521,7 +539,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesTypeFilterNoMatch(t *t
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -544,6 +562,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesTypeFilterNoMatch(t *t
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesAggregationType(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"__g0__":               "nginx_edge",
@@ -564,7 +584,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesAggregationType(t *tes
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -586,7 +606,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesAggregationType(t *tes
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -599,6 +619,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesAggregationType(t *tes
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesMultipleAggregationType(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"__g0__": "nginx_edge",
@@ -618,7 +640,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesMultipleAggregationTyp
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -629,7 +651,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesMultipleAggregationTyp
 					Aggregations: []aggregation.Type{aggregation.Sum},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -651,7 +673,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesMultipleAggregationTyp
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -664,7 +686,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesMultipleAggregationTyp
 					values: []expectedValue{{value: 60}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -677,6 +699,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesMultipleAggregationTyp
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixAndAggregationTags(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"__g0__": "nginx_edge",
@@ -699,7 +723,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixAndAggre
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -723,7 +747,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixAndAggre
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -736,6 +760,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixAndAggre
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixTag(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"__g0__": "nginx_edge",
@@ -757,7 +783,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixTag(t *t
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -780,7 +806,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixTag(t *t
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -793,6 +819,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixTag(t *t
 }
 
 func TestDownsamplerAggregationWithRulesConfigMappingRulesAugmentTag(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"app":      "nginx_edge",
@@ -814,7 +842,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesAugmentTag(t *testing.
 					Aggregations: []aggregation.Type{aggregation.Max},
 					StoragePolicies: []StoragePolicyConfiguration{
 						{
-							Resolution: 5 * time.Second,
+							Resolution: 1 * time.Second,
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
@@ -836,7 +864,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesAugmentTag(t *testing.
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
-						Resolution:  5 * time.Second,
+						Resolution:  1 * time.Second,
 						Retention:   30 * 24 * time.Hour,
 					},
 				},
@@ -849,6 +877,8 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesAugmentTag(t *testing.
 }
 
 func TestDownsamplerAggregationWithRulesConfigRollupRulesNoNameTag(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			"app":           "nginx_edge",
@@ -858,10 +888,10 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesNoNameTag(t *testing.T)
 		},
 		timedSamples: []testGaugeMetricTimedSample{
 			{value: 42},
-			{value: 64, offset: 5 * time.Second},
+			{value: 64, offset: 1 * time.Second},
 		},
 	}
-	res := 5 * time.Second
+	res := 1 * time.Second
 	ret := 30 * 24 * time.Hour
 	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
 		identTag: "endpoint",
@@ -907,6 +937,8 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesNoNameTag(t *testing.T)
 }
 
 func TestDownsamplerAggregationWithRulesConfigRollupRulesPerSecondSum(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			nameTag:         "http_requests",
@@ -917,10 +949,10 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesPerSecondSum(t *testing
 		},
 		timedSamples: []testGaugeMetricTimedSample{
 			{value: 42},
-			{value: 64, offset: 5 * time.Second},
+			{value: 64, offset: 1 * time.Second},
 		},
 	}
-	res := 5 * time.Second
+	res := 1 * time.Second
 	ret := 30 * 24 * time.Hour
 	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
 		rulesConfig: &RulesConfiguration{
@@ -965,7 +997,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesPerSecondSum(t *testing
 						"status_code":         "500",
 						"endpoint":            "/foo/bar",
 					},
-					values: []expectedValue{{value: 4.4}},
+					values: []expectedValue{{value: 22}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
 						Resolution:  res,
@@ -981,6 +1013,8 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesPerSecondSum(t *testing
 }
 
 func TestDownsamplerAggregationWithRulesConfigRollupRulesIncreaseAdd(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetrics := []testGaugeMetric{
 		testGaugeMetric{
 			tags: map[string]string{
@@ -991,10 +1025,10 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesIncreaseAdd(t *testing.
 				"not_rolled_up": "not_rolled_up_value_1",
 			},
 			timedSamples: []testGaugeMetricTimedSample{
-				{value: 42, offset: 5 * time.Second}, // +42 (should not be accounted since is a reset)
+				{value: 42, offset: 1 * time.Second}, // +42 (should not be accounted since is a reset)
 				// Explicit no value.
-				{value: 12, offset: 15 * time.Second}, // +12 - simulate a reset (should not be accounted)
-				{value: 33, offset: 20 * time.Second}, // +21
+				{value: 12, offset: 2 * time.Second}, // +12 - simulate a reset (should not be accounted)
+				{value: 33, offset: 3 * time.Second}, // +21
 			},
 		},
 		testGaugeMetric{
@@ -1006,14 +1040,14 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesIncreaseAdd(t *testing.
 				"not_rolled_up": "not_rolled_up_value_2",
 			},
 			timedSamples: []testGaugeMetricTimedSample{
-				{value: 13, offset: 5 * time.Second},  // +13 (should not be accounted since is a reset)
-				{value: 27, offset: 10 * time.Second}, // +14
+				{value: 13, offset: 1 * time.Second}, // +13 (should not be accounted since is a reset)
+				{value: 27, offset: 2 * time.Second}, // +14
 				// Explicit no value.
-				{value: 42, offset: 20 * time.Second}, // +15
+				{value: 42, offset: 3 * time.Second}, // +15
 			},
 		},
 	}
-	res := 5 * time.Second
+	res := 1 * time.Second
 	ret := 30 * 24 * time.Hour
 	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
 		rulesConfig: &RulesConfiguration{
@@ -1065,7 +1099,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesIncreaseAdd(t *testing.
 					},
 					values: []expectedValue{
 						{value: 14},
-						{value: 50, offset: 10 * time.Second},
+						{value: 50, offset: 1 * time.Second},
 					},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
@@ -1082,6 +1116,8 @@ func TestDownsamplerAggregationWithRulesConfigRollupRulesIncreaseAdd(t *testing.
 }
 
 func TestDownsamplerAggregationWithRulesConfigRollupRuleAndDropPolicy(t *testing.T) {
+	t.Parallel()
+
 	gaugeMetric := testGaugeMetric{
 		tags: map[string]string{
 			nameTag:         "http_requests",
@@ -1092,11 +1128,11 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleAndDropPolicy(t *testing
 		},
 		timedSamples: []testGaugeMetricTimedSample{
 			{value: 42},
-			{value: 64, offset: 5 * time.Second},
+			{value: 64, offset: 1 * time.Second},
 		},
 		expectDropPolicyApplied: true,
 	}
-	res := 5 * time.Second
+	res := 1 * time.Second
 	ret := 30 * 24 * time.Hour
 	filter := fmt.Sprintf("%s:http_requests app:* status_code:* endpoint:*", nameTag)
 	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
@@ -1146,7 +1182,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleAndDropPolicy(t *testing
 						"status_code":         "500",
 						"endpoint":            "/foo/bar",
 					},
-					values: []expectedValue{{value: 4.4}},
+					values: []expectedValue{{value: 22}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
 						Resolution:  res,
@@ -1462,7 +1498,9 @@ func testGaugeMetrics(opts testGaugeMetricsOptions) ([]testGaugeMetric, []testEx
 	if opts.timedSamples {
 		metric.samples = nil
 		metric.timedSamples = []testGaugeMetricTimedSample{
-			{value: 4}, {value: 5}, {value: 6},
+			{value: 4},
+			{value: 5},
+			{value: 6, offset: 1 * time.Nanosecond},
 		}
 	}
 	write := testExpectedWrite{
@@ -1730,6 +1768,8 @@ func testDownsamplerAggregationIngest(
 	if testOpts.sampleAppenderOpts != nil {
 		opts = *testOpts.sampleAppenderOpts
 	}
+	// make the current timestamp predictable:
+	now := time.Now().Truncate(time.Microsecond)
 	for _, metric := range testCounterMetrics {
 		appender.NextMetric()
 
@@ -1749,7 +1789,7 @@ func testDownsamplerAggregationIngest(
 		}
 		for _, sample := range metric.timedSamples {
 			if sample.time.IsZero() {
-				sample.time = time.Now() // Allow empty time to mean "now"
+				sample.time = now // Allow empty time to mean "now"
 			}
 			if sample.offset > 0 {
 				sample.time = sample.time.Add(sample.offset)
@@ -1777,7 +1817,7 @@ func testDownsamplerAggregationIngest(
 		}
 		for _, sample := range metric.timedSamples {
 			if sample.time.IsZero() {
-				sample.time = time.Now() // Allow empty time to mean "now"
+				sample.time = now // Allow empty time to mean "now"
 			}
 			if sample.offset > 0 {
 				sample.time = sample.time.Add(sample.offset)
@@ -1892,7 +1932,11 @@ func newTestDownsampler(t *testing.T, opts testDownsamplerOptions) testDownsampl
 			SetMetricsScope(instrumentOpts.MetricsScope().
 				SubScope("metrics-appender-pool")))
 
-	var cfg Configuration
+	cfg := Configuration{
+		BufferPastLimits: []BufferPastLimitConfiguration{
+			{Resolution: 0, BufferPast: 500 * time.Millisecond},
+		},
+	}
 	if opts.remoteClientMock != nil {
 		// Optionally set an override to use remote aggregation
 		// with a mock client

--- a/src/msg/integration/integration_test.go
+++ b/src/msg/integration/integration_test.go
@@ -23,9 +23,10 @@ package integration
 import (
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3/src/msg/topic"
 	"github.com/m3db/m3/src/x/test"
+
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )

--- a/src/msg/integration/integration_test.go
+++ b/src/msg/integration/integration_test.go
@@ -23,12 +23,12 @@ package integration
 import (
 	"testing"
 
-	"github.com/m3db/m3/src/msg/topic"
-	"github.com/m3db/m3/src/x/test"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+
+	"github.com/m3db/m3/src/msg/topic"
+	"github.com/m3db/m3/src/x/test"
 )
 
 const (

--- a/src/msg/integration/integration_test.go
+++ b/src/msg/integration/integration_test.go
@@ -23,12 +23,11 @@ package integration
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/m3db/m3/src/msg/topic"
 	"github.com/m3db/m3/src/x/test"
-
-	"github.com/fortytw2/leaktest"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 const (
@@ -37,11 +36,11 @@ const (
 )
 
 func TestSharedConsumer(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -58,11 +57,11 @@ func TestSharedConsumer(t *testing.T) {
 }
 
 func TestReplicatedConsumer(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -78,11 +77,11 @@ func TestReplicatedConsumer(t *testing.T) {
 }
 
 func TestSharedAndReplicatedConsumers(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -102,11 +101,11 @@ func TestSharedAndReplicatedConsumers(t *testing.T) {
 }
 
 func TestSharedConsumerWithDeadInstance(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -136,11 +135,11 @@ func TestSharedConsumerWithDeadInstance(t *testing.T) {
 }
 
 func TestSharedConsumerWithDeadConnection(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -165,11 +164,11 @@ func TestSharedConsumerWithDeadConnection(t *testing.T) {
 }
 
 func TestReplicatedConsumerWithDeadConnection(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -193,11 +192,11 @@ func TestReplicatedConsumerWithDeadConnection(t *testing.T) {
 }
 
 func TestSharedAndReplicatedConsumerWithDeadConnection(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -233,11 +232,11 @@ func TestSharedAndReplicatedConsumerWithDeadConnection(t *testing.T) {
 }
 
 func TestSharedConsumerAddInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -262,11 +261,11 @@ func TestSharedConsumerAddInstances(t *testing.T) {
 }
 
 func TestReplicatedConsumerAddInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -290,11 +289,11 @@ func TestReplicatedConsumerAddInstances(t *testing.T) {
 }
 
 func TestSharedAndReplicatedConsumerAddInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -330,11 +329,11 @@ func TestSharedAndReplicatedConsumerAddInstances(t *testing.T) {
 }
 
 func TestSharedConsumerRemoveInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -359,11 +358,11 @@ func TestSharedConsumerRemoveInstances(t *testing.T) {
 }
 
 func TestReplicatedConsumerRemoveInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -387,11 +386,11 @@ func TestReplicatedConsumerRemoveInstances(t *testing.T) {
 }
 
 func TestSharedAndReplicatedConsumerRemoveInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -427,11 +426,11 @@ func TestSharedAndReplicatedConsumerRemoveInstances(t *testing.T) {
 }
 
 func TestSharedConsumerReplaceInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -456,11 +455,11 @@ func TestSharedConsumerReplaceInstances(t *testing.T) {
 }
 
 func TestReplicatedConsumerReplaceInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -484,11 +483,11 @@ func TestReplicatedConsumerReplaceInstances(t *testing.T) {
 }
 
 func TestSharedAndReplicatedConsumerReplaceInstances(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -524,11 +523,11 @@ func TestSharedAndReplicatedConsumerReplaceInstances(t *testing.T) {
 }
 
 func TestRemoveConsumerService(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -552,11 +551,11 @@ func TestRemoveConsumerService(t *testing.T) {
 }
 
 func TestAddConsumerService(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.SkipNow() // Just skip if we're doing a short run
 	}
-
-	defer leaktest.Check(t)()
 
 	ctrl := gomock.NewController(test.Reporter{t})
 	defer ctrl.Finish()
@@ -578,4 +577,8 @@ func TestAddConsumerService(t *testing.T) {
 		require.Equal(t, s.ExpectedNumMessages(), s.consumerServices[1].numConsumed())
 		require.True(t, s.consumerServices[2].numConsumed() <= s.ExpectedNumMessages()*80/100)
 	}
+}
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreCurrent())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Improves runtime of top 3 slowest tests:
```

ok  	github.com/m3db/m3/src/cmd/services/m3coordinator/downsample	167.544s
ok  	github.com/m3db/m3/src/cmd/services/m3coordinator/downsample	19.045s

ok  	github.com/m3db/m3/src/msg/integration	54.265s
ok  	github.com/m3db/m3/src/msg/integration	13.191s

ok  	github.com/m3db/m3/src/cluster/kv/etcd	36.037s
ok  	github.com/m3db/m3/src/cluster/kv/etcd	13.441s
```
Had to switch to goleak as leaktest doesn't support parallel tests - should probably switch everywhere, but out of scope.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
