### PR TITLE
[cluster] Store shards in sorted form

### DIFF
--- a/src/cluster/placement/algo/sharded_test.go
+++ b/src/cluster/placement/algo/sharded_test.go
@@ -1230,8 +1230,8 @@ func verifyAllShardsInAvailableState(t *testing.T, p placement.Placement) {
 	for _, instance := range p.Instances() {
 		s := instance.Shards()
 		require.Equal(t, len(s.All()), len(s.ShardsForState(shard.Available)))
-		require.Nil(t, s.ShardsForState(shard.Initializing))
-		require.Nil(t, s.ShardsForState(shard.Leaving))
+		require.Empty(t, s.ShardsForState(shard.Initializing))
+		require.Empty(t, s.ShardsForState(shard.Leaving))
 	}
 }
 

--- a/src/cluster/shard/shard.go
+++ b/src/cluster/shard/shard.go
@@ -68,17 +68,19 @@ func (s State) Proto() (placementpb.ShardState, error) {
 func NewShard(id uint32) Shard { return &shard{id: id, state: Unknown} }
 
 // NewShardFromProto create a new shard from proto.
-func NewShardFromProto(shard *placementpb.Shard) (Shard, error) {
-	state, err := NewShardStateFromProto(shard.State)
+func NewShardFromProto(spb *placementpb.Shard) (Shard, error) {
+	state, err := NewShardStateFromProto(spb.State)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewShard(shard.Id).
-		SetState(state).
-		SetSourceID(shard.SourceId).
-		SetCutoverNanos(shard.CutoverNanos).
-		SetCutoffNanos(shard.CutoffNanos), nil
+	return &shard{
+		id:           spb.Id,
+		state:        state,
+		sourceID:     spb.SourceId,
+		cutoverNanos: spb.CutoverNanos,
+		cutoffNanos:  spb.CutoffNanos,
+	}, nil
 }
 
 type shard struct {
@@ -146,26 +148,26 @@ func (s *shard) Equals(other Shard) bool {
 }
 
 func (s *shard) Proto() (*placementpb.Shard, error) {
-	ss, err := s.State().Proto()
+	ss, err := s.state.Proto()
 	if err != nil {
 		return nil, err
 	}
 
 	return &placementpb.Shard{
-		Id:           s.ID(),
+		Id:           s.id,
 		State:        ss,
-		SourceId:     s.SourceID(),
+		SourceId:     s.sourceID,
 		CutoverNanos: s.cutoverNanos,
 		CutoffNanos:  s.cutoffNanos,
 	}, nil
 }
 
 func (s *shard) Clone() Shard {
-	return NewShard(s.ID()).
-		SetState(s.State()).
-		SetSourceID(s.SourceID()).
-		SetCutoverNanos(s.CutoverNanos()).
-		SetCutoffNanos(s.CutoffNanos())
+	if s == nil {
+		return nil
+	}
+	clone := *s
+	return &clone
 }
 
 // SortableShardsByIDAsc are sortable shards by ID in ascending order
@@ -188,11 +190,20 @@ func (s SortableIDsAsc) Less(i, j int) bool {
 
 // NewShards creates a new instance of Shards
 func NewShards(ss []Shard) Shards {
+	shrd := make([]Shard, len(ss))
+	copy(shrd, ss)
+
+	sort.Sort(SortableShardsByIDAsc(shrd))
+
 	shardMap := make(map[uint32]Shard, len(ss))
-	for _, s := range ss {
+	for _, s := range shrd {
 		shardMap[s.ID()] = s
 	}
-	return shards{shardsMap: shardMap}
+
+	return &shards{
+		shards:   shrd,
+		shardMap: shardMap,
+	}
 }
 
 // NewShardsFromProto creates a new set of shards from proto.
@@ -209,52 +220,75 @@ func NewShardsFromProto(shards []*placementpb.Shard) (Shards, error) {
 }
 
 type shards struct {
-	shardsMap map[uint32]Shard
+	shards   []Shard
+	shardMap map[uint32]Shard
 }
 
-func (ss shards) All() []Shard {
-	shards := make([]Shard, 0, len(ss.shardsMap))
-	for _, shard := range ss.shardsMap {
-		shards = append(shards, shard)
-	}
-	sort.Sort(SortableShardsByIDAsc(shards))
+func (ss *shards) All() []Shard {
+	shards := make([]Shard, len(ss.shards))
+	copy(shards, ss.shards)
+
 	return shards
 }
 
-func (ss shards) AllIDs() []uint32 {
-	ids := make([]uint32, 0, len(ss.shardsMap))
-	for _, shard := range ss.shardsMap {
-		ids = append(ids, shard.ID())
+func (ss *shards) AllIDs() []uint32 {
+	shardIDs := make([]uint32, 0, len(ss.shards))
+	for _, shrd := range ss.shards {
+		shardIDs = append(shardIDs, shrd.ID())
 	}
-	sort.Sort(SortableIDsAsc(ids))
-	return ids
+
+	return shardIDs
 }
 
-func (ss shards) NumShards() int {
-	return len(ss.shardsMap)
+func (ss *shards) NumShards() int {
+	return len(ss.shards)
 }
 
-func (ss shards) Shard(id uint32) (Shard, bool) {
-	shard, ok := ss.shardsMap[id]
-	return shard, ok
+func (ss *shards) Shard(id uint32) (Shard, bool) {
+	shard, ok := ss.shardMap[id]
+	if !ok {
+		return nil, false
+	}
+
+	return shard, true
 }
 
-func (ss shards) Add(shard Shard) {
-	ss.shardsMap[shard.ID()] = shard
+func (ss *shards) Add(shard Shard) {
+	id := shard.ID()
+	i := sort.Search(len(ss.shards), func(i int) bool { return ss.shards[i].ID() >= id })
+	if i < len(ss.shards) && ss.shards[i].ID() == id {
+		ss.shards[i] = shard
+		ss.shardMap[id] = shard
+		return
+	}
+
+	ss.shards = append(ss.shards, shard)
+	ss.shardMap[id] = shard
+
+	if i >= len(ss.shards)-1 {
+		return
+	}
+
+	copy(ss.shards[i+1:], ss.shards[i:])
+	ss.shards[i] = shard
 }
 
-func (ss shards) Remove(shard uint32) {
-	delete(ss.shardsMap, shard)
+func (ss *shards) Remove(id uint32) {
+	i := sort.Search(len(ss.shards), func(i int) bool { return ss.shards[i].ID() >= id })
+	if i < len(ss.shards) && ss.shards[i].ID() == id {
+		delete(ss.shardMap, id)
+		ss.shards = ss.shards[:i+copy(ss.shards[i:], ss.shards[i+1:])]
+	}
 }
 
-func (ss shards) Contains(shard uint32) bool {
-	_, ok := ss.shardsMap[shard]
+func (ss *shards) Contains(shard uint32) bool {
+	_, ok := ss.shardMap[shard]
 	return ok
 }
 
-func (ss shards) NumShardsForState(state State) int {
+func (ss *shards) NumShardsForState(state State) int {
 	count := 0
-	for _, s := range ss.shardsMap {
+	for _, s := range ss.shards {
 		if s.State() == state {
 			count++
 		}
@@ -262,9 +296,9 @@ func (ss shards) NumShardsForState(state State) int {
 	return count
 }
 
-func (ss shards) ShardsForState(state State) []Shard {
-	var r []Shard
-	for _, s := range ss.shardsMap {
+func (ss *shards) ShardsForState(state State) []Shard {
+	r := make([]Shard, 0, len(ss.shards))
+	for _, s := range ss.shards {
 		if s.State() == state {
 			r = append(r, s)
 		}
@@ -272,14 +306,13 @@ func (ss shards) ShardsForState(state State) []Shard {
 	return r
 }
 
-func (ss shards) Equals(other Shards) bool {
-	shards := ss.All()
-	otherShards := other.All()
-	if len(shards) != len(otherShards) {
+func (ss *shards) Equals(other Shards) bool {
+	if len(ss.shards) != other.NumShards() {
 		return false
 	}
 
-	for i, shard := range shards {
+	otherShards := other.All()
+	for i, shard := range ss.shards {
 		otherShard := otherShards[i]
 		if !shard.Equals(otherShard) {
 			return false
@@ -288,7 +321,7 @@ func (ss shards) Equals(other Shards) bool {
 	return true
 }
 
-func (ss shards) String() string {
+func (ss *shards) String() string {
 	var strs []string
 	for _, state := range validStates() {
 		ids := NewShards(ss.ShardsForState(state)).AllIDs()
@@ -298,10 +331,9 @@ func (ss shards) String() string {
 	return fmt.Sprintf("[%s]", strings.Join(strs, ", "))
 }
 
-func (ss shards) Proto() ([]*placementpb.Shard, error) {
-	res := make([]*placementpb.Shard, 0, len(ss.shardsMap))
-	// All() returns the shards in ID ascending order.
-	for _, shard := range ss.All() {
+func (ss *shards) Proto() ([]*placementpb.Shard, error) {
+	res := make([]*placementpb.Shard, 0, len(ss.shards))
+	for _, shard := range ss.shards {
 		sp, err := shard.Proto()
 		if err != nil {
 			return nil, err
@@ -312,21 +344,20 @@ func (ss shards) Proto() ([]*placementpb.Shard, error) {
 	return res, nil
 }
 
-func (ss shards) Clone() Shards {
-	shards := make([]Shard, ss.NumShards())
-	for i, shard := range ss.All() {
-		shards[i] = shard.Clone()
+func (ss *shards) Clone() Shards {
+	shrds := make([]Shard, 0, len(ss.shards))
+	shardMap := make(map[uint32]Shard, len(ss.shards))
+
+	for _, shrd := range ss.shards {
+		shrds = append(shrds, shrd.Clone())
+		shardMap[shrd.ID()] = shrd
 	}
 
-	return NewShards(shards)
+	return &shards{
+		shards:   shrds,
+		shardMap: shardMap,
+	}
 }
-
-// SortableShardProtosByIDAsc sorts shard protos by their ids in ascending order.
-type SortableShardProtosByIDAsc []*placementpb.Shard
-
-func (su SortableShardProtosByIDAsc) Len() int           { return len(su) }
-func (su SortableShardProtosByIDAsc) Less(i, j int) bool { return su[i].Id < su[j].Id }
-func (su SortableShardProtosByIDAsc) Swap(i, j int)      { su[i], su[j] = su[j], su[i] }
 
 // validStates returns all the valid states.
 func validStates() []State {

--- a/src/cluster/shard/shard_benchmark_test.go
+++ b/src/cluster/shard/shard_benchmark_test.go
@@ -22,7 +22,6 @@ package shard
 
 import (
 	"fmt"
-	"math/rand"
 	"runtime"
 	"testing"
 )
@@ -147,27 +146,4 @@ func BenchmarkShardsContains(b *testing.B) {
 			runtime.KeepAlive(res)
 		})
 	}
-}
-
-func randomIDs(seed int64, num int) []uint32 {
-	rnd := rand.New(rand.NewSource(seed)) // #nosec
-	ids := make([]uint32, num)
-
-	for i := uint32(0); i < uint32(num); i++ {
-		ids[i] = i
-	}
-
-	rnd.Shuffle(len(ids), func(i, j int) {
-		ids[i], ids[j] = ids[j], ids[i]
-	})
-	return ids
-}
-
-func makeTestShards(num int) []Shard {
-	shardIDs := randomIDs(0, num)
-	s := make([]Shard, num)
-	for i, shardID := range shardIDs {
-		s[i] = NewShard(shardID)
-	}
-	return s
 }

--- a/src/cluster/shard/shard_benchmark_test.go
+++ b/src/cluster/shard/shard_benchmark_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"testing"
+)
+
+func BenchmarkNewShards(b *testing.B) {
+	for i := 16; i <= 4096; i *= 4 {
+		rndShards := makeTestShards(i)
+		b.Run(fmt.Sprintf("%d shards", i), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				res := NewShards(rndShards)
+				runtime.KeepAlive(res)
+			}
+		})
+	}
+}
+
+func BenchmarkShardsAllShards(b *testing.B) {
+	for i := 16; i <= 4096; i *= 4 {
+		rndShards := makeTestShards(i)
+		shards := NewShards(rndShards)
+
+		b.Run(fmt.Sprintf("%d shards", i), func(b *testing.B) {
+			var res []Shard
+			for i := 0; i < b.N; i++ {
+				res = shards.All()
+			}
+			runtime.KeepAlive(res)
+		})
+	}
+}
+
+func BenchmarkShardsAllShardIDs(b *testing.B) {
+	for i := 16; i <= 4096; i *= 4 {
+		rndShards := makeTestShards(i)
+		shards := NewShards(rndShards)
+
+		b.Run(fmt.Sprintf("%d shards", i), func(b *testing.B) {
+			var res []uint32
+			for i := 0; i < b.N; i++ {
+				res = shards.AllIDs()
+			}
+			runtime.KeepAlive(res)
+		})
+	}
+}
+
+func BenchmarkShardsAdd(b *testing.B) {
+	for i := 16; i <= 4096; i *= 4 {
+		rndShards := makeTestShards(i)
+		b.Run(fmt.Sprintf("%d shards", i), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				res := NewShards(nil)
+				for j := 0; j < len(rndShards); j++ {
+					res.Add(rndShards[j])
+				}
+				if res.NumShards() != len(rndShards) {
+					b.Fail()
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkShardsEquals(b *testing.B) {
+	for i := 16; i <= 4096; i *= 4 {
+		rndShards := makeTestShards(i)
+		shards := NewShards(rndShards)
+		clone := shards.Clone()
+
+		b.Run(fmt.Sprintf("%d shards", i), func(b *testing.B) {
+			var res bool
+			for i := 0; i < b.N; i++ {
+				shards.Equals(clone)
+			}
+			runtime.KeepAlive(res)
+		})
+	}
+}
+
+func BenchmarkShardsNumShardsForState(b *testing.B) {
+	for i := 16; i <= 4096; i *= 4 {
+		rndShards := makeTestShards(i)
+		shards := NewShards(rndShards)
+
+		b.Run(fmt.Sprintf("%d shards", i), func(b *testing.B) {
+			var res int
+			for i := 0; i < b.N; i++ {
+				res = shards.NumShardsForState(defaultShardState)
+			}
+			runtime.KeepAlive(res)
+		})
+	}
+}
+
+func BenchmarkShardsShard(b *testing.B) {
+	for i := 16; i <= 4096; i *= 4 {
+		ids := randomIDs(1, i*2)
+		rndShards := makeTestShards(i)
+		shards := NewShards(rndShards)
+
+		b.Run(fmt.Sprintf("%d shards", i), func(b *testing.B) {
+			var res Shard
+			for i := 0; i < b.N; i++ {
+				res, _ = shards.Shard(ids[i%len(ids)])
+			}
+			runtime.KeepAlive(res)
+		})
+	}
+}
+
+func BenchmarkShardsContains(b *testing.B) {
+	for i := 16; i <= 4096; i *= 4 {
+		ids := randomIDs(1, i*2)
+		rndShards := makeTestShards(i)
+		shards := NewShards(rndShards)
+
+		b.Run(fmt.Sprintf("%d shards", i), func(b *testing.B) {
+			var res bool
+			for i := 0; i < b.N; i++ {
+				res = shards.Contains(ids[i%len(ids)])
+			}
+			runtime.KeepAlive(res)
+		})
+	}
+}
+
+func randomIDs(seed int64, num int) []uint32 {
+	rnd := rand.New(rand.NewSource(seed)) // #nosec
+	ids := make([]uint32, num)
+
+	for i := uint32(0); i < uint32(num); i++ {
+		ids[i] = i
+	}
+
+	rnd.Shuffle(len(ids), func(i, j int) {
+		ids[i], ids[j] = ids[j], ids[i]
+	})
+	return ids
+}
+
+func makeTestShards(num int) []Shard {
+	shardIDs := randomIDs(0, num)
+	s := make([]Shard, num)
+	for i, shardID := range shardIDs {
+		s[i] = NewShard(shardID)
+	}
+	return s
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Pretty much all Shards() API calls in use are either `.All()` or `.Shard()/Contains()`, and `.All()` always re-sorts the backing map to produce a sorted list of shards.

m3dbnode doesn't use it heavily, as it manages routing via it's own shardset wrapper. However, m3aggregator does - and it does it over a contended lock - even though it usually is 5 to 30-40 shards, it gets really expensive fast, especially if it has to be done multiple times for staged placements/diffing.
This change trades slower init via `NewShards()` and `.Add()` (the latter is barely used) for much faster `.All()` calls.
While the slowdown in less frequent calls is 1-5x, the speedup is at least an order of magnitude.

```
name                                    old time/op    new time/op    delta
NewShards/16_shards-12                     590ns ± 1%    1445ns ± 1%  +144.92%  (p=0.000 n=10+10)
NewShards/64_shards-12                    2.27µs ± 1%    6.61µs ± 1%  +190.92%  (p=0.000 n=10+9)
NewShards/256_shards-12                   8.92µs ± 0%   35.67µs ± 1%  +299.99%  (p=0.000 n=9+9)
NewShards/1024_shards-12                  35.3µs ± 1%   194.1µs ± 3%  +449.58%  (p=0.000 n=9+10)
NewShards/4096_shards-12                   147µs ± 1%     946µs ± 1%  +543.48%  (p=0.000 n=9+10)
ShardsAllShards/16_shards-12              1.05µs ± 1%    0.09µs ± 1%   -91.31%  (p=0.000 n=9+10)
ShardsAllShards/64_shards-12              6.75µs ± 2%    0.21µs ± 1%   -96.88%  (p=0.000 n=9+10)
ShardsAllShards/256_shards-12             34.9µs ± 2%     0.7µs ± 1%   -97.92%  (p=0.000 n=10+10)
ShardsAllShards/1024_shards-12             172µs ± 0%       3µs ± 1%   -98.21%  (p=0.000 n=6+10)
ShardsAllShards/4096_shards-12             834µs ± 1%      16µs ± 1%   -98.05%  (p=0.000 n=8+9)
ShardsAllShardIDs/16_shards-12             574ns ± 1%      66ns ± 1%   -88.49%  (p=0.000 n=10+10)
ShardsAllShardIDs/64_shards-12            4.27µs ± 1%    0.22µs ± 0%   -94.90%  (p=0.000 n=10+8)
ShardsAllShardIDs/256_shards-12           22.0µs ± 1%     0.8µs ± 1%   -96.35%  (p=0.000 n=10+10)
ShardsAllShardIDs/1024_shards-12           104µs ± 2%       4µs ± 1%   -96.60%  (p=0.000 n=10+10)
ShardsAllShardIDs/4096_shards-12           484µs ± 1%      16µs ± 1%   -96.60%  (p=0.000 n=10+9)
ShardsAdd/16_shards-12                    1.21µs ± 2%    2.02µs ± 2%   +67.24%  (p=0.000 n=9+10)
ShardsAdd/64_shards-12                    5.35µs ± 0%    9.83µs ± 1%   +83.89%  (p=0.000 n=8+10)
ShardsAdd/256_shards-12                   21.2µs ± 0%    49.4µs ± 1%  +133.47%  (p=0.000 n=8+10)
ShardsAdd/1024_shards-12                  83.7µs ± 0%   246.4µs ± 3%  +194.29%  (p=0.000 n=9+10)
ShardsAdd/4096_shards-12                   349µs ± 1%    1700µs ± 1%  +386.85%  (p=0.000 n=9+9)
ShardsEquals/16_shards-12                 2.49µs ± 1%    0.33µs ± 1%   -86.82%  (p=0.000 n=10+10)
ShardsEquals/64_shards-12                 14.7µs ± 1%     1.1µs ± 1%   -92.32%  (p=0.000 n=9+10)
ShardsEquals/256_shards-12                74.2µs ± 2%     4.4µs ± 2%   -94.03%  (p=0.000 n=10+9)
ShardsEquals/1024_shards-12                359µs ± 1%      18µs ± 0%   -95.00%  (p=0.000 n=9+10)
ShardsEquals/4096_shards-12               1.73ms ± 2%    0.08ms ± 0%   -95.35%  (p=0.000 n=10+8)
ShardsNumShardsForState/16_shards-12       205ns ± 1%      35ns ± 0%   -82.87%  (p=0.000 n=8+7)
ShardsNumShardsForState/64_shards-12       738ns ± 3%     137ns ± 1%   -81.40%  (p=0.000 n=9+9)
ShardsNumShardsForState/256_shards-12     3.22µs ± 2%    0.53µs ± 2%   -83.49%  (p=0.000 n=10+9)
ShardsNumShardsForState/1024_shards-12    13.2µs ± 2%     2.5µs ± 1%   -81.32%  (p=0.000 n=10+10)
ShardsNumShardsForState/4096_shards-12    53.1µs ± 1%    11.3µs ± 2%   -78.79%  (p=0.000 n=9+10)
ShardsShard/16_shards-12                  18.0ns ± 1%    18.7ns ± 1%    +3.65%  (p=0.000 n=9+10)
ShardsShard/64_shards-12                  19.1ns ± 3%    19.6ns ± 2%    +2.50%  (p=0.002 n=9+9)
ShardsShard/256_shards-12                 21.4ns ± 3%    21.3ns ± 2%      ~     (p=0.642 n=10+10)
ShardsShard/1024_shards-12                23.5ns ± 1%    24.0ns ± 1%    +2.30%  (p=0.000 n=10+10)
ShardsShard/4096_shards-12                26.1ns ± 2%    26.7ns ± 2%    +2.19%  (p=0.000 n=10+10)
ShardsContains/16_shards-12               17.3ns ± 3%    17.5ns ± 1%    +1.34%  (p=0.003 n=9+10)
ShardsContains/64_shards-12               18.2ns ± 0%    17.9ns ± 1%    -1.76%  (p=0.000 n=7+10)
ShardsContains/256_shards-12              20.0ns ± 0%    20.8ns ± 2%    +4.22%  (p=0.000 n=6+9)
ShardsContains/1024_shards-12             23.2ns ± 2%    24.0ns ± 2%    +3.23%  (p=0.000 n=10+10)
ShardsContains/4096_shards-12             26.4ns ± 3%    26.2ns ± 1%      ~     (p=0.341 n=10+10)

name                                    old allocs/op  new allocs/op  delta
NewShards/4096_shards-12                    3.00 ± 0%      6.00 ± 0%  +100.00%  (p=0.000 n=10+10)
ShardsAllShards/4096_shards-12              2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
ShardsAllShardIDs/4096_shards-12            2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
ShardsAdd/4096_shards-12                     137 ± 0%       155 ± 0%   +13.14%  (p=0.000 n=10+7)
ShardsEquals/4096_shards-12                 4.00 ± 0%      1.00 ± 0%   -75.00%  (p=0.000 n=10+10)
```
NB: benches ran on a busy laptop, so the very short calls have noisy values.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
