### PR TITLE
[docs] Update buildkite doc path

### DIFF
--- a/.buildkite/docs-docker-compose.yml
+++ b/.buildkite/docs-docker-compose.yml
@@ -3,7 +3,7 @@ services:
   docs:
     build:
         context: ./
-        dockerfile: ../docs/Dockerfile
+        dockerfile: ../site/content/docs/Dockerfile
     volumes:
       - ../:/go/src/github.com/m3db/m3
       - $SSH_AUTH_SOCK:/ssh-agent

--- a/site/content/docs/how_to/kubernetes.md
+++ b/site/content/docs/how_to/kubernetes.md
@@ -4,7 +4,7 @@ weight: 3
 ---
 
 
-**Please note:** If possible _PLEASE USE THE OPERATO_ to deploy to Kubernetes if you
+**Please note:** If possible _PLEASE USE THE OPERATOR_ to deploy to Kubernetes if you
 can. It is a considerably more streamlined setup.
 
 The operator leverages [custom resource definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)

--- a/site/content/docs/how_to/kubernetes.md
+++ b/site/content/docs/how_to/kubernetes.md
@@ -4,10 +4,10 @@ weight: 3
 ---
 
 
-**Please note:** If possible _[PLEASE USE THE OPERATOR](https://operator.m3db.io/)_ to deploy to Kubernetes if you
+**Please note:** If possible _PLEASE USE THE OPERATO_ to deploy to Kubernetes if you
 can. It is a considerably more streamlined setup.
 
-The [operator](https://operator.m3db.io/) leverages [custom resource definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+The operator leverages [custom resource definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
 (CRDs) to automatically handle operations such as managing cluster topology.
 
 The guide below provides static manifests to bootstrap a cluster on Kubernetes and should be considered


### PR DESCRIPTION
Temporarily removes links to operator to be able to pass the master build and regenerate documents and the operator site itself; will be readded after it's working.
