### PR TITLE
[query] Add lookback duration from query config

### DIFF
--- a/scripts/docker-integration-tests/prometheus/m3coordinator.yml
+++ b/scripts/docker-integration-tests/prometheus/m3coordinator.yml
@@ -23,3 +23,5 @@ query:
         value: hidden
     strip:
     - restricted_metrics_type
+
+lookbackDuration: 10m

--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -177,6 +177,25 @@ function test_prometheus_remote_write_map_tags {
     retry_with_backoff prometheus_query_native
 }
 
+function test_query_lookback_applied {
+  # Note: this test depends on the config in m3coordinator.yml for this test
+  # and the following config value "lookbackDuration: 10m".
+  echo "Test lookback config respected"
+  now=$(date +"%s")
+  # Write into past less than the lookback duration.
+  eight_mins_ago=$(( now - 480 ))
+  prometheus_remote_write \
+    "lookback_test" $eight_mins_ago 42 \
+    true "Expected request to succeed" \
+    200 "Expected request to return status code 200" \
+    "unaggregated"
+
+  # Now query and ensure that the latest timestamp is within the last two steps
+  # from now.
+  ATTEMPTS=2 TIMEOUT=2 MAX_TIMEOUT=4 retry_with_backoff  \
+    '[[ $(curl -s "0.0.0.0:7201/api/v1/query_range?query=lookback_test&step=15&start=$(expr $(date "+%s") - 600)&end=$(date "+%s")" | jq -r ".data.result[0].values[-1][0]") -gt $(expr $(date "+%s") - 30) ]]'
+}
+
 function test_query_limits_applied {
   # Test the default series limit applied when directly querying
   # coordinator (limit set to 100 in m3coordinator.yml)
@@ -373,6 +392,7 @@ test_prometheus_remote_write_empty_label_value_returns_400_status_code
 test_prometheus_remote_write_duplicate_label_returns_400_status_code
 test_prometheus_remote_write_too_old_returns_400_status_code
 test_prometheus_remote_write_restrict_metrics_type
+test_query_lookback_applied
 test_query_limits_applied
 test_query_restrict_metrics_type
 test_prometheus_query_native_timeout

--- a/scripts/docker-integration-tests/prometheus/test.sh
+++ b/scripts/docker-integration-tests/prometheus/test.sh
@@ -192,7 +192,7 @@ function test_query_lookback_applied {
 
   # Now query and ensure that the latest timestamp is within the last two steps
   # from now.
-  ATTEMPTS=2 TIMEOUT=2 MAX_TIMEOUT=4 retry_with_backoff  \
+  ATTEMPTS=10 TIMEOUT=2 MAX_TIMEOUT=4 retry_with_backoff  \
     '[[ $(curl -s "0.0.0.0:7201/api/v1/query_range?query=lookback_test&step=15&start=$(expr $(date "+%s") - 600)&end=$(date "+%s")" | jq -r ".data.result[0].values[-1][0]") -gt $(expr $(date "+%s") - 30) ]]'
 }
 

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -86,7 +86,7 @@ var (
 		ExtendedMetrics: &defaultMetricsExtendedMetricsType,
 	}
 
-	// 5m is the default lookback in Prometheus
+	// 5m is the default lookback in Prometheus.
 	defaultLookbackDuration = 5 * time.Minute
 
 	defaultCarbonIngesterAggregationType = aggregation.Mean

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -479,8 +479,12 @@ func Run(runOpts RunOptions) {
 		graphiteStorageOpts.RenderSeriesAllNaNs = cfg.Carbon.RenderSeriesAllNaNs
 	}
 
-	prometheusEngine := newPromQLEngine(cfg.Query, prometheusEngineRegistry,
+	prometheusEngine, err := newPromQLEngine(cfg, prometheusEngineRegistry,
 		instrumentOptions)
+	if err != nil {
+		logger.Fatal("unable to create PromQL engine", zap.Error(err))
+	}
+
 	handlerOptions, err := options.NewHandlerOptions(downsamplerAndWriter,
 		tagOptions, engine, prometheusEngine, m3dbClusters, clusterClient, cfg,
 		runOpts.DBConfig, fetchOptsBuilder, queryCtxOpts,
@@ -1154,18 +1158,24 @@ func newDownsamplerAndWriter(
 }
 
 func newPromQLEngine(
-	cfg config.QueryConfiguration,
+	cfg config.Configuration,
 	registry *extprom.Registry,
 	instrumentOpts instrument.Options,
-) *prometheuspromql.Engine {
+) (*prometheuspromql.Engine, error) {
+	lookbackDelta, err := cfg.LookbackDurationOrDefault()
+	if err != nil {
+		return nil, err
+	}
+
 	var (
 		kitLogger = kitlogzap.NewZapSugarLogger(instrumentOpts.Logger(), zapcore.InfoLevel)
 		opts      = prometheuspromql.EngineOpts{
-			Logger:     log.With(kitLogger, "component", "prometheus_engine"),
-			Reg:        registry,
-			MaxSamples: cfg.Prometheus.MaxSamplesPerQueryOrDefault(),
-			Timeout:    cfg.TimeoutOrDefault(),
+			Logger:        log.With(kitLogger, "component", "prometheus_engine"),
+			Reg:           registry,
+			MaxSamples:    cfg.Query.Prometheus.MaxSamplesPerQueryOrDefault(),
+			Timeout:       cfg.Query.TimeoutOrDefault(),
+			LookbackDelta: lookbackDelta,
 		}
 	)
-	return prometheuspromql.NewEngine(opts)
+	return prometheuspromql.NewEngine(opts), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds lookback duration to come from config for PromQL engine.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
