### PR TITLE
[query] Fix /m3query returning 500 on invalid query argument

### DIFF
--- a/src/cmd/tools/dtest/docker/harness/query_api_test.go
+++ b/src/cmd/tools/dtest/docker/harness/query_api_test.go
@@ -36,30 +36,22 @@ type urlTest struct {
 }
 
 func TestInvalidInstantQueryReturns400(t *testing.T) {
-	coord := singleDBNodeDockerResources.Coordinator()
+	urlPrefixes := []string{"", "prometheus/", "m3query/"}
 
-	urlPrefix := []string{"", "prometheus/", "m3query/"}
-
-	instantQueryBadRequestTest := addPrefixes(urlPrefix, []urlTest{
+	urlTests := addPrefixes(urlPrefixes, []urlTest{
 		{"missing query", queryURL("query", "")},
 		{"invalid query", queryURL("query", "@!")},
 		{"invalid time", queryURL("time", "INVALID")},
 		{"invalid timeout", queryURL("timeout", "INVALID")},
 	})
 
-	for _, tt := range instantQueryBadRequestTest {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.NoError(t, coord.RunQuery(verifyStatus(400), tt.url), "for query '%v'", tt.url)
-		})
-	}
+	testInvalidQueryReturns400(t, urlTests)
 }
 
 func TestInvalidRangeQueryReturns400(t *testing.T) {
-	coord := singleDBNodeDockerResources.Coordinator()
+	urlPrefixes := []string{"", "prometheus/", "m3query/"}
 
-	urlPrefix := []string{"", "prometheus/", "m3query/"}
-
-	queryBadRequestTest := addPrefixes(urlPrefix, []urlTest{
+	urlTests := addPrefixes(urlPrefixes, []urlTest{
 		{"missing query", queryRangeURL("query", "")},
 		{"invalid query", queryRangeURL("query", "@!")},
 		{"missing start", queryRangeURL("start", "")},
@@ -71,7 +63,13 @@ func TestInvalidRangeQueryReturns400(t *testing.T) {
 		{"invalid timeout", queryRangeURL("timeout", "INVALID")},
 	})
 
-	for _, tt := range queryBadRequestTest {
+	testInvalidQueryReturns400(t, urlTests)
+}
+
+func testInvalidQueryReturns400(t *testing.T, tests []urlTest) {
+	coord := singleDBNodeDockerResources.Coordinator()
+
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.NoError(t, coord.RunQuery(verifyStatus(400), tt.url), "for query '%v'", tt.url)
 		})

--- a/src/query/api/v1/handler/prometheus/native/read_common.go
+++ b/src/query/api/v1/handler/prometheus/native/read_common.go
@@ -176,7 +176,7 @@ func read(
 	parseOpts := engine.Options().ParseOptions()
 	parser, err := promql.Parse(params.Query, params.Step, tagOpts, parseOpts)
 	if err != nil {
-		return emptyResult, err
+		return emptyResult, xerrors.NewInvalidParamsError(err)
 	}
 
 	// Detect clients closing connections.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPER.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPER.md#adding-a-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes `m3query/api/v1/{query,query_range}` returning 500 on invalid query string. Plus additional tests

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
