### PR TITLE
[aggregator] Use NaN instead of math.MaxFloat64 and add sentinel guards

### DIFF
--- a/src/aggregator/aggregation/gauge_test.go
+++ b/src/aggregator/aggregation/gauge_test.go
@@ -42,6 +42,13 @@ func TestGaugeDefaultAggregationType(t *testing.T) {
 	require.Equal(t, 100.0, g.ValueOf(aggregation.Count))
 	require.Equal(t, 50.5, g.ValueOf(aggregation.Mean))
 	require.Equal(t, 0.0, g.ValueOf(aggregation.SumSq))
+
+	g = NewGauge(NewOptions(instrument.NewOptions()))
+	require.Equal(t, 0.0, g.Last())
+	require.Equal(t, 0.0, g.ValueOf(aggregation.Last))
+	require.Equal(t, 0.0, g.ValueOf(aggregation.Count))
+	require.Equal(t, 0.0, g.ValueOf(aggregation.Mean))
+	require.Equal(t, 0.0, g.ValueOf(aggregation.SumSq))
 }
 
 func TestGaugeCustomAggregationType(t *testing.T) {
@@ -77,6 +84,33 @@ func TestGaugeCustomAggregationType(t *testing.T) {
 			require.InDelta(t, 29.01149, v, 0.001)
 		default:
 			require.Equal(t, float64(0), v)
+			require.False(t, aggType.IsValidForGauge())
+		}
+	}
+
+	g = NewGauge(opts)
+	require.Equal(t, 0.0, g.Last())
+	for aggType := range aggregation.ValidTypes {
+		v := g.ValueOf(aggType)
+		switch aggType {
+		case aggregation.Last:
+			require.Equal(t, 0.0, v)
+		case aggregation.Min:
+			require.Equal(t, 0.0, v)
+		case aggregation.Max:
+			require.Equal(t, 0.0, v)
+		case aggregation.Mean:
+			require.Equal(t, 0.0, v)
+		case aggregation.Count:
+			require.Equal(t, 0.0, v)
+		case aggregation.Sum:
+			require.Equal(t, 0.0, v)
+		case aggregation.SumSq:
+			require.Equal(t, 0.0, v)
+		case aggregation.Stdev:
+			require.InDelta(t, 0.0, v, 0.0)
+		default:
+			require.Equal(t, 0.0, v)
 			require.False(t, aggType.IsValidForGauge())
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We've observed `-math.MaxFloat64` values for `Max` R2 gauge aggregations in some cases that appears to be caused by zero/non-`Update`'d `aggregation.Gauge` values.

This changes `Gauge` to properly handle zero values and not produce sentinel values as part of e.g. `Max()` and `Min()`.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
No.

**Does this PR require updating code package or user-facing documentation?**:
No.