### PR TITLE
[aggregator] Return NaN instead of 0 for NaN gauge values

### DIFF
--- a/src/aggregator/aggregation/gauge.go
+++ b/src/aggregator/aggregation/gauge.go
@@ -51,11 +51,6 @@ func NewGauge(opts Options) Gauge {
 
 // Update updates the gauge value.
 func (g *Gauge) Update(timestamp time.Time, value float64) {
-	// If this is not a valid value, drop it.
-	if math.IsNaN(value) {
-		return
-	}
-
 	if g.lastAt.IsZero() || timestamp.After(g.lastAt) {
 		// NB(r): Only set the last value if this value arrives
 		// after the wall clock timestamp of previous values, not
@@ -66,8 +61,13 @@ func (g *Gauge) Update(timestamp time.Time, value float64) {
 		g.Options.Metrics.Gauge.IncValuesOutOfOrder()
 	}
 
-	g.sum += value
 	g.count++
+
+	if math.IsNaN(value) {
+		return
+	}
+
+	g.sum += value
 	if math.IsNaN(g.max) || g.max < value {
 		g.max = value
 	}
@@ -110,17 +110,11 @@ func (g *Gauge) Stdev() float64 {
 
 // Min returns the minimum gauge value.
 func (g *Gauge) Min() float64 {
-	if math.IsNaN(g.min) {
-		return 0.0
-	}
 	return g.min
 }
 
 // Max returns the maximum gauge value.
 func (g *Gauge) Max() float64 {
-	if math.IsNaN(g.max) {
-		return 0.0
-	}
 	return g.max
 }
 

--- a/src/aggregator/aggregation/gauge_test.go
+++ b/src/aggregator/aggregation/gauge_test.go
@@ -21,6 +21,7 @@
 package aggregation
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -42,6 +43,8 @@ func TestGaugeDefaultAggregationType(t *testing.T) {
 	require.Equal(t, 100.0, g.ValueOf(aggregation.Count))
 	require.Equal(t, 50.5, g.ValueOf(aggregation.Mean))
 	require.Equal(t, 0.0, g.ValueOf(aggregation.SumSq))
+	require.Equal(t, 100.0, g.ValueOf(aggregation.Max))
+	require.Equal(t, 1.0, g.ValueOf(aggregation.Min))
 
 	g = NewGauge(NewOptions(instrument.NewOptions()))
 	require.Equal(t, 0.0, g.Last())
@@ -49,6 +52,8 @@ func TestGaugeDefaultAggregationType(t *testing.T) {
 	require.Equal(t, 0.0, g.ValueOf(aggregation.Count))
 	require.Equal(t, 0.0, g.ValueOf(aggregation.Mean))
 	require.Equal(t, 0.0, g.ValueOf(aggregation.SumSq))
+	require.True(t, math.IsNaN(g.ValueOf(aggregation.Max)))
+	require.True(t, math.IsNaN(g.ValueOf(aggregation.Min)))
 }
 
 func TestGaugeCustomAggregationType(t *testing.T) {
@@ -96,9 +101,9 @@ func TestGaugeCustomAggregationType(t *testing.T) {
 		case aggregation.Last:
 			require.Equal(t, 0.0, v)
 		case aggregation.Min:
-			require.Equal(t, 0.0, v)
+			require.True(t, math.IsNaN(v))
 		case aggregation.Max:
-			require.Equal(t, 0.0, v)
+			require.True(t, math.IsNaN(v))
 		case aggregation.Mean:
 			require.Equal(t, 0.0, v)
 		case aggregation.Count:


### PR DESCRIPTION
**What this PR does / why we need it**:
Following up on #2929, return NaN instead of zeroes so we can disambiguate the two. We also discard NaN if configured in [src/aggregator/aggregator/gauge_elem_gen.go:467](https://sourcegraph.com/github.com/m3db/m3@afda2712be42b40c577dfd61ff6ffb2a7121e722/-/blob/src/aggregator/aggregator/gauge_elem_gen.go#L467).

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
No.

**Does this PR require updating code package or user-facing documentation?**:
No.