### PR TITLE
[dbnode] Add DocRef() to NS and multiple series metadata types 

### DIFF
--- a/src/dbnode/persist/fs/merger.go
+++ b/src/dbnode/persist/fs/merger.go
@@ -256,7 +256,7 @@ func (m *merger) Merge(
 						Type:     persist.SeriesDocumentType,
 						Document: seriesMetadata,
 						// The lifetime of the shard series metadata is longly lived.
-						LifeTime: persist.SeriesMetadataLifeTimeLongLived,
+						LifeTime: persist.SeriesMetadataLifeTimeLong,
 					},
 				})
 			}

--- a/src/dbnode/persist/fs/merger.go
+++ b/src/dbnode/persist/fs/merger.go
@@ -249,10 +249,15 @@ func (m *merger) Merge(
 
 			if err == nil {
 				err = onFlush.OnFlushNewSeries(persist.OnFlushNewSeriesEvent{
-					Shard:          shard,
-					BlockStart:     startTime,
-					FirstWrite:     mergeWithData.FirstWrite,
-					SeriesMetadata: seriesMetadata,
+					Shard:      shard,
+					BlockStart: startTime,
+					FirstWrite: mergeWithData.FirstWrite,
+					SeriesMetadata: persist.SeriesMetadata{
+						Type:     persist.SeriesDocumentType,
+						Document: seriesMetadata,
+						// The lifetime of the shard series metadata is longly lived.
+						LifeTime: persist.SeriesMetadataLifeTimeLongLived,
+					},
 				})
 			}
 

--- a/src/dbnode/persist/types.go
+++ b/src/dbnode/persist/types.go
@@ -35,9 +35,7 @@ import (
 	"github.com/pborman/uuid"
 )
 
-var (
-	errReuseableTagIteratorRequired = errors.New("reuseable tags iterator is required")
-)
+var errReuseableTagIteratorRequired = errors.New("reuseable tags iterator is required")
 
 // Metadata is metadata for a time series, it can
 // have several underlying sources.
@@ -322,12 +320,49 @@ const (
 	FileSetIndexContentType
 )
 
+// SeriesMetadataLifeTime describes the memory life time type.
+type SeriesMetadataLifeTime int
+
+const (
+	// SeriesMetadataLifeTimeLongLived means the underlying memory's life time is long lived and exceeds
+	// the execution duration of the series metadata receiver.
+	SeriesMetadataLifeTimeLongLived SeriesMetadataLifeTime = iota
+	// SeriesMetadataLifeTimeShortLived means that the underlying memory is only valid for the duration
+	// of the OnFlushNewSeries call. Must clone the underlying bytes in order to extend the life time.
+	SeriesMetadataLifeTimeShortLived
+)
+
+// SeriesMetadataType describes the type of series metadata.
+type SeriesMetadataType int
+
+const (
+	// SeriesDocumentType means the metadata is in doc.Document form.
+	SeriesDocumentType SeriesMetadataType = iota
+	// SeriesIDAndEncodedTagsType means the metadata is in IDAndEncodedTags form.
+	SeriesIDAndEncodedTagsType
+)
+
+// IDAndEncodedTags contains a series ID and encoded tags.
+type IDAndEncodedTags struct {
+	ID          []byte
+	EncodedTags []byte
+}
+
+// SeriesMetadata captures different representations of series metadata and
+// the ownership status of the underlying memory.
+type SeriesMetadata struct {
+	Type             SeriesMetadataType
+	LifeTime         SeriesMetadataLifeTime
+	Document         doc.Document
+	IDAndEncodedTags IDAndEncodedTags
+}
+
 // OnFlushNewSeriesEvent is the fields related to a flush of a new series.
 type OnFlushNewSeriesEvent struct {
 	Shard          uint32
 	BlockStart     time.Time
 	FirstWrite     time.Time
-	SeriesMetadata doc.Document
+	SeriesMetadata SeriesMetadata
 }
 
 // OnFlushSeries performs work on a per series level.

--- a/src/dbnode/persist/types.go
+++ b/src/dbnode/persist/types.go
@@ -321,19 +321,19 @@ const (
 )
 
 // SeriesMetadataLifeTime describes the memory life time type.
-type SeriesMetadataLifeTime int
+type SeriesMetadataLifeTime uint8
 
 const (
-	// SeriesMetadataLifeTimeLongLived means the underlying memory's life time is long lived and exceeds
+	// SeriesMetadataLifeTimeLong means the underlying memory's life time is long lived and exceeds
 	// the execution duration of the series metadata receiver.
-	SeriesMetadataLifeTimeLongLived SeriesMetadataLifeTime = iota
+	SeriesMetadataLifeTimeLong SeriesMetadataLifeTime = iota
 	// SeriesMetadataLifeTimeShortLived means that the underlying memory is only valid for the duration
 	// of the OnFlushNewSeries call. Must clone the underlying bytes in order to extend the life time.
 	SeriesMetadataLifeTimeShortLived
 )
 
 // SeriesMetadataType describes the type of series metadata.
-type SeriesMetadataType int
+type SeriesMetadataType uint8
 
 const (
 	// SeriesDocumentType means the metadata is in doc.Document form.
@@ -344,17 +344,17 @@ const (
 
 // IDAndEncodedTags contains a series ID and encoded tags.
 type IDAndEncodedTags struct {
-	ID          []byte
-	EncodedTags []byte
+	ID          ident.BytesID
+	EncodedTags ts.EncodedTags
 }
 
 // SeriesMetadata captures different representations of series metadata and
 // the ownership status of the underlying memory.
 type SeriesMetadata struct {
-	Type             SeriesMetadataType
-	LifeTime         SeriesMetadataLifeTime
 	Document         doc.Document
 	IDAndEncodedTags IDAndEncodedTags
+	Type             SeriesMetadataType
+	LifeTime         SeriesMetadataLifeTime
 }
 
 // OnFlushNewSeriesEvent is the fields related to a flush of a new series.

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -41,6 +41,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/ts"
 	"github.com/m3db/m3/src/dbnode/ts/writes"
 	"github.com/m3db/m3/src/dbnode/x/xio"
+	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/context"
 	xerrors "github.com/m3db/m3/src/x/errors"
@@ -1792,4 +1793,12 @@ func (n *dbNamespace) aggregateTiles(
 		zap.Duration("took", time.Now().Sub(startedAt)))
 
 	return processedTileCount, nil
+}
+
+func (n *dbNamespace) DocRef(id ident.ID) (doc.Document, bool, error) {
+	shard, _, err := n.readableShardFor(id)
+	if err != nil {
+		return doc.Document{}, false, err
+	}
+	return shard.DocRef(id)
 }

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -1150,6 +1150,22 @@ func (mr *MockNamespaceMockRecorder) SetReadOnly(value interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadOnly", reflect.TypeOf((*MockNamespace)(nil).SetReadOnly), value)
 }
 
+// DocRef mocks base method
+func (m *MockNamespace) DocRef(id ident.ID) (doc.Document, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DocRef", id)
+	ret0, _ := ret[0].(doc.Document)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DocRef indicates an expected call of DocRef
+func (mr *MockNamespaceMockRecorder) DocRef(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocRef", reflect.TypeOf((*MockNamespace)(nil).DocRef), id)
+}
+
 // MockdatabaseNamespace is a mock of databaseNamespace interface
 type MockdatabaseNamespace struct {
 	ctrl     *gomock.Controller
@@ -1324,6 +1340,22 @@ func (m *MockdatabaseNamespace) SetReadOnly(value bool) {
 func (mr *MockdatabaseNamespaceMockRecorder) SetReadOnly(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReadOnly", reflect.TypeOf((*MockdatabaseNamespace)(nil).SetReadOnly), value)
+}
+
+// DocRef mocks base method
+func (m *MockdatabaseNamespace) DocRef(id ident.ID) (doc.Document, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DocRef", id)
+	ret0, _ := ret[0].(doc.Document)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// DocRef indicates an expected call of DocRef
+func (mr *MockdatabaseNamespaceMockRecorder) DocRef(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DocRef", reflect.TypeOf((*MockdatabaseNamespace)(nil).DocRef), id)
 }
 
 // Close mocks base method

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -285,6 +285,9 @@ type Namespace interface {
 
 	// SetReadOnly sets the value of ReadOnly option.
 	SetReadOnly(value bool)
+
+	// DocRef returns the doc if already present in a namespace shard.
+	DocRef(id ident.ID) (doc.Document, bool, error)
 }
 
 // NamespacesByID is a sortable slice of namespaces by ID.


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Expose a `DocRef()` method on db namespace. Also update the `OnFlushNewSeriesEvent` to add a `SeriesMetadata` type that supports multiple representations of underlying series metadata and memory life times. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
