### PR TITLE
[aggregator] Include `endpoint` tag in aggregator client instance queue

### DIFF
--- a/src/aggregator/client/queue.go
+++ b/src/aggregator/client/queue.go
@@ -128,8 +128,10 @@ type queue struct {
 
 func newInstanceQueue(instance placement.Instance, opts Options) instanceQueue {
 	var (
-		instrumentOpts     = opts.InstrumentOptions()
-		scope              = instrumentOpts.MetricsScope()
+		instrumentOpts = opts.InstrumentOptions()
+		scope          = instrumentOpts.MetricsScope().Tagged(map[string]string{
+			"endpoint": instance.Endpoint(),
+		})
 		connInstrumentOpts = instrumentOpts.SetMetricsScope(scope.SubScope("connection"))
 		connOpts           = opts.ConnectionOptions().
 					SetInstrumentOptions(connInstrumentOpts).
@@ -143,7 +145,7 @@ func newInstanceQueue(instance placement.Instance, opts Options) instanceQueue {
 	q := &queue{
 		dropType:           opts.QueueDropType(),
 		log:                iOpts.Logger(),
-		metrics:            newQueueMetrics(iOpts.MetricsScope(), queueSize),
+		metrics:            newQueueMetrics(scope, queueSize),
 		instance:           instance,
 		conn:               conn,
 		bufCh:              make(chan protobuf.Buffer, queueSize),

--- a/src/aggregator/client/queue.go
+++ b/src/aggregator/client/queue.go
@@ -128,10 +128,8 @@ type queue struct {
 
 func newInstanceQueue(instance placement.Instance, opts Options) instanceQueue {
 	var (
-		instrumentOpts = opts.InstrumentOptions()
-		scope          = instrumentOpts.MetricsScope().Tagged(map[string]string{
-			"endpoint": instance.Endpoint(),
-		})
+		instrumentOpts     = opts.InstrumentOptions()
+		scope              = instrumentOpts.MetricsScope()
 		connInstrumentOpts = instrumentOpts.SetMetricsScope(scope.SubScope("connection"))
 		connOpts           = opts.ConnectionOptions().
 					SetInstrumentOptions(connInstrumentOpts).
@@ -141,11 +139,12 @@ func newInstanceQueue(instance placement.Instance, opts Options) instanceQueue {
 		queueSize     = opts.InstanceQueueSize()
 		maxBatchSize  = opts.MaxBatchSize()
 		writeInterval = opts.BatchFlushDeadline()
+		instanceScope = scope.Tagged(map[string]string{"instance_id": instance.ID()})
 	)
 	q := &queue{
 		dropType:           opts.QueueDropType(),
 		log:                iOpts.Logger(),
-		metrics:            newQueueMetrics(scope, queueSize),
+		metrics:            newQueueMetrics(instanceScope, queueSize),
 		instance:           instance,
 		conn:               conn,
 		bufCh:              make(chan protobuf.Buffer, queueSize),


### PR DESCRIPTION
**What this PR does / why we need it**:

We noticed that, in some cases, the aggregator client queue is dropped when aggregator placement changes happen, as indicated by the "writer.queue.dropped" counter.
However that counter and other instance queue metrics do not have the instance endpoint tag which makes troubleshooting difficult.
Having the instance endpoint would also allow us to tell whether data is dropped only for one instance/replica or all of them, i.e. whether there is data loss.


**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
