### PR TITLE
[aggregator/client] Include instance ID in write errors

### DIFF
--- a/src/aggregator/client/queue.go
+++ b/src/aggregator/client/queue.go
@@ -218,6 +218,7 @@ func (q *queue) writeAndReset() {
 	if err := q.writeFn(q.buf); err != nil {
 		q.log.Error("error writing data",
 			zap.Int("buffer_size", len(q.buf)),
+			zap.String("target_instance_id", q.instance.ID()),
 			zap.String("target_instance", q.instance.Endpoint()),
 			zap.Error(err),
 		)


### PR DESCRIPTION
There are cases when, during a placement change of aggregator service, the client fails to write to an instance.
On the managed platform instance ID and instance endpoint look very different: it's impossible to tell the instance ID from the endpoint without taking a look at placement details. Add instance ID to the error log message.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
