### PR TITLE
[cluster] Expose underlying staged placement version

### DIFF
--- a/src/cluster/placement/placement_mock.go
+++ b/src/cluster/placement/placement_mock.go
@@ -1134,6 +1134,20 @@ func (mr *MockActiveStagedPlacementMockRecorder) ActivePlacement() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivePlacement", reflect.TypeOf((*MockActiveStagedPlacement)(nil).ActivePlacement))
 }
 
+// Version mocks base method
+func (m *MockActiveStagedPlacement) Version() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Version")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Version indicates an expected call of Version
+func (mr *MockActiveStagedPlacementMockRecorder) Version() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockActiveStagedPlacement)(nil).Version))
+}
+
 // Close mocks base method
 func (m *MockActiveStagedPlacement) Close() error {
 	m.ctrl.T.Helper()

--- a/src/cluster/placement/staged_placement_test.go
+++ b/src/cluster/placement/staged_placement_test.go
@@ -296,7 +296,7 @@ func TestNewActiveStagedPlacement(t *testing.T) {
 			}
 		},
 	)
-	ap := newActiveStagedPlacement(testActivePlacements, opts).(*activeStagedPlacement)
+	ap := newActiveStagedPlacement(testActivePlacements, 0, opts)
 	require.Equal(t, len(testActivePlacements), len(allInstances))
 	require.Equal(t, len(testActivePlacements), len(ap.placements))
 	for i := 0; i < len(testActivePlacements); i++ {
@@ -380,7 +380,7 @@ func TestActiveStagedPlacementCloseSuccess(t *testing.T) {
 				removedInstances = append(removedInstances, placement.Instances())
 			}
 		})
-	p := newActiveStagedPlacement(testActivePlacements, opts)
+	p := newActiveStagedPlacement(testActivePlacements, 0, opts)
 	require.NoError(t, p.Close())
 	require.Equal(t, 2, len(addedInstances))
 	require.Equal(t, 2, len(removedInstances))
@@ -452,9 +452,16 @@ func TestStagedPlacementNilProto(t *testing.T) {
 func TestStagedPlacementValidProto(t *testing.T) {
 	sp, err := NewStagedPlacementFromProto(1, testStagedPlacementProto, NewActiveStagedPlacementOptions())
 	require.NoError(t, err)
+
 	pss := sp.(*stagedPlacement)
 	require.Equal(t, 1, pss.Version())
+	require.Equal(t, 1, pss.ActiveStagedPlacement(0).Version())
+
+	pss.SetVersion(42)
+	require.Equal(t, 42, pss.ActiveStagedPlacement(0).Version())
+
 	require.Equal(t, len(pss.placements), len(testStagedPlacementProto.Snapshots))
+
 	for i := 0; i < len(testStagedPlacementProto.Snapshots); i++ {
 		validateSnapshot(t, testActivePlacements[i], pss.placements[i])
 	}

--- a/src/cluster/placement/staged_placement_watcher_test.go
+++ b/src/cluster/placement/staged_placement_watcher_test.go
@@ -169,3 +169,5 @@ func (mp *mockPlacement) ActivePlacement() (Placement, DoneFn, error) {
 }
 
 func (mp *mockPlacement) Close() error { return mp.closeFn() }
+
+func (mp *mockPlacement) Version() int { return 0 }

--- a/src/cluster/placement/types.go
+++ b/src/cluster/placement/types.go
@@ -271,6 +271,9 @@ type ActiveStagedPlacement interface {
 	// function when the caller is done using the placement, and any errors encountered.
 	ActivePlacement() (Placement, DoneFn, error)
 
+	// Version returns the version of the underlying staged placement.
+	Version() int
+
 	// Close closes the active staged placement.
 	Close() error
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Add plumbing, so staged placement watcher users can get the actual underlying KV value version for active placement from the underlying staged placement set.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
