### PR TITLE
WIP [dbnode] Fix races in retrieveRequest

### DIFF
--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -959,7 +959,7 @@ func (req *retrieveRequest) Finalize() {
 func (req *retrieveRequest) resetForReuse() {
 	req.resultWg = sync.WaitGroup{}
 	req.finalized.Store(false)
-	req.finalizes = 0
+	atomic.StoreUint32(&req.finalizes, 0)
 	req.source = nil
 	req.shard = 0
 	req.id = nil

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -50,6 +50,7 @@ import (
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
 
+	uatomic "go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
@@ -774,8 +775,6 @@ func (reqs *shardRetrieveRequests) resetQueued() {
 
 // Don't forget to update the resetForReuse method when adding a new field
 type retrieveRequest struct {
-	finalized          bool
-	waitingForCallback bool
 	resultWg           sync.WaitGroup
 
 	pool *reqPool
@@ -801,6 +800,9 @@ type retrieveRequest struct {
 	// we free this request) so we track this with an atomic here.
 	finalizes uint32
 	shard     uint32
+
+	finalized          uatomic.Bool
+	waitingForCallback bool
 
 	notFound bool
 	success  bool
@@ -946,18 +948,17 @@ func (req *retrieveRequest) Segment() (ts.Segment, error) {
 func (req *retrieveRequest) Finalize() {
 	// May not actually finalize the request, depending on if
 	// retriever is done too
-	if req.finalized {
+	if req.finalized.Swap(true) {
 		return
 	}
 
 	req.resultWg.Wait()
-	req.finalized = true
 	req.onCallerOrRetrieverDone()
 }
 
 func (req *retrieveRequest) resetForReuse() {
 	req.resultWg = sync.WaitGroup{}
-	req.finalized = false
+	req.finalized.Store(false)
 	req.finalizes = 0
 	req.source = nil
 	req.shard = 0

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/m3db/m3/src/cluster/shard"
 	"github.com/m3db/m3/src/dbnode/digest"
+	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/sharding"
@@ -50,7 +51,6 @@ import (
 
 	"github.com/fortytw2/leaktest"
 	"github.com/golang/mock/gomock"
-	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -194,8 +194,7 @@ func testBlockRetrieverHighConcurrentSeeks(t *testing.T, shouldCacheShardIndices
 		updateOpenLeaseConcurrency = 4
 		// NB(r): Try to make sure same req structs are reused frequently
 		// to surface any race issues that might occur with pooling.
-		poolOpts = pool.NewObjectPoolOptions().
-				SetSize(fetchConcurrency / 2)
+		poolOpts = pool.NewObjectPoolOptions().SetSize(fetchConcurrency / 2)
 	)
 	segReaderPool := xio.NewSegmentReaderPool(poolOpts)
 	segReaderPool.Init()
@@ -857,7 +856,7 @@ func testBlockRetrieverHandlesSeekErrors(t *testing.T, ctrl *gomock.Controller, 
 }
 
 func testTagsFromIDAndVolume(seriesID string, volume int) ident.Tags {
-	tags := []ident.Tag{}
+	var tags []ident.Tag
 	for j := 0; j < 5; j++ {
 		tags = append(tags, ident.StringTag(
 			fmt.Sprintf("%s.tag.%d.name", seriesID, j),


### PR DESCRIPTION
**What this PR does / why we need it**:
Attempts to fix two race conditions in `retrieveRequest` which I discovered while troubleshooting an integration test locally.

**Special notes for your reviewer**:
Not completely sure if this is a proper fix. Struggling to understand the interleaving of `req.finalized` and `req.resultWg.Wait()` in the original code.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
