### PR TITLE
[coordinator] add graphite names to aggregation types

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -601,7 +601,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesAggregationType(t *tes
 					tags: map[string]string{
 						"__g0__": "nginx_edge",
 						"__g1__": "health",
-						"__g2__": "Max",
+						"__g2__": "upper",
 					},
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
@@ -668,7 +668,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesMultipleAggregationTyp
 					tags: map[string]string{
 						"__g0__": "nginx_edge",
 						"__g1__": "health",
-						"__g2__": "Max",
+						"__g2__": "upper",
 					},
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{
@@ -681,7 +681,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesMultipleAggregationTyp
 					tags: map[string]string{
 						"__g0__": "nginx_edge",
 						"__g1__": "health",
-						"__g2__": "Sum",
+						"__g2__": "sum",
 					},
 					values: []expectedValue{{value: 60}},
 					attributes: &storagemetadata.Attributes{
@@ -742,7 +742,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixAndAggre
 						"__g1__": "counter",
 						"__g2__": "nginx_edge",
 						"__g3__": "health",
-						"__g4__": "Max",
+						"__g4__": "upper",
 					},
 					values: []expectedValue{{value: 30}},
 					attributes: &storagemetadata.Attributes{

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -595,7 +595,7 @@ func (a *metricsAppender) augmentTags(
 			var (
 				count = tags.countPrefix(graphite.Prefix)
 				name  = graphite.TagName(count)
-				value = types[0].GraphiteName()
+				value = types[0].Name()
 			)
 			tags.append(name, value)
 		}

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -595,7 +595,7 @@ func (a *metricsAppender) augmentTags(
 			var (
 				count = tags.countPrefix(graphite.Prefix)
 				name  = graphite.TagName(count)
-				value = types[0].Bytes()
+				value = types[0].GraphiteName()
 			)
 			tags.append(name, value)
 		}

--- a/src/metrics/aggregation/type.go
+++ b/src/metrics/aggregation/type.go
@@ -104,13 +104,13 @@ var (
 
 	typeStringNames = map[Type][]byte{
 		Last:   []byte("last"),
-		Min:    []byte("min"),
+		Min:    []byte("lower"),
 		Max:    []byte("upper"),
 		Mean:   []byte("mean"),
 		Median: []byte("median"),
 		Count:  []byte("count"),
 		Sum:    []byte("sum"),
-		SumSq:  []byte("sum_squares"),
+		SumSq:  []byte("sum_sq"),
 		Stdev:  []byte("stdev"),
 		P10:    []byte("p10"),
 		P20:    []byte("p20"),
@@ -124,7 +124,8 @@ var (
 		P95:    []byte("p95"),
 		P99:    []byte("p99"),
 		P999:   []byte("p999"),
-		P9999:  []byte("p9999")}
+		P9999:  []byte("p9999"),
+	}
 )
 
 // Type defines an aggregation function.

--- a/src/metrics/aggregation/type.go
+++ b/src/metrics/aggregation/type.go
@@ -101,6 +101,30 @@ var (
 	}
 
 	typeStringMap map[string]Type
+
+	graphiteAggregationNames = map[Type][]byte{
+		Last:   []byte("last"),
+		Min:    []byte("min"),
+		Max:    []byte("upper"),
+		Mean:   []byte("mean"),
+		Median: []byte("median"),
+		Count:  []byte("count"),
+		Sum:    []byte("sum"),
+		SumSq:  []byte("sum_squares"),
+		Stdev:  []byte("stdev"),
+		P10:    []byte("p10"),
+		P20:    []byte("p20"),
+		P30:    []byte("p30"),
+		P40:    []byte("p40"),
+		P50:    []byte("p50"),
+		P60:    []byte("p60"),
+		P70:    []byte("p70"),
+		P80:    []byte("p80"),
+		P90:    []byte("p90"),
+		P95:    []byte("p95"),
+		P99:    []byte("p99"),
+		P999:   []byte("p999"),
+		P9999:  []byte("p9999")}
 )
 
 // Type defines an aggregation function.
@@ -230,6 +254,15 @@ func (a *Type) UnmarshalText(data []byte) error {
 	}
 	*a = parsed
 	return nil
+}
+
+// GraphiteName returns the graphite name of the Type.
+func (a Type) GraphiteName() []byte {
+	name, ok := graphiteAggregationNames[a]
+	if ok {
+		return name
+	}
+	return a.Bytes()
 }
 
 func validateProtoType(a aggregationpb.AggregationType) error {

--- a/src/metrics/aggregation/type.go
+++ b/src/metrics/aggregation/type.go
@@ -102,7 +102,7 @@ var (
 
 	typeStringMap map[string]Type
 
-	graphiteAggregationNames = map[Type][]byte{
+	typeStringNames = map[Type][]byte{
 		Last:   []byte("last"),
 		Min:    []byte("min"),
 		Max:    []byte("upper"),
@@ -256,9 +256,9 @@ func (a *Type) UnmarshalText(data []byte) error {
 	return nil
 }
 
-// GraphiteName returns the graphite name of the Type.
-func (a Type) GraphiteName() []byte {
-	name, ok := graphiteAggregationNames[a]
+// Name returns the name of the Type.
+func (a Type) Name() []byte {
+	name, ok := typeStringNames[a]
 	if ok {
 		return name
 	}

--- a/src/metrics/aggregation/types_options_test.go
+++ b/src/metrics/aggregation/types_options_test.go
@@ -61,7 +61,6 @@ func TestOptionsSetDefaultTimerAggregationTypes(t *testing.T) {
 	o := NewTypesOptions().SetDefaultTimerAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultTimerAggregationTypes())
 	require.Equal(t, []float64{0.99, 0.9999}, o.Quantiles())
-	//fmt.Printf("type string %v\n", o.(*options).counterTypeStrings)
 	require.Equal(t, typeStrings(nil), o.(*options).counterTypeStrings)
 }
 

--- a/src/metrics/aggregation/types_options_test.go
+++ b/src/metrics/aggregation/types_options_test.go
@@ -61,6 +61,7 @@ func TestOptionsSetDefaultTimerAggregationTypes(t *testing.T) {
 	o := NewTypesOptions().SetDefaultTimerAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultTimerAggregationTypes())
 	require.Equal(t, []float64{0.99, 0.9999}, o.Quantiles())
+	//fmt.Printf("type string %v\n", o.(*options).counterTypeStrings)
 	require.Equal(t, typeStrings(nil), o.(*options).counterTypeStrings)
 }
 
@@ -449,32 +450,8 @@ func validateQuantiles(t *testing.T, o TypesOptions) {
 }
 
 func typeStrings(overrides map[Type][]byte) [][]byte {
-	defaultTypeStrings := map[Type][]byte{
-		Last:   []byte("last"),
-		Min:    []byte("lower"),
-		Max:    []byte("upper"),
-		Mean:   []byte("mean"),
-		Median: []byte("median"),
-		Count:  []byte("count"),
-		Sum:    []byte("sum"),
-		SumSq:  []byte("sum_sq"),
-		Stdev:  []byte("stdev"),
-		P10:    []byte("p10"),
-		P20:    []byte("p20"),
-		P30:    []byte("p30"),
-		P40:    []byte("p40"),
-		P50:    []byte("p50"),
-		P60:    []byte("p60"),
-		P70:    []byte("p70"),
-		P80:    []byte("p80"),
-		P90:    []byte("p90"),
-		P95:    []byte("p95"),
-		P99:    []byte("p99"),
-		P999:   []byte("p999"),
-		P9999:  []byte("p9999"),
-	}
 	res := make([][]byte, maxTypeID+1)
-	for t, bstr := range defaultTypeStrings {
+	for t, bstr := range typeStringNames {
 		if override, exist := overrides[t]; exist {
 			res[t.ID()] = override
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:
In a previous change we added support for graphite ingestion through the prometheus remote write endpoints. As a part of this we added support to extend the graphite path with the aggregation type.. This PR makes sure that the aggregation type matches with the exact graphite names rather than the internal M3 aggregation types

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
The graphite aggregation option on mapping rules now writes metrics with graphite compatible paths, so will be different from prior to this release.
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
