### PR TITLE
[etcd] Expose cached etcd clients in cluster etcd config service

### DIFF
--- a/src/cluster/client/etcd/client.go
+++ b/src/cluster/client/etcd/client.go
@@ -56,22 +56,22 @@ const (
 
 var errInvalidNamespace = errors.New("invalid namespace")
 
-var (
-	// make sure m3cluster and etcd client interfaces are implemented, and
-	// EtcdConfigService is a superset of cluster client.
-	_ client.Client = EtcdConfigService((*csclient)(nil))
-)
+// make sure m3cluster and etcd client interfaces are implemented, and that
+// Client is a superset of cluster.Client.
+var _ client.Client = Client((*csclient)(nil))
 
 type newClientFn func(cluster Cluster) (*clientv3.Client, error)
 
 type cacheFileForZoneFn func(zone string) etcdkv.CacheFileFn
 
-// EtcdClient is a cached etcd client for a zone.
-type EtcdClient struct {
+// ZoneClient is a cached etcd client for a zone.
+type ZoneClient struct {
 	Client *clientv3.Client
 	Zone   string
 }
 
+// NewEtcdConfigServiceClient returns a new etcd-backed cluster client.
+//nolint:golint
 func NewEtcdConfigServiceClient(opts Options) (*csclient, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
@@ -293,14 +293,14 @@ func (c *csclient) etcdClientGen(zone string) (*clientv3.Client, error) {
 	return cli, nil
 }
 
-// EtcdClients returns all currently cached etcd clients.
-func (c *csclient) EtcdClients() []EtcdClient {
+// Clients returns all currently cached etcd clients.
+func (c *csclient) Clients() []ZoneClient {
 	c.Lock()
 	defer c.Unlock()
 
 	var (
 		zones   = make([]string, 0, len(c.clis))
-		clients = make([]EtcdClient, 0, len(c.clis))
+		clients = make([]ZoneClient, 0, len(c.clis))
 	)
 
 	for k := range c.clis {
@@ -310,7 +310,7 @@ func (c *csclient) EtcdClients() []EtcdClient {
 	sort.Strings(zones)
 
 	for _, zone := range zones {
-		clients = append(clients, EtcdClient{Zone: zone, Client: c.clis[zone]})
+		clients = append(clients, ZoneClient{Zone: zone, Client: c.clis[zone]})
 	}
 
 	return clients

--- a/src/cluster/client/etcd/client_test.go
+++ b/src/cluster/client/etcd/client_test.go
@@ -27,9 +27,10 @@ import (
 	"github.com/m3db/m3/src/cluster/kv"
 	"github.com/m3db/m3/src/cluster/services"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/integration"
-	"github.com/stretchr/testify/require"
 )
 
 func TestETCDClientGen(t *testing.T) {
@@ -295,6 +296,29 @@ func TestReuseKVStore(t *testing.T) {
 	client.storeLock.Lock()
 	require.Equal(t, 2, len(client.stores))
 	client.storeLock.Unlock()
+}
+
+func TestGetEtcdClients(t *testing.T) {
+	opts := testOptions()
+	c, err := NewEtcdConfigServiceClient(opts)
+	require.NoError(t, err)
+
+	c1, err := c.etcdClientGen("zone2")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(c.clis))
+
+	c2, err := c.etcdClientGen("zone1")
+	require.NoError(t, err)
+	require.Equal(t, 2, len(c.clis))
+	require.False(t, c1 == c2)
+
+	clients := c.EtcdClients()
+	require.Len(t, clients, 2)
+
+	assert.Equal(t, clients[0].Zone, "zone1")
+	assert.Equal(t, clients[0].Client, c2)
+	assert.Equal(t, clients[1].Zone, "zone2")
+	assert.Equal(t, clients[1].Client, c1)
 }
 
 func TestValidateNamespace(t *testing.T) {

--- a/src/cluster/client/etcd/client_test.go
+++ b/src/cluster/client/etcd/client_test.go
@@ -312,7 +312,7 @@ func TestGetEtcdClients(t *testing.T) {
 	require.Equal(t, 2, len(c.clis))
 	require.False(t, c1 == c2)
 
-	clients := c.EtcdClients()
+	clients := c.Clients()
 	require.Len(t, clients, 2)
 
 	assert.Equal(t, clients[0].Zone, "zone1")

--- a/src/cluster/client/etcd/types.go
+++ b/src/cluster/client/etcd/types.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/retry"
@@ -134,4 +135,11 @@ type Cluster interface {
 
 	DialTimeout() time.Duration
 	SetDialTimeout(value time.Duration) Cluster
+}
+
+// EtcdConfigService is an etcd-backed m3cluster client.
+type EtcdConfigService interface {
+	client.Client
+
+	EtcdClients() []EtcdClient
 }

--- a/src/cluster/client/etcd/types.go
+++ b/src/cluster/client/etcd/types.go
@@ -137,9 +137,9 @@ type Cluster interface {
 	SetDialTimeout(value time.Duration) Cluster
 }
 
-// EtcdConfigService is an etcd-backed m3cluster client.
-type EtcdConfigService interface {
+// Client is an etcd-backed m3cluster client.
+type Client interface {
 	client.Client
 
-	EtcdClients() []EtcdClient
+	Clients() []ZoneClient
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Expose underlying etcd clients so their state can be inspected, endpoints synced from external source/trigger, etc.
The existing cluster Client interface is far too limiting, even if it's built with etcd in mind.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
