### PR TITLE
[cluster] Fix deadlock in new ActiveStagedPlacement method

### DIFF
--- a/src/cluster/placement/staged_placement_test.go
+++ b/src/cluster/placement/staged_placement_test.go
@@ -461,7 +461,7 @@ func testActiveStagedPlacementVersionWhileExpiring(t *testing.T) {
 		t.Fatalf("test timed out, deadlock?")
 	}
 
-	// release placement lock to allow expiration process to proceed
+	// release placement lock to unblock expiration process
 	doneFn()
 	select {
 	case <-doneCh:
@@ -469,7 +469,7 @@ func testActiveStagedPlacementVersionWhileExpiring(t *testing.T) {
 		t.Fatalf("test timed out, deadlock?")
 	}
 
-	// there's no good way to know when expire process has been completed,
+	// there's no good way to determine when expire process has been completed,
 	// try polling for 100ms
 	for i := 0; i < 100; i++ {
 		if ranCleanup.Load() && p.expiring.Load() == int32(0) {

--- a/src/cluster/placement/staged_placement_test.go
+++ b/src/cluster/placement/staged_placement_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/cluster/shard"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 var (
@@ -395,7 +396,6 @@ func TestActiveStagedPlacementExpireAlreadyClosed(t *testing.T) {
 	p := &activeStagedPlacement{
 		placements: append([]Placement{}, testActivePlacements...),
 		nowFn:      func() time.Time { return time.Unix(0, 99999) },
-		expiring:   1,
 		closed:     true,
 		onPlacementsRemovedFn: func(placements []Placement) {
 			for _, placement := range placements {
@@ -403,9 +403,83 @@ func TestActiveStagedPlacementExpireAlreadyClosed(t *testing.T) {
 			}
 		},
 	}
+	p.expiring.Store(1)
 	p.expire()
-	require.Equal(t, int32(0), p.expiring)
+	require.Equal(t, int32(0), p.expiring.Load())
 	require.Nil(t, removedInstances)
+}
+
+func TestActiveStagedPlacementVersionWhileExpiring(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		// test itself is fast, unless there's a deadlock
+		testActiveStagedPlacementVersionWhileExpiring(t)
+	}
+}
+
+//nolint:gocyclo
+func testActiveStagedPlacementVersionWhileExpiring(t *testing.T) {
+	var (
+		doneCh     = make(chan struct{})
+		signalCh   = make(chan struct{})
+		version    int
+		ranCleanup atomic.Bool
+	)
+
+	p := newActiveStagedPlacement(append([]Placement{}, testActivePlacements...), 42, nil)
+	p.nowFn = func() time.Time {
+		return time.Unix(0, testActivePlacements[len(testActivePlacements)-1].CutoverNanos()+1)
+	}
+	p.onPlacementsRemovedFn = func(_ []Placement) {
+		ranCleanup.Store(true)
+	}
+
+	go func() {
+		defer close(doneCh)
+		for {
+			version = p.Version()
+			select {
+			case signalCh <- struct{}{}:
+				return
+			default:
+			}
+		}
+	}()
+
+	pl, doneFn, err := p.ActivePlacement()
+	require.NoError(t, err)
+	require.NotNil(t, pl)
+	require.NotNil(t, doneFn)
+
+	// active placement is not the first in the list, so cleanup for past
+	// placements should be triggered:
+	require.Equal(t, int32(1), p.expiring.Load())
+
+	// make sure p.Version() call was attempted at least once
+	select {
+	case <-signalCh:
+	case <-time.After(time.Second):
+		t.Fatalf("test timed out, deadlock?")
+	}
+
+	// release placement lock so cleanup can proceed:
+	doneFn()
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatalf("test timed out, deadlock?")
+	}
+
+	// no hooks to know when expire process has been completed, so poll for 100ms:
+	for i := 0; i < 100; i++ {
+		if ranCleanup.Load() && p.expiring.Load() == int32(0) {
+			break
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	require.Equal(t, 42, version)
+	require.True(t, ranCleanup.Load())
+	require.Equal(t, int32(0), p.expiring.Load())
 }
 
 func TestActiveStagedPlacementExpireAlreadyExpired(t *testing.T) {
@@ -413,15 +487,15 @@ func TestActiveStagedPlacementExpireAlreadyExpired(t *testing.T) {
 	p := &activeStagedPlacement{
 		placements: append([]Placement{}, testActivePlacements...),
 		nowFn:      func() time.Time { return time.Unix(0, 0) },
-		expiring:   1,
 		onPlacementsRemovedFn: func(placements []Placement) {
 			for _, placement := range placements {
 				removedInstances = append(removedInstances, placement.Instances())
 			}
 		},
 	}
+	p.expiring.Store(1)
 	p.expire()
-	require.Equal(t, int32(0), p.expiring)
+	require.Equal(t, int32(0), p.expiring.Load())
 	require.Nil(t, removedInstances)
 }
 
@@ -430,15 +504,15 @@ func TestActiveStagedPlacementExpireSuccess(t *testing.T) {
 	p := &activeStagedPlacement{
 		placements: append([]Placement{}, testActivePlacements...),
 		nowFn:      func() time.Time { return time.Unix(0, 99999) },
-		expiring:   1,
 		onPlacementsRemovedFn: func(placements []Placement) {
 			for _, placement := range placements {
 				removedInstances = append(removedInstances, placement.Instances())
 			}
 		},
 	}
+	p.expiring.Store(1)
 	p.expire()
-	require.Equal(t, int32(0), p.expiring)
+	require.Equal(t, int32(0), p.expiring.Load())
 	require.Equal(t, [][]Instance{testActivePlacements[0].Instances()}, removedInstances)
 	require.Equal(t, 1, len(p.placements))
 	validateSnapshot(t, testActivePlacements[1], p.placements[0])

--- a/src/cluster/placement/staged_placement_test.go
+++ b/src/cluster/placement/staged_placement_test.go
@@ -450,8 +450,8 @@ func testActiveStagedPlacementVersionWhileExpiring(t *testing.T) {
 	require.NotNil(t, pl)
 	require.NotNil(t, doneFn)
 
-	// active placement is not the first in the list, so cleanup for past
-	// placements should be triggered:
+	// active placement is not the first in the list - expiration of past
+	// placements must be triggered
 	require.Equal(t, int32(1), p.expiring.Load())
 
 	// make sure p.Version() call was attempted at least once
@@ -461,7 +461,7 @@ func testActiveStagedPlacementVersionWhileExpiring(t *testing.T) {
 		t.Fatalf("test timed out, deadlock?")
 	}
 
-	// release placement lock so cleanup can proceed:
+	// release placement lock to allow expiration process to proceed
 	doneFn()
 	select {
 	case <-doneCh:
@@ -469,7 +469,8 @@ func testActiveStagedPlacementVersionWhileExpiring(t *testing.T) {
 		t.Fatalf("test timed out, deadlock?")
 	}
 
-	// no hooks to know when expire process has been completed, so poll for 100ms:
+	// there's no good way to know when expire process has been completed,
+	// try polling for 100ms
 	for i := 0; i < 100; i++ {
 		if ranCleanup.Load() && p.expiring.Load() == int32(0) {
 			break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes deadlock introduced in #2963: `Version()` could cause a deadlock, if an expire cycle was triggered on a `ActiveStagedPlacement()` call.

Root cause is that I've used a lock - that is also kinda acting as a refcounter and is not meant to be used for this case - to access a variable that was safe to read concurrently. 

The added test always deadlocks on master.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
