### PR TITLE
[SITE] Fix broken og meta tags on static pages

### DIFF
--- a/site/static/about/index.html
+++ b/site/static/about/index.html
@@ -44,7 +44,7 @@
         <meta property="og:title" content="M3: Open Source Metrics Engine"/>
         <meta property="og:site_name" content="M3"/>
         
-            <meta property="og:url" content="#"/>
+            <meta property="og:url" content="/about"/>
         
         <meta property="og:type" content="website"/>
         <meta name="twitter:title" content="M3: Open Source Metrics Engine"/>
@@ -53,9 +53,8 @@
 
         <!-- Image -->
         
-            <meta property="og:image" content="../images/page/og-about.jpg"/>
-            <meta name="twitter:image" content="../images/page/og-about.jpg"/>
-        
+        <meta property="og:image" content="/images/logo-square.png"/>
+        <meta name="twitter:image" content="/images/logo-square.png"/>
 
         <!-- Description -->
         

--- a/site/static/community/index.html
+++ b/site/static/community/index.html
@@ -44,7 +44,7 @@
         <meta property="og:title" content="M3: Open Source Metrics Engine"/>
         <meta property="og:site_name" content="M3"/>
         
-            <meta property="og:url" content="#"/>
+            <meta property="og:url" content="/community"/>
         
         <meta property="og:type" content="website"/>
         <meta name="twitter:title" content="M3: Open Source Metrics Engine"/>
@@ -52,9 +52,8 @@
         <meta name="twitter:card" content="summary_large_image"/>
 
         <!-- Image -->
-        
-            <meta property="og:image" content="../images/page/og-community.jpg"/>
-            <meta name="twitter:image" content="../images/page/og-community.jpg"/>
+        <meta property="og:image" content="/images/logo-square.png"/>
+        <meta name="twitter:image" content="/images/logo-square.png"/>
         
 
         <!-- Description -->

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -44,7 +44,7 @@
         <meta property="og:title" content="M3: Open Source Metrics Engine"/>
         <meta property="og:site_name" content="M3"/>
         
-            <meta property="og:url" content="#"/>
+            <meta property="og:url" content="/"/>
         
         <meta property="og:type" content="website"/>
         <meta name="twitter:title" content="M3: Open Source Metrics Engine"/>
@@ -53,8 +53,8 @@
 
         <!-- Image -->
         
-            <meta property="og:image" content="../images/page/og-home.jpg"/>
-            <meta name="twitter:image" content="../images/page/og-home.jpg"/>
+            <meta property="og:image" content="/images/logo-square.png"/>
+            <meta name="twitter:image" content="/images/logo-square.png"/>
         
 
         <!-- Description -->


### PR DESCRIPTION
This PR fixes some broken links to `og:meta` tags on static pages.

Signed-off-by: ChrisChinchilla <chris@chronosphere.io>