### PR TITLE
[tools] Add benchmarking support to read_data_files

### DIFF
--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -68,7 +68,8 @@ func main() {
 		volume         = getopt.Int64Long("volume", 'v', 0, "Volume number")
 		fileSetTypeArg = getopt.StringLong("fileset-type", 't', flushType, fmt.Sprintf("%s|%s", flushType, snapshotType))
 		idFilter       = getopt.StringLong("id-filter", 'f', "", "ID Contains Filter (optional)")
-		benchmark      = getopt.StringLong("benchmark", 'B', "", "benchmark mode (optional), [series/datapoints]")
+		benchmark      = getopt.StringLong(
+			"benchmark", 'B', "", "benchmark mode (optional), [series/datapoints]")
 	)
 	getopt.Parse()
 
@@ -98,13 +99,13 @@ func main() {
 		log.Fatalf("unknown fileset type: %s", *fileSetTypeArg)
 	}
 
-	var benchmarkMode benchmarkMode
+	var benchMode benchmarkMode
 	switch *benchmark {
 	case "":
 	case "series":
-		benchmarkMode = benchmarkSeries
+		benchMode = benchmarkSeries
 	case "datapoints":
-		benchmarkMode = benchmarkDatapoints
+		benchMode = benchmarkDatapoints
 	default:
 		log.Fatalf("unknown benchmark type: %s", *benchmark)
 	}
@@ -155,13 +156,13 @@ func main() {
 			continue
 		}
 
-		if benchmarkMode != benchmarkSeries {
+		if benchMode != benchmarkSeries {
 			data.IncRef()
 
 			iter := m3tsz.NewReaderIterator(bytes.NewReader(data.Bytes()), true, encodingOpts)
 			for iter.Next() {
 				dp, _, annotation := iter.Current()
-				if benchmarkMode == benchmarkNone {
+				if benchMode == benchmarkNone {
 					// Use fmt package so it goes to stdout instead of stderr
 					fmt.Printf("{id: %s, dp: %+v", id.String(), dp)
 					if len(annotation) > 0 {
@@ -183,15 +184,15 @@ func main() {
 		seriesCount++
 	}
 
-	if benchmarkMode != benchmarkNone {
-		runTime := time.Now().Sub(start)
+	if benchMode != benchmarkNone {
+		runTime := time.Since(start)
 		fmt.Printf("Running time: %s\n", runTime)
 		fmt.Printf("\n%d series read\n", seriesCount)
 		if runTime > 0 {
 			fmt.Printf("(%.2f series/second)\n", float64(seriesCount)/runTime.Seconds())
 		}
 
-		if benchmarkMode == benchmarkDatapoints {
+		if benchMode == benchmarkDatapoints {
 			fmt.Printf("\n%d datapoints decoded\n", datapointCount)
 			fmt.Printf("(%.2f datapoints/second)\n", float64(datapointCount)/runTime.Seconds())
 		}

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -41,18 +41,34 @@ import (
 	"go.uber.org/zap"
 )
 
-const snapshotType = "snapshot"
-const flushType = "flush"
+const (
+	snapshotType = "snapshot"
+	flushType    = "flush"
+)
+
+type benchmarkMode uint8
+
+const (
+	// benchmarkNone prints the data read to the standard output and does not measure performance.
+	benchmarkNone benchmarkMode = iota
+
+	// benchmarkSeries benchmarks time series read performance (skipping datapoint decoding).
+	benchmarkSeries
+
+	// benchmarkDatapoints benchmarks series read, including datapoint decoding.
+	benchmarkDatapoints
+)
 
 func main() {
 	var (
 		optPathPrefix  = getopt.StringLong("path-prefix", 'p', "", "Path prefix [e.g. /var/lib/m3db]")
-		optNamespace   = getopt.StringLong("namespace", 'n', "", "Namespace [e.g. metrics]")
+		optNamespace   = getopt.StringLong("namespace", 'n', "default", "Namespace [e.g. metrics]")
 		optShard       = getopt.Uint32Long("shard", 's', 0, "Shard [expected format uint32]")
 		optBlockstart  = getopt.Int64Long("block-start", 'b', 0, "Block Start Time [in nsec]")
 		volume         = getopt.Int64Long("volume", 'v', 0, "Volume number")
 		fileSetTypeArg = getopt.StringLong("fileset-type", 't', flushType, fmt.Sprintf("%s|%s", flushType, snapshotType))
 		idFilter       = getopt.StringLong("id-filter", 'f', "", "ID Contains Filter (optional)")
+		benchmark      = getopt.StringLong("benchmark", 'B', "", "benchmark mode (optional), [series/datapoints]")
 	)
 	getopt.Parse()
 
@@ -82,12 +98,30 @@ func main() {
 		log.Fatalf("unknown fileset type: %s", *fileSetTypeArg)
 	}
 
+	var benchmarkMode benchmarkMode
+	switch *benchmark {
+	case "":
+	case "series":
+		benchmarkMode = benchmarkSeries
+	case "datapoints":
+		benchmarkMode = benchmarkDatapoints
+	default:
+		log.Fatalf("unknown benchmark type: %s", *benchmark)
+	}
+
 	bytesPool := tools.NewCheckedBytesPool()
 	bytesPool.Init()
 
 	encodingOpts := encoding.NewOptions().SetBytesPool(bytesPool)
 
 	fsOpts := fs.NewOptions().SetFilePathPrefix(*optPathPrefix)
+
+	var (
+		seriesCount    = 0
+		datapointCount = 0
+		start          = time.Now()
+	)
+
 	reader, err := fs.NewReader(bytesPool, fsOpts)
 	if err != nil {
 		log.Fatalf("could not create new reader: %v", err)
@@ -121,23 +155,45 @@ func main() {
 			continue
 		}
 
-		data.IncRef()
-		iter := m3tsz.NewReaderIterator(bytes.NewReader(data.Bytes()), true, encodingOpts)
-		for iter.Next() {
-			dp, _, annotation := iter.Current()
-			// Use fmt package so it goes to stdout instead of stderr
-			fmt.Printf("{id: %s, dp: %+v", id.String(), dp)
-			if len(annotation) > 0 {
-				fmt.Printf(", annotation: %s", base64.StdEncoding.EncodeToString(annotation))
-			}
-			fmt.Println("}")
-		}
-		if err := iter.Err(); err != nil {
-			log.Fatalf("unable to iterate original data: %v", err)
-		}
-		iter.Close()
+		if benchmarkMode != benchmarkSeries {
+			data.IncRef()
 
-		data.DecRef()
+			iter := m3tsz.NewReaderIterator(bytes.NewReader(data.Bytes()), true, encodingOpts)
+			for iter.Next() {
+				dp, _, annotation := iter.Current()
+				if benchmarkMode == benchmarkNone {
+					// Use fmt package so it goes to stdout instead of stderr
+					fmt.Printf("{id: %s, dp: %+v", id.String(), dp)
+					if len(annotation) > 0 {
+						fmt.Printf(", annotation: %s", base64.StdEncoding.EncodeToString(annotation))
+					}
+					fmt.Println("}")
+				}
+				datapointCount++
+			}
+			if err := iter.Err(); err != nil {
+				log.Fatalf("unable to iterate original data: %v", err)
+			}
+			iter.Close()
+
+			data.DecRef()
+		}
+
 		data.Finalize()
+		seriesCount++
+	}
+
+	if benchmarkMode != benchmarkNone {
+		runTime := time.Now().Sub(start)
+		fmt.Printf("Running time: %s\n", runTime)
+		fmt.Printf("\n%d series read\n", seriesCount)
+		if runTime > 0 {
+			fmt.Printf("(%.2f series/second)\n", float64(seriesCount)/runTime.Seconds())
+		}
+
+		if benchmarkMode == benchmarkDatapoints {
+			fmt.Printf("\n%d datapoints decoded\n", datapointCount)
+			fmt.Printf("(%.2f datapoints/second)\n", float64(datapointCount)/runTime.Seconds())
+		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds benchmarking support to `read_data_files` utility. There are two benchmarking modes:
- read series only (do not decode the datapoints)
- read series and decode the datapoints

It was already useful for me for measuring improvement of https://github.com/m3db/m3/pull/2827#issuecomment-739335010 and I believe there will be more use cases in future.

**Special notes for your reviewer**:

Sample output:
```
> read_data_files -b 1596009600000000000 -p ~/testdata/m3db -s 4 -v 0 -B datapoints
Running time: 460.262013ms

7315 series read
(15893.12 series/second)

3852592 datapoints decoded
(8370432.26 datapoints/second)
```

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
