### PR TITLE
[aggregator] Fix panic on shutdown in ForwardedWriter

### DIFF
--- a/src/aggregator/aggregator/forwarded_writer_test.go
+++ b/src/aggregator/aggregator/forwarded_writer_test.go
@@ -21,7 +21,9 @@
 package aggregator
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/m3db/m3/src/aggregator/client"
 	"github.com/m3db/m3/src/metrics/aggregation"
@@ -32,6 +34,7 @@ import (
 	"github.com/m3db/m3/src/metrics/policy"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 )
@@ -54,11 +57,43 @@ func TestForwardedWriterRegisterWriterClosed(t *testing.T) {
 		mt     = metric.CounterType
 		mid    = id.RawID("foo")
 		aggKey = testForwardedWriterAggregationKey
+		closed = make(chan struct{})
+		wg     sync.WaitGroup
 	)
-	w.Close()
 
-	_, _, err := w.Register(mt, mid, aggKey)
-	require.Equal(t, errForwardedWriterClosed, err)
+	c.EXPECT().Flush().AnyTimes()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			var err error
+
+			assert.NotPanics(t, func() {
+				if err = w.Flush(); err != nil {
+					require.Equal(t, errForwardedWriterClosed, err)
+				}
+			})
+
+			if err != nil {
+				break
+			}
+			time.Sleep(1 * time.Microsecond)
+		}
+
+		assert.NotPanics(t, func() {
+			_, _, err := w.Register(mt, mid, aggKey)
+			require.Equal(t, errForwardedWriterClosed, err)
+
+			err = w.Flush()
+			require.Equal(t, errForwardedWriterClosed, err)
+		})
+	}()
+
+	require.NoError(t, w.Close())
+	close(closed)
+	wg.Wait()
 }
 
 func TestForwardedWriterRegisterNewAggregation(t *testing.T) {
@@ -390,12 +425,10 @@ func TestForwardedWriterCloseWriterClosed(t *testing.T) {
 		w = newForwardedWriter(0, c, tally.NoopScope)
 	)
 
-	// Close the writer and validate that the fields are nil'ed out.
+	// Close the writer
 	require.NoError(t, w.Close())
 	fw := w.(*forwardedWriter)
-	require.True(t, fw.closed)
-	require.Nil(t, fw.client)
-	require.Nil(t, fw.aggregations)
+	require.True(t, fw.closed.Load())
 
 	// Closing the writer a second time results in an error.
 	require.Equal(t, errForwardedWriterClosed, w.Close())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
M3 Aggregator was panicking on shutdown as Flush() and Close() are called concurrently. It no longer resets the internal fields to nil, but that's never been necessary.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
