### PR TITLE
[dbnode] Skip out of retention index segments during bootstrap.

### DIFF
--- a/src/dbnode/persist/fs/index_claims_manager.go
+++ b/src/dbnode/persist/fs/index_claims_manager.go
@@ -40,9 +40,9 @@ var (
 	// errMustUseSingleClaimsManager returned when a second claims manager
 	// created, since this is a violation of expected behavior.
 	errMustUseSingleClaimsManager = errors.New("not using single global claims manager")
-	// errOutOfRetentionClaim returned when reserving a claim that is
+	// ErrOutOfRetentionClaim returned when reserving a claim that is
 	// out of retention.
-	errOutOfRetentionClaim = errors.New("out of retention index volume claim")
+	ErrOutOfRetentionClaim = errors.New("out of retention index volume claim")
 
 	globalIndexClaimsManagers uint64
 )
@@ -110,7 +110,7 @@ func (i *indexClaimsManager) ClaimNextIndexFileSetVolumeIndex(
 
 	// Reject out of retention claims.
 	if blockStart.Before(earliestBlockStart) {
-		return 0, errOutOfRetentionClaim
+		return 0, ErrOutOfRetentionClaim
 	}
 
 	volumeIndexClaimsByBlockStart, ok := i.volumeIndexClaims[md.ID().String()]

--- a/src/dbnode/persist/fs/index_claims_manager_test.go
+++ b/src/dbnode/persist/fs/index_claims_manager_test.go
@@ -129,7 +129,7 @@ func TestIndexClaimsManagerOutOfRetention(t *testing.T) {
 		md,
 		blockStart,
 	)
-	require.Equal(t, errOutOfRetentionClaim, err)
+	require.Equal(t, ErrOutOfRetentionClaim, err)
 
 	// Verify that the out of retention entry has been deleted as well.
 	_, ok = mgr.volumeIndexClaims[md.ID().String()][xtime.ToUnixNano(blockStart)]

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -21,6 +21,7 @@
 package fs
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -83,8 +84,9 @@ type fileSystemSource struct {
 }
 
 type fileSystemSourceMetrics struct {
-	persistedIndexBlocksRead  tally.Counter
-	persistedIndexBlocksWrite tally.Counter
+	persistedIndexBlocksRead           tally.Counter
+	persistedIndexBlocksWrite          tally.Counter
+	persistedIndexBlocksOutOfRetention tally.Counter
 }
 
 func newFileSystemSource(opts Options) (bootstrap.Source, error) {
@@ -105,8 +107,9 @@ func newFileSystemSource(opts Options) (bootstrap.Source, error) {
 		idPool:      opts.IdentifierPool(),
 		newReaderFn: fs.NewReader,
 		metrics: fileSystemSourceMetrics{
-			persistedIndexBlocksRead:  scope.Counter("persist-index-blocks-read"),
-			persistedIndexBlocksWrite: scope.Counter("persist-index-blocks-write"),
+			persistedIndexBlocksRead:           scope.Counter("persist-index-blocks-read"),
+			persistedIndexBlocksWrite:          scope.Counter("persist-index-blocks-write"),
+			persistedIndexBlocksOutOfRetention: scope.Counter("persist-index-blocks-out-of-retention"),
 		},
 	}
 	s.newReaderPoolOpts.Alloc = s.newReader
@@ -408,6 +411,17 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 	requestedRanges := timeWindowReaders.Ranges
 	remainingRanges := requestedRanges.Copy()
 	shardReaders := timeWindowReaders.Readers
+	defer func() {
+		// Return readers to pool.
+		for _, shardReaders := range shardReaders {
+			for _, r := range shardReaders.Readers {
+				if err := r.Close(); err == nil {
+					readerPool.Put(r)
+				}
+			}
+		}
+	}()
+
 	for shard, shardReaders := range shardReaders {
 		shard := uint32(shard)
 		readers := shardReaders.Readers
@@ -590,7 +604,14 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 				blockStart,
 				blockEnd,
 			)
-			if err != nil {
+			if errors.Is(err, fs.ErrOutOfRetentionClaim) {
+				// Bail early if the index segment is already out of retention.
+				// This can happen when the edge of requested ranges at time of data bootstrap
+				// is now out of retention.
+				s.log.Debug("skipping out of retention index segment", buildIndexLogFields...)
+				s.metrics.persistedIndexBlocksOutOfRetention.Inc(1)
+				return
+			} else if err != nil {
 				instrument.EmitAndLogInvariantViolation(iopts, func(l *zap.Logger) {
 					l.Error("persist fs index bootstrap failed",
 						zap.Error(err),
@@ -635,15 +656,6 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 		runResult.Lock()
 		runResult.index.IndexResults()[xtime.ToUnixNano(blockStart)].SetBlock(idxpersist.DefaultIndexVolumeType, result.NewIndexBlock(segments, newFulfilled))
 		runResult.Unlock()
-	}
-
-	// Return readers to pool.
-	for _, shardReaders := range shardReaders {
-		for _, r := range shardReaders.Readers {
-			if err := r.Close(); err == nil {
-				readerPool.Put(r)
-			}
-		}
 	}
 
 	s.markRunResultErrorsAndUnfulfilled(runResult, requestedRanges,

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -21,6 +21,7 @@
 package peers
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -50,6 +51,7 @@ import (
 	xresource "github.com/m3db/m3/src/x/resource"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
+	"github.com/uber-go/tally"
 
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
@@ -61,6 +63,11 @@ type peersSource struct {
 	log               *zap.Logger
 	newPersistManager func() (persist.Manager, error)
 	nowFn             clock.NowFn
+	metrics           peersSourceMetrics
+}
+
+type peersSourceMetrics struct {
+	persistedIndexBlocksOutOfRetention tally.Counter
 }
 
 type persistenceFlush struct {
@@ -76,6 +83,8 @@ func newPeersSource(opts Options) (bootstrap.Source, error) {
 	}
 
 	iopts := opts.ResultOptions().InstrumentOptions()
+	scope := iopts.MetricsScope().SubScope("peers-bootstrapper")
+	iopts = iopts.SetMetricsScope(scope)
 	return &peersSource{
 		opts: opts,
 		log:  iopts.Logger().With(zap.String("bootstrapper", "peers")),
@@ -83,6 +92,9 @@ func newPeersSource(opts Options) (bootstrap.Source, error) {
 			return fs.NewPersistManager(opts.FilesystemOptions())
 		},
 		nowFn: opts.ResultOptions().ClockOptions().NowFn(),
+		metrics: peersSourceMetrics{
+			persistedIndexBlocksOutOfRetention: scope.Counter("persist-index-blocks-out-of-retention"),
+		},
 	}, nil
 }
 
@@ -824,7 +836,17 @@ func (s *peersSource) processReaders(
 		timesWithErrors []time.Time
 		totalEntries    int
 	)
-	defer docsPool.Put(batch)
+	defer func() {
+		docsPool.Put(batch)
+		// Return readers to pool.
+		for _, shardReaders := range timeWindowReaders.Readers {
+			for _, r := range shardReaders.Readers {
+				if err := r.Close(); err == nil {
+					readerPool.Put(r)
+				}
+			}
+		}
+	}()
 
 	requestedRanges := timeWindowReaders.Ranges
 	remainingRanges := requestedRanges.Copy()
@@ -934,7 +956,14 @@ func (s *peersSource) processReaders(
 			blockStart,
 			blockEnd,
 		)
-		if err != nil {
+		if errors.Is(err, fs.ErrOutOfRetentionClaim) {
+			// Bail early if the index segment is already out of retention.
+			// This can happen when the edge of requested ranges at time of data bootstrap
+			// is now out of retention.
+			s.log.Debug("skipping out of retention index segment", buildIndexLogFields...)
+			s.metrics.persistedIndexBlocksOutOfRetention.Inc(1)
+			return remainingRanges, timesWithErrors
+		} else if err != nil {
 			instrument.EmitAndLogInvariantViolation(iopts, func(l *zap.Logger) {
 				l.Error("persist fs index bootstrap failed",
 					zap.Stringer("namespace", ns.ID()),
@@ -977,15 +1006,6 @@ func (s *peersSource) processReaders(
 	resultLock.Lock()
 	r.IndexResults()[xtime.ToUnixNano(blockStart)].SetBlock(idxpersist.DefaultIndexVolumeType, result.NewIndexBlock(segments, newFulfilled))
 	resultLock.Unlock()
-
-	// Return readers to pool.
-	for _, shardReaders := range timeWindowReaders.Readers {
-		for _, r := range shardReaders.Readers {
-			if err := r.Close(); err == nil {
-				readerPool.Put(r)
-			}
-		}
-	}
 
 	return remainingRanges, timesWithErrors
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -27,6 +27,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/m3db/m3/src/cluster/shard"
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/namespace"
@@ -52,10 +56,6 @@ import (
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
 	"github.com/uber-go/tally"
-
-	"github.com/opentracing/opentracing-go"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 type peersSource struct {

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/source.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -55,7 +56,6 @@ import (
 	xresource "github.com/m3db/m3/src/x/resource"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
-	"github.com/uber-go/tally"
 )
 
 type peersSource struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Skip out of retention index segments during bootstrap. This can happen if the edge of the requested ranges is already out of retention by the time we start bootstrapping index data. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
