### PR TITLE
[x/net/http] Add Proxy field to HTTPClientOptions

### DIFF
--- a/src/x/net/http/client.go
+++ b/src/x/net/http/client.go
@@ -44,6 +44,14 @@ type HTTPClientOptions struct {
 
 // NewHTTPClient constructs a new HTTP Client.
 func NewHTTPClient(o HTTPClientOptions) *http.Client {
+	// Before we added the Proxy option, we unconditionally set the field in
+	// the http.Transport we construct below to http.ProxyFromEnvironment. To
+	// keep that behavior unchanged now that we added the field, we need to
+	// set the option if it is nil.
+  if o.Proxy == nil {
+		o.Proxy = http.ProxyFromEnvironment
+	}
+
 	return &http.Client{
 		Timeout: o.RequestTimeout,
 		Transport: &http.Transport{

--- a/src/x/net/http/client.go
+++ b/src/x/net/http/client.go
@@ -23,8 +23,13 @@ package xhttp
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 )
+
+// ProxyFunc is a type alias for the proxy function used by the standard
+// library's http.Transport struct.
+type ProxyFunc func(*http.Request) (*url.URL, error)
 
 // HTTPClientOptions specify HTTP Client options.
 type HTTPClientOptions struct {
@@ -34,6 +39,7 @@ type HTTPClientOptions struct {
 	IdleConnTimeout    time.Duration `yaml:"idleConnTimeout"`
 	MaxIdleConns       int           `yaml:"maxIdleConns"`
 	DisableCompression bool          `yaml:"disableCompression"`
+	Proxy              ProxyFunc     `yaml:"proxy"`
 }
 
 // NewHTTPClient constructs a new HTTP Client.
@@ -41,7 +47,7 @@ func NewHTTPClient(o HTTPClientOptions) *http.Client {
 	return &http.Client{
 		Timeout: o.RequestTimeout,
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
+			Proxy: o.Proxy,
 			Dial: (&net.Dialer{
 				Timeout:   o.ConnectTimeout,
 				KeepAlive: o.KeepAlive,
@@ -67,5 +73,6 @@ func DefaultHTTPClientOptions() HTTPClientOptions {
 		// DisableCompression is true by default since we have seen
 		// a large amount of overhead with compression.
 		DisableCompression: true,
+		Proxy:              ProxyFunc(http.ProxyFromEnvironment),
 	}
 }

--- a/src/x/net/http/client.go
+++ b/src/x/net/http/client.go
@@ -48,7 +48,7 @@ func NewHTTPClient(o HTTPClientOptions) *http.Client {
 	// the http.Transport we construct below to http.ProxyFromEnvironment. To
 	// keep that behavior unchanged now that we added the field, we need to
 	// set the option if it is nil.
-  if o.Proxy == nil {
+	if o.Proxy == nil {
 		o.Proxy = http.ProxyFromEnvironment
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This commit adds a new field, `Proxy`, to `HTTPClientOptions` that will be used to configure the corresponding `Proxy` field in the transport of the client that is created from the options. This allows the caller to use the standard library's built-in support for connecting to a target via proxy.

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
