### PR TITLE
[dbnode] Validate index segments and properly mark fulfilled ranges

### DIFF
--- a/src/dbnode/integration/fs_bootstrap_index_partial_shards_test.go
+++ b/src/dbnode/integration/fs_bootstrap_index_partial_shards_test.go
@@ -1,0 +1,231 @@
+// +build integration
+
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/dbnode/integration/generate"
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/retention"
+	"github.com/m3db/m3/src/dbnode/storage/index"
+	"github.com/m3db/m3/src/m3ninx/doc"
+	"github.com/m3db/m3/src/m3ninx/idx"
+	idxpersist "github.com/m3db/m3/src/m3ninx/persist"
+	"github.com/m3db/m3/src/x/ident"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilesystemBootstrapIndexPartialShards tests bootstrapping index blocks with missing shards.
+// This tests the node leave case where a node can accept new shards and persist data for those shards
+// before crashing leaving the node with an index block that only partially fulfills the requested shard
+// time ranges.
+func TestFilesystemBootstrapIndexPartialShards(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow() // Just skip if we're doing a short run
+	}
+
+	var (
+		blockSize = 2 * time.Hour
+		rOpts     = retention.NewOptions().SetRetentionPeriod(2 * blockSize).SetBlockSize(blockSize)
+		idxOpts   = namespace.NewIndexOptions().SetEnabled(true).SetBlockSize(2 * blockSize)
+		nOpts     = namespace.NewOptions().SetRetentionOptions(rOpts).SetIndexOptions(idxOpts)
+		numShards = 6
+	)
+	ns1, err := namespace.NewMetadata(testNamespaces[0], nOpts)
+	require.NoError(t, err)
+
+	opts := NewTestOptions(t).
+		SetNamespaces([]namespace.Metadata{ns1}).
+		SetNumShards(numShards)
+
+	// Test setup
+	setup, err := NewTestSetup(t, opts, nil)
+	require.NoError(t, err)
+	defer setup.Close()
+
+	require.NoError(t, setup.InitializeBootstrappers(InitializeBootstrappersOptions{
+		WithFileSystem: true,
+	}))
+
+	// Write test data
+	now := setup.NowFn()()
+
+	fooSeries := generate.Series{
+		ID:   ident.StringID("foo"),
+		Tags: ident.NewTags(ident.StringTag("city", "new_york"), ident.StringTag("foo", "foo")),
+	}
+	fooDoc := doc.Document{
+		ID: fooSeries.ID.Bytes(),
+		Fields: []doc.Field{
+			doc.Field{Name: []byte("city"), Value: []byte("new_york")},
+			doc.Field{Name: []byte("foo"), Value: []byte("foo")},
+		},
+	}
+
+	barSeries := generate.Series{
+		ID:   ident.StringID("bar"),
+		Tags: ident.NewTags(ident.StringTag("city", "new_jersey")),
+	}
+	barDoc := doc.Document{
+		ID: barSeries.ID.Bytes(),
+		Fields: []doc.Field{
+			doc.Field{Name: []byte("city"), Value: []byte("new_jersey")},
+		},
+	}
+
+	bazSeries := generate.Series{
+		ID:   ident.StringID("baz"),
+		Tags: ident.NewTags(ident.StringTag("city", "seattle")),
+	}
+	bazDoc := doc.Document{
+		ID: bazSeries.ID.Bytes(),
+		Fields: []doc.Field{
+			doc.Field{Name: []byte("city"), Value: []byte("seattle")},
+		},
+	}
+
+	daxSeries := generate.Series{
+		ID:   ident.StringID("dax"),
+		Tags: ident.NewTags(ident.StringTag("city", "new_harmony")),
+	}
+
+	duxSeries := generate.Series{
+		ID:   ident.StringID("dux"),
+		Tags: ident.NewTags(ident.StringTag("city", "los_angeles")),
+	}
+
+	// The first set of shards/series/index docs represent local shards and the second set
+	// represents peer bootstrapped shards.
+	shardSetLocal, err := newTestShardSetFromRange(numShards, 0, numShards/2) // Half were originally local.
+	require.NoError(t, err)
+	shardSetPeer, err := newTestShardSetFromRange(numShards, numShards/2, numShards) // Half from peers.
+	require.NoError(t, err)
+	seriesMapsLocal := generate.BlocksByStart([]generate.BlockConfig{
+		{
+			IDs:       []string{fooSeries.ID.String()},
+			Tags:      fooSeries.Tags,
+			NumPoints: 100,
+			Start:     now.Add(-blockSize),
+		},
+		{
+			IDs:       []string{barSeries.ID.String()},
+			Tags:      barSeries.Tags,
+			NumPoints: 100,
+			Start:     now.Add(-blockSize),
+		},
+		{
+			IDs:       []string{fooSeries.ID.String()},
+			Tags:      fooSeries.Tags,
+			NumPoints: 50,
+			Start:     now,
+		},
+		{
+			IDs:       []string{bazSeries.ID.String()},
+			Tags:      bazSeries.Tags,
+			NumPoints: 50,
+			Start:     now,
+		},
+	})
+	seriesMapsPeer := generate.BlocksByStart([]generate.BlockConfig{
+		{
+			IDs:       []string{daxSeries.ID.String()},
+			Tags:      daxSeries.Tags,
+			NumPoints: 100,
+			Start:     now.Add(-blockSize),
+		},
+		{
+			IDs:       []string{duxSeries.ID.String()},
+			Tags:      duxSeries.Tags,
+			NumPoints: 100,
+			Start:     now,
+		},
+	})
+
+	indexDocsLocal := []doc.Document{
+		fooDoc,
+		barDoc,
+		bazDoc,
+	}
+
+	require.NoError(t, writeTestDataToDiskWithShards(ns1, setup, seriesMapsLocal, 0, shardSetLocal))
+	require.NoError(t, writeTestDataToDiskWithShards(ns1, setup, seriesMapsPeer, 0, shardSetPeer))
+	require.NoError(t, writeTestIndexDataToDisk(
+		ns1,
+		setup.StorageOpts(),
+		idxpersist.DefaultIndexVolumeType,
+		now.Add(-blockSize),
+		shardSetLocal.AllIDs(),
+		indexDocsLocal,
+	))
+
+	// Start the server with filesystem bootstrapper
+	log := setup.StorageOpts().InstrumentOptions().Logger()
+	log.Debug("filesystem bootstrap index partial shards test")
+	require.NoError(t, setup.StartServer())
+	log.Debug("server is now up")
+
+	// Stop the server
+	defer func() {
+		require.NoError(t, setup.StopServer())
+		log.Debug("server is now down")
+	}()
+
+	// Issue some index queries
+	session, err := setup.M3DBClient().DefaultSession()
+	require.NoError(t, err)
+
+	start := now.Add(-rOpts.RetentionPeriod())
+	end := now.Add(blockSize)
+	queryOpts := index.QueryOptions{StartInclusive: start, EndExclusive: end}
+
+	// Match all new_*r*
+	regexpQuery, err := idx.NewRegexpQuery([]byte("city"), []byte("new_.*r.*"))
+	require.NoError(t, err)
+	iter, fetchResponse, err := session.FetchTaggedIDs(ns1.ID(),
+		index.Query{Query: regexpQuery}, queryOpts)
+	require.NoError(t, err)
+	defer iter.Finalize()
+
+	verifyQueryMetadataResults(t, iter, fetchResponse.Exhaustive, verifyQueryMetadataResultsOptions{
+		namespace:  ns1.ID(),
+		exhaustive: true,
+		expected:   []generate.Series{fooSeries, barSeries, daxSeries},
+	})
+
+	// Match all *e*e*
+	regexpQuery, err = idx.NewRegexpQuery([]byte("city"), []byte(".*e.*e.*"))
+	require.NoError(t, err)
+	iter, fetchResponse, err = session.FetchTaggedIDs(ns1.ID(),
+		index.Query{Query: regexpQuery}, queryOpts)
+	require.NoError(t, err)
+	defer iter.Finalize()
+
+	verifyQueryMetadataResults(t, iter, fetchResponse.Exhaustive, verifyQueryMetadataResultsOptions{
+		namespace:  ns1.ID(),
+		exhaustive: true,
+		expected:   []generate.Series{barSeries, bazSeries, duxSeries},
+	})
+}

--- a/src/dbnode/integration/integration.go
+++ b/src/dbnode/integration/integration.go
@@ -349,6 +349,7 @@ func writeTestDataToDisk(
 	return writeTestDataToDiskWithShards(metadata, setup, seriesMaps, volume, setup.ShardSet())
 }
 
+// nolint: unused
 func writeTestDataToDiskWithShards(
 	metadata namespace.Metadata,
 	setup TestSetup,

--- a/src/dbnode/integration/integration.go
+++ b/src/dbnode/integration/integration.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	persistfs "github.com/m3db/m3/src/dbnode/persist/fs"
+	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap"
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
@@ -345,9 +346,19 @@ func writeTestDataToDisk(
 	seriesMaps generate.SeriesBlocksByStart,
 	volume int,
 ) error {
+	return writeTestDataToDiskWithShards(metadata, setup, seriesMaps, volume, setup.ShardSet())
+}
+
+func writeTestDataToDiskWithShards(
+	metadata namespace.Metadata,
+	setup TestSetup,
+	seriesMaps generate.SeriesBlocksByStart,
+	volume int,
+	shardSet sharding.ShardSet,
+) error {
 	ropts := metadata.Options().RetentionOptions()
 	writer := generate.NewWriter(setup.GeneratorOptions(ropts))
-	return writer.WriteData(namespace.NewContextFrom(metadata), setup.ShardSet(), seriesMaps, volume)
+	return writer.WriteData(namespace.NewContextFrom(metadata), shardSet, seriesMaps, volume)
 }
 
 func writeTestSnapshotsToDiskWithPredicate(

--- a/src/dbnode/integration/serve.go
+++ b/src/dbnode/integration/serve.go
@@ -41,15 +41,20 @@ import (
 	"go.uber.org/zap"
 )
 
-// newTestShardSet creates a default shard set
-func newTestShardSet(numShards int) (sharding.ShardSet, error) {
+// newTestShardSetFromOffset creates a default shard set from an offset.
+func newTestShardSetFromRange(numShards, start, end int) (sharding.ShardSet, error) {
 	var ids []uint32
-	for i := uint32(0); i < uint32(numShards); i++ {
+	for i := uint32(start); i < uint32(end); i++ {
 		ids = append(ids, i)
 	}
 
 	shards := sharding.NewShards(ids, shard.Available)
 	return sharding.NewShardSet(shards, sharding.DefaultHashFn(numShards))
+}
+
+// newTestShardSet creates a default shard set from offset 0.
+func newTestShardSet(numShards int) (sharding.ShardSet, error) {
+	return newTestShardSetFromRange(numShards, 0, numShards)
 }
 
 // newTopologyInitializerForShardSet creates a default topology initializer for a shard set

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -1595,8 +1595,9 @@ func CompleteCheckpointFileExists(filePath string) (bool, error) {
 	return f.Size() == CheckpointFileSizeBytes, nil
 }
 
-// CheckpointFilePathUnsafe is a method to get the checkpoint file path given a namespace/block/volume index
-// and is meant to be used only in testing and is unsafe for normal use.
+// CheckpointFilePathUnsafe is a method to get the checkpoint file path given a
+// namespace/block/volume index and is meant to be used only in testing and is
+// unsafe for normal use.
 func CheckpointFilePathUnsafe(prefix string, t time.Time, index int) string {
 	return filesetPathFromTimeAndIndex(prefix, t, index, checkpointFileSuffix)
 }

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -82,9 +82,7 @@ const (
 	errUnexpectedFilenamePattern = "unexpected filename: %s"
 )
 
-var (
-	defaultBufioReaderSize = bufio.NewReader(nil).Size()
-)
+var defaultBufioReaderSize = bufio.NewReader(nil).Size()
 
 type fileOpener func(filePath string) (*os.File, error)
 
@@ -923,7 +921,6 @@ func SortedSnapshotMetadataFiles(opts Options) (
 		path.Join(
 			snapshotsDirPath,
 			fmt.Sprintf("*%s%s%s", separator, metadataFileSuffix, fileSuffix)))
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1564,7 +1561,7 @@ func NextIndexSnapshotFileIndex(filePathPrefix string, namespace ident.ID, block
 		return -1, err
 	}
 
-	var currentSnapshotIndex = -1
+	currentSnapshotIndex := -1
 	for _, snapshot := range snapshotFiles {
 		if snapshot.ID.BlockStart.Equal(blockStart) {
 			currentSnapshotIndex = snapshot.ID.VolumeIndex
@@ -1596,6 +1593,12 @@ func CompleteCheckpointFileExists(filePath string) (bool, error) {
 	// Make sure the checkpoint file was completely written out and its
 	// not just an empty file.
 	return f.Size() == CheckpointFileSizeBytes, nil
+}
+
+// CheckpointFilePathUnsafe is a method to get the checkpoint file path given a namespace/block/volume index
+// and is meant to be used only in testing and is unsafe for normal use.
+func CheckpointFilePathUnsafe(prefix string, t time.Time, index int) string {
+	return filesetPathFromTimeAndIndex(prefix, t, index, checkpointFileSuffix)
 }
 
 // FileExists returns whether a file at the given path exists.

--- a/src/dbnode/persist/fs/index_read.go
+++ b/src/dbnode/persist/fs/index_read.go
@@ -341,13 +341,15 @@ func (r *indexReader) validateSegmentFileDigest(segmentIdx, fileIdx int) error {
 		return fmt.Errorf(
 			"(%w) have not read correct number of segment files to validate segment %d checksums: "+
 				"need=%d, actual=%d",
-			ErrIndexReaderValidationFailed, segmentIdx, fileIdx+1, len(r.readDigests.segments[segmentIdx].files))
+			ErrIndexReaderValidationFailed, segmentIdx, fileIdx+1,
+			len(r.readDigests.segments[segmentIdx].files))
 	}
 	if fileIdx >= len(r.expectedDigest.SegmentDigests[segmentIdx].Files) {
 		return fmt.Errorf(
 			"(%w) have not read correct number of segment files to validate segment %d checksums: "+
 				"need=%d, actual=%d",
-			ErrIndexReaderValidationFailed, segmentIdx, fileIdx+1, len(r.expectedDigest.SegmentDigests[segmentIdx].Files))
+			ErrIndexReaderValidationFailed, segmentIdx, fileIdx+1,
+			len(r.expectedDigest.SegmentDigests[segmentIdx].Files))
 	}
 
 	expected := r.expectedDigest.SegmentDigests[segmentIdx].Files[fileIdx].Digest

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -698,4 +698,5 @@ type DataEntryProcessor interface {
 	ProcessEntry(StreamedDataEntry) error
 }
 
+// DeleteFilesFn deletes files passed in as arg.
 type DeleteFilesFn func(files []string) error

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -697,3 +697,5 @@ type DataEntryProcessor interface {
 	// ProcessEntry processes a single StreamedDataEntry.
 	ProcessEntry(StreamedDataEntry) error
 }
+
+type DeleteFilesFn func(files []string) error

--- a/src/dbnode/storage/bootstrap/bootstrap_mock.go
+++ b/src/dbnode/storage/bootstrap/bootstrap_mock.go
@@ -703,6 +703,21 @@ func (mr *MockCacheMockRecorder) InfoFilesForShard(ns, shard interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InfoFilesForShard", reflect.TypeOf((*MockCache)(nil).InfoFilesForShard), ns, shard)
 }
 
+// IndexInfoFilesForNamespace mocks base method
+func (m *MockCache) IndexInfoFilesForNamespace(ns namespace.Metadata) ([]fs.ReadIndexInfoFileResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IndexInfoFilesForNamespace", ns)
+	ret0, _ := ret[0].([]fs.ReadIndexInfoFileResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IndexInfoFilesForNamespace indicates an expected call of IndexInfoFilesForNamespace
+func (mr *MockCacheMockRecorder) IndexInfoFilesForNamespace(ns interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexInfoFilesForNamespace", reflect.TypeOf((*MockCache)(nil).IndexInfoFilesForNamespace), ns)
+}
+
 // ReadInfoFiles mocks base method
 func (m *MockCache) ReadInfoFiles() InfoFilesByNamespace {
 	m.ctrl.T.Helper()

--- a/src/dbnode/storage/bootstrap/bootstrapper/README.md
+++ b/src/dbnode/storage/bootstrap/bootstrapper/README.md
@@ -6,6 +6,7 @@ The collection of bootstrappers comprise the task executed when bootstrapping a 
 
 - `fs`: The filesystem bootstrapper, used to bootstrap as much data as possible from the local filesystem.
 - `peers`: The peers bootstrapper, used to bootstrap any remaining data from peers. This is used for a full node join too.
+  - *NOTE*: For the node leave case, the peers bs will persist default volume type index filesets to disk with non-overlapping shard time ranges to avoid re-building the entire index segment w/ new shards.
 - `commitlog`: The commit log bootstrapper, currently only used in the case that peers bootstrapping fails. Once the current block is being snapshotted frequently to disk it might be faster and make more sense to not actively use the peers bootstrapper and just use a combination of the filesystem bootstrapper and the minimal time range required from the commit log bootstrapper.
     - *NOTE*: the commitlog bootstrapper is special cased in that it runs for the *entire* bootstrappable range per shard whereas other bootstrappers fill in the unfulfilled gaps as bootstrapping progresses.
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -23,6 +23,7 @@ package fs
 import (
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -1072,6 +1073,7 @@ func (s *fileSystemSource) validateAndDeleteCorruptedIndexBlocks(
 			}
 			continue
 		}
+		log.Println("[YEET] validated index block start ->", indexBlockStartUnixNanos)
 
 		validatedIndexBlocks[indexBlockStartUnixNanos] = append(validatedIndexBlocks[indexBlockStartUnixNanos], validatedIndexBlock{
 			volumeType: volumeTypeFromInfo(&infoFile.Info),

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -23,7 +23,6 @@ package fs
 import (
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -1073,7 +1072,6 @@ func (s *fileSystemSource) validateAndDeleteCorruptedIndexBlocks(
 			}
 			continue
 		}
-		log.Println("[YEET] validated index block start ->", indexBlockStartUnixNanos)
 
 		validatedIndexBlocks[indexBlockStartUnixNanos] = append(validatedIndexBlocks[indexBlockStartUnixNanos], validatedIndexBlock{
 			volumeType: volumeTypeFromInfo(&infoFile.Info),

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -740,7 +740,7 @@ func (s *fileSystemSource) appendIndexFilesetFilesToDelete(
 		}
 	}
 
-	// Remove index results for the block in question
+	// Remove index results for the block we're deleting.
 	if err := removeIndexResults(ns, blockStart, runResult); err != nil {
 		instrument.EmitAndLogInvariantViolation(iopts, func(l *zap.Logger) {
 			l.Error("error removing partial/corrupted index results",
@@ -1056,6 +1056,9 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		return bootstrapFromIndexPersistedBlocksResult{}, err
 	}
 
+	// Track corrupted block starts as we will attempt to later recover
+	// from corruption by building an index segment from TSDB data.
+	corruptedBlockStarts := make(map[xtime.UnixNano]struct{})
 	for _, infoFile := range infoFiles {
 		if err := infoFile.Err.Error(); err != nil {
 			s.log.Error("unable to read index info file",
@@ -1068,7 +1071,17 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		}
 
 		info := infoFile.Info
-		indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
+		indexBlockStartUnixNanos := xtime.UnixNano(info.BlockStart)
+		indexBlockStart := indexBlockStartUnixNanos.ToTime()
+
+		if _, ok := corruptedBlockStarts[indexBlockStartUnixNanos]; ok {
+			s.log.Info("index block corrupted skipping index info file",
+				zap.Stringer("namespace", ns.ID()),
+				zap.Stringer("blockStart", indexBlockStart),
+				zap.String("filepath", infoFile.Err.Filepath()),
+			)
+			continue
+		}
 
 		indexBlockRange := xtime.Range{
 			Start: indexBlockStart,
@@ -1125,9 +1138,18 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 				zap.Time("blockStart", indexBlockStart),
 				zap.Int("volumeIndex", infoFile.ID.VolumeIndex),
 			)
-			// Emit a metric for failed validations.
 			if errors.Is(err, fs.ErrIndexReaderValidationFailed) {
+				// Emit a metric for failed validations.
 				s.metrics.indexBlocksFailedValidation.Inc(1)
+				// Track corrupted blocks and remove any loaded results.
+				corruptedBlockStarts[indexBlockStartUnixNanos] = struct{}{}
+				if err := removeIndexResults(ns, indexBlockStart, res.result); err != nil {
+					s.log.Error("error removing partial/corrupted index results",
+						zap.Error(err),
+						zap.Stringer("namespace", ns.ID()),
+						zap.Time("blockStart", indexBlockStart),
+					)
+				}
 			}
 			continue
 		}

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -606,18 +606,21 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 			// Use debug level with full log fidelity.
 			s.log.Debug("building file set index segment", buildIndexLogFields...)
 			// Use info log with more high level attributes.
+			// NB(bodu): In the case of missing index filesets, it is possible to
+			// bootstrap more index data than we need as re-building index segments
+			// for a block may include index data from other index volume types.
 			s.log.Info("rebuilding file set index segment",
 				zap.Stringer("namespace", ns.ID()),
 				zap.Int("totalEntries", totalEntries),
 				zap.Time("blockStart", blockStart),
 				zap.Time("blockEnd", blockEnd))
-			// NB(bodu): The index claims manager ensures that we properly advance the volume index
-			// past existing volume indices.
 			indexBlock, err = bootstrapper.PersistBootstrapIndexSegment(
 				ns,
 				requestedRanges,
 				builder.Builder(),
 				persistManager,
+				// NB(bodu): The index claims manager ensures that we properly
+				// advance the volume index past existing volume indices.
 				s.opts.IndexClaimsManager(),
 				s.opts.ResultOptions(),
 				existingIndexBlock.Fulfilled(),

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -1064,7 +1064,10 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		// index volume already. We sort info files by block start and index volume so we should
 		// have seen a default volume by now if it exists and is not corrupted.
 		if volumeType != idxpersist.DefaultIndexVolumeType &&
-			indexBlockExistsInResults(res.result.index.IndexResults(), indexBlockStartUnixNano, volumeType) {
+			!indexBlockExistsInResults(
+				res.result.index.IndexResults(),
+				indexBlockStartUnixNano,
+				idxpersist.DefaultIndexVolumeType) {
 			s.log.Info("skipping index fileset missing default index volume type",
 				zap.Stringer("namespace", ns.ID()),
 				zap.Stringer("blockStart", indexBlockStart),

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -23,9 +23,11 @@ package fs
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
+	indexpb "github.com/m3db/m3/src/dbnode/generated/proto/index"
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
@@ -87,7 +89,10 @@ type fileSystemSource struct {
 type fileSystemSourceMetrics struct {
 	persistedIndexBlocksRead           tally.Counter
 	persistedIndexBlocksWrite          tally.Counter
+	persistedIndexBlocksRead           tally.Counter
+	persistedIndexBlocksWrite          tally.Counter
 	persistedIndexBlocksOutOfRetention tally.Counter
+	indexBlocksFailedValidation        tally.Counter
 }
 
 func newFileSystemSource(opts Options) (bootstrap.Source, error) {
@@ -112,6 +117,7 @@ func newFileSystemSource(opts Options) (bootstrap.Source, error) {
 			persistedIndexBlocksRead:           scope.Counter("persist-index-blocks-read"),
 			persistedIndexBlocksWrite:          scope.Counter("persist-index-blocks-write"),
 			persistedIndexBlocksOutOfRetention: scope.Counter("persist-index-blocks-out-of-retention"),
+			indexBlocksFailedValidation:        scope.Counter("index-blocks-failed-validation"),
 		},
 	}
 	s.newReaderPoolOpts.Alloc = s.newReader
@@ -1025,6 +1031,14 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		return bootstrapFromIndexPersistedBlocksResult{}, err
 	}
 
+	// Sort info files by block start and index volume type (default comes first)
+	sort.Slice(infoFiles, func(i, j int) bool {
+		if infoFiles[i].Info.BlockStart != infoFiles[j].Info.BlockStart {
+			return infoFiles[i].Info.BlockStart < infoFiles[j].Info.BlockStart
+		}
+		return volumeTypeFromInfo(infoFiles[i].Info) == idxpersist.DefaultIndexVolumeType
+	})
+
 	for _, infoFile := range infoFiles {
 		if err := infoFile.Err.Error(); err != nil {
 			s.log.Error("unable to read index info file",
@@ -1037,7 +1051,25 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		}
 
 		info := infoFile.Info
-		indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
+		indexBlockStartUnixNano := xtime.UnixNano(info.BlockStart)
+		indexBlockStart := indexBlockStartUnixNano.ToTime()
+		volumeType := volumeTypeFromInfo(info)
+
+		// NB(bodu): Skip non default index volumes for this block if we have not seen a default
+		// index volume already. We sort info files by block start and index volume so we should
+		// have seen a default volume by now if it exists and is not corrupted.
+		if volumeType != idxpersist.DefaultIndexVolumeType &&
+			indexBlockExistsInResults(res.result.index.IndexResults(), indexBlockStartUnixNano, volumeType) {
+			s.log.Info("skipping index fileset missing default index volume type",
+				zap.Stringer("namespace", ns.ID()),
+				zap.Stringer("blockStart", indexBlockStart),
+				zap.String("volumeType", string(volumeType)),
+				zap.Stringer("shardTimeRanges", shardTimeRanges),
+				zap.String("filepath", infoFile.Err.Filepath()),
+			)
+			continue
+		}
+
 		indexBlockRange := xtime.Range{
 			Start: indexBlockStart,
 			End:   indexBlockStart.Add(indexBlockSize),
@@ -1093,6 +1125,10 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 				zap.Time("blockStart", indexBlockStart),
 				zap.Int("volumeIndex", infoFile.ID.VolumeIndex),
 			)
+			// Emit a metric for failed validations.
+			if errors.Is(err, fs.ErrIndexReaderValidationFailed) {
+				s.metrics.indexBlocksFailedValidation.Inc(1)
+			}
 			continue
 		}
 
@@ -1108,10 +1144,6 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		persistedSegments := make([]result.Segment, 0, len(readResult.Segments))
 		for _, segment := range readResult.Segments {
 			persistedSegments = append(persistedSegments, result.NewSegment(segment, true))
-		}
-		volumeType := idxpersist.DefaultIndexVolumeType
-		if info.IndexVolumeType != nil {
-			volumeType = idxpersist.IndexVolumeType(info.IndexVolumeType.Value)
 		}
 		indexBlockByVolumeType := result.NewIndexBlockByVolumeType(indexBlockStart)
 		indexBlockByVolumeType.SetBlock(volumeType, result.NewIndexBlock(persistedSegments, segmentsFulfilled))
@@ -1167,4 +1199,25 @@ func (r *runResult) mergedResult(other *runResult) *runResult {
 		data:  result.MergedDataBootstrapResult(r.data, other.data),
 		index: result.MergedIndexBootstrapResult(r.index, other.index),
 	}
+}
+
+func volumeTypeFromInfo(info indexpb.IndexVolumeInfo) idxpersist.IndexVolumeType {
+	volumeType := idxpersist.DefaultIndexVolumeType
+	if info.IndexVolumeType != nil {
+		volumeType = idxpersist.IndexVolumeType(info.IndexVolumeType.Value)
+	}
+	return volumeType
+}
+
+func indexBlockExistsInResults(
+	results result.IndexResults,
+	blockStart xtime.UnixNano,
+	volumeType idxpersist.IndexVolumeType,
+) bool {
+	indexBlockByVolumeType, ok := results[blockStart]
+	if !ok {
+		return false
+	}
+	_, ok = indexBlockByVolumeType.GetBlock(volumeType)
+	return ok
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -735,7 +735,7 @@ func (s *fileSystemSource) appendIndexFilesetFilesToDelete(
 			info.IndexVolumeType != nil &&
 			idxpersist.IndexVolumeType(info.IndexVolumeType.Value) !=
 				idxpersist.DefaultIndexVolumeType {
-			filesToDelete = append(filesToDelete, infoFile.AbsoluteFilePaths...)
+			filesToDelete = append(filesToDelete, infoFiles[i].AbsoluteFilePaths...)
 		}
 	}
 	return filesToDelete

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -764,12 +764,12 @@ func removeIndexResults(
 	multiErr := xerrors.NewMultiError()
 	results, ok := runResult.index.IndexResults()[xtime.ToUnixNano(blockStart)]
 	if ok {
-		for _, indexBlock := range results.Iter() {
+		for volumeType, indexBlock := range results.Iter() {
 			for _, seg := range indexBlock.Segments() {
 				multiErr = multiErr.Add(seg.Segment().Close())
 			}
+			results.DeleteBlock(volumeType)
 		}
-		delete(runResult.index.IndexResults(), xtime.ToUnixNano(blockStart))
 	}
 	return multiErr.FinalError()
 }
@@ -871,21 +871,17 @@ func (s *fileSystemSource) read(
 ) (*runResult, error) {
 	var (
 		seriesCachePolicy = s.opts.ResultOptions().SeriesCachePolicy()
-		res               *runResult
+		res               = newRunResult()
 	)
 	if shardTimeRanges.IsEmpty() {
 		return newRunResult(), nil
 	}
 
-	setOrMergeResult := func(newResult *runResult) {
+	mergeResult := func(newResult *runResult) {
 		if newResult == nil {
 			return
 		}
-		if res == nil {
-			res = newResult
-		} else {
-			res = res.mergedResult(newResult)
-		}
+		res = res.mergedResult(newResult)
 	}
 
 	if run == bootstrapDataRunType {
@@ -917,7 +913,7 @@ func (s *fileSystemSource) read(
 			shardTimeRanges = shardTimeRanges.Copy()
 			shardTimeRanges.Subtract(r.fulfilled)
 			// Set or merge result.
-			setOrMergeResult(r.result)
+			mergeResult(r.result)
 		}
 		logSpan("bootstrap_from_index_persisted_blocks_done")
 	}
@@ -956,8 +952,6 @@ func (s *fileSystemSource) read(
 		Cache:                     cache,
 	})
 
-	bootstrapFromReadersRunResult := newRunResult()
-
 	var buildWg sync.WaitGroup
 	for i := 0; i < indexSegmentConcurrency; i++ {
 		alloc := s.opts.ResultOptions().IndexDocumentsBuilderAllocator()
@@ -993,7 +987,7 @@ func (s *fileSystemSource) read(
 		buildWg.Add(1)
 		go func() {
 			s.bootstrapFromReaders(run, md,
-				accumulator, runOpts, bootstrapFromReadersRunResult,
+				accumulator, runOpts, res,
 				readerPool, readersCh, builder,
 				&bootstrapper.SharedPersistManager{Mgr: persistManager},
 				&bootstrapper.SharedCompactor{Compactor: compactor},
@@ -1003,9 +997,6 @@ func (s *fileSystemSource) read(
 	}
 
 	buildWg.Wait()
-
-	// Merge any existing results if necessary.
-	setOrMergeResult(bootstrapFromReadersRunResult)
 
 	return res, nil
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -705,7 +705,8 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 		remainingRanges, timesWithErrors)
 }
 
-// appendIndexFilesetFilesToDelete appends non default index volume type index filesets for deletion.
+// appendIndexFilesetFilesToDelete appends non default index volume type index
+// filesets for deletion.
 func (s *fileSystemSource) appendIndexFilesetFilesToDelete(
 	ns namespace.Metadata,
 	blockStart time.Time,
@@ -721,14 +722,14 @@ func (s *fileSystemSource) appendIndexFilesetFilesToDelete(
 				zap.Stringer("namespace", ns.ID()))
 		})
 	}
-	for _, infoFile := range infoFiles {
-		if err := infoFile.Err.Error(); err != nil {
+	for i := range infoFiles {
+		if err := infoFiles[i].Err.Error(); err != nil {
 			// We already log errors once when bootstrapping from persisted
 			// index blocks just continue here.
 			continue
 		}
 
-		info := infoFile.Info
+		info := infoFiles[i].Info
 		indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
 		if blockStart.Equal(indexBlockStart) &&
 			info.IndexVolumeType != nil &&
@@ -1036,7 +1037,7 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		if infoFiles[i].Info.BlockStart != infoFiles[j].Info.BlockStart {
 			return infoFiles[i].Info.BlockStart < infoFiles[j].Info.BlockStart
 		}
-		return volumeTypeFromInfo(infoFiles[i].Info) == idxpersist.DefaultIndexVolumeType
+		return volumeTypeFromInfo(&infoFiles[i].Info) == idxpersist.DefaultIndexVolumeType
 	})
 
 	for _, infoFile := range infoFiles {
@@ -1053,7 +1054,11 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		info := infoFile.Info
 		indexBlockStartUnixNano := xtime.UnixNano(info.BlockStart)
 		indexBlockStart := indexBlockStartUnixNano.ToTime()
-		volumeType := volumeTypeFromInfo(info)
+		volumeType := volumeTypeFromInfo(&info)
+
+		if res.result == nil {
+			res.result = newRunResult()
+		}
 
 		// NB(bodu): Skip non default index volumes for this block if we have not seen a default
 		// index volume already. We sort info files by block start and index volume so we should
@@ -1136,9 +1141,6 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		s.metrics.persistedIndexBlocksRead.Inc(1)
 
 		// Record result.
-		if res.result == nil {
-			res.result = newRunResult()
-		}
 		segmentsFulfilled := willFulfill
 		// NB(bodu): All segments read from disk are already persisted.
 		persistedSegments := make([]result.Segment, 0, len(readResult.Segments))
@@ -1201,7 +1203,7 @@ func (r *runResult) mergedResult(other *runResult) *runResult {
 	}
 }
 
-func volumeTypeFromInfo(info indexpb.IndexVolumeInfo) idxpersist.IndexVolumeType {
+func volumeTypeFromInfo(info *indexpb.IndexVolumeInfo) idxpersist.IndexVolumeType {
 	volumeType := idxpersist.DefaultIndexVolumeType
 	if info.IndexVolumeType != nil {
 		volumeType = idxpersist.IndexVolumeType(info.IndexVolumeType.Value)

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -92,8 +92,6 @@ type fileSystemSource struct {
 type fileSystemSourceMetrics struct {
 	persistedIndexBlocksRead           tally.Counter
 	persistedIndexBlocksWrite          tally.Counter
-	persistedIndexBlocksRead           tally.Counter
-	persistedIndexBlocksWrite          tally.Counter
 	persistedIndexBlocksOutOfRetention tally.Counter
 	indexBlocksFailedValidation        tally.Counter
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -80,6 +80,7 @@ type fileSystemSource struct {
 	idPool            ident.Pool
 	newReaderFn       newDataFileSetReaderFn
 	newReaderPoolOpts bootstrapper.NewReaderPoolOptions
+	deleteFilesFn     fs.DeleteFilesFn
 	metrics           fileSystemSourceMetrics
 }
 
@@ -100,12 +101,13 @@ func newFileSystemSource(opts Options) (bootstrap.Source, error) {
 	opts = opts.SetInstrumentOptions(iopts)
 
 	s := &fileSystemSource{
-		opts:        opts,
-		fsopts:      opts.FilesystemOptions(),
-		log:         iopts.Logger().With(zap.String("bootstrapper", "filesystem")),
-		nowFn:       opts.ResultOptions().ClockOptions().NowFn(),
-		idPool:      opts.IdentifierPool(),
-		newReaderFn: fs.NewReader,
+		opts:          opts,
+		fsopts:        opts.FilesystemOptions(),
+		log:           iopts.Logger().With(zap.String("bootstrapper", "filesystem")),
+		nowFn:         opts.ResultOptions().ClockOptions().NowFn(),
+		idPool:        opts.IdentifierPool(),
+		newReaderFn:   fs.NewReader,
+		deleteFilesFn: fs.DeleteFiles,
 		metrics: fileSystemSourceMetrics{
 			persistedIndexBlocksRead:           scope.Counter("persist-index-blocks-read"),
 			persistedIndexBlocksWrite:          scope.Counter("persist-index-blocks-write"),
@@ -331,6 +333,7 @@ func (s *fileSystemSource) bootstrapFromReaders(
 	builder *result.IndexBuilder,
 	persistManager *bootstrapper.SharedPersistManager,
 	compactor *bootstrapper.SharedCompactor,
+	cache bootstrap.Cache,
 ) {
 	resultOpts := s.opts.ResultOptions()
 
@@ -341,7 +344,7 @@ func (s *fileSystemSource) bootstrapFromReaders(
 
 		s.loadShardReadersDataIntoShardResult(run, ns, accumulator,
 			runOpts, runResult, resultOpts, timeWindowReaders, readerPool,
-			builder, persistManager, compactor)
+			builder, persistManager, compactor, cache)
 	}
 }
 
@@ -395,6 +398,7 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 	builder *result.IndexBuilder,
 	persistManager *bootstrapper.SharedPersistManager,
 	compactor *bootstrapper.SharedCompactor,
+	cache bootstrap.Cache,
 ) {
 	var (
 		blockPool            = ropts.DatabaseBlockOptions().DatabaseBlockPool()
@@ -592,7 +596,35 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 		}
 
 		if shouldFlush && satisifiedFlushRanges {
+			// NB(bodu): If we are persisting an index segment to disk, we need to delete any existing
+			// index filesets not of the default index volume type (if there was a default index fileset here
+			// then we would've bootstrapped from the persisted index segment already).
+			var (
+				filesToDelete  = []string{}
+				persistSuccess bool
+			)
+			defer func() {
+				if persistSuccess {
+					if err := s.deleteFilesFn(filesToDelete); err != nil {
+						instrument.EmitAndLogInvariantViolation(iopts, func(l *zap.Logger) {
+							l.Error("failed to delete non default index filesets",
+								zap.Error(err),
+								zap.Stringer("namespace", ns.ID()),
+								zap.Stringer("requestedRanges", requestedRanges))
+						})
+					}
+				}
+			}()
+			filesToDelete = s.appendIndexFilesetFilesToDelete(ns, blockStart, cache, filesToDelete, iopts)
+
+			// Use debug level with full log fidelity.
 			s.log.Debug("building file set index segment", buildIndexLogFields...)
+			// Use info log with more high level attributes.
+			s.log.Info("rebuilding file set index segment",
+				zap.Stringer("namespace", ns.ID()),
+				zap.Int("totalEntries", totalEntries),
+				zap.Time("blockStart", blockStart),
+				zap.Time("blockEnd", blockEnd))
 			indexBlock, err = bootstrapper.PersistBootstrapIndexSegment(
 				ns,
 				requestedRanges,
@@ -604,6 +636,7 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 				blockStart,
 				blockEnd,
 			)
+
 			if errors.Is(err, fs.ErrOutOfRetentionClaim) {
 				// Bail early if the index segment is already out of retention.
 				// This can happen when the edge of requested ranges at time of data bootstrap
@@ -611,7 +644,13 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 				s.log.Debug("skipping out of retention index segment", buildIndexLogFields...)
 				s.metrics.persistedIndexBlocksOutOfRetention.Inc(1)
 				return
-			} else if err != nil {
+			}
+
+			if err == nil {
+				// Track success.
+				s.metrics.persistedIndexBlocksWrite.Inc(1)
+				persistSuccess = true
+			} else {
 				instrument.EmitAndLogInvariantViolation(iopts, func(l *zap.Logger) {
 					l.Error("persist fs index bootstrap failed",
 						zap.Error(err),
@@ -619,8 +658,6 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 						zap.Stringer("requestedRanges", requestedRanges))
 				})
 			}
-			// Track success.
-			s.metrics.persistedIndexBlocksWrite.Inc(1)
 		} else {
 			s.log.Info("building in-memory index segment", buildIndexLogFields...)
 			indexBlock, err = bootstrapper.BuildBootstrapIndexSegment(
@@ -660,6 +697,41 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 
 	s.markRunResultErrorsAndUnfulfilled(runResult, requestedRanges,
 		remainingRanges, timesWithErrors)
+}
+
+// appendIndexFilesetFilesToDelete appends non default index volume type index filesets for deletion.
+func (s *fileSystemSource) appendIndexFilesetFilesToDelete(
+	ns namespace.Metadata,
+	blockStart time.Time,
+	cache bootstrap.Cache,
+	filesToDelete []string,
+	iopts instrument.Options,
+) []string {
+	infoFiles, err := cache.IndexInfoFilesForNamespace(ns)
+	if err != nil {
+		instrument.EmitAndLogInvariantViolation(iopts, func(l *zap.Logger) {
+			l.Error("failed to get index info files from cache",
+				zap.Error(err),
+				zap.Stringer("namespace", ns.ID()))
+		})
+	}
+	for _, infoFile := range infoFiles {
+		if err := infoFile.Err.Error(); err != nil {
+			// We already log errors once when bootstrapping from persisted
+			// index blocks just continue here.
+			continue
+		}
+
+		info := infoFile.Info
+		indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
+		if blockStart.Equal(indexBlockStart) &&
+			info.IndexVolumeType != nil &&
+			idxpersist.IndexVolumeType(info.IndexVolumeType.Value) !=
+				idxpersist.DefaultIndexVolumeType {
+			filesToDelete = append(filesToDelete, infoFile.AbsoluteFilePaths...)
+		}
+	}
+	return filesToDelete
 }
 
 func (s *fileSystemSource) readNextEntryAndRecordBlock(
@@ -797,7 +869,7 @@ func (s *fileSystemSource) read(
 		// subtract the shard + time ranges from what we intend to bootstrap
 		// for those we found.
 		r, err := s.bootstrapFromIndexPersistedBlocks(md,
-			shardTimeRanges)
+			shardTimeRanges, cache)
 		if err != nil {
 			s.log.Warn("filesystem bootstrapped failed to read persisted index blocks")
 		} else {
@@ -884,7 +956,8 @@ func (s *fileSystemSource) read(
 				accumulator, runOpts, bootstrapFromReadersRunResult,
 				readerPool, readersCh, builder,
 				&bootstrapper.SharedPersistManager{Mgr: persistManager},
-				&bootstrapper.SharedCompactor{Compactor: compactor})
+				&bootstrapper.SharedCompactor{Compactor: compactor},
+				cache)
 			buildWg.Done()
 		}()
 	}
@@ -940,14 +1013,17 @@ type bootstrapFromIndexPersistedBlocksResult struct {
 func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 	ns namespace.Metadata,
 	shardTimeRanges result.ShardTimeRanges,
+	cache bootstrap.Cache,
 ) (bootstrapFromIndexPersistedBlocksResult, error) {
 	res := bootstrapFromIndexPersistedBlocksResult{
 		fulfilled: result.NewShardTimeRanges(),
 	}
 
 	indexBlockSize := ns.Options().IndexOptions().BlockSize()
-	infoFiles := fs.ReadIndexInfoFiles(s.fsopts.FilePathPrefix(), ns.ID(),
-		s.fsopts.InfoReaderBufferSize())
+	infoFiles, err := cache.IndexInfoFilesForNamespace(ns)
+	if err != nil {
+		return bootstrapFromIndexPersistedBlocksResult{}, err
+	}
 
 	for _, infoFile := range infoFiles {
 		if err := infoFile.Err.Error(); err != nil {
@@ -1043,7 +1119,13 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		// as we've already passed the ranges fulfilled to the block that
 		// we place in the IndexResuts with the call to Add(...).
 		res.result.index.Add(indexBlockByVolumeType, nil)
-		res.fulfilled.AddRanges(segmentsFulfilled)
+
+		// NB(bodu): We only mark ranges as fulfilled for the default index volume type.
+		// It's possible to have other index volume types but the default type is required to
+		// fulfill bootstrappable ranges.
+		if volumeType == idxpersist.DefaultIndexVolumeType {
+			res.fulfilled.AddRanges(segmentsFulfilled)
+		}
 	}
 
 	return res, nil

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -23,7 +23,6 @@ package fs
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 
@@ -50,6 +49,7 @@ import (
 	"github.com/m3db/m3/src/x/checked"
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/context"
+	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/pool"
@@ -603,8 +603,7 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 
 		if shouldFlush && satisifiedFlushRanges {
 			// NB(bodu): If we are persisting an index segment to disk, we need to delete any existing
-			// index filesets not of the default index volume type (if there was a default index fileset here
-			// then we would've bootstrapped from the persisted index segment already).
+			// index filesets at this block start. The newly persisted index segments becomes the new source of truth.
 			var (
 				filesToDelete  = []string{}
 				persistSuccess bool
@@ -621,7 +620,7 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 					}
 				}
 			}()
-			filesToDelete = s.appendIndexFilesetFilesToDelete(ns, blockStart, cache, filesToDelete, iopts)
+			filesToDelete = s.appendIndexFilesetFilesToDelete(ns, blockStart, cache, filesToDelete, runResult, iopts)
 
 			// Use debug level with full log fidelity.
 			s.log.Debug("building file set index segment", buildIndexLogFields...)
@@ -631,6 +630,8 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 				zap.Int("totalEntries", totalEntries),
 				zap.Time("blockStart", blockStart),
 				zap.Time("blockEnd", blockEnd))
+			// NB(bodu): The index claims manager ensures that we properly advance the volume index
+			// past existing volume indices.
 			indexBlock, err = bootstrapper.PersistBootstrapIndexSegment(
 				ns,
 				requestedRanges,
@@ -705,13 +706,15 @@ func (s *fileSystemSource) loadShardReadersDataIntoShardResult(
 		remainingRanges, timesWithErrors)
 }
 
-// appendIndexFilesetFilesToDelete appends non default index volume type index
-// filesets for deletion.
+// appendIndexFilesetFilesToDelete appends all index filesets at a block start for deletion.
+// Also removes index results from given block start since results are not complete and/or corrupted
+// and require an index segment rebuild.
 func (s *fileSystemSource) appendIndexFilesetFilesToDelete(
 	ns namespace.Metadata,
 	blockStart time.Time,
 	cache bootstrap.Cache,
 	filesToDelete []string,
+	runResult *runResult,
 	iopts instrument.Options,
 ) []string {
 	infoFiles, err := cache.IndexInfoFilesForNamespace(ns)
@@ -719,6 +722,7 @@ func (s *fileSystemSource) appendIndexFilesetFilesToDelete(
 		instrument.EmitAndLogInvariantViolation(iopts, func(l *zap.Logger) {
 			l.Error("failed to get index info files from cache",
 				zap.Error(err),
+				zap.Time("blockStart", blockStart),
 				zap.Stringer("namespace", ns.ID()))
 		})
 	}
@@ -731,14 +735,43 @@ func (s *fileSystemSource) appendIndexFilesetFilesToDelete(
 
 		info := infoFiles[i].Info
 		indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
-		if blockStart.Equal(indexBlockStart) &&
-			info.IndexVolumeType != nil &&
-			idxpersist.IndexVolumeType(info.IndexVolumeType.Value) !=
-				idxpersist.DefaultIndexVolumeType {
+		if blockStart.Equal(indexBlockStart) {
 			filesToDelete = append(filesToDelete, infoFiles[i].AbsoluteFilePaths...)
 		}
 	}
+
+	// Remove index results for the block in question
+	if err := removeIndexResults(ns, blockStart, runResult); err != nil {
+		instrument.EmitAndLogInvariantViolation(iopts, func(l *zap.Logger) {
+			l.Error("error removing partial/corrupted index results",
+				zap.Error(err),
+				zap.Time("blockStart", blockStart),
+				zap.Stringer("namespace", ns.ID()))
+		})
+	}
+
 	return filesToDelete
+}
+
+func removeIndexResults(
+	ns namespace.Metadata,
+	blockStart time.Time,
+	runResult *runResult,
+) error {
+	runResult.Lock()
+	defer runResult.Unlock()
+
+	multiErr := xerrors.NewMultiError()
+	results, ok := runResult.index.IndexResults()[xtime.ToUnixNano(blockStart)]
+	if ok {
+		for _, indexBlock := range results.Iter() {
+			for _, seg := range indexBlock.Segments() {
+				multiErr = multiErr.Add(seg.Segment().Close())
+			}
+		}
+		delete(runResult.index.IndexResults(), xtime.ToUnixNano(blockStart))
+	}
+	return multiErr.FinalError()
 }
 
 func (s *fileSystemSource) readNextEntryAndRecordBlock(
@@ -1032,14 +1065,6 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		return bootstrapFromIndexPersistedBlocksResult{}, err
 	}
 
-	// Sort info files by block start and index volume type (default comes first)
-	sort.Slice(infoFiles, func(i, j int) bool {
-		if infoFiles[i].Info.BlockStart != infoFiles[j].Info.BlockStart {
-			return infoFiles[i].Info.BlockStart < infoFiles[j].Info.BlockStart
-		}
-		return volumeTypeFromInfo(&infoFiles[i].Info) == idxpersist.DefaultIndexVolumeType
-	})
-
 	for _, infoFile := range infoFiles {
 		if err := infoFile.Err.Error(); err != nil {
 			s.log.Error("unable to read index info file",
@@ -1052,31 +1077,7 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 		}
 
 		info := infoFile.Info
-		indexBlockStartUnixNano := xtime.UnixNano(info.BlockStart)
-		indexBlockStart := indexBlockStartUnixNano.ToTime()
-		volumeType := volumeTypeFromInfo(&info)
-
-		if res.result == nil {
-			res.result = newRunResult()
-		}
-
-		// NB(bodu): Skip non default index volumes for this block if we have not seen a default
-		// index volume already. We sort info files by block start and index volume so we should
-		// have seen a default volume by now if it exists and is not corrupted.
-		if volumeType != idxpersist.DefaultIndexVolumeType &&
-			!indexBlockExistsInResults(
-				res.result.index.IndexResults(),
-				indexBlockStartUnixNano,
-				idxpersist.DefaultIndexVolumeType) {
-			s.log.Info("skipping index fileset missing default index volume type",
-				zap.Stringer("namespace", ns.ID()),
-				zap.Stringer("blockStart", indexBlockStart),
-				zap.String("volumeType", string(volumeType)),
-				zap.Stringer("shardTimeRanges", shardTimeRanges),
-				zap.String("filepath", infoFile.Err.Filepath()),
-			)
-			continue
-		}
+		indexBlockStart := xtime.UnixNano(info.BlockStart).ToTime()
 
 		indexBlockRange := xtime.Range{
 			Start: indexBlockStart,
@@ -1151,7 +1152,12 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 			persistedSegments = append(persistedSegments, result.NewSegment(segment, true))
 		}
 		indexBlockByVolumeType := result.NewIndexBlockByVolumeType(indexBlockStart)
+		volumeType := volumeTypeFromInfo(&info)
 		indexBlockByVolumeType.SetBlock(volumeType, result.NewIndexBlock(persistedSegments, segmentsFulfilled))
+
+		if res.result == nil {
+			res.result = newRunResult()
+		}
 		// NB(r): Don't need to call MarkFulfilled on the IndexResults here
 		// as we've already passed the ranges fulfilled to the block that
 		// we place in the IndexResuts with the call to Add(...).
@@ -1212,17 +1218,4 @@ func volumeTypeFromInfo(info *indexpb.IndexVolumeInfo) idxpersist.IndexVolumeTyp
 		volumeType = idxpersist.IndexVolumeType(info.IndexVolumeType.Value)
 	}
 	return volumeType
-}
-
-func indexBlockExistsInResults(
-	results result.IndexResults,
-	blockStart xtime.UnixNano,
-	volumeType idxpersist.IndexVolumeType,
-) bool {
-	indexBlockByVolumeType, ok := results[blockStart]
-	if !ok {
-		return false
-	}
-	_, ok = indexBlockByVolumeType.GetBlock(volumeType)
-	return ok
 }

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -305,7 +305,7 @@ func validateGoodTaggedSeries(
 	}
 }
 
-func TestBootstrapIndexAndMissingDefaultVolumeType(t *testing.T) {
+func TestBootstrapIndexAndUnfulfilledRanges(t *testing.T) {
 	dir := createTempDir(t)
 	defer os.RemoveAll(dir)
 
@@ -337,7 +337,8 @@ func TestBootstrapIndexAndMissingDefaultVolumeType(t *testing.T) {
 
 	// Write out non default type index volume type index block and ensure
 	// that it gets deleted and is not loaded into the index results to test
-	// the missing default index volume type volume index case.
+	// the unfulfilled shard time ranges case (missing default index volume type
+	// and/or index segments failed validation).
 	var (
 		notDefaultIndexVolumeType = idxpersist.IndexVolumeType("not-default")
 		shards                    = map[uint32]struct{}{testShard: struct{}{}}

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -513,7 +513,11 @@ func TestBootstrapIndexUnfulfilledRanges(t *testing.T) {
 		src.fsopts.InfoReaderBufferSize())
 	require.Equal(t, 1, len(infoFiles[1:]))
 
-	for i := range infoFiles[1:] {
+	for i := range infoFiles {
+		// Skip non default index volumes since we wrote no test data to these.
+		if volumeTypeFromInfo(&infoFiles[i].Info) != idxpersist.DefaultIndexVolumeType {
+			continue
+		}
 		validateInfoFile(t, times.start.UnixNano(), &infoFiles[i])
 	}
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/index/convert"
 	"github.com/m3db/m3/src/m3ninx/index/segment/mem"
 	idxpersist "github.com/m3db/m3/src/m3ninx/persist"
+	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
 	xtime "github.com/m3db/m3/src/x/time"
 	"github.com/stretchr/testify/require"
@@ -334,8 +335,44 @@ func TestBootstrapIndex(t *testing.T) {
 		times.shardTimeRanges, opts.FilesystemOptions(), nsMD)
 	defer tester.Finish()
 
+	// Write out non default type index volume type index block and ensure
+	// that it gets delete and is not loaded into the index results to test
+	// the missing default index volume type volume index case.
+	var (
+		notDefaultIndexVolumeType = idxpersist.IndexVolumeType("not-default")
+		shards                    = map[uint32]struct{}{testShard: struct{}{}}
+		filesToDelete             []string
+	)
+	idxWriter, err := fs.NewIndexWriter(src.fsopts)
+	require.NoError(t, err)
+	require.NoError(t, idxWriter.Open(fs.IndexWriterOpenOptions{
+		Identifier: fs.FileSetFileIdentifier{
+			FileSetContentType: persist.FileSetIndexContentType,
+			Namespace:          nsMD.ID(),
+			BlockStart:         times.start,
+			VolumeIndex:        1,
+		},
+		BlockSize:       nsMD.Options().IndexOptions().BlockSize(),
+		FileSetType:     persist.FileSetFlushType,
+		Shards:          shards,
+		IndexVolumeType: notDefaultIndexVolumeType,
+	}))
+	// Don't need to write any actual data.
+	require.NoError(t, idxWriter.Close())
+	src.deleteFilesFn = func(files []string) error {
+		filesToDelete = append(filesToDelete, files...)
+		multiErr := xerrors.NewMultiError()
+		for _, f := range files {
+			multiErr = multiErr.Add(os.Remove(f))
+		}
+		return multiErr.FinalError()
+	}
+
 	tester.TestReadWith(src)
 	indexResults := tester.ResultForNamespace(nsMD.ID()).IndexResult.IndexResults()
+
+	// Ensure we are attempting to delete a single index fileset (in this case w/ no data).
+	require.Len(t, filesToDelete, 3)
 
 	// Check that single persisted segment got written out
 	infoFiles := fs.ReadIndexInfoFiles(src.fsopts.FilePathPrefix(), testNs1ID,
@@ -361,6 +398,11 @@ func TestBootstrapIndex(t *testing.T) {
 	segment := block.Segments()[0]
 	require.True(t, ok)
 	require.True(t, segment.IsPersisted())
+
+	// Check that the non default index volume type (missing default index volume type)
+	// was not added to the index results.
+	_, ok = blockByVolumeType.GetBlock(notDefaultIndexVolumeType)
+	require.False(t, ok)
 
 	// Check that the second segment is mutable and was not written out
 	blockByVolumeType, ok = indexResults[xtime.ToUnixNano(times.start.Add(testIndexBlockSize))]

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -305,7 +305,7 @@ func validateGoodTaggedSeries(
 	}
 }
 
-func TestBootstrapIndex(t *testing.T) {
+func TestBootstrapIndexAndIndexSegmentsFailedValidation(t *testing.T) {
 	dir := createTempDir(t)
 	defer os.RemoveAll(dir)
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -305,7 +305,7 @@ func validateGoodTaggedSeries(
 	}
 }
 
-func TestBootstrapIndexAndIndexSegmentsFailedValidation(t *testing.T) {
+func TestBootstrapIndexAndMissingDefaultVolumeType(t *testing.T) {
 	dir := createTempDir(t)
 	defer os.RemoveAll(dir)
 
@@ -336,7 +336,7 @@ func TestBootstrapIndexAndIndexSegmentsFailedValidation(t *testing.T) {
 	defer tester.Finish()
 
 	// Write out non default type index volume type index block and ensure
-	// that it gets delete and is not loaded into the index results to test
+	// that it gets deleted and is not loaded into the index results to test
 	// the missing default index volume type volume index case.
 	var (
 		notDefaultIndexVolumeType = idxpersist.IndexVolumeType("not-default")
@@ -420,7 +420,7 @@ func TestBootstrapIndexAndIndexSegmentsFailedValidation(t *testing.T) {
 	// Validate that wrote the block out (and no index blocks
 	// were read as existing index blocks on disk)
 	counters := scope.Snapshot().Counters()
-	require.Equal(t, int64(0), counters["fs-bootstrapper.persist-index-blocks-read+"].Value())
+	require.Equal(t, int64(1), counters["fs-bootstrapper.persist-index-blocks-read+"].Value())
 	require.Equal(t, int64(1), counters["fs-bootstrapper.persist-index-blocks-write+"].Value())
 }
 

--- a/src/dbnode/storage/bootstrap/cache.go
+++ b/src/dbnode/storage/bootstrap/cache.go
@@ -88,12 +88,15 @@ func (c *cache) InfoFilesForShard(ns namespace.Metadata, shard uint32) ([]fs.Rea
 	return infoFileResults, nil
 }
 
-func (c *cache) IndexInfoFilesForNamespace(ns namespace.Metadata) ([]fs.ReadIndexInfoFileResult, error) {
+func (c *cache) IndexInfoFilesForNamespace(ns namespace.Metadata) (
+	[]fs.ReadIndexInfoFileResult,
+	error,
+) {
 	infoFiles, ok := c.readIndexInfoFiles()[ns]
 	// This should never happen as Cache object is initialized with all namespaces to bootstrap.
 	if !ok {
-		return nil, fmt.Errorf("attempting to read index info files for namespace %v not specified at bootstrap "+
-			"startup", ns.ID().String())
+		return nil, fmt.Errorf("attempting to read index info files for namespace %v not "+
+			"specified at bootstrap startup", ns.ID().String())
 	}
 	return infoFiles, nil
 }
@@ -144,7 +147,8 @@ func (c *cache) readIndexInfoFiles() IndexInfoFilesByNamespace {
 }
 
 func (c *cache) populateIndexInfoFilesByNamespaceWithLock() {
-	for _, finder := range c.namespaceDetails {
+	for i := range c.namespaceDetails {
+		finder := c.namespaceDetails[i]
 		c.indexInfoFilesByNamespace[finder.Namespace] = fs.ReadIndexInfoFiles(
 			c.fsOpts.FilePathPrefix(), finder.Namespace.ID(),
 			c.fsOpts.InfoReaderBufferSize())

--- a/src/dbnode/storage/bootstrap/cache.go
+++ b/src/dbnode/storage/bootstrap/cache.go
@@ -39,11 +39,13 @@ var (
 type cache struct {
 	sync.Mutex
 
-	fsOpts               fs.Options
-	namespaceDetails     []NamespaceDetails
-	infoFilesByNamespace InfoFilesByNamespace
-	iOpts                instrument.Options
-	hasPopulatedInfo     bool
+	fsOpts                    fs.Options
+	namespaceDetails          []NamespaceDetails
+	infoFilesByNamespace      InfoFilesByNamespace
+	indexInfoFilesByNamespace IndexInfoFilesByNamespace
+	iOpts                     instrument.Options
+	hasPopulatedInfo          bool
+	hasPopulatedIndexInfo     bool
 }
 
 // NewCache creates a cache specifically to be used during the bootstrap process.
@@ -54,10 +56,11 @@ func NewCache(options CacheOptions) (Cache, error) {
 		return nil, err
 	}
 	return &cache{
-		fsOpts:               options.FilesystemOptions(),
-		namespaceDetails:     options.NamespaceDetails(),
-		infoFilesByNamespace: make(InfoFilesByNamespace, len(options.NamespaceDetails())),
-		iOpts:                options.InstrumentOptions(),
+		fsOpts:                    options.FilesystemOptions(),
+		namespaceDetails:          options.NamespaceDetails(),
+		infoFilesByNamespace:      make(InfoFilesByNamespace, len(options.NamespaceDetails())),
+		indexInfoFilesByNamespace: make(IndexInfoFilesByNamespace, len(options.NamespaceDetails())),
+		iOpts:                     options.InstrumentOptions(),
 	}, nil
 }
 
@@ -85,10 +88,21 @@ func (c *cache) InfoFilesForShard(ns namespace.Metadata, shard uint32) ([]fs.Rea
 	return infoFileResults, nil
 }
 
+func (c *cache) IndexInfoFilesForNamespace(ns namespace.Metadata) ([]fs.ReadIndexInfoFileResult, error) {
+	infoFiles, ok := c.readIndexInfoFiles()[ns]
+	// This should never happen as Cache object is initialized with all namespaces to bootstrap.
+	if !ok {
+		return nil, fmt.Errorf("attempting to read index info files for namespace %v not specified at bootstrap "+
+			"startup", ns.ID().String())
+	}
+	return infoFiles, nil
+}
+
 func (c *cache) Evict() {
 	c.Lock()
 	defer c.Unlock()
 	c.hasPopulatedInfo = false
+	c.hasPopulatedIndexInfo = false
 }
 
 func (c *cache) ReadInfoFiles() InfoFilesByNamespace {
@@ -111,11 +125,29 @@ func (c *cache) populateInfoFilesByNamespaceWithLock() {
 		}
 		for _, shard := range finder.Shards {
 			result[shard] = fs.ReadInfoFiles(c.fsOpts.FilePathPrefix(),
-				finder.Namespace.ID(), shard, c.fsOpts.InfoReaderBufferSize(), c.fsOpts.DecodingOptions(),
-				persist.FileSetFlushType)
+				finder.Namespace.ID(), shard, c.fsOpts.InfoReaderBufferSize(),
+				c.fsOpts.DecodingOptions(), persist.FileSetFlushType)
 		}
 
 		c.infoFilesByNamespace[finder.Namespace] = result
+	}
+}
+
+func (c *cache) readIndexInfoFiles() IndexInfoFilesByNamespace {
+	c.Lock()
+	defer c.Unlock()
+	if !c.hasPopulatedIndexInfo {
+		c.populateIndexInfoFilesByNamespaceWithLock()
+		c.hasPopulatedIndexInfo = true
+	}
+	return c.indexInfoFilesByNamespace
+}
+
+func (c *cache) populateIndexInfoFilesByNamespaceWithLock() {
+	for _, finder := range c.namespaceDetails {
+		c.indexInfoFilesByNamespace[finder.Namespace] = fs.ReadIndexInfoFiles(
+			c.fsOpts.FilePathPrefix(), finder.Namespace.ID(),
+			c.fsOpts.InfoReaderBufferSize())
 	}
 }
 

--- a/src/dbnode/storage/bootstrap/cache_test.go
+++ b/src/dbnode/storage/bootstrap/cache_test.go
@@ -136,7 +136,7 @@ func TestCacheReadInfoFilesInvariantViolation(t *testing.T) {
 
 func TestCacheReadIndexInfoFiles(t *testing.T) {
 	dir := createTempDir(t)
-	defer os.RemoveAll(dir)
+	defer require.NoError(t, os.RemoveAll(dir))
 
 	md1 := testNamespaceMetadata(t, ident.StringID("ns1"))
 	md2 := testNamespaceMetadata(t, ident.StringID("ns2"))
@@ -144,8 +144,8 @@ func TestCacheReadIndexInfoFiles(t *testing.T) {
 	fsOpts := testFilesystemOptions.SetFilePathPrefix(dir)
 
 	shards := map[uint32]struct{}{
-		0: struct{}{},
-		1: struct{}{},
+		0: {},
+		1: {},
 	}
 	writeIndexFilesets(t, md1.ID(), shards, fsOpts)
 	writeIndexFilesets(t, md2.ID(), shards, fsOpts)

--- a/src/dbnode/storage/bootstrap/cache_test.go
+++ b/src/dbnode/storage/bootstrap/cache_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/retention"
+	idxpersist "github.com/m3db/m3/src/m3ninx/persist"
 	"github.com/m3db/m3/src/x/checked"
 	"github.com/m3db/m3/src/x/ident"
 
@@ -133,6 +134,54 @@ func TestCacheReadInfoFilesInvariantViolation(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCacheReadIndexInfoFiles(t *testing.T) {
+	dir := createTempDir(t)
+	defer os.RemoveAll(dir)
+
+	md1 := testNamespaceMetadata(t, ident.StringID("ns1"))
+	md2 := testNamespaceMetadata(t, ident.StringID("ns2"))
+
+	fsOpts := testFilesystemOptions.SetFilePathPrefix(dir)
+
+	shards := map[uint32]struct{}{
+		0: struct{}{},
+		1: struct{}{},
+	}
+	writeIndexFilesets(t, md1.ID(), shards, fsOpts)
+	writeIndexFilesets(t, md2.ID(), shards, fsOpts)
+
+	opts := NewCacheOptions().
+		SetFilesystemOptions(fsOpts).
+		SetInstrumentOptions(fsOpts.InstrumentOptions()).
+		SetNamespaceDetails([]NamespaceDetails{
+			{
+				Namespace: md1,
+				Shards:    []uint32{0, 1},
+			},
+			{
+				Namespace: md2,
+				Shards:    []uint32{0, 1},
+			},
+		})
+	cache, err := NewCache(opts)
+	require.NoError(t, err)
+
+	infoFilesByNamespace := cache.ReadInfoFiles()
+	require.NotEmpty(t, infoFilesByNamespace)
+
+	// Ensure we have two namespaces.
+	require.Equal(t, 2, len(infoFilesByNamespace))
+
+	// Ensure each shard has three info files (one for each fileset written).
+	infoFiles, err := cache.IndexInfoFilesForNamespace(md1)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(infoFiles))
+
+	infoFiles, err = cache.IndexInfoFilesForNamespace(md2)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(infoFiles))
+}
+
 func testNamespaceMetadata(t *testing.T, nsID ident.ID) namespace.Metadata {
 	rOpts := testRetentionOptions.SetBlockSize(testBlockSize)
 	md, err := namespace.NewMetadata(nsID, testNamespaceOptions.
@@ -152,6 +201,45 @@ type testSeries struct {
 	id   string
 	tags map[string]string
 	data []byte
+}
+
+func writeIndexFilesets(
+	t *testing.T,
+	namespace ident.ID,
+	shards map[uint32]struct{},
+	fsOpts fs.Options,
+) {
+	blockStart := testStart
+	blockSize := 10 * time.Hour
+	numBlocks := 3
+	for i := 0; i < numBlocks; i++ {
+		writeIndexFiles(t, namespace, shards, blockStart.Add(time.Duration(i)*blockSize),
+			blockSize, fsOpts)
+	}
+}
+
+func writeIndexFiles(
+	t *testing.T,
+	namespace ident.ID,
+	shards map[uint32]struct{},
+	blockStart time.Time,
+	blockSize time.Duration,
+	fsOpts fs.Options,
+) {
+	idxWriter, err := fs.NewIndexWriter(fsOpts)
+	require.NoError(t, err)
+	require.NoError(t, idxWriter.Open(fs.IndexWriterOpenOptions{
+		Identifier: fs.FileSetFileIdentifier{
+			FileSetContentType: persist.FileSetIndexContentType,
+			Namespace:          namespace,
+			BlockStart:         blockStart,
+		},
+		BlockSize:       blockSize,
+		FileSetType:     persist.FileSetFlushType,
+		Shards:          shards,
+		IndexVolumeType: idxpersist.DefaultIndexVolumeType,
+	}))
+	require.NoError(t, idxWriter.Close())
 }
 
 func writeFilesets(t *testing.T, namespace ident.ID, shard uint32, fsOpts fs.Options) {

--- a/src/dbnode/storage/bootstrap/result/result_index.go
+++ b/src/dbnode/storage/bootstrap/result/result_index.go
@@ -312,11 +312,6 @@ func (b IndexBlockByVolumeType) SetBlock(volumeType persist.IndexVolumeType, blo
 	b.data[volumeType] = block
 }
 
-// DeleteBlock deletes an IndexBlock for volumeType.
-func (b IndexBlockByVolumeType) DeleteBlock(volumeType persist.IndexVolumeType) {
-	delete(b.data, volumeType)
-}
-
 // Iter returns the underlying iterable map data.
 func (b IndexBlockByVolumeType) Iter() map[persist.IndexVolumeType]IndexBlock {
 	return b.data

--- a/src/dbnode/storage/bootstrap/result/result_index.go
+++ b/src/dbnode/storage/bootstrap/result/result_index.go
@@ -312,6 +312,11 @@ func (b IndexBlockByVolumeType) SetBlock(volumeType persist.IndexVolumeType, blo
 	b.data[volumeType] = block
 }
 
+// DeleteBlock deletes an IndexBlock for volumeType.
+func (b IndexBlockByVolumeType) DeleteBlock(volumeType persist.IndexVolumeType) {
+	delete(b.data, volumeType)
+}
+
 // Iter returns the underlying iterable map data.
 func (b IndexBlockByVolumeType) Iter() map[persist.IndexVolumeType]IndexBlock {
 	return b.data

--- a/src/dbnode/storage/bootstrap/types.go
+++ b/src/dbnode/storage/bootstrap/types.go
@@ -430,6 +430,9 @@ type InfoFileResultsPerShard map[uint32][]fs.ReadInfoFileResult
 // InfoFilesByNamespace maps a namespace to info files grouped by shard.
 type InfoFilesByNamespace map[namespace.Metadata]InfoFileResultsPerShard
 
+// IndexInfoFilesByNamespace maps a namespace to index info files.
+type IndexInfoFilesByNamespace map[namespace.Metadata][]fs.ReadIndexInfoFileResult
+
 // Cache provides a snapshot of info files for use throughout all stages of the bootstrap.
 type Cache interface {
 	// InfoFilesForNamespace returns the info files grouped by namespace.
@@ -437,6 +440,9 @@ type Cache interface {
 
 	// InfoFilesForShard returns the info files grouped by shard for the provided namespace.
 	InfoFilesForShard(ns namespace.Metadata, shard uint32) ([]fs.ReadInfoFileResult, error)
+
+	// IndexInfoFilesForNamespace returns the index info files.
+	IndexInfoFilesForNamespace(ns namespace.Metadata) ([]fs.ReadIndexInfoFileResult, error)
 
 	// ReadInfoFiles returns info file results for each shard grouped by namespace. A cached copy
 	// is returned if the info files have already been read.

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -39,12 +39,12 @@ import (
 	"go.uber.org/zap"
 )
 
-type commitLogFilesFn func(commitlog.Options) (persist.CommitLogFiles, []commitlog.ErrorWithPath, error)
-type snapshotMetadataFilesFn func(fs.Options) ([]fs.SnapshotMetadata, []fs.SnapshotMetadataErrorWithPaths, error)
+type (
+	commitLogFilesFn        func(commitlog.Options) (persist.CommitLogFiles, []commitlog.ErrorWithPath, error)
+	snapshotMetadataFilesFn func(fs.Options) ([]fs.SnapshotMetadata, []fs.SnapshotMetadataErrorWithPaths, error)
+)
 
 type snapshotFilesFn func(filePathPrefix string, namespace ident.ID, shard uint32) (fs.FileSetFilesSlice, error)
-
-type deleteFilesFn func(files []string) error
 
 type deleteInactiveDirectoriesFn func(parentDirPath string, activeDirNames []string) error
 
@@ -68,7 +68,7 @@ type cleanupManager struct {
 	snapshotMetadataFilesFn snapshotMetadataFilesFn
 	snapshotFilesFn         snapshotFilesFn
 
-	deleteFilesFn               deleteFilesFn
+	deleteFilesFn               fs.DeleteFilesFn
 	deleteInactiveDirectoriesFn deleteInactiveDirectoriesFn
 	warmFlushCleanupInProgress  bool
 	coldFlushCleanupInProgress  bool
@@ -213,6 +213,7 @@ func (m *cleanupManager) ColdFlushCleanup(t time.Time, isBootstrapped bool) erro
 
 	return multiErr.FinalError()
 }
+
 func (m *cleanupManager) Report() {
 	m.RLock()
 	coldFlushCleanupInProgress := m.coldFlushCleanupInProgress

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -40,8 +40,16 @@ import (
 )
 
 type (
-	commitLogFilesFn        func(commitlog.Options) (persist.CommitLogFiles, []commitlog.ErrorWithPath, error)
-	snapshotMetadataFilesFn func(fs.Options) ([]fs.SnapshotMetadata, []fs.SnapshotMetadataErrorWithPaths, error)
+	commitLogFilesFn func(commitlog.Options) (
+		persist.CommitLogFiles,
+		[]commitlog.ErrorWithPath,
+		error,
+	)
+	snapshotMetadataFilesFn func(fs.Options) (
+		[]fs.SnapshotMetadata,
+		[]fs.SnapshotMetadataErrorWithPaths,
+		error,
+	)
 )
 
 type snapshotFilesFn func(filePathPrefix string, namespace ident.ID, shard uint32) (fs.FileSetFilesSlice, error)

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -87,9 +87,7 @@ const (
 	defaultFlushDocsBatchSize = 8192
 )
 
-var (
-	allQuery = idx.NewAllQuery()
-)
+var allQuery = idx.NewAllQuery()
 
 // nolint: maligned
 type nsIndex struct {
@@ -109,7 +107,7 @@ type nsIndex struct {
 
 	namespaceRuntimeOptsMgr namespace.RuntimeOptionsManager
 	indexFilesetsBeforeFn   indexFilesetsBeforeFn
-	deleteFilesFn           deleteFilesFn
+	deleteFilesFn           fs.DeleteFilesFn
 	readIndexInfoFilesFn    readIndexInfoFilesFn
 
 	newBlockFn            index.NewBlockFn

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1994,6 +1994,10 @@ func (i *nsIndex) CleanupExpiredFileSets(t time.Time) error {
 	return i.deleteFilesFn(filesets)
 }
 
+// CleanupDuplicateFileSets only considers an index fileset of the same index volume type
+// that covers a superset of shard time ranges as a dupe. We can have index filesets
+// of the default volume type that have non-overlapping shard time ranges in the node leave
+// case where we accept new shards and a index fileset is persisted to disk w/ the new shards.
 func (i *nsIndex) CleanupDuplicateFileSets() error {
 	fsOpts := i.opts.CommitLogOptions().FilesystemOptions()
 	infoFiles := i.readIndexInfoFilesFn(

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -172,7 +172,7 @@ type dbShard struct {
 	newFSMergeWithMemFn      newFSMergeWithMemFn
 	filesetsFn               filesetsFn
 	filesetPathsBeforeFn     filesetPathsBeforeFn
-	deleteFilesFn            deleteFilesFn
+	deleteFilesFn            fs.DeleteFilesFn
 	snapshotFilesFn          snapshotFilesFn
 	newReaderFn              fs.NewReaderFn
 	sleepFn                  func(time.Duration)
@@ -1330,7 +1330,6 @@ func (s *dbShard) insertSeriesForIndexingAsyncBatched(
 			entryRefCountIncremented: true,
 		},
 	})
-
 	// i.e. unable to enqueue into shard insert queue
 	if err != nil {
 		entry.OnIndexFinalize(indexBlockStart) // release any reference's we've held for indexing


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Validate and remove corrupted index segments. Only mark fulfilled ranges for default index volume type persisted blocks. 

Also adds an additional test to cover bootstrapping partial shards in index segments. This is the node leave case where the peers bootstrapper fetches and persists data for additional shards and crashes before writing index data to disk. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
