### PR TITLE
[m3coordinator] Allow downsampler to configure custom rule store

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -102,6 +102,9 @@ var (
 	errRollupRuleNoTransforms       = errors.New("rollup rule has no transforms set")
 )
 
+// CustomRuleStoreFn is a function to swap the backend used for the rule stores.
+type CustomRuleStoreFn func(kv.Store) (kv.Store, error)
+
 // DownsamplerOptions is a set of required downsampler options.
 type DownsamplerOptions struct {
 	Storage                    storage.Storage

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -149,6 +149,9 @@ type RunOptions struct {
 	// CustomBuildTags are additional tags to be added to the instrument build
 	// reporter.
 	CustomBuildTags map[string]string
+
+	// ApplyCustomRuleStore provides an option to swap the backend used for the rule stores.
+	ApplyCustomRuleStore downsample.CustomRuleStoreFn
 }
 
 // InstrumentOptionsReady is a set of instrument options
@@ -669,7 +672,7 @@ func newM3DBStorage(
 		ds, err := newDownsampler(
 			cfg.Downsample, clusterClient,
 			fanoutStorage, clusterNamespacesWatcher,
-			tsdbOpts.TagOptions(), instrumentOptions, rwOpts)
+			tsdbOpts.TagOptions(), instrumentOptions, rwOpts, runOpts.ApplyCustomRuleStore)
 		if err != nil {
 			return nil, err
 		}
@@ -728,6 +731,7 @@ func newDownsampler(
 	tagOptions models.TagOptions,
 	instrumentOpts instrument.Options,
 	rwOpts xio.Options,
+	applyCustomRuleStore downsample.CustomRuleStoreFn,
 ) (downsample.Downsampler, error) {
 	// Namespace the downsampler metrics.
 	instrumentOpts = instrumentOpts.SetMetricsScope(
@@ -742,6 +746,12 @@ func newDownsampler(
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create KV store from the "+
 			"cluster management config client")
+	}
+	if applyCustomRuleStore != nil {
+		kvStore, err = applyCustomRuleStore(kvStore)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to apply custom rule store")
+		}
 	}
 
 	tagEncoderOptions := serialize.NewTagEncoderOptions()


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables clients to specify custom rule stores, and provides this custom rule store to the downsampler.

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE