### PR TITLE
[dbnode] Add ability to force enable cold writes from config

### DIFF
--- a/src/cmd/services/m3dbnode/config/config.go
+++ b/src/cmd/services/m3dbnode/config/config.go
@@ -207,6 +207,10 @@ type DBConfiguration struct {
 
 	// Debug configuration.
 	Debug config.DebugConfiguration `yaml:"debug"`
+
+	// ForceColdWritesEnabled will force enable cold writes for all namespaces
+	// if set.
+	ForceColdWritesEnabled *bool `yaml:"forceColdWritesEnabled"`
 }
 
 // LoggingOrDefault returns the logging configuration or defaults.

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -729,6 +729,7 @@ func TestConfiguration(t *testing.T) {
   debug:
     mutexProfileFraction: 0
     blockProfileRate: 0
+    forceColdWritesEnabled: null
 coordinator: null
 `
 

--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -729,7 +729,7 @@ func TestConfiguration(t *testing.T) {
   debug:
     mutexProfileFraction: 0
     blockProfileRate: 0
-    forceColdWritesEnabled: null
+  forceColdWritesEnabled: null
 coordinator: null
 `
 

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -651,6 +651,11 @@ func Run(runOpts RunOptions) {
 	}()
 	opts = opts.SetIndexClaimsManager(icm)
 
+	if value := cfg.ForceColdWritesEnabled; value != nil {
+		// Allow forcing cold writes to be enabled by config.
+		opts = opts.SetForceColdWritesEnabled(*value)
+	}
+
 	forceColdWrites := opts.ForceColdWritesEnabled()
 	var envCfgResults environment.ConfigureResults
 	if len(envConfig.Statics) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds the ability to force enable cold writes from config.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
