### PR TITLE
[dbnode] Introduce a field for RPC error code and Resource Exhausted error type

### DIFF
--- a/src/aggregator/server/http/handlers.go
+++ b/src/aggregator/server/http/handlers.go
@@ -148,7 +148,7 @@ func writeResponse(w http.ResponseWriter, resp interface{}, err error) {
 
 	if err == nil {
 		w.WriteHeader(http.StatusOK)
-	} else if xerrors.IsInvalidParams(err) {
+	} else if xerrors.IsInvalidParams(err) || xerrors.IsResourceExhausted(err) {
 		w.WriteHeader(http.StatusBadRequest)
 	} else {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/src/cluster/etcd/watchmanager/manager.go
+++ b/src/cluster/etcd/watchmanager/manager.go
@@ -91,7 +91,8 @@ func (w *manager) watchChanWithTimeout(key string, rev int64) (clientv3.WatchCha
 		return watchChan, cancelFn, nil
 	case <-time.After(timeout):
 		cancelFn()
-		return nil, nil, fmt.Errorf("etcd watch create timed out after %s for key: %s", timeout.String(), key)
+		return nil, nil, fmt.Errorf("etcd watch create timed out after %s for key: %s",
+			timeout.String(), key)
 	}
 }
 

--- a/src/cluster/etcd/watchmanager/manager_test.go
+++ b/src/cluster/etcd/watchmanager/manager_test.go
@@ -27,18 +27,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3/src/cluster/mocks"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/integration"
 	"golang.org/x/net/context"
+
+	"github.com/m3db/m3/src/cluster/mocks"
 )
 
 func TestWatchChan(t *testing.T) {
-	wh, ec, _, _, _, closer := testSetup(t)
+	wh, ec, _, _, _, closer := testSetup(t) //nolint:dogsled
 	defer closer()
 
 	wc, _, err := wh.watchChanWithTimeout("foo", 0)

--- a/src/cluster/kv/etcd/store.go
+++ b/src/cluster/kv/etcd/store.go
@@ -33,9 +33,9 @@ import (
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/retry"
 
-	"go.etcd.io/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 	"github.com/uber-go/tally"
+	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )

--- a/src/cluster/services/heartbeat/etcd/store.go
+++ b/src/cluster/services/heartbeat/etcd/store.go
@@ -35,9 +35,9 @@ import (
 	"github.com/m3db/m3/src/x/retry"
 	"github.com/m3db/m3/src/x/watch"
 
-	"go.etcd.io/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 	"github.com/uber-go/tally"
+	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )

--- a/src/dbnode/client/fetch_attempt.go
+++ b/src/dbnode/client/fetch_attempt.go
@@ -59,7 +59,7 @@ func (f *fetchAttempt) perform() error {
 		f.args.ids, f.args.start, f.args.end)
 	f.result = result
 
-	if IsBadRequestError(err) {
+	if IsBadRequestError(err) || IsResourceExhaustedError(err) {
 		// Do not retry bad request errors
 		err = xerrors.NewNonRetryableError(err)
 	}

--- a/src/dbnode/client/fetch_state.go
+++ b/src/dbnode/client/fetch_state.go
@@ -31,7 +31,6 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/x/xpool"
-	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/serialize"
 )
@@ -137,12 +136,7 @@ func (f *fetchState) completionFn(
 	result interface{},
 	resultErr error,
 ) {
-	if IsBadRequestError(resultErr) {
-		// Wrap with invalid params and non-retryable so it is
-		// not retried.
-		resultErr = xerrors.NewInvalidParamsError(resultErr)
-		resultErr = xerrors.NewNonRetryableError(resultErr)
-	}
+	resultErr = WrapIfNonRetryable(resultErr)
 
 	f.Lock()
 	defer func() {

--- a/src/dbnode/client/fetch_tagged_results_accumulator.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator.go
@@ -208,7 +208,11 @@ func (accum *fetchTaggedResultAccumulator) accumulatedResult(
 		err := fmt.Errorf("unable to satisfy consistency requirements: shards=%d, err=%v",
 			accum.numShardsPending, accum.errors)
 		for i := range accum.errors {
-			if IsBadRequestError(accum.errors[i]) {
+			if IsResourceExhaustedError(accum.errors[i]) {
+				err = xerrors.NewResourceExhaustedError(err)
+				err = xerrors.NewNonRetryableError(err)
+				break
+			} else if IsBadRequestError(accum.errors[i]) {
 				err = xerrors.NewInvalidParamsError(err)
 				err = xerrors.NewNonRetryableError(err)
 				break

--- a/src/dbnode/client/write_attempt.go
+++ b/src/dbnode/client/write_attempt.go
@@ -69,7 +69,7 @@ func (w *writeAttempt) perform() error {
 		w.args.namespace, w.args.id, w.args.tags, w.args.t,
 		w.args.value, w.args.unit, w.args.annotation)
 
-	if IsBadRequestError(err) {
+	if IsBadRequestError(err) || IsResourceExhaustedError(err) {
 		// Do not retry bad request errors
 		err = xerrors.NewNonRetryableError(err)
 	}

--- a/src/dbnode/client/write_state.go
+++ b/src/dbnode/client/write_state.go
@@ -116,12 +116,7 @@ func (w *writeState) completionFn(result interface{}, err error) {
 	var wErr error
 
 	if err != nil {
-		if IsBadRequestError(err) {
-			// Wrap with invalid params and non-retryable so it is
-			// not retried.
-			err = xerrors.NewInvalidParamsError(err)
-			err = xerrors.NewNonRetryableError(err)
-		}
+		err = WrapIfNonRetryable(err)
 		wErr = xerrors.NewRenamedError(err, fmt.Errorf("error writing to host %s: %v", hostID, err))
 	} else if hostShardSet, ok := w.topoMap.LookupHostShardSet(hostID); !ok {
 		errStr := "missing host shard in writeState completionFn: %s"

--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -29,12 +29,19 @@ enum TimeType {
 
 enum ErrorType {
 	INTERNAL_ERROR,
-	BAD_REQUEST
+	BAD_REQUEST,
+	RESOURCE_EXHAUSTED
+}
+
+enum ErrorCode {
+    NONE,
+    RESOURCE_EXHAUSTED
 }
 
 exception Error {
 	1: required ErrorType type = ErrorType.INTERNAL_ERROR
 	2: required string message
+	3: optional ErrorCode code = ErrorCode.NONE
 }
 
 exception WriteBatchRawErrors {

--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -29,8 +29,7 @@ enum TimeType {
 
 enum ErrorType {
 	INTERNAL_ERROR,
-	BAD_REQUEST,
-	RESOURCE_EXHAUSTED
+	BAD_REQUEST
 }
 
 enum ErrorCode {

--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -33,8 +33,8 @@ enum ErrorType {
 }
 
 enum ErrorCode {
-    NONE,
-    RESOURCE_EXHAUSTED
+    NONE               = 0x00,
+    RESOURCE_EXHAUSTED = 0x01
 }
 
 exception Error {

--- a/src/dbnode/generated/thrift/rpc/rpc.go
+++ b/src/dbnode/generated/thrift/rpc/rpc.go
@@ -107,9 +107,8 @@ func (p *TimeType) Value() (driver.Value, error) {
 type ErrorType int64
 
 const (
-	ErrorType_INTERNAL_ERROR     ErrorType = 0
-	ErrorType_BAD_REQUEST        ErrorType = 1
-	ErrorType_RESOURCE_EXHAUSTED ErrorType = 2
+	ErrorType_INTERNAL_ERROR ErrorType = 0
+	ErrorType_BAD_REQUEST    ErrorType = 1
 )
 
 func (p ErrorType) String() string {
@@ -118,8 +117,6 @@ func (p ErrorType) String() string {
 		return "INTERNAL_ERROR"
 	case ErrorType_BAD_REQUEST:
 		return "BAD_REQUEST"
-	case ErrorType_RESOURCE_EXHAUSTED:
-		return "RESOURCE_EXHAUSTED"
 	}
 	return "<UNSET>"
 }
@@ -130,8 +127,6 @@ func ErrorTypeFromString(s string) (ErrorType, error) {
 		return ErrorType_INTERNAL_ERROR, nil
 	case "BAD_REQUEST":
 		return ErrorType_BAD_REQUEST, nil
-	case "RESOURCE_EXHAUSTED":
-		return ErrorType_RESOURCE_EXHAUSTED, nil
 	}
 	return ErrorType(0), fmt.Errorf("not a valid ErrorType string")
 }

--- a/src/dbnode/network/server/httpjson/handlers.go
+++ b/src/dbnode/network/server/httpjson/handlers.go
@@ -266,7 +266,7 @@ func writeError(w http.ResponseWriter, errValue interface{}) {
 	case Error:
 		w.WriteHeader(v.StatusCode())
 	case error:
-		if xerrors.IsInvalidParams(v) {
+		if xerrors.IsInvalidParams(v) || xerrors.IsResourceExhausted(v) {
 			w.WriteHeader(http.StatusBadRequest)
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/src/dbnode/network/server/tchannelthrift/cluster/service.go
+++ b/src/dbnode/network/server/tchannelthrift/cluster/service.go
@@ -241,7 +241,7 @@ func (s *service) Fetch(tctx thrift.Context, req *rpc.FetchRequest) (*rpc.FetchR
 
 	it, err := session.Fetch(nsID, tsID, start, end)
 	if err != nil {
-		return nil, toRPCError(err)
+		return nil, convert.ToRPCError(err)
 	}
 
 	defer it.Close()
@@ -337,7 +337,7 @@ func (s *service) Write(tctx thrift.Context, req *rpc.WriteRequest) error {
 	tsID := s.idPool.GetStringID(ctx, req.ID)
 	err = session.Write(nsID, tsID, ts, dp.Value, unit, dp.Annotation)
 	if err != nil {
-		return toRPCError(err)
+		return convert.ToRPCError(err)
 	}
 	return nil
 }
@@ -371,7 +371,7 @@ func (s *service) WriteTagged(tctx thrift.Context, req *rpc.WriteTaggedRequest) 
 	err = session.WriteTagged(nsID, tsID, ident.NewTagsIterator(tags),
 		ts, dp.Value, unit, dp.Annotation)
 	if err != nil {
-		return toRPCError(err)
+		return convert.ToRPCError(err)
 	}
 	return nil
 }
@@ -396,14 +396,4 @@ func (s *service) Truncate(tctx thrift.Context, req *rpc.TruncateRequest) (*rpc.
 	res := rpc.NewTruncateResult_()
 	res.NumSeries = truncated
 	return res, nil
-}
-
-func toRPCError(err error) *rpc.Error {
-	if client.IsResourceExhaustedError(err) {
-		return tterrors.NewResourceExhaustedError(err)
-	}
-	if client.IsBadRequestError(err) {
-		return tterrors.NewBadRequestError(err)
-	}
-	return tterrors.NewInternalError(err)
 }

--- a/src/dbnode/network/server/tchannelthrift/convert/convert.go
+++ b/src/dbnode/network/server/tchannelthrift/convert/convert.go
@@ -192,6 +192,9 @@ func ToRPCError(err error) *rpc.Error {
 	if xerrors.IsInvalidParams(err) {
 		return tterrors.NewBadRequestError(err)
 	}
+	if xerrors.IsResourceExhausted(err) {
+		return tterrors.NewResourceExhaustedError(err)
+	}
 	return tterrors.NewInternalError(err)
 }
 

--- a/src/dbnode/network/server/tchannelthrift/errors/errors.go
+++ b/src/dbnode/network/server/tchannelthrift/errors/errors.go
@@ -46,7 +46,8 @@ func IsBadRequestError(err *rpc.Error) bool {
 
 // IsResourceExhaustedError returns whether the error is a resource exhausted error.
 func IsResourceExhaustedError(err *rpc.Error) bool {
-	return err != nil && err.Code == rpc.ErrorCode_RESOURCE_EXHAUSTED
+	lowestByteMask := rpc.ErrorCode(0xff)
+	return err != nil && err.Code&lowestByteMask == rpc.ErrorCode_RESOURCE_EXHAUSTED
 }
 
 // NewInternalError creates a new internal error

--- a/src/dbnode/network/server/tchannelthrift/errors/errors.go
+++ b/src/dbnode/network/server/tchannelthrift/errors/errors.go
@@ -46,11 +46,7 @@ func IsBadRequestError(err *rpc.Error) bool {
 
 // IsResourceExhaustedError returns whether the error is a resource exhausted error.
 func IsResourceExhaustedError(err *rpc.Error) bool {
-	// NB: To maintain better backwards compatibility, Resource Exhausted errors might also be
-	// defined by BAD_REQUEST error type coupled with RESOURCE_EXHAUSTED error code
-	return err != nil &&
-		(err.Type == rpc.ErrorType_RESOURCE_EXHAUSTED ||
-			(err.Type == rpc.ErrorType_BAD_REQUEST && err.Code == rpc.ErrorCode_RESOURCE_EXHAUSTED))
+	return err != nil && err.Code == rpc.ErrorCode_RESOURCE_EXHAUSTED
 }
 
 // NewInternalError creates a new internal error
@@ -66,8 +62,7 @@ func NewBadRequestError(err error) *rpc.Error {
 // NewResourceExhaustedError creates a new resource exhausted error.
 func NewResourceExhaustedError(err error) *rpc.Error {
 	// NB: To maintain better backwards compatibility, using BAD_REQUEST error type coupled with
-	// RESOURCE_EXHAUSTED error code. After a reasonable amount of time this should be switched to
-	// RESOURCE_EXHAUSTED error code (added after M3 release v1.0.0)
+	// RESOURCE_EXHAUSTED error code
 	return newError(rpc.ErrorType_BAD_REQUEST, rpc.ErrorCode_RESOURCE_EXHAUSTED, err)
 }
 

--- a/src/dbnode/network/server/tchannelthrift/errors/errors_test.go
+++ b/src/dbnode/network/server/tchannelthrift/errors/errors_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorTypesAreRecognized(t *testing.T) {
+	someError := errors.New("")
+	assert.True(t, IsBadRequestError(NewBadRequestError(someError)))
+	assert.True(t, IsResourceExhaustedError(NewResourceExhaustedError(someError)))
+	assert.True(t, IsInternalError(NewInternalError(someError)))
+}
+
+func TestResourceExhaustedBackwardsCompatibility(t *testing.T) {
+	assert.True(t, IsBadRequestError(NewResourceExhaustedError(errors.New(""))))
+}

--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -1027,7 +1027,8 @@ func (s *service) FetchBatchRaw(tctx thrift.Context, req *rpc.FetchBatchRawReque
 		segments, rpcErr := s.readEncodedResult(ctx, nsID, encodedResults[i].result)
 		if rpcErr != nil {
 			rawResult.Err = rpcErr
-			if tterrors.IsBadRequestError(rawResult.Err) {
+			if tterrors.IsBadRequestError(rawResult.Err) ||
+				tterrors.IsResourceExhaustedError(rawResult.Err) {
 				nonRetryableErrors++
 			} else {
 				retryableErrors++
@@ -1093,7 +1094,8 @@ func (s *service) FetchBatchRawV2(tctx thrift.Context, req *rpc.FetchBatchRawV2R
 		encodedResult, err := db.ReadEncoded(ctx, nsIdx, tsID, start, end)
 		if err != nil {
 			rawResult.Err = convert.ToRPCError(err)
-			if tterrors.IsBadRequestError(rawResult.Err) {
+			if tterrors.IsBadRequestError(rawResult.Err) ||
+				tterrors.IsResourceExhaustedError(rawResult.Err) {
 				nonRetryableErrors++
 			} else {
 				retryableErrors++
@@ -1104,7 +1106,8 @@ func (s *service) FetchBatchRawV2(tctx thrift.Context, req *rpc.FetchBatchRawV2R
 		segments, rpcErr := s.readEncodedResult(ctx, nsIdx, encodedResult)
 		if rpcErr != nil {
 			rawResult.Err = rpcErr
-			if tterrors.IsBadRequestError(rawResult.Err) {
+			if tterrors.IsBadRequestError(rawResult.Err) ||
+				tterrors.IsResourceExhaustedError(rawResult.Err) {
 				nonRetryableErrors++
 			} else {
 				retryableErrors++
@@ -2542,7 +2545,7 @@ func (r *writeBatchPooledReq) HandleError(index int, err error) {
 		return
 	}
 
-	if xerrors.IsInvalidParams(err) {
+	if xerrors.IsInvalidParams(err) || xerrors.IsResourceExhausted(err) {
 		r.nonRetryableErrors++
 		r.errs = append(
 			r.errs,

--- a/src/dbnode/storage/limits/query_limits.go
+++ b/src/dbnode/storage/limits/query_limits.go
@@ -192,7 +192,7 @@ func (q *lookbackLimit) exceeded() error {
 func (q *lookbackLimit) checkLimit(recent int64) error {
 	if q.options.Limit > 0 && recent > q.options.Limit {
 		q.metrics.exceeded.Inc(1)
-		return xerrors.NewInvalidParamsError(fmt.Errorf(
+		return xerrors.NewResourceExhaustedError(fmt.Errorf(
 			"query aborted due to limit: name=%s, limit=%d, current=%d, within=%s",
 			q.name, q.options.Limit, recent, q.options.Lookback))
 	}

--- a/src/dbnode/storage/limits/query_limits_test.go
+++ b/src/dbnode/storage/limits/query_limits_test.go
@@ -66,7 +66,7 @@ func TestQueryLimits(t *testing.T) {
 	require.Error(t, queryLimits.DocsLimit().Inc(2, nil))
 	err = queryLimits.AnyExceeded()
 	require.Error(t, err)
-	require.True(t, xerrors.IsInvalidParams(err))
+	require.True(t, xerrors.IsResourceExhausted(err))
 
 	opts = testQueryLimitOptions(docOpts, bytesOpts, instrument.NewOptions())
 	queryLimits, err = NewQueryLimits(opts)
@@ -81,7 +81,7 @@ func TestQueryLimits(t *testing.T) {
 	require.Error(t, queryLimits.BytesReadLimit().Inc(2, nil))
 	err = queryLimits.AnyExceeded()
 	require.Error(t, err)
-	require.True(t, xerrors.IsInvalidParams(err))
+	require.True(t, xerrors.IsResourceExhausted(err))
 }
 
 func TestLookbackLimit(t *testing.T) {
@@ -160,7 +160,7 @@ func verifyLimit(t *testing.T, limit *lookbackLimit, inc int, expectedLimit int6
 		require.NoError(t, err)
 	} else {
 		require.Error(t, err)
-		require.True(t, xerrors.IsInvalidParams(err))
+		require.True(t, xerrors.IsResourceExhausted(err))
 		exceededCount++
 	}
 	err = limit.exceeded()
@@ -168,7 +168,7 @@ func verifyLimit(t *testing.T, limit *lookbackLimit, inc int, expectedLimit int6
 		require.NoError(t, err)
 	} else {
 		require.Error(t, err)
-		require.True(t, xerrors.IsInvalidParams(err))
+		require.True(t, xerrors.IsResourceExhausted(err))
 		exceededCount++
 	}
 	return exceededCount

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1567,7 +1567,7 @@ func (s *dbShard) insertSeriesBatch(inserts []dbShardInsert) error {
 			_, _, err = entry.Series.Write(ctx, write.timestamp, write.value,
 				write.unit, annotationBytes, write.opts)
 			if err != nil {
-				if xerrors.IsInvalidParams(err) {
+				if xerrors.IsInvalidParams(err) || xerrors.IsResourceExhausted(err) {
 					s.metrics.insertAsyncWriteInvalidParamsErrors.Inc(1)
 				} else {
 					s.metrics.insertAsyncWriteInternalErrors.Inc(1)

--- a/src/query/api/experimental/annotated/handler.go
+++ b/src/query/api/experimental/annotated/handler.go
@@ -92,7 +92,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if batchErr != nil {
 		var foundInternalErr bool
 		for _, err := range batchErr.Errors() {
-			if client.IsBadRequestError(err) {
+			if client.IsBadRequestError(err) || client.IsResourceExhaustedError(err) {
 				continue
 			}
 			foundInternalErr = true

--- a/src/query/api/v1/handler/influxdb/write.go
+++ b/src/query/api/v1/handler/influxdb/write.go
@@ -308,10 +308,10 @@ func (iwh *ingestWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	)
 	for _, err := range errs {
 		switch {
-		case client.IsBadRequestError(err):
+		case client.IsBadRequestError(err) || client.IsResourceExhaustedError(err):
 			numBadRequest++
 			lastBadRequestErr = err.Error()
-		case xerrors.IsInvalidParams(err):
+		case xerrors.IsInvalidParams(err) || xerrors.IsResourceExhausted(err):
 			numBadRequest++
 			lastBadRequestErr = err.Error()
 		default:

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -361,10 +361,10 @@ func (h *PromWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		)
 		for _, err := range errs {
 			switch {
-			case client.IsBadRequestError(err):
+			case client.IsBadRequestError(err) || client.IsResourceExhaustedError(err):
 				numBadRequest++
 				lastBadRequestErr = err.Error()
-			case xerrors.IsInvalidParams(err):
+			case xerrors.IsInvalidParams(err) || xerrors.IsResourceExhausted(err):
 				numBadRequest++
 				lastBadRequestErr = err.Error()
 			default:

--- a/src/x/errors/errors.go
+++ b/src/x/errors/errors.go
@@ -130,6 +130,40 @@ func GetInnerInvalidParamsError(err error) error {
 	return nil
 }
 
+type resourceExhaustedError struct {
+	containedError
+}
+
+// NewResourceExhaustedError creates a new resource exhausted error.
+func NewResourceExhaustedError(inner error) error {
+	return resourceExhaustedError{containedError{inner}}
+}
+
+func (e resourceExhaustedError) Error() string {
+	return e.inner.Error()
+}
+
+func (e resourceExhaustedError) InnerError() error {
+	return e.inner
+}
+
+// IsResourceExhausted returns true if this is a resource exhausted error.
+func IsResourceExhausted(err error) bool {
+	return GetInnerResourceExhaustedError(err) != nil
+}
+
+// GetInnerResourceExhaustedError returns an inner resource exhausted error if contained by
+// this error, nil otherwise.
+func GetInnerResourceExhaustedError(err error) error {
+	for err != nil {
+		if _, ok := err.(resourceExhaustedError); ok { //nolint:errorlint
+			return InnerError(err)
+		}
+		err = InnerError(err)
+	}
+	return nil
+}
+
 type retryableError struct {
 	containedError
 }

--- a/src/x/net/http/errors.go
+++ b/src/x/net/http/errors.go
@@ -108,7 +108,7 @@ func getStatusCode(err error) int {
 	case Error:
 		return v.Code()
 	case error:
-		if xerrors.IsInvalidParams(v) {
+		if xerrors.IsInvalidParams(v) || xerrors.IsResourceExhausted(v) {
 			return http.StatusBadRequest
 		} else if errors.Is(err, context.DeadlineExceeded) {
 			return http.StatusGatewayTimeout


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Introduces `Resource Exhausted` error type and uses it for `query limit exceeded` errors. This includes adding `code` field to `rpc.Error` and introducing new `xerrors.NewResourceExhaustedError()`.

**Special notes for your reviewer**:

There are quite a few changes, it might be a bit more convenient to review the them commit-by-commit.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
