### PR TITLE
[dbnode] Emit consistencyResultError from fetchTaggedResultAccumulator

### DIFF
--- a/src/dbnode/client/errors.go
+++ b/src/dbnode/client/errors.go
@@ -56,8 +56,13 @@ func IsBadRequestError(err error) bool {
 
 // IsConsistencyResultError determines if the error is a consistency result error.
 func IsConsistencyResultError(err error) bool {
-	_, ok := err.(consistencyResultErr)
-	return ok
+	for err != nil {
+		if _, ok := err.(consistencyResultErr); ok { //nolint:errorlint
+			return true
+		}
+		err = xerrors.InnerError(err)
+	}
+	return false
 }
 
 // NumResponded returns how many nodes responded for a given error
@@ -117,8 +122,8 @@ func isHostNotAvailableError(err error) bool {
 
 type consistencyResultError interface {
 	error
+	xerrors.ContainedError
 
-	InnerError() error
 	numResponded() int
 	numSuccess() int
 }

--- a/src/dbnode/client/fetch_tagged_results_accumulator.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator.go
@@ -209,9 +209,10 @@ func (accum *fetchTaggedResultAccumulator) accumulatedResult(
 		responded := enqueued
 		consistencyErr := newConsistencyResultError(accum.consistencyLevel, enqueued, responded,
 			accum.errors)
-		err := fmt.Errorf("unable to satisfy consistency requirements: shards=%d, err=%v",
+		err := xerrors.Wrapf(
+			consistencyErr,
+			"unable to satisfy consistency requirements: shards=%d, err=%v",
 			accum.numShardsPending, consistencyErr)
-		err = xerrors.NewRenamedError(consistencyErr, err)
 		for i := range accum.errors {
 			if IsBadRequestError(accum.errors[i]) {
 				err = xerrors.NewInvalidParamsError(err)

--- a/src/dbnode/client/fetch_tagged_results_accumulator.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator.go
@@ -205,8 +205,13 @@ func (accum *fetchTaggedResultAccumulator) accumulatedResult(
 		doneAccumulating := true
 		// NB(r): Use new renamed error to keep the underlying error
 		// (invalid/retryable) type.
+		enqueued := accum.topoMap.HostsLen()
+		responded := enqueued
+		consistencyErr := newConsistencyResultError(accum.consistencyLevel, enqueued, responded,
+			accum.errors)
 		err := fmt.Errorf("unable to satisfy consistency requirements: shards=%d, err=%v",
-			accum.numShardsPending, accum.errors)
+			accum.numShardsPending, consistencyErr)
+		err = xerrors.NewRenamedError(consistencyErr, err)
 		for i := range accum.errors {
 			if IsBadRequestError(accum.errors[i]) {
 				err = xerrors.NewInvalidParamsError(err)

--- a/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator_merge_test.go
@@ -343,6 +343,10 @@ func (tm testFetchStateWorkflow) run() fetchTaggedResultAccumulator {
 		}
 		assert.Equal(tm.t, s.expectedDone, done, fmt.Sprintf("i=%d, step=%+v", i, s))
 		assert.Equal(tm.t, s.expectedErr, err != nil, fmt.Sprintf("i=%d, step=%+v, err=%v", i, s, err))
+		if err != nil {
+			assert.True(tm.t, IsConsistencyResultError(err),
+				fmt.Sprintf("i=%d, step=%+v, expected consistency result error", i, s))
+		}
 	}
 	return accum
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Updates `fetchTaggedResultAccumulator` to emit `consistencyResultError` instead of generic `fmt.Errorf()`. This should make it easier to distinguish the error type from the outside, using `client.IsConsistencyResultError()`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
