### PR TITLE
[DOCS] Fix new API paths and add Docker version

### DIFF
--- a/site/config/_default/config.toml
+++ b/site/config/_default/config.toml
@@ -147,11 +147,13 @@ offlineSearch = false
   [params.api]
     localCordinator = "http://localhost:7201/"
     apiEndpoint = "api/v1/"
-
+# TODO: Can all the below be consolidated?
   [[params.versions]]
     version = "1.0"
     url = ""
 
+  [params.releases]
+    docker = "v1.0.0"
 
 # TODO: Do not like doing this really
 [markup]

--- a/site/content/includes/quickstart-common-steps.md
+++ b/site/content/includes/quickstart-common-steps.md
@@ -21,8 +21,6 @@ This quickstart uses the _{{% apiendpoint %}}database/create_ endpoint that crea
 
 You can create [placements](/docs/operational_guide/placement_configuration/) and [namespaces](/docs/operational_guide/namespace_configuration/#advanced-hard-way) separately if you need more control over their settings.
 
-The `namespaceName` argument must match the namespace in the `local` section of the `M3Coordinator` YAML configuration. If you [add any namespaces](/docs/operational_guide/namespace_configuration) you also need to add them to the `local` section of `M3Coordinator`'s YAML configuration.
-
 In another terminal, use the following command.
 
 {{< tabs name="create_placement_namespace" >}}
@@ -125,13 +123,13 @@ Placement initialization can take a minute or two. Once all the shards have the 
 {"level":"info","ts":1598367624.03023,"msg":"bootstrapped"}
 ```
 
-You can check on the status by calling the _{{% apiendpoint %}}placement_ endpoint:
+You can check on the status by calling the _{{% apiendpoint %}}services/m3db/placement_ endpoint:
 
 {{< tabs name="check_placement" >}}
 {{% tab name="Command" %}}
 
 ```shell
-curl {{% apiendpoint %}}placement | jq .
+curl {{% apiendpoint %}}services/m3db/placement | jq .
 ```
 
 {{% /tab %}}
@@ -190,15 +188,36 @@ curl {{% apiendpoint %}}placement | jq .
 [Read more about the bootstrapping process](/docs/operational_guide/bootstrapping_crash_recovery/).
 {{% /notice %}}
 
+### Ready a Namespace
+<!-- TODO: Why?> -->
+Once a namespace has finished bootstrapping, you must mark it as ready before receiving traffic by using the _{{% apiendpoint %}}namespace/ready_.
+
+{{< tabs name="ready_namespaces" >}}
+{{% tab name="Command" %}}
+
+{{% codeinclude file="docs/includes/quickstart/ready-namespace.sh" language="shell" %}}
+
+{{% /tab %}}
+{{% tab name="Output" %}}
+
+```json
+{
+"ready": true
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### View Details of a Namespace
 
-You can also view the attributes of all namespaces by calling the _{{% apiendpoint %}}namespace_ endpoint
+You can also view the attributes of all namespaces by calling the _{{% apiendpoint %}}services/m3db/namespace_ endpoint
 
 {{< tabs name="check_namespaces" >}}
 {{% tab name="Command" %}}
 
 ```shell
-curl {{% apiendpoint %}}namespace | jq .
+curl {{% apiendpoint %}}services/m3db/namespace | jq .
 ```
 
 {{% notice tip %}}

--- a/site/content/quickstart/docker.md
+++ b/site/content/quickstart/docker.md
@@ -41,7 +41,7 @@ The command below creates a persistent data directory on the host operating syst
 {{% tab name="Command" %}}
 
 ```shell
-docker run -p 7201:7201 -p 7203:7203 --name m3db -v $(pwd)/m3db_data:/var/lib/m3db quay.io/m3db/m3dbnode:latest
+docker run -p 7201:7201 -p 7203:7203 --name m3db -v $(pwd)/m3db_data:/var/lib/m3db quay.io/m3db/m3dbnode:{{% docker-version %}}
 ```
 
 {{% /tab %}}

--- a/site/layouts/shortcodes/docker-version.html
+++ b/site/layouts/shortcodes/docker-version.html
@@ -1,0 +1,1 @@
+{{ .Site.Params.releases.docker }}


### PR DESCRIPTION
@gediminasgu pointed out a handful of small API changes that I wasn't aware of, and this the quickstart fell out of date.

It also looks like #2795 override some changes from @nate as I single sourced some steps in that PR that went against git history so weren't really noticed in reviewing that PR.

Also after recommendation this PR sets a specific Docker version instead of using `latest`, and I have started adding config variables for the current versions of various releases, so it can be updated in one place.