### PR TITLE
[dbnode] Add server.StorageOptions to TestSetup

### DIFF
--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -42,6 +42,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/runtime"
+	"github.com/m3db/m3/src/dbnode/server"
 	"github.com/m3db/m3/src/dbnode/sharding"
 	"github.com/m3db/m3/src/dbnode/storage"
 	"github.com/m3db/m3/src/dbnode/storage/block"
@@ -61,7 +62,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
-	tchannel "github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -80,12 +81,8 @@ var (
 
 	testSchemaHistory = prototest.NewSchemaHistory()
 	testSchema        = prototest.NewMessageDescriptor(testSchemaHistory)
-	testSchemaDesc    = namespace.GetTestSchemaDescr(testSchema)
 	testProtoMessages = prototest.NewProtoTestMessages(testSchema)
-	testProtoEqual    = func(expect, actual []byte) bool {
-		return prototest.ProtoEqual(testSchema, expect, actual)
-	}
-	testProtoIter = prototest.NewProtoMessageIterator(testProtoMessages)
+	testProtoIter     = prototest.NewProtoMessageIterator(testProtoMessages)
 )
 
 // nowSetterFn is the function that sets the current time
@@ -105,6 +102,7 @@ type testSetup struct {
 
 	db                cluster.Database
 	storageOpts       storage.Options
+	serverStorageOpts server.StorageOptions
 	fsOpts            fs.Options
 	blockLeaseManager block.LeaseManager
 	hostID            string
@@ -133,8 +131,10 @@ type testSetup struct {
 	namespaces     []namespace.Metadata
 
 	// signals
-	doneCh   chan struct{}
-	closedCh chan struct{}
+	doneCh chan struct {
+	}
+	closedCh chan struct {
+	}
 }
 
 // TestSetup is a test setup.
@@ -157,6 +157,7 @@ type TestSetup interface {
 	FilePathPrefix() string
 	StorageOpts() storage.Options
 	SetStorageOpts(storage.Options)
+	SetServerStorageOpts(server.StorageOptions)
 	Origin() topology.Host
 	ServerIsBootstrapped() bool
 	StopServer() error
@@ -605,6 +606,10 @@ func (ts *testSetup) SetStorageOpts(opts storage.Options) {
 	ts.storageOpts = opts
 }
 
+func (ts *testSetup) SetServerStorageOpts(opts server.StorageOptions) {
+	ts.serverStorageOpts = opts
+}
+
 func (ts *testSetup) TopologyInitializer() topology.Initializer {
 	return ts.topoInit
 }
@@ -732,7 +737,7 @@ func (ts *testSetup) startServerBase(waitForBootstrap bool) error {
 		if err := openAndServe(
 			ts.httpClusterAddr(), ts.tchannelClusterAddr(),
 			ts.httpNodeAddr(), ts.tchannelNodeAddr(), ts.httpDebugAddr(),
-			ts.db, ts.m3dbClient, ts.storageOpts, ts.doneCh,
+			ts.db, ts.m3dbClient, ts.storageOpts, ts.serverStorageOpts, ts.doneCh,
 		); err != nil {
 			select {
 			case resultCh <- err:
@@ -1004,22 +1009,19 @@ func newClients(
 	tchannelNodeAddr string,
 ) (client.AdminClient, client.AdminClient, error) {
 	var (
-		clientOpts = defaultClientOptions(topoInit).
-				SetClusterConnectTimeout(opts.ClusterConnectionTimeout()).
-				SetFetchRequestTimeout(opts.FetchRequestTimeout()).
-				SetWriteConsistencyLevel(opts.WriteConsistencyLevel()).
-				SetTopologyInitializer(topoInit).
-				SetUseV2BatchAPIs(true)
+		clientOpts = defaultClientOptions(topoInit).SetClusterConnectTimeout(
+			opts.ClusterConnectionTimeout()).
+			SetFetchRequestTimeout(opts.FetchRequestTimeout()).
+			SetWriteConsistencyLevel(opts.WriteConsistencyLevel()).
+			SetTopologyInitializer(topoInit).
+			SetUseV2BatchAPIs(true)
 
 		origin             = newOrigin(id, tchannelNodeAddr)
 		verificationOrigin = newOrigin(id+"-verification", tchannelNodeAddr)
 
-		adminOpts = clientOpts.(client.AdminOptions).
-				SetOrigin(origin).
-				SetSchemaRegistry(schemaReg)
-		verificationAdminOpts = adminOpts.
-					SetOrigin(verificationOrigin).
-					SetSchemaRegistry(schemaReg)
+		adminOpts = clientOpts.(client.AdminOptions).SetOrigin(origin).SetSchemaRegistry(schemaReg)
+
+		verificationAdminOpts = adminOpts.SetOrigin(verificationOrigin).SetSchemaRegistry(schemaReg)
 	)
 
 	if opts.ProtoEncoding() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows more flexible `TestSetup` configuration for integration tests.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE