### PR TITLE
[aggregator] Pack some tcp client structs for lower memory utilization

### DIFF
--- a/src/aggregator/client/conn_options.go
+++ b/src/aggregator/client/conn_options.go
@@ -117,15 +117,15 @@ type ConnectionOptions interface {
 type connectionOptions struct {
 	clockOpts      clock.Options
 	instrumentOpts instrument.Options
+	writeRetryOpts retry.Options
+	rwOpts         xio.Options
 	connTimeout    time.Duration
-	connKeepAlive  bool
 	writeTimeout   time.Duration
+	maxDuration    time.Duration
 	initThreshold  int
 	maxThreshold   int
 	multiplier     int
-	maxDuration    time.Duration
-	writeRetryOpts retry.Options
-	rwOpts         xio.Options
+	connKeepAlive  bool
 }
 
 // NewConnectionOptions create a new set of connection options.

--- a/src/aggregator/client/payload.go
+++ b/src/aggregator/client/payload.go
@@ -55,8 +55,8 @@ type timedPayload struct {
 }
 
 type timedWithStagedMetadatas struct {
-	metric    aggregated.Metric
 	metadatas metadata.StagedMetadatas
+	metric    aggregated.Metric
 }
 
 type passthroughPayload struct {
@@ -65,10 +65,10 @@ type passthroughPayload struct {
 }
 
 type payloadUnion struct {
-	payloadType              payloadType
-	untimed                  untimedPayload
 	forwarded                forwardedPayload
+	untimed                  untimedPayload
 	timed                    timedPayload
 	timedWithStagedMetadatas timedWithStagedMetadatas
 	passthrough              passthroughPayload
+	payloadType              payloadType
 }

--- a/src/aggregator/client/ref_count.go
+++ b/src/aggregator/client/ref_count.go
@@ -25,8 +25,8 @@ import "sync/atomic"
 type destructorFn func()
 
 type refCount struct {
-	n            int32
 	destructorFn destructorFn
+	n            int32
 }
 
 func (rc *refCount) SetRefCount(n int)             { atomic.StoreInt32(&rc.n, int32(n)) }

--- a/src/aggregator/client/writer.go
+++ b/src/aggregator/client/writer.go
@@ -65,14 +65,14 @@ type writer struct {
 
 	log               *zap.Logger
 	metrics           writerMetrics
-	flushSize         int
-	maxTimerBatchSize int
 	encoderOpts       protobuf.UnaggregatedOptions
 	queue             instanceQueue
+	flushSize         int
+	maxTimerBatchSize int
 
-	closed             bool
 	encodersByShard    map[uint32]*lockedEncoder
 	newLockedEncoderFn newLockedEncoderFn
+	closed             bool
 }
 
 func newInstanceWriter(instance placement.Instance, opts Options) instanceWriter {
@@ -534,8 +534,8 @@ func newWriterMetrics(s tally.Scope) writerMetrics {
 }
 
 type lockedEncoder struct {
-	sync.Mutex
 	protobuf.UnaggregatedEncoder
+	sync.Mutex
 }
 
 func newLockedEncoder(encoderOpts protobuf.UnaggregatedOptions) *lockedEncoder {
@@ -544,8 +544,8 @@ func newLockedEncoder(encoderOpts protobuf.UnaggregatedOptions) *lockedEncoder {
 }
 
 type refCountedWriter struct {
-	refCount
 	instanceWriter
+	refCount
 }
 
 func newRefCountedWriter(instance placement.Instance, opts Options) *refCountedWriter {

--- a/src/metrics/encoding/protobuf/aggregated_encoder.go
+++ b/src/metrics/encoding/protobuf/aggregated_encoder.go
@@ -68,5 +68,9 @@ func (enc *aggregatedEncoder) Encode(
 }
 
 func (enc *aggregatedEncoder) Buffer() Buffer {
-	return NewBuffer(enc.buf, enc.pool)
+	var fn PoolReleaseFn
+	if enc.pool != nil {
+		fn = enc.pool.Put
+	}
+	return NewBuffer(enc.buf, fn)
 }

--- a/src/metrics/encoding/protobuf/buffer_test.go
+++ b/src/metrics/encoding/protobuf/buffer_test.go
@@ -37,13 +37,11 @@ func TestBufferWithPool(t *testing.T) {
 	data := p.Get(16)[:16]
 	data[0] = 0xff
 
-	buf := NewBuffer(data, p)
-	require.Equal(t, data, buf.Bytes())
-	require.False(t, buf.closed)
+	buf := NewBuffer(data, p.Put)
+	require.NotNil(t, buf.buf)
 
 	buf.Close()
-	require.True(t, buf.closed)
-	require.Nil(t, buf.pool)
+	require.Nil(t, buf.finalizer)
 	require.Nil(t, buf.buf)
 
 	// Verify that closing the buffer returns the buffer to pool.
@@ -60,11 +58,10 @@ func TestBufferNilPool(t *testing.T) {
 	data := make([]byte, 16)
 	buf := NewBuffer(data, nil)
 	require.Equal(t, data, buf.Bytes())
-	require.False(t, buf.closed)
+	require.NotNil(t, buf.buf)
 
 	buf.Close()
-	require.True(t, buf.closed)
-	require.Nil(t, buf.pool)
+	require.Nil(t, buf.finalizer)
 	require.Nil(t, buf.buf)
 }
 

--- a/src/metrics/encoding/protobuf/unaggregated_encoder.go
+++ b/src/metrics/encoding/protobuf/unaggregated_encoder.go
@@ -111,7 +111,7 @@ func (enc *unaggregatedEncoder) Truncate(n int) error {
 }
 
 func (enc *unaggregatedEncoder) Relinquish() Buffer {
-	res := NewBuffer(enc.buf[:enc.used], enc.pool)
+	res := NewBuffer(enc.buf[:enc.used], enc.pool.Put)
 	enc.buf = nil
 	enc.used = 0
 	return res


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Reorder some fields of per-connection/per-queue structs:
```
/Users/vytenis/gocode/m3/src/metrics/encoding/protobuf/buffer.go:30:13: struct with 40 pointer bytes could be 24
/Users/vytenis/gocode/m3/src/aggregator/client/conn_options.go:117:24: struct with 120 pointer bytes could be 64
/Users/vytenis/gocode/m3/src/aggregator/client/payload.go:67:19: struct with 416 pointer bytes could be 408
/Users/vytenis/gocode/m3/src/aggregator/client/ref_count.go:27:15: struct with 16 pointer bytes could be 8
/Users/vytenis/gocode/m3/src/aggregator/client/writer.go:63:13: struct with 168 pointer bytes could be 120
/Users/vytenis/gocode/m3/src/aggregator/client/writer.go:536:20: struct with 24 pointer bytes could be 16
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
