### PR TITLE
[coordinator] Properly report cache misses in matcher

### DIFF
--- a/src/metrics/matcher/cache/cache.go
+++ b/src/metrics/matcher/cache/cache.go
@@ -267,7 +267,7 @@ func (c *cache) tryGetWithLock(
 	res := rules.EmptyMatchResult
 	results, exists := c.namespaces.Get(namespace)
 	if !exists {
-		c.metrics.hits.Inc(1)
+		c.metrics.misses.Inc(1)
 		return res, true
 	}
 	entry, exists := results.elems.Get(id)

--- a/src/metrics/matcher/cache/cache_test.go
+++ b/src/metrics/matcher/cache/cache_test.go
@@ -29,6 +29,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber-go/tally"
+
+	"github.com/m3db/m3/src/x/instrument"
+
 	"github.com/m3db/m3/src/metrics/rules"
 	"github.com/m3db/m3/src/x/clock"
 
@@ -46,11 +50,16 @@ var (
 )
 
 func TestCacheMatchNamespaceDoesNotExist(t *testing.T) {
-	opts := testCacheOptions()
+	testScope := tally.NewTestScope("", map[string]string{})
+	opts := testCacheOptions().
+		SetInstrumentOptions(instrument.NewOptions().SetMetricsScope(testScope))
 	c := NewCache(opts)
 
 	res := c.ForwardMatch([]byte("nonexistentNs"), []byte("foo"), 0, 0)
 	require.Equal(t, testEmptyMatchResult, res)
+
+	testScope.Snapshot().Counters()["misses+"].Value()
+	require.Equal(t, int64(1), testScope.Snapshot().Counters()["misses+"].Value())
 }
 
 func TestCacheMatchIDCachedValidNoPromotion(t *testing.T) {
@@ -309,7 +318,9 @@ func TestCacheMatchIDCachedInvalidSourceValidWithEviction(t *testing.T) {
 }
 
 func TestCacheMatchIDNotCachedAndDoesNotExistInSource(t *testing.T) {
-	opts := testCacheOptions()
+	testScope := tally.NewTestScope("", map[string]string{})
+	opts := testCacheOptions().
+		SetInstrumentOptions(instrument.NewOptions().SetMetricsScope(testScope))
 	c := NewCache(opts).(*cache)
 	now := time.Now()
 	c.nowFn = func() time.Time { return now }
@@ -318,6 +329,8 @@ func TestCacheMatchIDNotCachedAndDoesNotExistInSource(t *testing.T) {
 
 	res := c.ForwardMatch([]byte("nsfoo"), []byte("nonExistent"), now.UnixNano(), now.UnixNano())
 	require.Equal(t, testEmptyMatchResult, res)
+
+	require.Equal(t, int64(1), testScope.Snapshot().Counters()["misses+"].Value())
 }
 
 func TestCacheMatchIDNotCachedSourceValidNoEviction(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Cache misses were being incorrectly reported as hits.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE