### PR TITLE
[coordinator] Ignore rollup rule storage policies when deciding to utilize auto-mapping rules

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -127,15 +127,16 @@ func defaultMetricsAppenderOptions(opts DownsamplerOptions, agg agg) metricsAppe
 	}
 
 	return metricsAppenderOptions{
-		agg:                    agg.aggregator,
-		clientRemote:           agg.clientRemote,
-		clockOpts:              agg.clockOpts,
-		tagEncoderPool:         agg.pools.tagEncoderPool,
-		matcher:                agg.matcher,
-		metricTagsIteratorPool: agg.pools.metricTagsIteratorPool,
-		debugLogging:           debugLogging,
-		logger:                 logger,
-		augmentM3Tags:          agg.augmentM3Tags,
+		agg:                                  agg.aggregator,
+		clientRemote:                         agg.clientRemote,
+		clockOpts:                            agg.clockOpts,
+		tagEncoderPool:                       agg.pools.tagEncoderPool,
+		matcher:                              agg.matcher,
+		metricTagsIteratorPool:               agg.pools.metricTagsIteratorPool,
+		debugLogging:                         debugLogging,
+		logger:                               logger,
+		augmentM3Tags:                        agg.augmentM3Tags,
+		includeRollupsOnDefaultRuleFiltering: agg.includeRollupsOnDefaultRuleFiltering,
 	}
 }
 

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -98,11 +98,12 @@ type metricsAppenderOptions struct {
 	agg          aggregator.Aggregator
 	clientRemote client.Client
 
-	defaultStagedMetadatasProtos []metricpb.StagedMetadatas
-	matcher                      matcher.Matcher
-	tagEncoderPool               serialize.TagEncoderPool
-	metricTagsIteratorPool       serialize.MetricTagsIteratorPool
-	augmentM3Tags                bool
+	defaultStagedMetadatasProtos         []metricpb.StagedMetadatas
+	matcher                              matcher.Matcher
+	tagEncoderPool                       serialize.TagEncoderPool
+	metricTagsIteratorPool               serialize.MetricTagsIteratorPool
+	augmentM3Tags                        bool
+	includeRollupsOnDefaultRuleFiltering bool
 
 	clockOpts    clock.Options
 	debugLogging bool
@@ -230,23 +231,37 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 		// name and tags (i.e. overwriting each other).
 		a.mappingRuleStoragePolicies = a.mappingRuleStoragePolicies[:0]
 
-		mappingRuleStagedMetadatas := matchResult.ForExistingIDAt(nowNanos)
-		if !mappingRuleStagedMetadatas.IsDefault() && len(mappingRuleStagedMetadatas) != 0 {
-			a.debugLogMatch("downsampler applying matched mapping rule",
-				debugLogMatchOptions{Meta: mappingRuleStagedMetadatas})
+		ruleStagedMetadatas := matchResult.ForExistingIDAt(nowNanos)
+		if !ruleStagedMetadatas.IsDefault() && len(ruleStagedMetadatas) != 0 {
+			a.debugLogMatch("downsampler applying matched rule",
+				debugLogMatchOptions{Meta: ruleStagedMetadatas})
 
-			// Collect all the current active mapping rules
-			for _, stagedMetadata := range mappingRuleStagedMetadatas {
+			// Collect storage policies for all the current active mapping rules.
+			// TODO: we should convert this to iterate over pointers
+			// nolint:gocritic
+			for _, stagedMetadata := range ruleStagedMetadatas {
 				for _, pipe := range stagedMetadata.Pipelines {
-					for _, sp := range pipe.StoragePolicies {
-						a.mappingRuleStoragePolicies =
-							append(a.mappingRuleStoragePolicies, sp)
+					// Skip rollup rules unless configured otherwise.
+					// We only want to consider mapping rules here,
+					// as we still want to apply default mapping rules to
+					// metrics that are rolled up to ensure the underlying metric
+					// gets written to aggregated namespaces.
+					if a.includeRollupsOnDefaultRuleFiltering || !pipe.IsRollupRule() {
+						for _, sp := range pipe.StoragePolicies {
+							a.mappingRuleStoragePolicies =
+								append(a.mappingRuleStoragePolicies, sp)
+						}
+					} else {
+						a.debugLogMatch(
+							"skipping rollup rule in populating active mapping rule policies",
+							debugLogMatchOptions{},
+						)
 					}
 				}
 			}
 
 			// Only sample if going to actually aggregate
-			pipelines := mappingRuleStagedMetadatas[len(mappingRuleStagedMetadatas)-1]
+			pipelines := ruleStagedMetadatas[len(ruleStagedMetadatas)-1]
 			a.curr.Pipelines =
 				append(a.curr.Pipelines, pipelines.Pipelines...)
 		}

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -246,7 +246,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 					// as we still want to apply default mapping rules to
 					// metrics that are rolled up to ensure the underlying metric
 					// gets written to aggregated namespaces.
-					if a.includeRollupsOnDefaultRuleFiltering || !pipe.IsRollupRule() {
+					if a.includeRollupsOnDefaultRuleFiltering || pipe.IsMappingRule() {
 						for _, sp := range pipe.StoragePolicies {
 							a.mappingRuleStoragePolicies =
 								append(a.mappingRuleStoragePolicies, sp)

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -225,10 +225,11 @@ type agg struct {
 	aggregator   aggregator.Aggregator
 	clientRemote client.Client
 
-	clockOpts     clock.Options
-	matcher       matcher.Matcher
-	pools         aggPools
-	augmentM3Tags bool
+	clockOpts                            clock.Options
+	matcher                              matcher.Matcher
+	pools                                aggPools
+	augmentM3Tags                        bool
+	includeRollupsOnDefaultRuleFiltering bool
 }
 
 // Configuration configurates a downsampler.
@@ -270,6 +271,14 @@ type Configuration struct {
 	// Furthermore, the option is automatically enabled if static rules are
 	// used and any filter contain an __m3_type__ tag.
 	AugmentM3Tags bool `yaml:"augmentM3Tags"`
+
+	// IncludeRollupsOnDefaultRuleFiltering will include rollup rules
+	// when deciding if the downsampler should ignore the default auto mapping rules
+	// based on the storage policies applied on a given rule.
+	// This is usually not what you want to do, as it means the raw metric
+	// that is being rolled up by your rule will not be forward into aggregated namespaces,
+	// and will only be written to the unaggregated namespace.
+	IncludeRollupsOnDefaultRuleFiltering bool `yaml:"includeRollupsOnDefaultRuleFiltering"`
 }
 
 // MatcherConfiguration is the configuration for the rule matcher.
@@ -788,10 +797,11 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		}
 
 		return agg{
-			clientRemote:  client,
-			matcher:       matcher,
-			pools:         pools,
-			augmentM3Tags: augmentM3Tags,
+			clientRemote:                         client,
+			matcher:                              matcher,
+			pools:                                pools,
+			augmentM3Tags:                        augmentM3Tags,
+			includeRollupsOnDefaultRuleFiltering: cfg.IncludeRollupsOnDefaultRuleFiltering,
 		}, nil
 	}
 
@@ -953,10 +963,11 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	}
 
 	return agg{
-		aggregator:    aggregatorInstance,
-		matcher:       matcher,
-		pools:         pools,
-		augmentM3Tags: augmentM3Tags,
+		aggregator:                           aggregatorInstance,
+		matcher:                              matcher,
+		pools:                                pools,
+		augmentM3Tags:                        augmentM3Tags,
+		includeRollupsOnDefaultRuleFiltering: cfg.IncludeRollupsOnDefaultRuleFiltering,
 	}, nil
 }
 

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -106,6 +106,12 @@ func (m PipelineMetadata) IsDefault() bool {
 		m.DropPolicy.IsDefault()
 }
 
+// IsRollupRule returns whether this is a rollup rule pipeline metadata.
+// nolint:gocritic
+func (m PipelineMetadata) IsRollupRule() bool {
+	return !m.Pipeline.IsEmpty()
+}
+
 // IsDropPolicyApplied returns whether this is the default standard pipeline
 // but with the drop policy applied.
 func (m PipelineMetadata) IsDropPolicyApplied() bool {

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -106,10 +106,10 @@ func (m PipelineMetadata) IsDefault() bool {
 		m.DropPolicy.IsDefault()
 }
 
-// IsRollupRule returns whether this is a rollup rule pipeline metadata.
+// IsMappingRule returns whether this is a rollup rule pipeline metadata.
 // nolint:gocritic
-func (m PipelineMetadata) IsRollupRule() bool {
-	return !m.Pipeline.IsEmpty()
+func (m PipelineMetadata) IsMappingRule() bool {
+	return m.Pipeline.IsEmpty()
 }
 
 // IsDropPolicyApplied returns whether this is the default standard pipeline


### PR DESCRIPTION
Skip rollup rule storage policies when deciding whether to apply default auto mapping rules that write raw metrics to aggregated namespaces. We only want to consider mapping rules here, as we want to apply these rules to metrics that are rolled up to ensure the underlying metric gets written to aggregated namespaces.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE