### PR TITLE
[dbnode] Add ExcludeOrigin to skip localhost on BorrowConnections

### DIFF
--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -655,6 +655,10 @@ func (s *session) BorrowConnections(
 			// Error or has broken
 			return
 		}
+		if opts.ExcludeOrigin && s.origin != nil && s.origin.ID() == host.ID() {
+			// Skip origin host.
+			return
+		}
 
 		var (
 			userResult WithBorrowConnectionResult
@@ -937,7 +941,7 @@ func (s *session) setTopologyWithLock(topoMap topology.Map, queues []hostQueue, 
 
 	if s.pools.multiReaderIteratorArray == nil {
 		s.pools.multiReaderIteratorArray = encoding.NewMultiReaderIteratorArrayPool([]pool.Bucket{
-			pool.Bucket{
+			{
 				Capacity: replicas,
 				Count:    s.opts.SeriesIteratorPoolSize(),
 			},

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -260,6 +260,9 @@ type BorrowConnectionOptions struct {
 	// ContinueOnBorrowError allows skipping hosts that cannot borrow
 	// a connection for.
 	ContinueOnBorrowError bool
+	// ExcludeOrigin will exclude attempting to borrow a connection for
+	// the origin host (i.e. the local host).
+	ExcludeOrigin bool
 }
 
 // BorrowConnectionsResult is a result used when borrowing connections.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Add the ability to skip the origin host when attempting to borrow a connection.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
