### PR TITLE
[DOCS] Update to cluster docs

### DIFF
--- a/site/content/cluster/binaries_cluster.md
+++ b/site/content/cluster/binaries_cluster.md
@@ -211,35 +211,6 @@ curl -X POST {{% apiendpoint %}}database/create -d '{
 
 If you need to setup multiple namespaces, you can run the command above multiple times with different namespace configurations.
 
-### Ready a Namespace
-<!-- TODO: Why?> -->
-Once a namespace has finished bootstrapping, you must mark it as ready before receiving traffic by using the _{{% apiendpoint %}}namespace/ready_.
-
-{{< tabs name="ready_namespaces" >}}
-{{% tab name="Command" %}}
-
-{{< codeinclude file="docs/includes/quickstart/ready-namespace.sh" language="shell" >}}
-
-{{% /tab %}}
-{{% tab name="Output" %}}
-
-```json
-{
-  "ready": true
-}
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
-### Replication factor
-
-We recommend a replication factor of **3**, with each replica spread across failure domains such as a physical server rack, data center or availability zone. Read our [replication factor recommendations](/docs/operational_guide/replication_and_deployment_in_zones) for more details.
-
-### Shards
-
-Read the [placement configuration guide](/docs/operational_guide/placement_configuration) to determine the appropriate number of shards to specify.
-
 {{< fileinclude file="cluster-common-steps.md" >}}
 
 <!-- ## Next Steps

--- a/site/content/cluster/binaries_cluster.md
+++ b/site/content/cluster/binaries_cluster.md
@@ -10,30 +10,7 @@ This guide shows you the steps involved in creating an M3 cluster using M3 binar
 This guide assumes you have read the [quickstart](/docs/quickstart/binaries), and builds upon the concepts in that guide.
 {{% /notice %}}
 
-## M3 Architecture
-
-Here's a typical M3 deployment:
-
-<!-- TODO: Update image -->
-
-![Typical Deployment](/cluster_architecture.png)
-
-An M3 deployment typically has two main node types:
-
--   **Coordinator node**: `m3coordinator` nodes coordinate reads and writes across all nodes in the cluster. It's a lightweight process, and does not store any data. This role typically runs alongside a Prometheus instance, or is part of a collector agent such as statsD.
--   **Storage node**: The `m3dbnode` processes are the workhorses of M3, they store data and serve reads and writes.
-
-A `m3coordinator` node exposes two ports:
-
--   `7201` to manage the cluster topology, you make most API calls to this endpoint
--   `7203` for Prometheus to scrape the metrics produced by M3DB and M3Coordinator
-
-## Prerequisites
-
-M3 uses [etcd](https://etcd.io/) as a distributed key-value storage for the following functions:
-
--   Update cluster configuration in realtime
--   Manage placements for distributed and sharded clusters
+{{< fileinclude file="cluster-architecture.md" >}}
 
 ## Download and Install a Binary
 
@@ -51,8 +28,6 @@ You can download the latest release as [pre-compiled binaries from the M3 GitHub
 [Clone the codebase](https://github.com/m3db/m3) and run `make m3dbnode` to generate a binary for a combination coordinator and storage node, or `make m3coordinator` to generate a binary for a standalone coordinator node.
 
 ## Provision a Host
-
-Enough background, let's create a real cluster!
 
 M3 in production can run on local or cloud-based VMs, or bare-metal servers. M3 supports all popular Linux distributions (Ubuntu, RHEL, CentOS), and [let us know](https://github.com/m3db/m3/issues/new/choose) if you have any issues with your preferred distribution.
 

--- a/site/content/cluster/kubernetes_cluster.md
+++ b/site/content/cluster/kubernetes_cluster.md
@@ -21,6 +21,10 @@ We recommend you use [our Kubernetes operator](/docs/operator/operator) to deplo
 -   A running Kubernetes cluster.
     -   For local testing, you can use [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), [Docker desktop](https://www.docker.com/products/docker-desktop), or [we have a script](https://raw.githubusercontent.com/m3db/m3db-operator/master/scripts/kind-create-cluster.sh) you can use to start a 3 node cluster with [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
+{{% notice note %}}
+The rest of this guide uses minikube, you may need to change some of the steps to suit your local cluster.
+{{% /notice %}}
+
 ## Create An etcd Cluster
 
 M3 stores its cluster placements and runtime metadata in [etcd](https://etcd.io) and needs a running cluster to communicate with.

--- a/site/content/cluster/kubernetes_cluster.md
+++ b/site/content/cluster/kubernetes_cluster.md
@@ -14,6 +14,8 @@ This guide assumes you have read the [quickstart](/docs/quickstart/docker), and 
 We recommend you use [our Kubernetes operator](/docs/operator/operator) to deploy M3 to a cluster. It is a more streamlined setup that uses [custom resource definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to automatically handle operations such as managing cluster placements.
 {{% /notice %}}
 
+{{< fileinclude file="cluster-architecture.md" >}}
+
 ## Prerequisites
 
 -   A running Kubernetes cluster.
@@ -82,5 +84,7 @@ kubectl delete m3dbcluster simple-cluster
 ```
 
 By default, the operator uses [finalizers](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers) to delete the placement and namespaces associated with a cluster before the custom resources. If you do not want this behavior, set `keepEtcdDataOnDelete` to `true` in the cluster configuration.
+
+<!-- TODO: Placement, same as Binaries? -->
 
 {{< fileinclude file="cluster-common-steps.md" >}}

--- a/site/content/includes/cluster-architecture.md
+++ b/site/content/includes/cluster-architecture.md
@@ -1,0 +1,31 @@
+## M3 Architecture
+
+<!-- TODO: Update image -->
+
+![Typical Deployment](/cluster_architecture.png)
+
+### Node types
+
+An M3 deployment typically has two main node types:
+
+- **[Storage nodes](/docs/m3db)** (`m3dbnode`) are the workhorses of M3, they store data and serve reads and writes.
+- **[Coordinator nodes](/docs/m3coordinator)** (`m3coordinator`) coordinate reads and writes across all nodes in the cluster. It's a lightweight process, and does not store any data. This role typically runs alongside a Prometheus instance, or is part of a collector agent such as statsD.
+
+A `m3coordinator` node exposes two external ports:
+
+-   `7201` to manage the cluster topology, you make most API calls to this endpoint
+-   `7203` for Prometheus to scrape the metrics produced by M3DB and M3Coordinator
+
+There are two other less-commonly used node types:
+
+- **[Query nodes](/docs/m3query)** (`m3query`) are an alternative query option to using M3's built-in PromQL support.
+- **[Aggregator nodes](/docs/m3aggregator)** cluster and aggregate metrics before storing them in storage nodes. Coordinator nodes can also perform this role but are not cluster-aware.
+
+<!-- TODO: Add more about what's bundled -->
+
+## Prerequisites
+
+M3 uses [etcd](https://etcd.io/) as a distributed key-value storage for the following functions:
+
+-   Update cluster configuration in realtime
+-   Manage placements for distributed and sharded clusters

--- a/site/content/includes/cluster-architecture.md
+++ b/site/content/includes/cluster-architecture.md
@@ -19,7 +19,7 @@ A `m3coordinator` node exposes two external ports:
 There are two other less-commonly used node types:
 
 - **[Query nodes](/docs/m3query)** (`m3query`) are an alternative query option to using M3's built-in PromQL support.
-- **[Aggregator nodes](/docs/m3aggregator)** cluster and aggregate metrics before storing them in storage nodes. Coordinator nodes can also perform this role but are not cluster-aware.
+- **[Aggregator nodes](/docs/how_to/aggregator)** cluster and aggregate metrics before storing them in storage nodes. Coordinator nodes can also perform this role but are not cluster-aware.
 
 <!-- TODO: Add more about what's bundled -->
 

--- a/site/content/includes/cluster-common-steps.md
+++ b/site/content/includes/cluster-common-steps.md
@@ -1,3 +1,32 @@
+### Ready a Namespace
+<!-- TODO: Why?> -->
+Once a namespace has finished bootstrapping, you must mark it as ready before receiving traffic by using the _{{% apiendpoint %}}namespace/ready_.
+
+{{< tabs name="ready_namespaces" >}}
+{{% tab name="Command" %}}
+
+{{< codeinclude file="docs/includes/quickstart/ready-namespace.sh" language="shell" >}}
+
+{{% /tab %}}
+{{% tab name="Output" %}}
+
+```json
+{
+  "ready": true
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Replication factor
+
+We recommend a replication factor of **3**, with each replica spread across failure domains such as a physical server rack, data center or availability zone. Read our [replication factor recommendations](/docs/operational_guide/replication_and_deployment_in_zones) for more details.
+
+### Shards
+
+Read the [placement configuration guide](/docs/operational_guide/placement_configuration) to determine the appropriate number of shards to specify.
+
 ## Writing and Querying Metrics
 
 ### Writing Metrics

--- a/site/content/includes/m3query/annotated_config.yaml
+++ b/site/content/includes/m3query/annotated_config.yaml
@@ -1,0 +1,246 @@
+# The server listen address
+listenAddress: <url>
+
+# Metrics configuration
+# TODO: Which is what?
+metrics:
+  # Scope of metrics root
+  # TODO: Again, which is?
+  scope:
+    # Prefix prepended to metrics collected
+    prefix: <string>
+    # Reporting frequendy of metrics collected
+    reportingInterval: <duration>
+    # Tags shared by metrics collected
+    tags: <map of strings>
+  # Configuration for a Prometheus reporter (if used)
+  prometheus:
+    # Metrics collection endpoint for application
+    # Default = "/metrics"
+    handlerPath: <string>
+    # Listen address for metrics
+    # Default = "0.0.0.0:7203"
+    listenAddress: <url>
+    # Metric sanitization type, valid options: [none, m3, prometheus]
+    # Default = "none"
+    sanitization: <string>
+  # Sampling rate for metrics. min=0.0, max=1.0
+  # TODO: What does this mean exactly?
+  samplingRate: <float>
+  # Enable Go runtime metrics, valid options: [none, simple, moderate, detailed]
+  # See https://github.com/m3db/m3/blob/master/src/x/instrument/extended.go#L39:L64 for more details
+  extended: <string>
+
+# Logging configuration
+# TODO: More detail than this 
+# https://github.com/m3db/m3/blob/9f129cf9f16430cc5a399f60aa5684fb72b55bb5/src/cmd/services/m3query/config/config.go#L116
+logging:
+  level: info
+
+# Enables tracing, if nothing configured, tracing is disabled
+tracing:
+  # Name for tracing service
+  serviceName: <string>
+  # Tracing backen to use, valid options: [jaeger, lightstep]
+  backend: <string>
+  # If using Jaeger, options to send to tracing backend
+  jaeger:
+  # If using Lightstep, options to send to tracing backend
+  lightstep:
+
+clusters:
+  - namespaces:
+      - namespace: default
+        type: unaggregated
+        retention: 48h
+    client:
+      config:
+        service:
+          # TODO: ?
+          env: default_env
+          # Availability zone, valid options: [user-defined, embedded]
+          zone: <string>
+          # TODO: ??
+          service: m3db
+          # Directory to store cached etcd data
+          cacheDir: <string>
+          # Identify the etcd hosts this node should connect to
+          etcdClusters:
+            # TODO: Confusing, if you use embedded, why do you still need endpoints?
+            # TODO: Embedded vs seed nodes embedded??
+            # Availability zone, valid options: [user-defined, embedded]
+            - zone: <string>
+              # Member nodes of the etcd cluster, in form url:port
+              endpoints:
+                - <url>
+        seedNodes:
+          initialCluster:
+            - hostID: m3db_local
+              endpoint: http://127.0.0.1:2380
+      # The consistency level for writing to a cluster, valid options: [none, one, majority, all]
+      writeConsistencyLevel: <string>
+      # The consistency level for reading from a cluster, valid options: [none, one, unstrict_majority, majority, unstrict_all, all]
+      readConsistencyLevel: <string>
+      # The timeout for writing data
+      # TODO: Defaults?
+      writeTimeout: <duration>
+      # The fetch timeout for any given query
+      # Range =  30s to 5m
+      fetchTimeout: <duration>
+      # The cluster connect timeout    
+      connectTimeout: <duration>
+      # Configuration for retrying write operations
+      writeRetry:
+        initialBackoff: <duration>
+        # Factor for exponential backoff
+        backoffFactor: <float>
+        # Maximum backoff time
+        maxBackoff: <duration>
+        # Maximum retry attempts
+        maxRetries: <int>
+        # Add randomness to wait intervals
+        jitter: <bool>
+      # Configuration for retrying fetch operations
+      # TODO: Query?
+      fetchRetry:
+        initialBackoff: <duration>
+        # Factor for exponential backoff
+        backoffFactor: <float>
+        # Maximum backoff time
+        maxBackoff: <duration>
+        # Maximum retry attempts
+        maxRetries: <int>
+        # Add randomness to wait intervals
+        jitter: <bool>
+      # The amount of times a background check fails before a connection is taken out of consideration
+      backgroundHealthCheckFailLimit: <int>
+      # The factor of the host connect time when sleeping between a failed health check and the next check
+      backgroundHealthCheckFailThrottleFactor: <float>
+
+# TODO:
+local:
+
+# Configuration for the placemement, namespaces and database management endpoints.
+clusterManagement:
+  # etcd client configuration
+  etcd:
+    # TODO: ?
+    env: default_env
+    # Availability zone, valid options: [user-defined, embedded]
+    zone: <string>
+    # TODO: ??
+    service: m3db
+    # Directory to store cached etcd data
+    cacheDir: <string>
+    # Identify the etcd hosts this node should connect to
+    etcdClusters:
+    m3sd:
+    # The revision that watch requests start from
+    watchWithRevision: <int>
+    newDirectoryNode:
+    retry:
+    # The timeout for etcd requests
+    requestTimeout: <duration>
+    # The timeout for a watchChan initialization
+    watchChanInitTimeout: <duration>
+    # Frequency to check if a watch chan is no longer subscribed and should be closed
+    watchChanCheckInterval: <duration>
+    # The delay before resetting the etcd watch chan
+    watchChanResetInterval: <duration>
+
+# TODO:
+filter:
+
+# TODO:
+rpc:
+
+# TODO:
+backend:
+
+# The worker pool policy for read requests
+readWorkerPoolPolicy:
+  # Worker pool automatically grows to capacity
+  grow: <bool>
+  # Static pool size, or initial size for dynamically growing pools
+  size: <int>
+
+# The worker pool policy for write requests
+writeWorkerPoolPolicy:
+  # Worker pool automatically grows to capacity
+  grow: <bool>
+  # Static pool size, or initial size for dynamically growing pools
+  size: <int>
+
+# TODO:
+writeForwarding:
+
+# TODO:
+downsample:
+
+# TODO:
+ingest:
+
+# Configuration for the carbon server
+# TODO: Which is?
+carbon:
+  ingester:
+  aggregateNamespacesAllData:
+  # A constant time to shift start by
+  shiftTimeStart: <duration>
+  # A constant time to shift end by
+  shiftTimeEnd: <duration>
+  # A constant set of steps to shift start by
+  shiftStepsStart: <int>
+  # A constant set of steps to shift end by
+  shiftStepsEnd: <int>
+  # A constant set of steps to shift start by, if and only if, the end is an exact match to the resolution boundary of a query, and the start is an exact match to the resolution boundary
+  shiftStepsStartWhenAtResolutionBoundary: <int>
+  # A constant set of steps to shift end by, if and only if, the start is an exact match to the resolution boundary of a query, and the end is an exact match to the resolution boundary
+  shiftStepsEndWhenAtResolutionBoundary: <int>
+  # A constant set of steps to shift start by, if and only if, the start is an exact match to the resolution boundary of a query, and the end is NOT an exact match to the resolution boundary
+  shiftStepsEndWhenStartAtResolutionBoundary: <int>
+  # A constant set of steps to shift end by, if and only if, the end is an exact match to the resolution boundary of a query, and the start is NOT an exact match to the resolution boundary
+  shiftStepsStartWhenEndAtResolutionBoundary: <int>
+  # Render partial datapoints when the start time is between a datapoint's resolution step size
+  renderPartialStart: <bool>
+  # Render partial datapoints when the end time is between a datapoint's resolution step size
+  renderPartialEnd: <bool>
+  # Render series that have only NaNs for entire output instead of returning an empty array of datapoints
+  renderSeriesAllNaNs: <bool>
+  # escape all characters using a backslash in a quoted string instead of only escaping quotes
+  compileEscapeAllNotOnlyQuotes: <bool>
+
+# TODO:
+query:
+
+# TODO:
+limits:
+
+# Additional configuration for metrics tags
+# Read https://m3db.io/docs/how_to/query/#id-generation for more details
+tagOptions:
+  # TODO: To do…
+  idScheme: <id_scheme>
+
+# Sets the lookback duration for queries
+# TODO: Which means what?
+# Default = 5m
+lookbackDuration: <duration>
+
+# The result options for a query
+resultOptions:
+  # Keeps NaNs before returning query results.
+  # Default = false
+  keepNans: <bool>
+
+# TODO:
+experimental:
+
+# TODO:
+storeMetricsType:
+
+# TODO:
+multiProcess:
+
+# TODO:
+debug:

--- a/site/content/operator/api.md
+++ b/site/content/operator/api.md
@@ -8,24 +8,25 @@ chapter: true
 This document enumerates the Custom Resource Definitions used by the M3DB Operator. It is auto-generated from code comments.
 
 ## Table of Contents
-* [ClusterCondition](#clustercondition)
-* [ClusterSpec](#clusterspec)
-* [ExternalCoordinatorConfig](#externalcoordinatorconfig)
-* [IsolationGroup](#isolationgroup)
-* [M3DBCluster](#m3dbcluster)
-* [M3DBClusterList](#m3dbclusterlist)
-* [M3DBStatus](#m3dbstatus)
-* [NodeAffinityTerm](#nodeaffinityterm)
-* [AggregatedAttributes](#aggregatedattributes)
-* [Aggregation](#aggregation)
-* [AggregationOptions](#aggregationoptions)
-* [DownsampleOptions](#downsampleoptions)
-* [IndexOptions](#indexoptions)
-* [Namespace](#namespace)
-* [NamespaceOptions](#namespaceoptions)
-* [RetentionOptions](#retentionoptions)
-* [PodIdentity](#podidentity)
-* [PodIdentityConfig](#podidentityconfig)
+- [Table of Contents](#table-of-contents)
+- [ClusterCondition](#clustercondition)
+- [ClusterSpec](#clusterspec)
+- [ExternalCoordinatorConfig](#externalcoordinatorconfig)
+- [IsolationGroup](#isolationgroup)
+- [M3DBCluster](#m3dbcluster)
+- [M3DBClusterList](#m3dbclusterlist)
+- [M3DBStatus](#m3dbstatus)
+- [NodeAffinityTerm](#nodeaffinityterm)
+- [AggregatedAttributes](#aggregatedattributes)
+- [Aggregation](#aggregation)
+- [AggregationOptions](#aggregationoptions)
+- [DownsampleOptions](#downsampleoptions)
+- [IndexOptions](#indexoptions)
+- [Namespace](#namespace)
+- [NamespaceOptions](#namespaceoptions)
+- [RetentionOptions](#retentionoptions)
+- [PodIdentity](#podidentity)
+- [PodIdentityConfig](#podidentityconfig)
 
 ## ClusterCondition
 
@@ -220,7 +221,7 @@ Namespace defines an M3DB namespace or points to a preset M3DB namespace.
 
 ## NamespaceOptions
 
-NamespaceOptions defines parameters for an M3DB namespace. See https://m3db.io/docs/operational_guide/namespace_configuration/ for more details.
+NamespaceOptions defines parameters for an M3DB namespace. Read [the namespace configuration guide](/docs/operational_guide/namespace_configuration) for more details.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |


### PR DESCRIPTION
This PR single-sources a few pieces of content around the cluster quoickstarts, and adds a bit more explanation around things. It also fixes a few small steps for the K8s guide.

The K8s and binaries cluster guides are a little different from each other right now, mostly as I have had a lot of issues getting a local K8s cluster to work properly, and there are so many ways people have this setup anyway… Over time I would like to improve it…