### PR TITLE
[cluster] Fix flaky watchmanager tests

### DIFF
--- a/src/cluster/etcd/watchmanager/manager_test.go
+++ b/src/cluster/etcd/watchmanager/manager_test.go
@@ -38,7 +38,6 @@ import (
 )
 
 func TestWatchChan(t *testing.T) {
-	t.Parallel()
 	wh, ecluster, _, _, _, closer := testCluster(t) //nolint:dogsled
 	defer closer()
 
@@ -68,7 +67,6 @@ func TestWatchChan(t *testing.T) {
 }
 
 func TestWatchSimple(t *testing.T) {
-	t.Parallel()
 	wh, ec, updateCalled, shouldStop, doneCh, closer := testSetup(t)
 	defer closer()
 	integration.WaitClientV3(t, ec)
@@ -117,7 +115,6 @@ func TestWatchSimple(t *testing.T) {
 }
 
 func TestWatchRecreate(t *testing.T) {
-	t.Parallel()
 	wh, ecluster, updateCalled, shouldStop, doneCh, closer := testCluster(t)
 	defer closer()
 
@@ -168,7 +165,6 @@ func TestWatchRecreate(t *testing.T) {
 }
 
 func TestWatchNoLeader(t *testing.T) {
-	t.Parallel()
 	const (
 		watchInitAndRetryDelay = 200 * time.Millisecond
 		watchCheckInterval     = 50 * time.Millisecond
@@ -239,9 +235,7 @@ func TestWatchNoLeader(t *testing.T) {
 
 	require.NoError(t, ecluster.Members[1].Restart(t))
 	require.NoError(t, ecluster.Members[2].Restart(t))
-	ecluster.WaitLeader(t)
-	// restart healthy member, too, to force client reconnect if it's not healthy
-	require.NoError(t, ecluster.Members[0].Restart(t))
+
 	// wait for leader + election delay just in case
 	time.Sleep(time.Duration(3*ecluster.Members[0].ElectionTicks) * tickDuration)
 
@@ -278,7 +272,6 @@ func TestWatchNoLeader(t *testing.T) {
 }
 
 func TestWatchCompactedRevision(t *testing.T) {
-	t.Parallel()
 	wh, ec, updateCalled, shouldStop, doneCh, closer := testSetup(t)
 	defer closer()
 

--- a/src/cluster/etcd/watchmanager/manager_test.go
+++ b/src/cluster/etcd/watchmanager/manager_test.go
@@ -239,6 +239,9 @@ func TestWatchNoLeader(t *testing.T) {
 
 	require.NoError(t, ecluster.Members[1].Restart(t))
 	require.NoError(t, ecluster.Members[2].Restart(t))
+	ecluster.WaitLeader(t)
+	// restart healthy member, too, to force client reconnect if it's not healthy
+	require.NoError(t, ecluster.Members[0].Restart(t))
 	// wait for leader + election delay just in case
 	time.Sleep(time.Duration(3*ecluster.Members[0].ElectionTicks) * tickDuration)
 

--- a/src/cluster/kv/etcd/store_test.go
+++ b/src/cluster/kv/etcd/store_test.go
@@ -84,8 +84,6 @@ func TestGetAndSet(t *testing.T) {
 }
 
 func TestNoCache(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 
 	store, err := NewStore(ec, opts)
@@ -152,8 +150,6 @@ func TestCacheDirCreation(t *testing.T) {
 }
 
 func TestCache(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 
 	f, err := ioutil.TempFile("", "")
@@ -206,8 +202,6 @@ func TestCache(t *testing.T) {
 }
 
 func TestSetIfNotExist(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 	defer closeFn()
 
@@ -227,8 +221,6 @@ func TestSetIfNotExist(t *testing.T) {
 }
 
 func TestCheckAndSet(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 	defer closeFn()
 
@@ -255,8 +247,6 @@ func TestCheckAndSet(t *testing.T) {
 }
 
 func TestWatchClose(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 	defer closeFn()
 
@@ -306,8 +296,6 @@ func TestWatchClose(t *testing.T) {
 }
 
 func TestWatchLastVersion(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 	defer closeFn()
 
@@ -350,8 +338,6 @@ func TestWatchLastVersion(t *testing.T) {
 }
 
 func TestWatchFromExist(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 	defer closeFn()
 
@@ -389,8 +375,6 @@ func TestWatchFromExist(t *testing.T) {
 }
 
 func TestWatchFromNotExist(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 	defer closeFn()
 
@@ -434,8 +418,6 @@ func TestGetFromKvNotFound(t *testing.T) {
 }
 
 func TestMultipleWatchesFromExist(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 	defer closeFn()
 
@@ -486,8 +468,6 @@ func TestMultipleWatchesFromExist(t *testing.T) {
 }
 
 func TestMultipleWatchesFromNotExist(t *testing.T) {
-	t.Parallel()
-
 	ec, opts, closeFn := testStore(t)
 	defer closeFn()
 
@@ -530,8 +510,6 @@ func TestMultipleWatchesFromNotExist(t *testing.T) {
 }
 
 func TestWatchNonBlocking(t *testing.T) {
-	t.Parallel()
-
 	ecluster, opts, closeFn := testCluster(t)
 	defer closeFn()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes flaky tests for WatchManager. I thought it was something with my environment (I got flakes once in a while locally), but since they are flaking in CI, it got me stumped for a while.
Now I consistently have repeatable results locally:
```
╰─$ go test ./src/cluster/etcd/watchmanager/... -run TestWatchNoLeader -count 50                                                                                                                                                                                                                                                                                      1 ↵
ok  	github.com/m3db/m3/src/cluster/etcd/watchmanager	172.472s
go test ./src/cluster/etcd/watchmanager/... -run TestWatchNoLeader -count 50  17.23s user 18.21s system 20% cpu 2:54.38 total
```
I think the issue was that it was testing cluster readiness, but not necessarily the client readiness.
edit: maybe it's both, since stand-alone test does not flake, but CI does - made etcd tests serial by removing `t.Parallel()`.
