### PR TITLE
[dbnode] Log namespace and shard upon invalid series read/write count

### DIFF
--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -860,9 +860,9 @@ func (s *dbShard) purgeExpiredSeries(expiredEntries []*lookup.Entry) {
 		// The contract requires all entries to have count >= 1.
 		if count < 1 {
 			s.logger.Error("purgeExpiredSeries encountered invalid series read/write count",
-				zap.String("namespace", s.namespace.ID().String()),
+				zap.Stringer("namespace", s.namespace.ID()),
 				zap.Uint32("shard", s.ID()),
-				zap.String("series", series.ID().String()),
+				zap.Stringer("series", series.ID()),
 				zap.Int32("readerWriterCount", count))
 			continue
 		}

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -860,6 +860,8 @@ func (s *dbShard) purgeExpiredSeries(expiredEntries []*lookup.Entry) {
 		// The contract requires all entries to have count >= 1.
 		if count < 1 {
 			s.logger.Error("purgeExpiredSeries encountered invalid series read/write count",
+				zap.String("namespace", s.namespace.ID().String()),
+				zap.Uint32("shard", s.ID()),
 				zap.String("series", series.ID().String()),
 				zap.Int32("readerWriterCount", count))
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds namespace and shard id fields to the log message of "purgeExpiredSeries encountered invalid series read/write count" error that I need to investigate.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
