### PR TITLE
[dbnode] Remove allocation per series ID when streaming block from disk

### DIFF
--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -808,12 +808,14 @@ func (s *service) fetchReadEncoded(ctx context.Context,
 	// Re-use reader and id for more memory-efficient processing of
 	// tags from doc.Metadata
 	reader := docs.NewEncodedDocumentReader()
-	id := ident.NewReusableBytesID()
 	for _, entry := range results.Map().Iter() {
 		idx := i
 		i++
 
-		id.Reset(entry.Key())
+		// NB(r): Use a bytes ID here so that this ID doesn't need to be
+		// copied by the blockRetriever in the streamRequest method when
+		// it checks if the ID is finalizeable or not with IsNoFinalize.
+		id := ident.BytesID(entry.Key())
 
 		d := entry.Value()
 		metadata, err := docs.MetadataFromDocument(d, reader)

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -565,9 +565,17 @@ func (r *blockRetriever) streamRequest(
 	nsCtx namespace.Context,
 ) (bool, error) {
 	req.shard = shard
-	// NB(r): Clone the ID as we're not positive it will stay valid throughout
-	// the lifecycle of the async request.
-	req.id = r.idPool.Clone(id)
+
+	// NB(r): If the ID is a ident.BytesID then we can just hold
+	// onto this ID.
+	seriesID := id
+	if !seriesID.IsNoFinalize() {
+		// NB(r): Clone the ID as we're not positive it will stay valid throughout
+		// the lifecycle of the async request.
+		seriesID = r.idPool.Clone(id)
+	}
+
+	req.id = seriesID
 	req.start = startTime
 	req.blockSize = r.blockSize
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This removes the allocation per series per block done when streaming a request from disk if the ID pool is exhausted.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
