### PR TITLE
Replace bytes.Compare() == 0 with bytes.Equal()

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -692,8 +692,8 @@ func (i *nsIndex) writeBatches(
 				for _, matchField := range i.doNotIndexWithFields {
 					matchedField := false
 					for _, actualField := range d.Fields {
-						if bytes.Compare(actualField.Name, matchField.Name) == 0 {
-							matchedField = bytes.Compare(actualField.Value, matchField.Value) == 0
+						if bytes.Equal(actualField.Name, matchField.Name) {
+							matchedField = bytes.Equal(actualField.Value, matchField.Value)
 							break
 						}
 					}

--- a/src/query/models/tags.go
+++ b/src/query/models/tags.go
@@ -306,7 +306,7 @@ func (t Tags) validate() error {
 			}
 
 			prev := tags.Tags[i-1]
-			if bytes.Compare(prev.Name, tag.Name) == 0 {
+			if bytes.Equal(prev.Name, tag.Name) {
 				return fmt.Errorf("tags duplicate: '%s' appears more than once",
 					tags.Tags[i-1].Name)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Replace `bytes.Compare() == 0` with `bytes.Equal()`. According to benchmark in https://github.com/m3db/m3/pull/3097 , this might improve performance.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
