### PR TITLE
[m3db] Check bloom filter before stream request allocation

### DIFF
--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -562,7 +562,7 @@ func (r *blockRetriever) fetchBatch(
 	}
 }
 
-func (r *blockRetriever) checkSeriesInBloomFilter(
+func (r *blockRetriever) seriesPresentInBloomFilter(
 	id ident.ID,
 	shard uint32,
 	startTime time.Time,
@@ -653,7 +653,7 @@ func (r *blockRetriever) Stream(
 	onRetrieve block.OnRetrieveBlock,
 	nsCtx namespace.Context,
 ) (xio.BlockReader, error) {
-	found, err := r.checkSeriesInBloomFilter(id, shard, startTime)
+	found, err := r.seriesPresentInBloomFilter(id, shard, startTime)
 	if err != nil {
 		return xio.EmptyBlockReader, err
 	}
@@ -696,7 +696,7 @@ func (r *blockRetriever) StreamWideEntry(
 	filter schema.WideEntryFilter,
 	nsCtx namespace.Context,
 ) (block.StreamedWideEntry, error) {
-	found, err := r.checkSeriesInBloomFilter(id, shard, startTime)
+	found, err := r.seriesPresentInBloomFilter(id, shard, startTime)
 	if err != nil {
 		return block.EmptyStreamedWideEntry, err
 	}

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -89,12 +89,13 @@ const (
 type blockRetriever struct {
 	sync.RWMutex
 
-	opts            BlockRetrieverOptions
-	fsOpts          Options
-	logger          *zap.Logger
-	queryLimits     limits.QueryLimits
-	bytesReadLimit  limits.LookbackLimit
-	seriesReadCount tally.Counter
+	opts                    BlockRetrieverOptions
+	fsOpts                  Options
+	logger                  *zap.Logger
+	queryLimits             limits.QueryLimits
+	bytesReadLimit          limits.LookbackLimit
+	seriesReadCount         tally.Counter
+	seriesBloomFilterMisses tally.Counter
 
 	newSeekerMgrFn newSeekerMgrFn
 
@@ -126,18 +127,19 @@ func NewBlockRetriever(
 	scope := fsOpts.InstrumentOptions().MetricsScope().SubScope("retriever")
 
 	return &blockRetriever{
-		opts:            opts,
-		fsOpts:          fsOpts,
-		logger:          fsOpts.InstrumentOptions().Logger(),
-		queryLimits:     opts.QueryLimits(),
-		bytesReadLimit:  opts.QueryLimits().BytesReadLimit(),
-		seriesReadCount: scope.Counter("series-read"),
-		newSeekerMgrFn:  NewSeekerManager,
-		reqPool:         opts.RetrieveRequestPool(),
-		bytesPool:       opts.BytesPool(),
-		idPool:          opts.IdentifierPool(),
-		status:          blockRetrieverNotOpen,
-		notifyFetch:     make(chan struct{}, 1),
+		opts:                    opts,
+		fsOpts:                  fsOpts,
+		logger:                  fsOpts.InstrumentOptions().Logger(),
+		queryLimits:             opts.QueryLimits(),
+		bytesReadLimit:          opts.QueryLimits().BytesReadLimit(),
+		seriesReadCount:         scope.Counter("series-read"),
+		seriesBloomFilterMisses: scope.Counter("series-bloom-filter-misses"),
+		newSeekerMgrFn:          NewSeekerManager,
+		reqPool:                 opts.RetrieveRequestPool(),
+		bytesPool:               opts.BytesPool(),
+		idPool:                  opts.IdentifierPool(),
+		status:                  blockRetrieverNotOpen,
+		notifyFetch:             make(chan struct{}, 1),
 		// We just close this channel when the fetchLoops should shutdown, so no
 		// buffering is required
 		fetchLoopsShouldShutdownCh: make(chan struct{}),
@@ -560,6 +562,33 @@ func (r *blockRetriever) fetchBatch(
 	}
 }
 
+func (r *blockRetriever) checkSeriesInBloomFilter(
+	id ident.ID,
+	shard uint32,
+	startTime time.Time,
+) (bool, error) {
+	// Capture variable and RLock() because this slice can be modified in the
+	// Open() method
+	r.RLock()
+	// This should never happen unless caller tries to use Stream() before Open()
+	if r.seekerMgr == nil {
+		r.RUnlock()
+		return false, errNoSeekerMgr
+	}
+	r.RUnlock()
+
+	idExists, err := r.seekerMgr.Test(id, shard, startTime)
+	if err != nil {
+		return false, err
+	}
+
+	if !idExists {
+		r.seriesBloomFilterMisses.Inc(1)
+	}
+
+	return idExists, nil
+}
+
 // streamRequest returns a bool indicating if the ID was found, and any errors.
 func (r *blockRetriever) streamRequest(
 	ctx context.Context,
@@ -568,11 +597,11 @@ func (r *blockRetriever) streamRequest(
 	id ident.ID,
 	startTime time.Time,
 	nsCtx namespace.Context,
-) (bool, error) {
+) error {
 	req.resultWg.Add(1)
 	r.seriesReadCount.Inc(1)
 	if err := r.queryLimits.DiskSeriesReadLimit().Inc(1, req.source); err != nil {
-		return false, err
+		return err
 	}
 	req.shard = shard
 
@@ -592,29 +621,9 @@ func (r *blockRetriever) streamRequest(
 	// Ensure to finalize at the end of request
 	ctx.RegisterFinalizer(req)
 
-	// Capture variable and RLock() because this slice can be modified in the
-	// Open() method
-	r.RLock()
-	// This should never happen unless caller tries to use Stream() before Open()
-	if r.seekerMgr == nil {
-		r.RUnlock()
-		return false, errNoSeekerMgr
-	}
-	r.RUnlock()
-
-	idExists, err := r.seekerMgr.Test(id, shard, startTime)
-	if err != nil {
-		return false, err
-	}
-
-	// If the ID is not in the seeker's bloom filter, then it's definitely not on
-	// disk and we can return immediately.
-	if !idExists {
-		return false, nil
-	}
 	reqs, err := r.shardRequests(shard)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	reqs.Lock()
@@ -633,7 +642,7 @@ func (r *blockRetriever) streamRequest(
 	// the data. This means that even though we're returning nil for error
 	// here, the caller may still encounter an error when they attempt to
 	// read the data.
-	return true, nil
+	return nil
 }
 
 func (r *blockRetriever) Stream(
@@ -644,6 +653,16 @@ func (r *blockRetriever) Stream(
 	onRetrieve block.OnRetrieveBlock,
 	nsCtx namespace.Context,
 ) (xio.BlockReader, error) {
+	found, err := r.checkSeriesInBloomFilter(id, shard, startTime)
+	if err != nil {
+		return xio.EmptyBlockReader, err
+	}
+	// If the ID is not in the seeker's bloom filter, then it's definitely not on
+	// disk and we can return immediately.
+	if !found {
+		return xio.EmptyBlockReader, nil
+	}
+
 	req := r.reqPool.Get()
 	req.onRetrieve = onRetrieve
 	req.streamReqType = streamDataReq
@@ -655,16 +674,10 @@ func (r *blockRetriever) Stream(
 		}
 	}
 
-	found, err := r.streamRequest(ctx, req, shard, id, startTime, nsCtx)
+	err = r.streamRequest(ctx, req, shard, id, startTime, nsCtx)
 	if err != nil {
 		req.resultWg.Done()
 		return xio.EmptyBlockReader, err
-	}
-
-	if !found {
-		req.onRetrieved(ts.Segment{}, namespace.Context{})
-		req.success = true
-		req.onDone()
 	}
 
 	// The request may not have completed yet, but it has an internal
@@ -683,20 +696,24 @@ func (r *blockRetriever) StreamWideEntry(
 	filter schema.WideEntryFilter,
 	nsCtx namespace.Context,
 ) (block.StreamedWideEntry, error) {
+	found, err := r.checkSeriesInBloomFilter(id, shard, startTime)
+	if err != nil {
+		return block.EmptyStreamedWideEntry, err
+	}
+	// If the ID is not in the seeker's bloom filter, then it's definitely not on
+	// disk and we can return immediately.
+	if !found {
+		return block.EmptyStreamedWideEntry, nil
+	}
+
 	req := r.reqPool.Get()
 	req.streamReqType = streamWideEntryReq
 	req.wideFilter = filter
 
-	found, err := r.streamRequest(ctx, req, shard, id, startTime, nsCtx)
+	err = r.streamRequest(ctx, req, shard, id, startTime, nsCtx)
 	if err != nil {
 		req.resultWg.Done()
 		return block.EmptyStreamedWideEntry, err
-	}
-
-	if !found {
-		req.wideEntry = xio.WideEntry{}
-		req.success = true
-		req.onDone()
 	}
 
 	// The request may not have completed yet, but it has an internal

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -94,7 +94,6 @@ type blockRetriever struct {
 	logger                  *zap.Logger
 	queryLimits             limits.QueryLimits
 	bytesReadLimit          limits.LookbackLimit
-	seriesReadCount         tally.Counter
 	seriesBloomFilterMisses tally.Counter
 
 	newSeekerMgrFn newSeekerMgrFn
@@ -132,7 +131,6 @@ func NewBlockRetriever(
 		logger:                  fsOpts.InstrumentOptions().Logger(),
 		queryLimits:             opts.QueryLimits(),
 		bytesReadLimit:          opts.QueryLimits().BytesReadLimit(),
-		seriesReadCount:         scope.Counter("series-read"),
 		seriesBloomFilterMisses: scope.Counter("series-bloom-filter-misses"),
 		newSeekerMgrFn:          NewSeekerManager,
 		reqPool:                 opts.RetrieveRequestPool(),
@@ -599,7 +597,6 @@ func (r *blockRetriever) streamRequest(
 	nsCtx namespace.Context,
 ) error {
 	req.resultWg.Add(1)
-	r.seriesReadCount.Inc(1)
 	if err := r.queryLimits.DiskSeriesReadLimit().Inc(1, req.source); err != nil {
 		return err
 	}

--- a/src/dbnode/persist/fs/retriever_test.go
+++ b/src/dbnode/persist/fs/retriever_test.go
@@ -839,8 +839,6 @@ func TestLimitSeriesReadFromDisk(t *testing.T) {
 	require.Contains(t, err.Error(), "query aborted due to limit")
 
 	snapshot := scope.Snapshot()
-	seriesRead := snapshot.Counters()["test.retriever.series-read+"]
-	require.Equal(t, int64(2), seriesRead.Value())
 	seriesLimit := snapshot.Counters()["test.query-limit.exceeded+limit=disk-series-read"]
 	require.Equal(t, int64(1), seriesLimit.Value())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When querying, we check the bloom filter first before grabbing a request from the request pool. This has the additional effect of not incrementing / checking the series read limit until after we know whether we'll be reading from disk.

**Special notes for your reviewer**:
I added a separate method `seriesPresentInBloomFilter` that needs to be invoked for both the `Stream` and `StreamWideEntry` APIs, rather than trying to push all the request logic into the shared `streamRequest` method. This seemed desirable to avoid making `streamRequest` overly generic.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE