### PR TITLE
[query] Take bounds into account for list endpoints

### DIFF
--- a/src/query/api/v1/handler/prometheus/common.go
+++ b/src/query/api/v1/handler/prometheus/common.go
@@ -181,7 +181,9 @@ func ParseStartAndEnd(
 	r *http.Request,
 	parseOpts xpromql.ParseOptions,
 ) (time.Time, time.Time, error) {
-	r.ParseForm()
+	if err := r.ParseForm(); err != nil {
+		return time.Time{}, time.Time{}, xerrors.NewInvalidParamsError(err)
+	}
 
 	start, err := util.ParseTimeStringWithDefault(r.FormValue("start"),
 		time.Unix(0, 0))

--- a/src/query/api/v1/handler/prometheus/common_test.go
+++ b/src/query/api/v1/handler/prometheus/common_test.go
@@ -23,15 +23,20 @@ package prometheus
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/parser/promql"
 	"github.com/m3db/m3/src/query/test"
 	xerrors "github.com/m3db/m3/src/x/errors"
+	xhttp "github.com/m3db/m3/src/x/net/http"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPromCompressedReadSuccess(t *testing.T) {
@@ -102,7 +107,7 @@ func TestRenderSeriesMatchResultsNoTags(t *testing.T) {
 	}
 
 	seriesMatchResult := []models.Metrics{
-		models.Metrics{
+		{
 			toTags("name", tag{name: "a", value: "b"}, tag{name: "role", value: "appears"}),
 			toTags("name2", tag{name: "c", value: "d"}, tag{name: "e", value: "f"}),
 		},
@@ -133,5 +138,56 @@ func TestRenderSeriesMatchResultsNoTags(t *testing.T) {
 		}
 
 		assert.Equal(t, expected, w.value)
+	}
+}
+
+func TestParseStartAndEnd(t *testing.T) {
+	endTime := time.Now().Truncate(time.Hour)
+	opts := promql.NewParseOptions().SetNowFn(func() time.Time { return endTime })
+
+	tests := []struct {
+		querystring string
+		exStart     time.Time
+		exEnd       time.Time
+		exErr       bool
+	}{
+		{querystring: "", exStart: time.Unix(0, 0), exEnd: endTime},
+		{querystring: "start=100", exStart: time.Unix(100, 0), exEnd: endTime},
+		{querystring: "start=100&end=200", exStart: time.Unix(100, 0), exEnd: time.Unix(200, 0)},
+		{querystring: "start=200&end=100", exErr: true},
+		{querystring: "start=foo&end=100", exErr: true},
+		{querystring: "start=100&end=bar", exErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("GET_%s", tt.querystring), func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/?%s", tt.querystring), nil)
+			require.NoError(t, err)
+
+			start, end, err := ParseStartAndEnd(req, opts)
+			if tt.exErr {
+				require.Error(t, err)
+			} else {
+				assert.Equal(t, tt.exStart, start)
+				assert.Equal(t, tt.exEnd, end)
+			}
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("POST_%s", tt.querystring), func(t *testing.T) {
+			b := bytes.NewBuffer([]byte(tt.querystring))
+			req, err := http.NewRequest(http.MethodPost, "/", b)
+			require.NoError(t, err)
+			req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeFormURLEncoded)
+
+			start, end, err := ParseStartAndEnd(req, opts)
+			if tt.exErr {
+				require.Error(t, err)
+			} else {
+				assert.Equal(t, tt.exStart, start)
+				assert.Equal(t, tt.exEnd, end)
+			}
+		})
 	}
 }

--- a/src/query/api/v1/handler/prometheus/common_test.go
+++ b/src/query/api/v1/handler/prometheus/common_test.go
@@ -22,6 +22,7 @@ package prometheus
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -161,7 +162,8 @@ func TestParseStartAndEnd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("GET_%s", tt.querystring), func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/?%s", tt.querystring), nil)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+				fmt.Sprintf("/?%s", tt.querystring), nil)
 			require.NoError(t, err)
 
 			start, end, err := ParseStartAndEnd(req, opts)
@@ -177,7 +179,7 @@ func TestParseStartAndEnd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("POST_%s", tt.querystring), func(t *testing.T) {
 			b := bytes.NewBuffer([]byte(tt.querystring))
-			req, err := http.NewRequest(http.MethodPost, "/", b)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", b)
 			require.NoError(t, err)
 			req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeFormURLEncoded)
 

--- a/src/query/api/v1/handler/prometheus/native/list_tags_test.go
+++ b/src/query/api/v1/handler/prometheus/native/list_tags_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 type listTagsMatcher struct {
-	now time.Time
+	start, end time.Time
 }
 
 func (m *listTagsMatcher) String() string { return "list tags query" }
@@ -52,12 +52,12 @@ func (m *listTagsMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
-	if !q.Start.Equal(time.Time{}) {
+	if !q.Start.Equal(m.start) {
 		return false
 	}
 
 	// NB: end time for the query should be roughly `Now`
-	if !q.End.Equal(m.now) {
+	if !q.End.Equal(m.end) {
 		return false
 	}
 
@@ -119,7 +119,7 @@ func testListTags(t *testing.T, meta block.ResultMetadata, header string) {
 		SetNowFn(nowFn)
 	h := NewListTagsHandler(opts)
 	for _, method := range []string{"GET", "POST"} {
-		matcher := &listTagsMatcher{now: now}
+		matcher := &listTagsMatcher{start: time.Unix(0, 0), end: now}
 		store.EXPECT().CompleteTags(gomock.Any(), matcher, gomock.Any()).
 			Return(storeResult, nil)
 
@@ -150,25 +150,19 @@ func TestListErrorTags(t *testing.T) {
 
 	// setup storage and handler
 	store := storage.NewMockStorage(ctrl)
-	now := time.Now()
-	nowFn := func() time.Time {
-		return now
-	}
-
 	fb, err := handleroptions.NewFetchOptionsBuilder(
 		handleroptions.FetchOptionsBuilderOptions{Timeout: 15 * time.Second})
 	require.NoError(t, err)
 	opts := options.EmptyHandlerOptions().
 		SetStorage(store).
-		SetFetchOptionsBuilder(fb).
-		SetNowFn(nowFn)
+		SetFetchOptionsBuilder(fb)
 	handler := NewListTagsHandler(opts)
 	for _, method := range []string{"GET", "POST"} {
-		matcher := &listTagsMatcher{now: now}
+		matcher := &listTagsMatcher{start: time.Unix(100, 0), end: time.Unix(1000, 0)}
 		store.EXPECT().CompleteTags(gomock.Any(), matcher, gomock.Any()).
 			Return(nil, errors.New("err"))
 
-		req := httptest.NewRequest(method, "/labels", nil)
+		req := httptest.NewRequest(method, "/labels?start=100&end=1000", nil)
 		w := httptest.NewRecorder()
 
 		handler.ServeHTTP(w, req)

--- a/src/query/api/v1/handler/prometheus/remote/tag_values_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values_test.go
@@ -44,8 +44,8 @@ import (
 )
 
 type tagValuesMatcher struct {
-	now       time.Time
-	filterTag string
+	start, end time.Time
+	filterTag  string
 }
 
 func (m *tagValuesMatcher) String() string { return "tag values query" }
@@ -55,11 +55,11 @@ func (m *tagValuesMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
-	if !q.Start.Equal(time.Time{}) {
+	if !q.Start.Equal(m.start) {
 		return false
 	}
 
-	if !q.End.Equal(m.now) {
+	if !q.End.Equal(m.end) {
 		return false
 	}
 
@@ -123,7 +123,7 @@ func TestTagValues(t *testing.T) {
 	url := fmt.Sprintf("/label/{%s}/values", NameReplace)
 
 	for _, tt := range names {
-		path := fmt.Sprintf("/label/%s/values", tt.name)
+		path := fmt.Sprintf("/label/%s/values?start=100", tt.name)
 		req, err := http.NewRequest("GET", path, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -132,7 +132,8 @@ func TestTagValues(t *testing.T) {
 		rr := httptest.NewRecorder()
 		router := mux.NewRouter()
 		matcher := &tagValuesMatcher{
-			now:       now,
+			start:     time.Unix(100, 0),
+			end:       now,
 			filterTag: tt.name,
 		}
 
@@ -146,7 +147,7 @@ func TestTagValues(t *testing.T) {
 			},
 			Metadata: block.ResultMetadata{
 				Exhaustive: false,
-				Warnings:   []block.Warning{block.Warning{Name: "foo", Message: "bar"}},
+				Warnings:   []block.Warning{{Name: "foo", Message: "bar"}},
 			},
 		}
 

--- a/src/query/parser/promql/options.go
+++ b/src/query/parser/promql/options.go
@@ -21,8 +21,11 @@
 package promql
 
 import (
+	"time"
+
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/parser"
+	xclock "github.com/m3db/m3/src/x/clock"
 	"github.com/prometheus/prometheus/pkg/labels"
 	pql "github.com/prometheus/prometheus/promql/parser"
 )
@@ -53,28 +56,38 @@ func defaultMetricSelectorFn(query string) ([]*labels.Matcher, error) {
 	return pql.ParseMetricSelector(query)
 }
 
+func defaultNowFn() time.Time {
+	return time.Now()
+}
+
 // ParseOptions are options for the Prometheus parser.
 type ParseOptions interface {
 	// ParseFn gets the parse function.
 	ParseFn() ParseFn
 	// SetParseFn sets the parse function.
-	SetParseFn(f ParseFn) ParseOptions
+	SetParseFn(ParseFn) ParseOptions
 
 	// MetricSelectorFn gets the metric selector function.
 	MetricSelectorFn() MetricSelectorFn
 	// SetMetricSelectorFn sets the metric selector function.
-	SetMetricSelectorFn(f MetricSelectorFn) ParseOptions
+	SetMetricSelectorFn(MetricSelectorFn) ParseOptions
 
 	// FunctionParseExpr gets the parsing function.
 	FunctionParseExpr() ParseFunctionExpr
 	// SetFunctionParseExpr sets the parsing function.
-	SetFunctionParseExpr(f ParseFunctionExpr) ParseOptions
+	SetFunctionParseExpr(ParseFunctionExpr) ParseOptions
+
+	// NowFn gets the now function.
+	NowFn() xclock.NowFn
+	// SetNowFn sets the now function.
+	SetNowFn(xclock.NowFn) ParseOptions
 }
 
 type parseOptions struct {
 	parseFn     ParseFn
 	selectorFn  MetricSelectorFn
 	fnParseExpr ParseFunctionExpr
+	nowFn       xclock.NowFn
 }
 
 // NewParseOptions creates a new parse options.
@@ -83,6 +96,7 @@ func NewParseOptions() ParseOptions {
 		parseFn:     defaultParseFn,
 		selectorFn:  defaultMetricSelectorFn,
 		fnParseExpr: NewFunctionExpr,
+		nowFn:       defaultNowFn,
 	}
 }
 
@@ -113,5 +127,15 @@ func (o *parseOptions) FunctionParseExpr() ParseFunctionExpr {
 func (o *parseOptions) SetFunctionParseExpr(f ParseFunctionExpr) ParseOptions {
 	opts := *o
 	opts.fnParseExpr = f
+	return &opts
+}
+
+func (o *parseOptions) NowFn() xclock.NowFn {
+	return o.nowFn
+}
+
+func (o *parseOptions) SetNowFn(f xclock.NowFn) ParseOptions {
+	opts := *o
+	opts.nowFn = f
 	return &opts
 }

--- a/src/query/parser/promql/options.go
+++ b/src/query/parser/promql/options.go
@@ -23,11 +23,12 @@ package promql
 import (
 	"time"
 
+	"github.com/prometheus/prometheus/pkg/labels"
+	pql "github.com/prometheus/prometheus/promql/parser"
+
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/parser"
 	xclock "github.com/m3db/m3/src/x/clock"
-	"github.com/prometheus/prometheus/pkg/labels"
-	pql "github.com/prometheus/prometheus/promql/parser"
 )
 
 // ParseFunctionExpr parses arguments to a function expression, returning


### PR DESCRIPTION
Adds bounds parsing to `/api/v1/labels` and `/api/v1/label/<label_name>/values` endpoints