### PR TITLE
[dbnode] Use DefaultTestOptions in unit tests

### DIFF
--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -64,7 +64,7 @@ import (
 var (
 	testIndexOptions          = index.NewOptions()
 	testNamespaceOptions      = namespace.NewOptions()
-	testStorageOpts           = storage.NewOptions()
+	testStorageOpts           = storage.DefaultTestOptions()
 	testTChannelThriftOptions = tchannelthrift.NewOptions()
 )
 

--- a/src/dbnode/persist/fs/migration/migration_test.go
+++ b/src/dbnode/persist/fs/migration/migration_test.go
@@ -83,7 +83,7 @@ func TestToVersion1_1Run(t *testing.T) {
 		SetNewMergerFn(fs.NewMerger).
 		SetPersistManager(pm).
 		SetNamespaceMetadata(md).
-		SetStorageOptions(storage.NewOptions().
+		SetStorageOptions(storage.DefaultTestOptions().
 			SetPersistManager(pm).
 			SetIndexClaimsManager(icm).
 			SetNamespaceInitializer(namespace.NewStaticInitializer([]namespace.Metadata{md})).

--- a/src/dbnode/persist/fs/migration/task_options_test.go
+++ b/src/dbnode/persist/fs/migration/task_options_test.go
@@ -137,7 +137,7 @@ func TestPersistManager(t *testing.T) {
 
 func TestStorageOptions(t *testing.T) {
 	opts := NewTaskOptions()
-	value := storage.NewOptions()
+	value := storage.DefaultTestOptions()
 	require.Equal(t, value, opts.SetStorageOptions(value).StorageOptions())
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/options_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/migrator/options_test.go
@@ -43,7 +43,7 @@ func TestOptionsValidateStorageOptions(t *testing.T) {
 	opts = opts.SetStorageOptions(nil)
 	require.Error(t, opts.Validate())
 
-	opts = opts.SetStorageOptions(storage.NewOptions())
+	opts = opts.SetStorageOptions(storage.DefaultTestOptions())
 	require.Error(t, opts.Validate())
 }
 

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
@@ -970,7 +970,7 @@ func newTestStorageOptions(
 	md, err := namespace.NewMetadata(testNs1ID, testNamespaceOptions)
 	require.NoError(t, err)
 
-	return storage.NewOptions().
+	return storage.DefaultTestOptions().
 		SetPersistManager(pm).
 		SetIndexClaimsManager(icm).
 		SetNamespaceInitializer(namespace.NewStaticInitializer([]namespace.Metadata{md})).

--- a/src/dbnode/storage/cluster/database_test.go
+++ b/src/dbnode/storage/cluster/database_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testOpts = storage.NewOptions()
+var testOpts = storage.DefaultTestOptions()
 
 func newTestDatabase(
 	t *testing.T,

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -183,7 +183,8 @@ type options struct {
 	tileAggregator                  TileAggregator
 }
 
-// NewOptions creates a new set of storage options with defaults
+// NewOptions creates a new set of storage options with defaults.
+// NB: expensive, in tests use DefaultTestOptions instead.
 func NewOptions() Options {
 	return newOptions(defaultPoolOptions)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`storage.NewOptions` is expensive because it creates full size object pools.
There is a more lightweight `storage.DefaultTestOptions` for test code, I've switched to this implementation in some unit tests that were using `storage.NewOptions` before.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
