### PR TITLE
[m3db] [m3coordinator] Properly pipe along require-exhaustive param for aggregate queries

### DIFF
--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -404,6 +404,7 @@ struct AggregateQueryRawRequest {
 	8: optional TimeType rangeType = TimeType.UNIX_SECONDS
 	9: optional binary source
 	10: optional i64 docsLimit
+	11: optional bool requireExhaustive
 }
 
 struct AggregateQueryRawResult {
@@ -432,6 +433,7 @@ struct AggregateQueryRequest {
 	8: optional TimeType rangeType = TimeType.UNIX_SECONDS
 	9: optional binary source
 	10: optional i64 docsLimit
+	11: optional bool requireExhaustive
 }
 
 struct AggregateQueryResult {

--- a/src/dbnode/generated/thrift/rpc/rpc.go
+++ b/src/dbnode/generated/thrift/rpc/rpc.go
@@ -9616,6 +9616,7 @@ func (p *HealthResult_) String() string {
 //  - RangeType
 //  - Source
 //  - DocsLimit
+//  - RequireExhaustive
 type AggregateQueryRawRequest struct {
 	Query              []byte             `thrift:"query,1,required" db:"query" json:"query"`
 	RangeStart         int64              `thrift:"rangeStart,2,required" db:"rangeStart" json:"rangeStart"`
@@ -9627,6 +9628,7 @@ type AggregateQueryRawRequest struct {
 	RangeType          TimeType           `thrift:"rangeType,8" db:"rangeType" json:"rangeType,omitempty"`
 	Source             []byte             `thrift:"source,9" db:"source" json:"source,omitempty"`
 	DocsLimit          *int64             `thrift:"docsLimit,10" db:"docsLimit" json:"docsLimit,omitempty"`
+	RequireExhaustive  *bool              `thrift:"requireExhaustive,11" db:"requireExhaustive" json:"requireExhaustive,omitempty"`
 }
 
 func NewAggregateQueryRawRequest() *AggregateQueryRawRequest {
@@ -9694,6 +9696,15 @@ func (p *AggregateQueryRawRequest) GetDocsLimit() int64 {
 	}
 	return *p.DocsLimit
 }
+
+var AggregateQueryRawRequest_RequireExhaustive_DEFAULT bool
+
+func (p *AggregateQueryRawRequest) GetRequireExhaustive() bool {
+	if !p.IsSetRequireExhaustive() {
+		return AggregateQueryRawRequest_RequireExhaustive_DEFAULT
+	}
+	return *p.RequireExhaustive
+}
 func (p *AggregateQueryRawRequest) IsSetSeriesLimit() bool {
 	return p.SeriesLimit != nil
 }
@@ -9716,6 +9727,10 @@ func (p *AggregateQueryRawRequest) IsSetSource() bool {
 
 func (p *AggregateQueryRawRequest) IsSetDocsLimit() bool {
 	return p.DocsLimit != nil
+}
+
+func (p *AggregateQueryRawRequest) IsSetRequireExhaustive() bool {
+	return p.RequireExhaustive != nil
 }
 
 func (p *AggregateQueryRawRequest) Read(iprot thrift.TProtocol) error {
@@ -9779,6 +9794,10 @@ func (p *AggregateQueryRawRequest) Read(iprot thrift.TProtocol) error {
 			}
 		case 10:
 			if err := p.ReadField10(iprot); err != nil {
+				return err
+			}
+		case 11:
+			if err := p.ReadField11(iprot); err != nil {
 				return err
 			}
 		default:
@@ -9913,6 +9932,15 @@ func (p *AggregateQueryRawRequest) ReadField10(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *AggregateQueryRawRequest) ReadField11(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 11: ", err)
+	} else {
+		p.RequireExhaustive = &v
+	}
+	return nil
+}
+
 func (p *AggregateQueryRawRequest) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("AggregateQueryRawRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -9946,6 +9974,9 @@ func (p *AggregateQueryRawRequest) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField10(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField11(oprot); err != nil {
 			return err
 		}
 	}
@@ -10103,6 +10134,21 @@ func (p *AggregateQueryRawRequest) writeField10(oprot thrift.TProtocol) (err err
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 10:docsLimit: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *AggregateQueryRawRequest) writeField11(oprot thrift.TProtocol) (err error) {
+	if p.IsSetRequireExhaustive() {
+		if err := oprot.WriteFieldBegin("requireExhaustive", thrift.BOOL, 11); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 11:requireExhaustive: ", p), err)
+		}
+		if err := oprot.WriteBool(bool(*p.RequireExhaustive)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.requireExhaustive (11) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 11:requireExhaustive: ", p), err)
 		}
 	}
 	return err
@@ -10544,6 +10590,7 @@ func (p *AggregateQueryRawResultTagValueElement) String() string {
 //  - RangeType
 //  - Source
 //  - DocsLimit
+//  - RequireExhaustive
 type AggregateQueryRequest struct {
 	Query              *Query             `thrift:"query,1" db:"query" json:"query,omitempty"`
 	RangeStart         int64              `thrift:"rangeStart,2,required" db:"rangeStart" json:"rangeStart"`
@@ -10555,6 +10602,7 @@ type AggregateQueryRequest struct {
 	RangeType          TimeType           `thrift:"rangeType,8" db:"rangeType" json:"rangeType,omitempty"`
 	Source             []byte             `thrift:"source,9" db:"source" json:"source,omitempty"`
 	DocsLimit          *int64             `thrift:"docsLimit,10" db:"docsLimit" json:"docsLimit,omitempty"`
+	RequireExhaustive  *bool              `thrift:"requireExhaustive,11" db:"requireExhaustive" json:"requireExhaustive,omitempty"`
 }
 
 func NewAggregateQueryRequest() *AggregateQueryRequest {
@@ -10627,6 +10675,15 @@ func (p *AggregateQueryRequest) GetDocsLimit() int64 {
 	}
 	return *p.DocsLimit
 }
+
+var AggregateQueryRequest_RequireExhaustive_DEFAULT bool
+
+func (p *AggregateQueryRequest) GetRequireExhaustive() bool {
+	if !p.IsSetRequireExhaustive() {
+		return AggregateQueryRequest_RequireExhaustive_DEFAULT
+	}
+	return *p.RequireExhaustive
+}
 func (p *AggregateQueryRequest) IsSetQuery() bool {
 	return p.Query != nil
 }
@@ -10653,6 +10710,10 @@ func (p *AggregateQueryRequest) IsSetSource() bool {
 
 func (p *AggregateQueryRequest) IsSetDocsLimit() bool {
 	return p.DocsLimit != nil
+}
+
+func (p *AggregateQueryRequest) IsSetRequireExhaustive() bool {
+	return p.RequireExhaustive != nil
 }
 
 func (p *AggregateQueryRequest) Read(iprot thrift.TProtocol) error {
@@ -10714,6 +10775,10 @@ func (p *AggregateQueryRequest) Read(iprot thrift.TProtocol) error {
 			}
 		case 10:
 			if err := p.ReadField10(iprot); err != nil {
+				return err
+			}
+		case 11:
+			if err := p.ReadField11(iprot); err != nil {
 				return err
 			}
 		default:
@@ -10844,6 +10909,15 @@ func (p *AggregateQueryRequest) ReadField10(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *AggregateQueryRequest) ReadField11(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 11: ", err)
+	} else {
+		p.RequireExhaustive = &v
+	}
+	return nil
+}
+
 func (p *AggregateQueryRequest) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("AggregateQueryRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -10877,6 +10951,9 @@ func (p *AggregateQueryRequest) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField10(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField11(oprot); err != nil {
 			return err
 		}
 	}
@@ -11036,6 +11113,21 @@ func (p *AggregateQueryRequest) writeField10(oprot thrift.TProtocol) (err error)
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 10:docsLimit: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *AggregateQueryRequest) writeField11(oprot thrift.TProtocol) (err error) {
+	if p.IsSetRequireExhaustive() {
+		if err := oprot.WriteFieldBegin("requireExhaustive", thrift.BOOL, 11); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 11:requireExhaustive: ", p), err)
+		}
+		if err := oprot.WriteBool(bool(*p.RequireExhaustive)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.requireExhaustive (11) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 11:requireExhaustive: ", p), err)
 		}
 	}
 	return err

--- a/src/dbnode/network/server/tchannelthrift/convert/convert.go
+++ b/src/dbnode/network/server/tchannelthrift/convert/convert.go
@@ -326,6 +326,9 @@ func FromRPCAggregateQueryRequest(
 	if l := req.DocsLimit; l != nil {
 		opts.DocsLimit = int(*l)
 	}
+	if r := req.RequireExhaustive; r != nil {
+		opts.RequireExhaustive = *r
+	}
 
 	if len(req.Source) > 0 {
 		opts.Source = req.Source
@@ -377,6 +380,9 @@ func FromRPCAggregateQueryRawRequest(
 	}
 	if l := req.DocsLimit; l != nil {
 		opts.DocsLimit = int(*l)
+	}
+	if r := req.RequireExhaustive; r != nil {
+		opts.RequireExhaustive = *r
 	}
 
 	if len(req.Source) > 0 {
@@ -434,6 +440,10 @@ func ToRPCAggregateQueryRawRequest(
 	if opts.DocsLimit > 0 {
 		l := int64(opts.DocsLimit)
 		request.DocsLimit = &l
+	}
+	if opts.RequireExhaustive {
+		r := opts.RequireExhaustive
+		request.RequireExhaustive = &r
 	}
 
 	if len(opts.Source) > 0 {

--- a/src/dbnode/network/server/tchannelthrift/convert/convert_test.go
+++ b/src/dbnode/network/server/tchannelthrift/convert/convert_test.go
@@ -172,16 +172,18 @@ func TestConvertFetchTaggedRequest(t *testing.T) {
 
 func TestConvertAggregateRawQueryRequest(t *testing.T) {
 	var (
-		seriesLimit int64 = 10
-		docsLimit   int64 = 10
-		ns                = ident.StringID("abc")
+		seriesLimit       int64 = 10
+		docsLimit         int64 = 10
+		requireExhaustive       = true
+		ns                      = ident.StringID("abc")
 	)
 	opts := index.AggregationOptions{
 		QueryOptions: index.QueryOptions{
-			StartInclusive: time.Now().Add(-900 * time.Hour),
-			EndExclusive:   time.Now(),
-			SeriesLimit:    int(seriesLimit),
-			DocsLimit:      int(docsLimit),
+			StartInclusive:    time.Now().Add(-900 * time.Hour),
+			EndExclusive:      time.Now(),
+			SeriesLimit:       int(seriesLimit),
+			DocsLimit:         int(docsLimit),
+			RequireExhaustive: requireExhaustive,
 		},
 		Type: index.AggregateTagNamesAndValues,
 		FieldFilter: index.AggregateFieldFilter{
@@ -190,11 +192,12 @@ func TestConvertAggregateRawQueryRequest(t *testing.T) {
 		},
 	}
 	requestSkeleton := &rpc.AggregateQueryRawRequest{
-		NameSpace:   ns.Bytes(),
-		RangeStart:  mustToRpcTime(t, opts.StartInclusive),
-		RangeEnd:    mustToRpcTime(t, opts.EndExclusive),
-		SeriesLimit: &seriesLimit,
-		DocsLimit:   &docsLimit,
+		NameSpace:         ns.Bytes(),
+		RangeStart:        mustToRpcTime(t, opts.StartInclusive),
+		RangeEnd:          mustToRpcTime(t, opts.EndExclusive),
+		SeriesLimit:       &seriesLimit,
+		DocsLimit:         &docsLimit,
+		RequireExhaustive: &requireExhaustive,
 		TagNameFilter: [][]byte{
 			[]byte("some"),
 			[]byte("string"),

--- a/src/query/storage/index.go
+++ b/src/query/storage/index.go
@@ -95,11 +95,12 @@ func FetchOptionsToAggregateOptions(
 ) index.AggregationOptions {
 	return index.AggregationOptions{
 		QueryOptions: index.QueryOptions{
-			SeriesLimit:    fetchOptions.SeriesLimit,
-			DocsLimit:      fetchOptions.DocsLimit,
-			Source:         fetchOptions.Source,
-			StartInclusive: tagQuery.Start,
-			EndExclusive:   tagQuery.End,
+			SeriesLimit:       fetchOptions.SeriesLimit,
+			DocsLimit:         fetchOptions.DocsLimit,
+			Source:            fetchOptions.Source,
+			RequireExhaustive: fetchOptions.RequireExhaustive,
+			StartInclusive:    tagQuery.Start,
+			EndExclusive:      tagQuery.End,
 		},
 		FieldFilter: tagQuery.FilterNameTags,
 		Type:        convertAggregateQueryType(tagQuery.CompleteNameOnly),

--- a/src/query/storage/index_test.go
+++ b/src/query/storage/index_test.go
@@ -256,7 +256,9 @@ func TestFetchQueryToM3Query(t *testing.T) {
 
 func TestFetchOptionsToAggregateOptions(t *testing.T) {
 	fetchOptions := &FetchOptions{
-		SeriesLimit: 7,
+		SeriesLimit:       7,
+		DocsLimit:         8,
+		RequireExhaustive: true,
 	}
 
 	end := time.Now()
@@ -281,4 +283,7 @@ func TestFetchOptionsToAggregateOptions(t *testing.T) {
 	assert.Equal(t, index.AggregateTagNames, aggOpts.Type)
 	require.Equal(t, 1, len(aggOpts.FieldFilter))
 	require.Equal(t, "filter", string(aggOpts.FieldFilter[0]))
+	require.Equal(t, fetchOptions.SeriesLimit, aggOpts.SeriesLimit)
+	require.Equal(t, fetchOptions.DocsLimit, aggOpts.DocsLimit)
+	require.Equal(t, fetchOptions.RequireExhaustive, aggOpts.RequireExhaustive)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
[m3db] [m3coordinator] Properly pipe along require-exhaustive param for aggregate queries

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE 

**Does this PR require updating code package or user-facing documentation?**:
NONE