### PR TITLE
[dbnode] Add Shard.OpenStreamingReader method

### DIFF
--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -1954,6 +1954,43 @@ func TestShardAggregateTilesVerifySliceLengths(t *testing.T) {
 	require.EqualError(t, err, "blockReaders and sourceBlockVolumes length mismatch (0 != 1)")
 }
 
+func TestOpenStreamingReader(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	var (
+		blockStart = time.Now().Truncate(time.Hour)
+		testOpts   = DefaultTestOptions()
+	)
+
+	shard := testDatabaseShard(t, testOpts)
+	defer assert.NoError(t, shard.Close())
+
+	latestSourceVolume, err := shard.LatestVolume(blockStart)
+	require.NoError(t, err)
+
+	openOpts := fs.DataReaderOpenOptions{
+		Identifier: fs.FileSetFileIdentifier{
+			Namespace:   shard.namespace.ID(),
+			Shard:       shard.ID(),
+			BlockStart:  blockStart,
+			VolumeIndex: latestSourceVolume,
+		},
+		FileSetType:      persist.FileSetFlushType,
+		StreamingEnabled: true,
+	}
+
+	reader := fs.NewMockDataFileSetReader(ctrl)
+	reader.EXPECT().Open(openOpts).Return(nil)
+
+	shard.newReaderFn = func(pool.CheckedBytesPool, fs.Options) (fs.DataFileSetReader, error) {
+		return reader, nil
+	}
+
+	_, err = shard.OpenStreamingReader(blockStart)
+	require.NoError(t, err)
+}
+
 func TestShardScan(t *testing.T) {
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -1110,6 +1110,22 @@ func (mr *MockNamespaceMockRecorder) Shards() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shards", reflect.TypeOf((*MockNamespace)(nil).Shards))
 }
 
+// ReadableShardAt mocks base method
+func (m *MockNamespace) ReadableShardAt(shardID uint32) (databaseShard, namespace.Context, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadableShardAt", shardID)
+	ret0, _ := ret[0].(databaseShard)
+	ret1, _ := ret[1].(namespace.Context)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ReadableShardAt indicates an expected call of ReadableShardAt
+func (mr *MockNamespaceMockRecorder) ReadableShardAt(shardID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadableShardAt", reflect.TypeOf((*MockNamespace)(nil).ReadableShardAt), shardID)
+}
+
 // SetIndex mocks base method
 func (m *MockNamespace) SetIndex(reverseIndex NamespaceIndex) error {
 	m.ctrl.T.Helper()
@@ -1329,6 +1345,22 @@ func (m *MockdatabaseNamespace) Shards() []Shard {
 func (mr *MockdatabaseNamespaceMockRecorder) Shards() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shards", reflect.TypeOf((*MockdatabaseNamespace)(nil).Shards))
+}
+
+// ReadableShardAt mocks base method
+func (m *MockdatabaseNamespace) ReadableShardAt(shardID uint32) (databaseShard, namespace.Context, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadableShardAt", shardID)
+	ret0, _ := ret[0].(databaseShard)
+	ret1, _ := ret[1].(namespace.Context)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ReadableShardAt indicates an expected call of ReadableShardAt
+func (mr *MockdatabaseNamespaceMockRecorder) ReadableShardAt(shardID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadableShardAt", reflect.TypeOf((*MockdatabaseNamespace)(nil).ReadableShardAt), shardID)
 }
 
 // SetIndex mocks base method
@@ -1822,22 +1854,6 @@ func (mr *MockdatabaseNamespaceMockRecorder) AggregateTiles(ctx, sourceNs, opts 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AggregateTiles", reflect.TypeOf((*MockdatabaseNamespace)(nil).AggregateTiles), ctx, sourceNs, opts)
 }
 
-// ReadableShardAt mocks base method
-func (m *MockdatabaseNamespace) ReadableShardAt(shardID uint32) (databaseShard, namespace.Context, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadableShardAt", shardID)
-	ret0, _ := ret[0].(databaseShard)
-	ret1, _ := ret[1].(namespace.Context)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ReadableShardAt indicates an expected call of ReadableShardAt
-func (mr *MockdatabaseNamespaceMockRecorder) ReadableShardAt(shardID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadableShardAt", reflect.TypeOf((*MockdatabaseNamespace)(nil).ReadableShardAt), shardID)
-}
-
 // MockShard is a mock of Shard interface
 type MockShard struct {
 	ctrl     *gomock.Controller
@@ -1931,6 +1947,21 @@ func (mr *MockShardMockRecorder) ScanData(blockStart, processor interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanData", reflect.TypeOf((*MockShard)(nil).ScanData), blockStart, processor)
 }
 
+// OpenStreamingReader mocks base method
+func (m *MockShard) OpenStreamingReader(blockStart time.Time) (fs.DataFileSetReader, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenStreamingReader", blockStart)
+	ret0, _ := ret[0].(fs.DataFileSetReader)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenStreamingReader indicates an expected call of OpenStreamingReader
+func (mr *MockShardMockRecorder) OpenStreamingReader(blockStart interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenStreamingReader", reflect.TypeOf((*MockShard)(nil).OpenStreamingReader), blockStart)
+}
+
 // MockdatabaseShard is a mock of databaseShard interface
 type MockdatabaseShard struct {
 	ctrl     *gomock.Controller
@@ -2022,6 +2053,21 @@ func (m *MockdatabaseShard) ScanData(blockStart time.Time, processor fs.DataEntr
 func (mr *MockdatabaseShardMockRecorder) ScanData(blockStart, processor interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanData", reflect.TypeOf((*MockdatabaseShard)(nil).ScanData), blockStart, processor)
+}
+
+// OpenStreamingReader mocks base method
+func (m *MockdatabaseShard) OpenStreamingReader(blockStart time.Time) (fs.DataFileSetReader, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenStreamingReader", blockStart)
+	ret0, _ := ret[0].(fs.DataFileSetReader)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenStreamingReader indicates an expected call of OpenStreamingReader
+func (mr *MockdatabaseShardMockRecorder) OpenStreamingReader(blockStart interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenStreamingReader", reflect.TypeOf((*MockdatabaseShard)(nil).OpenStreamingReader), blockStart)
 }
 
 // OnEvictedFromWiredList mocks base method

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -283,6 +283,9 @@ type Namespace interface {
 	// Shards returns the shard description.
 	Shards() []Shard
 
+	// ReadableShardAt returns a readable (bootstrapped) shard by id.
+	ReadableShardAt(shardID uint32) (databaseShard, namespace.Context, error)
+
 	// SetIndex sets and enables reverse index for this namespace.
 	SetIndex(reverseIndex NamespaceIndex) error
 
@@ -475,9 +478,6 @@ type databaseNamespace interface {
 		sourceNs databaseNamespace,
 		opts AggregateTilesOptions,
 	) (int64, error)
-
-	// ReadableShardAt returns a shard of this namespace by shardID.
-	ReadableShardAt(shardID uint32) (databaseShard, namespace.Context, error)
 }
 
 // SeriesReadWriteRef is a read/write reference for a series,
@@ -515,6 +515,10 @@ type Shard interface {
 		blockStart time.Time,
 		processor fs.DataEntryProcessor,
 	) error
+
+	// OpenStreamingDataReader creates and opens a streaming fs.DataFileSetReader
+	// on the latest volume of the given block.
+	OpenStreamingReader(blockStart time.Time) (fs.DataFileSetReader, error)
 }
 
 type databaseShard interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `Shard.OpenStreamingReader` method. I found it to be more convenient to use that callback based `Shard.ScanData` (which I'm planning to remove soon).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
