### PR TITLE
[dbnode] Add abort method to cold flusher.

### DIFF
--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -1548,6 +1548,7 @@ func TestServiceFetchBlocksMetadataEndpointV2RawDatabaseNotSet(t *testing.T) {
 	require.Equal(t, tterrors.NewInternalError(errDatabaseIsNotInitializedYet), err)
 }
 
+//nolint:dupl
 func TestServiceFetchTagged(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/src/dbnode/persist/types.go
+++ b/src/dbnode/persist/types.go
@@ -386,5 +386,8 @@ func (n *NoOpColdFlushNamespace) OnFlushNewSeries(event OnFlushNewSeriesEvent) e
 	return nil
 }
 
+// Abort is a no-op.
+func (n *NoOpColdFlushNamespace) Abort() error { return nil }
+
 // Done is a no-op.
 func (n *NoOpColdFlushNamespace) Done() error { return nil }

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -572,7 +572,7 @@ type testOptions struct {
 func testBootstrapIndexWithPersistForIndexBlockAtRetentionEdge(t *testing.T, test testOptions) {
 	dir := createTempDir(t)
 	defer func() {
-		_ = os.RemoveAll(dir)
+		require.NoError(t, os.RemoveAll(dir))
 	}()
 
 	timesOpts := testTimesOptions{

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1767,7 +1767,7 @@ func (n *dbNamespace) aggregateTiles(
 		// Abort buildling reverse index if aggregation fails.
 		if err := onColdFlushNs.Abort(); err != nil {
 			n.log.Error("error aborting cold flush",
-				zap.String("sourceNs", sourceNs.ID().String()), zap.Error(err))
+				zap.Stringer("sourceNs", sourceNs.ID()), zap.Error(err))
 		}
 	}()
 	for _, targetShard := range targetShards {

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -1750,12 +1750,26 @@ func (n *dbNamespace) aggregateTiles(
 		blockReaders = append(blockReaders, reader)
 	}
 
+	// Cold flusher builds the reverse index for target (current) ns.
 	onColdFlushNs, err := n.opts.OnColdFlush().ColdFlushNamespace(n)
 	if err != nil {
 		return 0, err
 	}
 
-	var processedTileCount int64
+	var (
+		processedTileCount int64
+		aggregationSuccess bool
+	)
+	defer func() {
+		if aggregationSuccess {
+			return
+		}
+		// Abort buildling reverse index if aggregation fails.
+		if err := onColdFlushNs.Abort(); err != nil {
+			n.log.Error("error aborting cold flush",
+				zap.String("sourceNs", sourceNs.ID().String()), zap.Error(err))
+		}
+	}()
 	for _, targetShard := range targetShards {
 		sourceShard, _, err := sourceNs.ReadableShardAt(targetShard.ID())
 		if err != nil {
@@ -1789,6 +1803,8 @@ func (n *dbNamespace) aggregateTiles(
 		}
 	}
 
+	// Aggregation success, mark so we don't abort reverse index building (cold flusher).
+	aggregationSuccess = true
 	if err := onColdFlushNs.Done(); err != nil {
 		return 0, err
 	}

--- a/src/dbnode/storage/series/reader_test.go
+++ b/src/dbnode/storage/series/reader_test.go
@@ -612,6 +612,7 @@ func TestReaderFetchBlocksRobust(t *testing.T) {
 	}
 }
 
+//nolint:scopelint
 func TestReaderReadEncodedRobust(t *testing.T) {
 	for _, tc := range robustReaderTestCases {
 		tc := tc
@@ -631,7 +632,6 @@ func TestReaderReadEncodedRobust(t *testing.T) {
 
 			// Setup mocks.
 			for _, currTime := range tc.times {
-				tc := tc
 				cachedBlocks, wasInDiskCache := tc.cachedBlocks[xtime.ToUnixNano(currTime)]
 				if wasInDiskCache {
 					// If the data was in the disk cache then expect a read from it but don't expect

--- a/src/dbnode/storage/series/reader_test.go
+++ b/src/dbnode/storage/series/reader_test.go
@@ -26,6 +26,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/storage/block"
 	"github.com/m3db/m3/src/dbnode/ts"
@@ -33,10 +37,6 @@ import (
 	"github.com/m3db/m3/src/x/ident"
 	xtest "github.com/m3db/m3/src/x/test"
 	xtime "github.com/m3db/m3/src/x/time"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestReaderUsingRetrieverReadEncoded(t *testing.T) {
@@ -631,6 +631,7 @@ func TestReaderReadEncodedRobust(t *testing.T) {
 
 			// Setup mocks.
 			for _, currTime := range tc.times {
+				tc := tc
 				cachedBlocks, wasInDiskCache := tc.cachedBlocks[xtime.ToUnixNano(currTime)]
 				if wasInDiskCache {
 					// If the data was in the disk cache then expect a read from it but don't expect

--- a/src/dbnode/storage/series/series.go
+++ b/src/dbnode/storage/series/series.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/schema"
@@ -36,8 +38,6 @@ import (
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
-
-	"go.uber.org/zap"
 )
 
 var (

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -3717,6 +3717,20 @@ func (mr *MockOnColdFlushNamespaceMockRecorder) CheckpointAndMaybeCompact() *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckpointAndMaybeCompact", reflect.TypeOf((*MockOnColdFlushNamespace)(nil).CheckpointAndMaybeCompact))
 }
 
+// Abort mocks base method
+func (m *MockOnColdFlushNamespace) Abort() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Abort")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Abort indicates an expected call of Abort
+func (mr *MockOnColdFlushNamespaceMockRecorder) Abort() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockOnColdFlushNamespace)(nil).Abort))
+}
+
 // Done mocks base method
 func (m *MockOnColdFlushNamespace) Done() error {
 	m.ctrl.T.Helper()

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -1017,6 +1017,7 @@ type OnColdFlush interface {
 // OnColdFlushNamespace performs work on a per namespace level.
 type OnColdFlushNamespace interface {
 	persist.OnFlushSeries
+	Abort() error
 	Done() error
 }
 

--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -443,6 +443,7 @@ func TestDivideSeriesLists(t *testing.T) {
 	require.Error(t, err)
 }
 
+//nolint:govet
 func TestAverageSeriesWithWildcards(t *testing.T) {
 	ctx, _ := newConsolidationTestSeries()
 	defer ctx.Close()
@@ -548,10 +549,12 @@ func TestApplyByNode(t *testing.T) {
 			common.NewTestSeriesValues(ctx, 60000, []float64{10, 20, 30}))}}, nil).Times(2)
 
 	store.EXPECT().FetchByQuery(gomock.Any(), "servers.s1.disk.bytes_*", gomock.Any()).Return(
-		&storage.FetchResult{SeriesList: []*ts.Series{ts.NewSeries(ctx, "servers.s1.disk.bytes_free", start,
-			common.NewTestSeriesValues(ctx, 60000, []float64{90, 80, 70})),
+		&storage.FetchResult{SeriesList: []*ts.Series{
+			ts.NewSeries(ctx, "servers.s1.disk.bytes_free", start,
+				common.NewTestSeriesValues(ctx, 60000, []float64{90, 80, 70})),
 			ts.NewSeries(ctx, "servers.s1.disk.bytes_used", start,
-				common.NewTestSeriesValues(ctx, 60000, []float64{10, 20, 30}))}}, nil).Times(2)
+				common.NewTestSeriesValues(ctx, 60000, []float64{10, 20, 30})),
+		}}, nil).Times(2)
 
 	store.EXPECT().FetchByQuery(gomock.Any(), "servers.s2.disk.bytes_used", gomock.Any()).Return(
 		&storage.FetchResult{SeriesList: []*ts.Series{ts.NewSeries(ctx, "servers.s2.disk.bytes_used", start,
@@ -562,7 +565,8 @@ func TestApplyByNode(t *testing.T) {
 			ts.NewSeries(ctx, "servers.s2.disk.bytes_free", start,
 				common.NewTestSeriesValues(ctx, 60000, []float64{99, 98, 97})),
 			ts.NewSeries(ctx, "servers.s2.disk.bytes_used", start,
-				common.NewTestSeriesValues(ctx, 60000, []float64{1, 2, 3}))}}, nil).Times(2)
+				common.NewTestSeriesValues(ctx, 60000, []float64{1, 2, 3})),
+		}}, nil).Times(2)
 
 	tests := []struct {
 		nodeNum          int

--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -106,6 +106,7 @@ func sortByMaxima(ctx *common.Context, series singlePathSpec) (ts.SeriesList, er
 // the response time metric will be plotted only when the maximum value of the
 // corresponding request/s metric is > 10
 // Example: useSeriesAbove(ganglia.metric1.reqs,10,"reqs","time")
+//nolint:govet,gocritic
 func useSeriesAbove(
 	ctx *common.Context,
 	seriesList singlePathSpec,
@@ -314,7 +315,6 @@ func timeShift(
 	_ bool,
 	_ bool,
 ) (*unaryContextShifter, error) {
-
 	// TODO: implement resetEnd
 	if !(strings.HasPrefix(timeShiftS, "+") || strings.HasPrefix(timeShiftS, "-")) {
 		timeShiftS = "-" + timeShiftS
@@ -484,7 +484,6 @@ func offset(ctx *common.Context, input singlePathSpec, factor float64) (ts.Serie
 // transform converts values in a timeseries according to the valueTransformer.
 func transform(ctx *common.Context, input singlePathSpec,
 	fname func(inputName string) string, fn common.TransformFunc) (ts.SeriesList, error) {
-
 	t := common.NewStatelessTransformer(fn)
 	return common.Transform(ctx, ts.SeriesList(input), t, func(in *ts.Series) string {
 		return fname(in.Name())
@@ -818,7 +817,6 @@ func movingAverage(ctx *common.Context, input singlePathSpec, windowSizeValue ge
 	}
 
 	widowSize, err := parseWindowSize(windowSizeValue, input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -1136,8 +1134,8 @@ func asPercent(ctx *common.Context, input singlePathSpec, total genericInterface
 // expression.
 func exclude(_ *common.Context, input singlePathSpec, pattern string) (ts.SeriesList, error) {
 	rePattern, err := regexp.Compile(pattern)
-	//NB(rooz): we decided to just fail if regex compilation fails to
-	//differentiate it from an all-excluding regex
+	// NB(rooz): we decided to just fail if regex compilation fails to
+	// differentiate it from an all-excluding regex
 	if err != nil {
 		return ts.NewSeriesList(), err
 	}
@@ -1274,7 +1272,6 @@ func group(_ *common.Context, input multiplePathSpecs) (ts.SeriesList, error) {
 
 func derivativeTemplate(ctx *common.Context, input singlePathSpec, nameTemplate string,
 	fn func(float64, float64) float64) (ts.SeriesList, error) {
-
 	output := make([]*ts.Series, len(input.Values))
 	for i, in := range input.Values {
 		derivativeValues := ts.NewValues(ctx, in.MillisPerStep(), in.Len())

--- a/src/query/graphite/native/builtin_functions_test.go
+++ b/src/query/graphite/native/builtin_functions_test.go
@@ -595,11 +595,13 @@ func TestOffset(t *testing.T) {
 		outputs []float64
 	}{
 		{
-			[]float64{0, 1.0, 2.0, math.NaN(), 3.0}, 2.5,
+			[]float64{0, 1.0, 2.0, math.NaN(), 3.0},
+			2.5,
 			[]float64{2.5, 3.5, 4.5, math.NaN(), 5.5},
 		},
 		{
-			[]float64{0, 1.0, 2.0, math.NaN(), 3.0}, -0.5,
+			[]float64{0, 1.0, 2.0, math.NaN(), 3.0},
+			-0.5,
 			[]float64{-0.5, 0.5, 1.5, math.NaN(), 2.5},
 		},
 	}
@@ -624,7 +626,6 @@ func TestOffset(t *testing.T) {
 			xtest.Equalish(t, test.outputs[step], v, "invalid value for %d", step)
 		}
 	}
-
 }
 
 func TestPerSecond(t *testing.T) {
@@ -643,8 +644,11 @@ func TestPerSecond(t *testing.T) {
 		{10000, []float64{1, 2, 3, 4, 5}, []float64{math.NaN(), 0.1, 0.1, 0.1, 0.1}},
 
 		// decreasing value - rate of change not applicable
-		{1000, []float64{5, 4, 3, 2, 1},
-			[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()}},
+		{
+			1000,
+			[]float64{5, 4, 3, 2, 1},
+			[]float64{math.NaN(), math.NaN(), math.NaN(), math.NaN(), math.NaN()},
+		},
 
 		// skip over missing values
 		{1000, []float64{1, 2, math.NaN(), 4, 5}, []float64{math.NaN(), 1, math.NaN(), 1, 1}},
@@ -1460,6 +1464,7 @@ func TestHighestMax(t *testing.T) {
 	testRanking(t, ctx, tests, highestMax)
 }
 
+//nolint:govet
 func TestFallbackSeries(t *testing.T) {
 	ctx := common.NewTestContext()
 	defer ctx.Close()
@@ -1879,14 +1884,20 @@ func TestAsPercentWithSeriesTotal(t *testing.T) {
 		output     []float64
 	}{
 		{
-			100, []float64{10.0, 20.0, 30.0, 40.0, 50.0},
-			100, []float64{1000.0, 1000.0, 1000.0, 1000.0, 1000.0},
-			100, []float64{1.0, 2.0, 3.0, 4.0, 5.0},
+			100,
+			[]float64{10.0, 20.0, 30.0, 40.0, 50.0},
+			100,
+			[]float64{1000.0, 1000.0, 1000.0, 1000.0, 1000.0},
+			100,
+			[]float64{1.0, 2.0, 3.0, 4.0, 5.0},
 		},
 		{
-			100, []float64{12.0, 14.0, 16.0, math.NaN(), 20.0},
-			150, []float64{50.0, 50.0, 25.0, 50.0, 50.0},
-			300, []float64{28.0, 53.0},
+			100,
+			[]float64{12.0, 14.0, 16.0, math.NaN(), 20.0},
+			150,
+			[]float64{50.0, 50.0, 25.0, 50.0, 50.0},
+			300,
+			[]float64{28.0, 53.0},
 		},
 	}
 
@@ -1928,14 +1939,18 @@ func TestAsPercentWithFloatTotal(t *testing.T) {
 		output     []float64
 	}{
 		{
-			100, []float64{12.0, 14.0, 16.0, nan, 20.0},
+			100,
+			[]float64{12.0, 14.0, 16.0, nan, 20.0},
 			20.0,
-			100, []float64{60, 70, 80, nan, 100},
+			100,
+			[]float64{60, 70, 80, nan, 100},
 		},
 		{
-			100, []float64{12.0, 14.0, 16.0, nan, 20.0},
+			100,
+			[]float64{12.0, 14.0, 16.0, nan, 20.0},
 			0,
-			100, []float64{nan, nan, nan, nan, nan},
+			100,
+			[]float64{nan, nan, nan, nan, nan},
 		},
 	}
 
@@ -2081,7 +2096,6 @@ func TestAsPercentWithSeriesList(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 func testLogarithm(t *testing.T, base int, indices []int) {
@@ -3413,7 +3427,7 @@ func TestTimeShift(t *testing.T) {
 }
 
 func TestDelay(t *testing.T) {
-	var values = [3][]float64{
+	values := [3][]float64{
 		{54.0, 48.0, 92.0, 54.0, 14.0, 1.2},
 		{4.0, 5.0, math.NaN(), 6.4, 7.2, math.NaN()},
 		{math.NaN(), 8.0, 9.0, 10.6, 11.2, 12.2},


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds abort method to the cold flusher. 

Abort building reverse index if an error is encountered during tile aggregation.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
