### PR TITLE
[coordinator] add offset query support

### DIFF
--- a/src/query/api/v1/handler/prometheus/native/common.go
+++ b/src/query/api/v1/handler/prometheus/native/common.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
+	"github.com/m3db/m3/src/query/api/v1/types"
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/errors"
 	"github.com/m3db/m3/src/query/executor"
@@ -261,7 +262,7 @@ type RenderResultsOptions struct {
 // RenderResultsJSON renders results in JSON for range queries.
 func RenderResultsJSON(
 	w io.Writer,
-	result ReadResult,
+	result types.ReadResult,
 	opts RenderResultsOptions,
 ) error {
 	var (
@@ -352,7 +353,7 @@ func RenderResultsJSON(
 // renderResultsInstantaneousJSON renders results in JSON for instant queries.
 func renderResultsInstantaneousJSON(
 	w io.Writer,
-	result ReadResult,
+	result types.ReadResult,
 	keepNaNs bool,
 ) {
 	var (

--- a/src/query/api/v1/handler/prometheus/native/common_test.go
+++ b/src/query/api/v1/handler/prometheus/native/common_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
+	"github.com/m3db/m3/src/query/api/v1/types"
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/executor"
 	"github.com/m3db/m3/src/query/models"
@@ -206,7 +207,7 @@ func TestRenderResultsJSON(t *testing.T) {
 			})),
 	}
 
-	readResult := ReadResult{Series: series}
+	readResult := types.ReadResult{Series: series}
 	RenderResultsJSON(buffer, readResult, RenderResultsOptions{
 		Start:    params.Start,
 		End:      params.End,
@@ -316,7 +317,7 @@ func TestRenderResultsJSONWithDroppedNaNs(t *testing.T) {
 	meta := block.NewResultMetadata()
 	meta.AddWarning("foo", "bar")
 	meta.AddWarning("baz", "qux")
-	readResult := ReadResult{
+	readResult := types.ReadResult{
 		Series: series,
 		Meta:   meta,
 	}
@@ -397,7 +398,7 @@ func TestRenderInstantaneousResultsJSONVector(t *testing.T) {
 			})),
 	}
 
-	readResult := ReadResult{
+	readResult := types.ReadResult{
 		Series: series,
 		Meta:   block.NewResultMetadata(),
 	}
@@ -475,7 +476,7 @@ func TestRenderInstantaneousResultsNansOnlyJSON(t *testing.T) {
 			})),
 	}
 
-	readResult := ReadResult{
+	readResult := types.ReadResult{
 		Series: series,
 		Meta:   block.NewResultMetadata(),
 	}
@@ -535,7 +536,7 @@ func TestRenderInstantaneousResultsJSONScalar(t *testing.T) {
 			test.TagSliceToTags([]models.Tag{})),
 	}
 
-	readResult := ReadResult{
+	readResult := types.ReadResult{
 		Series:    series,
 		Meta:      block.NewResultMetadata(),
 		BlockType: block.BlockScalar,

--- a/src/query/api/v1/handler/prometheus/native/read_common.go
+++ b/src/query/api/v1/handler/prometheus/native/read_common.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/query/api/v1/handler"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus"
 	"github.com/m3db/m3/src/query/api/v1/options"
+	"github.com/m3db/m3/src/query/api/v1/types"
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/executor"
 	"github.com/m3db/m3/src/query/models"
@@ -71,13 +72,6 @@ func (m *promReadMetrics) incError(err error) {
 // ReadResponse is the response that gets returned to the user
 type ReadResponse struct {
 	Results []ts.Series `json:"results,omitempty"`
-}
-
-// ReadResult is a result from a remote read.
-type ReadResult struct {
-	Series    []*ts.Series
-	Meta      block.ResultMetadata
-	BlockType block.BlockType
 }
 
 // ParseRequest parses the given request.
@@ -156,7 +150,7 @@ func read(
 	ctx context.Context,
 	parsed ParsedOptions,
 	handlerOpts options.HandlerOptions,
-) (ReadResult, error) {
+) (types.ReadResult, error) {
 	var (
 		opts          = parsed.QueryOpts
 		fetchOpts     = parsed.FetchOpts
@@ -175,7 +169,7 @@ func read(
 		xopentracing.Duration("params.step", params.Step),
 	)
 
-	emptyResult := ReadResult{
+	emptyResult := types.ReadResult{
 		Meta:      block.NewResultMetadata(),
 		BlockType: block.BlockEmpty,
 	}
@@ -251,7 +245,7 @@ func read(
 
 	blockType := bl.Info().Type()
 
-	return ReadResult{
+	return types.ReadResult{
 		Series:    seriesList,
 		Meta:      resultMeta,
 		BlockType: blockType,

--- a/src/query/api/v1/types/types.go
+++ b/src/query/api/v1/types/types.go
@@ -1,0 +1,13 @@
+package types
+
+import (
+	"github.com/m3db/m3/src/query/block"
+	"github.com/m3db/m3/src/query/ts"
+)
+
+// ReadResult is a result from a remote read.
+type ReadResult struct {
+	Series    []*ts.Series
+	Meta      block.ResultMetadata
+	BlockType block.BlockType
+}

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -135,6 +135,9 @@ type FetchOptions struct {
 	Timeout time.Duration
 	// Source is the source for the query.
 	Source []byte
+	// QueryOffset indicates we need to additionally run an offset query with
+	// the specified offset duration.
+	QueryOffset *time.Duration
 }
 
 // FanoutOptions describes which namespaces should be fanned out to for

--- a/src/x/headers/headers.go
+++ b/src/x/headers/headers.go
@@ -126,4 +126,8 @@ const (
 	// schema to an older instance and still have it respond successfully
 	// using the fields it knows about.
 	JSONDisableDisallowUnknownFields = M3HeaderPrefix + "JSON-Disable-Disallow-Unknown-Fields"
+
+	// OffsetQueryHeader is the header added to indicate running additional
+	// offset queries.
+	OffsetQueryHeader = M3HeaderPrefix + "Offset-Query-Header"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to run additional offset query for the provided query given the `M3-Offset-Query-Header`. It additionally adds support for a query results process that can be used to process the results of the queries made.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
No

**Does this PR require updating code package or user-facing documentation?**:
No
