### PR TITLE
[aggregator] Reduce error handling overhead in rawtcp server

### DIFF
--- a/src/aggregator/server/rawtcp/server.go
+++ b/src/aggregator/server/rawtcp/server.go
@@ -143,31 +143,31 @@ func (s *handler) Handle(conn net.Conn) {
 		case encoding.CounterWithMetadatasType:
 			untimedMetric = current.CounterWithMetadatas.Counter.ToUnion()
 			stagedMetadatas = current.CounterWithMetadatas.StagedMetadatas
-			err = toAddUntimedError(s.aggregator.AddUntimed(untimedMetric, stagedMetadatas))
+			err = addUntimedError(s.aggregator.AddUntimed(untimedMetric, stagedMetadatas))
 		case encoding.BatchTimerWithMetadatasType:
 			untimedMetric = current.BatchTimerWithMetadatas.BatchTimer.ToUnion()
 			stagedMetadatas = current.BatchTimerWithMetadatas.StagedMetadatas
-			err = toAddUntimedError(s.aggregator.AddUntimed(untimedMetric, stagedMetadatas))
+			err = addUntimedError(s.aggregator.AddUntimed(untimedMetric, stagedMetadatas))
 		case encoding.GaugeWithMetadatasType:
 			untimedMetric = current.GaugeWithMetadatas.Gauge.ToUnion()
 			stagedMetadatas = current.GaugeWithMetadatas.StagedMetadatas
-			err = toAddUntimedError(s.aggregator.AddUntimed(untimedMetric, stagedMetadatas))
+			err = addUntimedError(s.aggregator.AddUntimed(untimedMetric, stagedMetadatas))
 		case encoding.ForwardedMetricWithMetadataType:
 			forwardedMetric = current.ForwardedMetricWithMetadata.ForwardedMetric
 			forwardMetadata = current.ForwardedMetricWithMetadata.ForwardMetadata
-			err = toAddForwardedError(s.aggregator.AddForwarded(forwardedMetric, forwardMetadata))
+			err = addForwardedError(s.aggregator.AddForwarded(forwardedMetric, forwardMetadata))
 		case encoding.TimedMetricWithMetadataType:
 			timedMetric = current.TimedMetricWithMetadata.Metric
 			timedMetadata = current.TimedMetricWithMetadata.TimedMetadata
-			err = toAddTimedError(s.aggregator.AddTimed(timedMetric, timedMetadata))
+			err = addTimedError(s.aggregator.AddTimed(timedMetric, timedMetadata))
 		case encoding.TimedMetricWithMetadatasType:
 			timedMetric = current.TimedMetricWithMetadatas.Metric
 			stagedMetadatas = current.TimedMetricWithMetadatas.StagedMetadatas
-			err = toAddTimedError(s.aggregator.AddTimedWithStagedMetadatas(timedMetric, stagedMetadatas))
+			err = addTimedError(s.aggregator.AddTimedWithStagedMetadatas(timedMetric, stagedMetadatas))
 		case encoding.PassthroughMetricWithMetadataType:
 			passthroughMetric = current.PassthroughMetricWithMetadata.Metric
 			passthroughMetadata = current.PassthroughMetricWithMetadata.StoragePolicy
-			err = toAddPassthroughError(s.aggregator.AddPassthrough(passthroughMetric, passthroughMetadata))
+			err = addPassthroughError(s.aggregator.AddPassthrough(passthroughMetric, passthroughMetadata))
 		default:
 			err = newUnknownMessageTypeError(current.Type)
 		}
@@ -265,54 +265,10 @@ func (e unknownMessageTypeError) Error() string {
 	return fmt.Sprintf("unknown message type %v", e.msgType)
 }
 
-type addUntimedError struct {
-	err error
-}
+type addForwardedError error
 
-func toAddUntimedError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return addUntimedError{err: err}
-}
+type addPassthroughError error
 
-func (e addUntimedError) Error() string { return e.err.Error() }
+type addTimedError error
 
-type addTimedError struct {
-	err error
-}
-
-func toAddTimedError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return addTimedError{err: err}
-}
-
-func (e addTimedError) Error() string { return e.err.Error() }
-
-type addForwardedError struct {
-	err error
-}
-
-func toAddForwardedError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return addForwardedError{err: err}
-}
-
-func (e addForwardedError) Error() string { return e.err.Error() }
-
-type addPassthroughError struct {
-	err error
-}
-
-func toAddPassthroughError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return addPassthroughError{err: err}
-}
-
-func (e addPassthroughError) Error() string { return e.err.Error() }
+type addUntimedError error


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The errors escape to the heap for no good reason, and makes rate-limiting more expensive than it should be:
```
src/aggregator/server/rawtcp/server.go:146:27: addUntimedError literal escapes to heap
src/aggregator/server/rawtcp/server.go:150:27: addUntimedError literal escapes to heap
src/aggregator/server/rawtcp/server.go:154:27: addUntimedError literal escapes to heap
src/aggregator/server/rawtcp/server.go:158:29: addForwardedError literal escapes to heap
src/aggregator/server/rawtcp/server.go:162:25: addTimedError literal escapes to heap
src/aggregator/server/rawtcp/server.go:166:25: addTimedError literal escapes to heap
src/aggregator/server/rawtcp/server.go:170:31: addPassthroughError literal escapes to heap
```
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
