### PR TITLE
[aggregator] Sample timers completely

### DIFF
--- a/src/aggregator/aggregator/aggregator_test.go
+++ b/src/aggregator/aggregator/aggregator_test.go
@@ -946,8 +946,9 @@ func TestAggregatorOwnedShards(t *testing.T) {
 
 func TestAggregatorAddMetricMetrics(t *testing.T) {
 	s := tally.NewTestScope("testScope", nil)
-	m := newAggregatorAddUntimedMetrics(s, instrument.TimerOptions{})
-	m.ReportSuccess(time.Second)
+	m := newAggregatorAddUntimedMetrics(s, instrument.TimerOptions{StandardSampleRate: 0.001})
+	m.ReportSuccess()
+	m.SuccessLatencyStopwatch().Stop()
 	m.ReportError(errInvalidMetricType)
 	m.ReportError(errShardNotOwned)
 	m.ReportError(errAggregatorShardNotWriteable)
@@ -980,9 +981,8 @@ func TestAggregatorAddMetricMetrics(t *testing.T) {
 	for _, id := range []string{
 		"testScope.success-latency+",
 	} {
-		ti, exists := timers[id]
+		_, exists := timers[id]
 		require.True(t, exists)
-		require.Equal(t, []time.Duration{time.Second}, ti.Values())
 	}
 
 	// Validate we do not have any gauges.
@@ -992,7 +992,8 @@ func TestAggregatorAddMetricMetrics(t *testing.T) {
 func TestAggregatorAddTimedMetrics(t *testing.T) {
 	s := tally.NewTestScope("testScope", nil)
 	m := newAggregatorAddTimedMetrics(s, instrument.TimerOptions{})
-	m.ReportSuccess(time.Second)
+	m.ReportSuccess()
+	m.SuccessLatencyStopwatch().Stop()
 	m.ReportError(errShardNotOwned)
 	m.ReportError(errAggregatorShardNotWriteable)
 	m.ReportError(errWriteNewMetricRateLimitExceeded)
@@ -1027,9 +1028,8 @@ func TestAggregatorAddTimedMetrics(t *testing.T) {
 	for _, id := range []string{
 		"testScope.success-latency+",
 	} {
-		ti, exists := timers[id]
+		_, exists := timers[id]
 		require.True(t, exists)
-		require.Equal(t, []time.Duration{time.Second}, ti.Values())
 	}
 
 	// Validate we do not have any gauges.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Timers in AddUntimed/etc. methods are usually heavily sampled, however the way it was recorded always recorded current time, which adds up to non-trivial overhead (1% of the profile or so).
This moves the timing logic to the (sampled) stopwatch.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
