### PR TITLE
[aggregator] Avoid large copies in entry rollup comparisons

### DIFF
--- a/src/aggregator/aggregator/aggregation_key.go
+++ b/src/aggregator/aggregator/aggregation_key.go
@@ -34,7 +34,7 @@ type aggregationKey struct {
 	idPrefixSuffixType IDPrefixSuffixType
 }
 
-func (k aggregationKey) Equal(other aggregationKey) bool {
+func (k aggregationKey) Equal(other *aggregationKey) bool {
 	return k.aggregationID == other.aggregationID &&
 		k.storagePolicy == other.storagePolicy &&
 		k.pipeline.Equal(other.pipeline) &&

--- a/src/aggregator/aggregator/aggregation_key_test.go
+++ b/src/aggregator/aggregator/aggregation_key_test.go
@@ -169,7 +169,7 @@ func TestAggregationKeyEqual(t *testing.T) {
 	}
 
 	for _, input := range inputs {
-		require.Equal(t, input.expected, input.a.Equal(input.b))
-		require.Equal(t, input.expected, input.b.Equal(input.a))
+		require.Equal(t, input.expected, input.a.Equal(&input.b))
+		require.Equal(t, input.expected, input.b.Equal(&input.a))
 	}
 }

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -2062,7 +2062,7 @@ func expectedLocalMetricsForGauge(
 func verifyForwardedMetrics(t *testing.T, expected, actual []testForwardedMetricWithMetadata) {
 	require.Equal(t, len(expected), len(actual))
 	for i := 0; i < len(expected); i++ {
-		require.True(t, expected[i].aggregationKey.Equal(actual[i].aggregationKey))
+		require.True(t, expected[i].aggregationKey.Equal(&actual[i].aggregationKey))
 		require.Equal(t, expected[i].timeNanos, actual[i].timeNanos)
 		if math.IsNaN(expected[i].value) {
 			require.True(t, math.IsNaN(actual[i].value))
@@ -2075,7 +2075,7 @@ func verifyForwardedMetrics(t *testing.T, expected, actual []testForwardedMetric
 func verifyOnForwardedFlushResult(t *testing.T, expected, actual []testOnForwardedFlushedData) {
 	require.Equal(t, len(expected), len(actual))
 	for i := 0; i < len(expected); i++ {
-		require.True(t, expected[i].aggregationKey.Equal(actual[i].aggregationKey))
+		require.True(t, expected[i].aggregationKey.Equal(&actual[i].aggregationKey))
 	}
 }
 

--- a/src/aggregator/aggregator/entry_benchmark_test.go
+++ b/src/aggregator/aggregator/entry_benchmark_test.go
@@ -1,0 +1,116 @@
+package aggregator
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3/src/metrics/aggregation"
+	"github.com/m3db/m3/src/metrics/pipeline"
+	"github.com/m3db/m3/src/metrics/pipeline/applied"
+	"github.com/m3db/m3/src/metrics/policy"
+	"github.com/m3db/m3/src/metrics/transformation"
+	xtime "github.com/m3db/m3/src/x/time"
+)
+
+func BenchmarkAggregationValues(b *testing.B) {
+	aggregationKeys := []aggregationKey{
+		{
+			aggregationID: aggregation.DefaultID,
+			storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			pipeline: applied.NewPipeline([]applied.OpUnion{
+				{
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+				},
+				{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
+						ID:            []byte("foo.baz1234"),
+						AggregationID: aggregation.DefaultID,
+					},
+				},
+			}),
+		},
+		{
+			aggregationID: aggregation.DefaultID,
+			storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			pipeline: applied.NewPipeline([]applied.OpUnion{
+				{
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+				},
+				{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
+						ID:            []byte("foo.baz55"),
+						AggregationID: aggregation.DefaultID,
+					},
+				},
+			}),
+		},
+		{
+			aggregationID: aggregation.DefaultID,
+			storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			pipeline: applied.NewPipeline([]applied.OpUnion{
+				{
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+				},
+				{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
+						ID:            []byte("foo.baz45"),
+						AggregationID: aggregation.DefaultID,
+					},
+				},
+			}),
+		},
+		{
+			aggregationID: aggregation.DefaultID,
+			storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			pipeline: applied.NewPipeline([]applied.OpUnion{
+				{
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+				},
+				{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
+						ID:            []byte("foo.baz1234"),
+						AggregationID: aggregation.DefaultID,
+					},
+				},
+			}),
+		},
+		{
+			aggregationID: aggregation.DefaultID,
+			storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, 48*time.Hour),
+			pipeline: applied.NewPipeline([]applied.OpUnion{
+				{
+					Type:           pipeline.TransformationOpType,
+					Transformation: pipeline.TransformationOp{Type: transformation.Absolute},
+				},
+				{
+					Type: pipeline.RollupOpType,
+					Rollup: applied.RollupOp{
+						ID:            []byte("foo.baz42"),
+						AggregationID: aggregation.DefaultID,
+					},
+				},
+			}),
+		},
+	}
+
+	vals := make(aggregationValues, len(aggregationKeys))
+	for i := range aggregationKeys {
+		vals[i] = aggregationValue{key: aggregationKeys[i]}
+	}
+
+	b.ResetTimer()
+	var contains bool
+	for n := 0; n < b.N; n++ {
+		contains = vals.contains(&aggregationKeys[len(aggregationKeys)-1])
+	}
+	runtime.KeepAlive(contains)
+}

--- a/src/aggregator/aggregator/entry_test.go
+++ b/src/aggregator/aggregator/entry_test.go
@@ -372,8 +372,8 @@ func TestEntryAddBatchTimerWithTimerBatchSizeLimit(t *testing.T) {
 	require.Equal(t, 2, len(e.aggregations))
 	require.Equal(t, 1, len(testDefaultStagedMetadatas))
 	require.Equal(t, 1, len(testDefaultStagedMetadatas[0].Pipelines))
-	for _, key := range testDefaultAggregationKeys {
-		idx := e.aggregations.index(key)
+	for i := range testDefaultAggregationKeys {
+		idx := e.aggregations.index(&testDefaultAggregationKeys[i])
 		require.True(t, idx >= 0)
 		elem := e.aggregations[idx].elem.Value.(*TimerElem)
 		require.Equal(t, 1, len(elem.values))
@@ -1327,7 +1327,7 @@ func TestEntryAddTimed(t *testing.T) {
 		storagePolicy:      testTimedMetadata.StoragePolicy,
 		idPrefixSuffixType: NoPrefixNoSuffix,
 	}
-	idx := e.aggregations.index(expectedKey)
+	idx := e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem := e.aggregations[idx].elem
 	require.Equal(t, 1, len(lists.lists))
@@ -1353,7 +1353,7 @@ func TestEntryAddTimed(t *testing.T) {
 	// Add the timed metric again with duplicate metadata should not result in an error.
 	require.NoError(t, e.AddTimed(testTimedMetric, testTimedMetadata))
 	require.Equal(t, 1, len(e.aggregations))
-	idx = e.aggregations.index(expectedKey)
+	idx = e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem = e.aggregations[idx].elem
 	values = expectedElem.Value.(*CounterElem).values
@@ -1367,7 +1367,7 @@ func TestEntryAddTimed(t *testing.T) {
 	metric.TimeNanos += testTimedMetadata.StoragePolicy.Resolution().Window.Nanoseconds()
 	require.NoError(t, e.AddTimed(metric, testTimedMetadata))
 	require.Equal(t, 1, len(e.aggregations))
-	idx = e.aggregations.index(expectedKey)
+	idx = e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem = e.aggregations[idx].elem
 	values = expectedElem.Value.(*CounterElem).values
@@ -1390,13 +1390,13 @@ func TestEntryAddTimed(t *testing.T) {
 		storagePolicy:      metadata.StoragePolicy,
 		idPrefixSuffixType: NoPrefixNoSuffix,
 	}
-	idx = e.aggregations.index(expectedKey)
+	idx = e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem = e.aggregations[idx].elem
 	values = expectedElem.Value.(*CounterElem).values
 	require.Equal(t, 2, len(values))
 	checkElemTombstoned(t, expectedElem.Value.(metricElem), nil)
-	idx = e.aggregations.index(expectedKeyNew)
+	idx = e.aggregations.index(&expectedKeyNew)
 	require.True(t, idx >= 0)
 	expectedElemNew := e.aggregations[idx].elem
 	require.Equal(t, 2, len(lists.lists))
@@ -1536,7 +1536,7 @@ func TestEntryAddForwarded(t *testing.T) {
 		numForwardedTimes:  testForwardMetadata1.NumForwardedTimes,
 		idPrefixSuffixType: WithPrefixWithSuffix,
 	}
-	idx := e.aggregations.index(expectedKey)
+	idx := e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem := e.aggregations[idx].elem
 	require.Equal(t, 1, len(lists.lists))
@@ -1563,7 +1563,7 @@ func TestEntryAddForwarded(t *testing.T) {
 	// Add the forwarded metric again with duplicate metadata should not result in an error.
 	require.NoError(t, e.AddForwarded(testForwardedMetric, testForwardMetadata1))
 	require.Equal(t, 1, len(e.aggregations))
-	idx = e.aggregations.index(expectedKey)
+	idx = e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem = e.aggregations[idx].elem
 	values = expectedElem.Value.(*CounterElem).values
@@ -1576,7 +1576,7 @@ func TestEntryAddForwarded(t *testing.T) {
 	metadata.SourceID = 67890
 	require.NoError(t, e.AddForwarded(testForwardedMetric, metadata))
 	require.Equal(t, 1, len(e.aggregations))
-	idx = e.aggregations.index(expectedKey)
+	idx = e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem = e.aggregations[idx].elem
 	values = expectedElem.Value.(*CounterElem).values
@@ -1589,7 +1589,7 @@ func TestEntryAddForwarded(t *testing.T) {
 	metric.TimeNanos += testForwardMetadata1.StoragePolicy.Resolution().Window.Nanoseconds()
 	require.NoError(t, e.AddForwarded(metric, testForwardMetadata1))
 	require.Equal(t, 1, len(e.aggregations))
-	idx = e.aggregations.index(expectedKey)
+	idx = e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem = e.aggregations[idx].elem
 	values = expectedElem.Value.(*CounterElem).values
@@ -1612,13 +1612,13 @@ func TestEntryAddForwarded(t *testing.T) {
 		numForwardedTimes:  testForwardMetadata2.NumForwardedTimes,
 		idPrefixSuffixType: WithPrefixWithSuffix,
 	}
-	idx = e.aggregations.index(expectedKey)
+	idx = e.aggregations.index(&expectedKey)
 	require.True(t, idx >= 0)
 	expectedElem = e.aggregations[idx].elem
 	values = expectedElem.Value.(*CounterElem).values
 	require.Equal(t, 2, len(values))
 	checkElemTombstoned(t, expectedElem.Value.(metricElem), nil)
-	idx = e.aggregations.index(expectedKeyNew)
+	idx = e.aggregations.index(&expectedKeyNew)
 	require.True(t, idx >= 0)
 	expectedElemNew := e.aggregations[idx].elem
 	require.Equal(t, 2, len(lists.lists))
@@ -1784,8 +1784,8 @@ func TestAggregationValues(t *testing.T) {
 		},
 	}
 	for _, input := range inputs {
-		require.Equal(t, input.expectedIndex, vals.index(input.key))
-		require.Equal(t, input.expectedContains, vals.contains(input.key))
+		require.Equal(t, input.expectedIndex, vals.index(&input.key))
+		require.Equal(t, input.expectedContains, vals.contains(&input.key))
 	}
 }
 
@@ -1952,8 +1952,9 @@ func testEntryAddUntimed(
 		require.Equal(t, now.UnixNano(), e.lastAccessNanos)
 
 		require.Equal(t, len(expectedAggregationKeys), len(e.aggregations))
-		for _, key := range expectedAggregationKeys {
-			idx := e.aggregations.index(key)
+		for i := range expectedAggregationKeys {
+			key := expectedAggregationKeys[i]
+			idx := e.aggregations.index(&key)
 			require.True(t, idx >= 0)
 			elem := e.aggregations[idx].elem
 			input.fn(t, elem, now.Truncate(key.storagePolicy.Resolution().Window))
@@ -1983,7 +1984,7 @@ func aggregationKeys(pipelines []metadata.PipelineMetadata) []aggregationKey {
 	for i := 0; i < len(aggregationKeys); i++ {
 		found := false
 		for j := 0; j < i; j++ {
-			if aggregationKeys[i].Equal(aggregationKeys[j]) {
+			if aggregationKeys[i].Equal(&aggregationKeys[j]) {
 				found = true
 				break
 			}

--- a/src/aggregator/aggregator/forwarded_writer_test.go
+++ b/src/aggregator/aggregator/forwarded_writer_test.go
@@ -128,7 +128,7 @@ func TestForwardedWriterRegisterNewAggregation(t *testing.T) {
 	// Validate that the aggregation key has been added.
 	require.Equal(t, 1, len(agg.byKey))
 	require.Equal(t, 1, agg.byKey[0].totalRefCnt)
-	require.True(t, aggKey.Equal(agg.byKey[0].key))
+	require.True(t, aggKey.Equal(&agg.byKey[0].key))
 	require.Equal(t, 0, len(agg.byKey[0].buckets))
 
 	// Validate that writeFn can be used to write data to the aggregation.

--- a/src/metrics/pipeline/applied/type.go
+++ b/src/metrics/pipeline/applied/type.go
@@ -186,7 +186,7 @@ func (p Pipeline) IsEmpty() bool { return p.Len() == 0 }
 func (p Pipeline) At(i int) OpUnion { return p.operations[i] }
 
 // Equal determines whether two pipelines are equal.
-func (p Pipeline) Equal(other Pipeline) bool {
+func (p *Pipeline) Equal(other Pipeline) bool {
 	if len(p.operations) != len(other.operations) {
 		return false
 	}

--- a/src/metrics/pipeline/type.go
+++ b/src/metrics/pipeline/type.go
@@ -200,10 +200,10 @@ func NewRollupOpFromProto(pb *pipelinepb.RollupOp) (RollupOp, error) {
 // SameTransform returns true if the two rollup operations have the same rollup transformation
 // (i.e., same new rollup metric name and same set of rollup tags).
 func (op RollupOp) SameTransform(other RollupOp) bool {
-	if !bytes.Equal(op.NewName, other.NewName) {
+	if len(op.Tags) != len(other.Tags) {
 		return false
 	}
-	if len(op.Tags) != len(other.Tags) {
+	if !bytes.Equal(op.NewName, other.NewName) {
 		return false
 	}
 	// Sort the tags and compare.
@@ -220,7 +220,7 @@ func (op RollupOp) SameTransform(other RollupOp) bool {
 }
 
 // Equal returns true if two rollup operations are equal.
-func (op RollupOp) Equal(other RollupOp) bool {
+func (op *RollupOp) Equal(other RollupOp) bool {
 	if !op.AggregationID.Equal(other.AggregationID) {
 		return false
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The heavy copy takes up approx 30% of the time in both profiles and benchmarks, which is totally unnecessary.
```
name                  old time/op    new time/op    delta
AggregationValues-12     108ns ± 3%      76ns ± 0%  -29.35%  (p=0.008 n=5+5)

name                  old alloc/op   new alloc/op   delta
AggregationValues-12     0.00B          0.00B          ~     (all equal)

name                  old allocs/op  new allocs/op  delta
AggregationValues-12      0.00           0.00          ~     (all equal)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
