### PR TITLE
[instrument] Improve sampled timer and stopwatch performance

### DIFF
--- a/src/x/instrument/methods_benchmark_test.go
+++ b/src/x/instrument/methods_benchmark_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package instrument
 
 import (

--- a/src/x/instrument/methods_benchmark_test.go
+++ b/src/x/instrument/methods_benchmark_test.go
@@ -1,0 +1,52 @@
+package instrument
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/uber-go/tally"
+)
+
+func BenchmarkSampledTimer(b *testing.B) {
+	tm := MustCreateSampledTimer(tally.NoopScope.Timer("test"), 0.5)
+	benchRecord(b, tm)
+	runtime.KeepAlive(tm)
+}
+
+func BenchmarkSampledTimerLowRate(b *testing.B) {
+	tm := MustCreateSampledTimer(tally.NoopScope.Timer("test"), 0.5)
+	benchRecord(b, tm)
+	runtime.KeepAlive(tm)
+}
+
+func BenchmarkSampledTimerStopwatch(b *testing.B) {
+	tm := MustCreateSampledTimer(tally.NoopScope.Timer("test"), 0.5)
+	benchStopwatch(b, tm)
+	runtime.KeepAlive(tm)
+}
+
+func BenchmarkSampledTimerStopwatchLowRate(b *testing.B) {
+	tm := MustCreateSampledTimer(tally.NoopScope.Timer("test"), 0.01)
+	benchStopwatch(b, tm)
+	runtime.KeepAlive(tm)
+}
+
+func benchStopwatch(b *testing.B, tm tally.Timer) {
+	b.RunParallel(func(pb *testing.PB) {
+		var sw tally.Stopwatch
+		for pb.Next() {
+			sw = tm.Start()
+			sw.Stop()
+		}
+		runtime.KeepAlive(sw)
+	})
+}
+
+func benchRecord(b *testing.B, tm tally.Timer) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			tm.Record(1 * time.Second)
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
```
name                             old time/op  new time/op  delta
SampledTimer                     18.0ns ± 3%  11.0ns ± 5%  -38.92%  (p=0.000 n=9+9)
SampledTimer-6                   33.5ns ± 2%   2.1ns ±11%  -93.59%  (p=0.000 n=9+10)
SampledTimer-12                  30.5ns ± 7%   1.6ns ± 5%  -94.80%  (p=0.000 n=10+10)
SampledTimerLowRate              18.0ns ± 4%  10.6ns ± 1%  -40.76%  (p=0.000 n=10+10)
SampledTimerLowRate-6            33.5ns ± 2%   2.0ns ± 2%  -94.17%  (p=0.000 n=10+8)
SampledTimerLowRate-12           29.5ns ± 5%   1.6ns ± 6%  -94.65%  (p=0.000 n=10+10)
SampledTimerStopwatch             100ns ± 2%    89ns ± 1%  -11.12%  (p=0.000 n=10+10)
SampledTimerStopwatch-6          37.3ns ± 3%  16.1ns ± 4%  -56.89%  (p=0.000 n=10+10)
SampledTimerStopwatch-12         33.1ns ± 5%  11.9ns ± 7%  -63.94%  (p=0.000 n=10+10)
SampledTimerStopwatchLowRate     22.1ns ± 7%   9.4ns ± 1%  -57.59%  (p=0.000 n=10+9)
SampledTimerStopwatchLowRate-6   31.6ns ± 3%   1.7ns ± 8%  -94.47%  (p=0.000 n=10+10)
SampledTimerStopwatchLowRate-12  27.3ns ± 6%   1.6ns ± 5%  -94.01%  (p=0.000 n=10+10)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
