### PR TITLE
Add background cancel monitor for index query

### DIFF
--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1564,11 +1564,11 @@ func (i *nsIndex) queryWithSpan(
 		state = asyncQueryExecState{
 			exhaustive: true,
 		}
-		deadline               = start.Add(timeout)
-		wg                     sync.WaitGroup
-		queryDoneCh            = make(chan struct{})
-		monitorCh              = make(chan monitorResult)
-		totalWaitTime          time.Duration
+		deadline      = start.Add(timeout)
+		wg            sync.WaitGroup
+		queryDoneCh   = make(chan struct{})
+		monitorCh     = make(chan monitorResult)
+		totalWaitTime time.Duration
 	)
 
 	// Create a cancellable lifetime and cancel it at end of this method so that
@@ -1676,7 +1676,7 @@ func (i *nsIndex) queryWithSpan(
 	err = state.multiErr.FinalError()
 	state.Unlock()
 
-	if err != nil && err != index.ErrCancelledQuery {
+	if err != nil && !errors.Is(err, index.ErrCancelledQuery) {
 		// an unexpected error occurred processing the query, bail without updating timing metrics.
 		// if the err ir ErrCancelledQuery, the monitor will report a timeout.
 		return false, err

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1569,7 +1569,6 @@ func (i *nsIndex) queryWithSpan(
 		queryDoneCh            = make(chan struct{})
 		monitorCh              = make(chan monitorResult)
 		totalWaitTime          time.Duration
-		indexMatchingStartTime = time.Now()
 	)
 
 	// Create a cancellable lifetime and cancel it at end of this method so that
@@ -1689,7 +1688,7 @@ func (i *nsIndex) queryWithSpan(
 	}
 
 	// update timing metrics even if the query was canceled due to a timeout
-	queryRuntime := time.Since(indexMatchingStartTime)
+	queryRuntime := time.Since(start)
 	queryRange := opts.EndExclusive.Sub(opts.StartInclusive)
 
 	i.metrics.queryTotalTime.ByRange.Record(queryRange, queryRuntime)

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -57,8 +57,8 @@ var (
 	ErrUnableToQueryBlockClosed = errors.New("unable to query, index block is closed")
 	// ErrUnableReportStatsBlockClosed is returned from Stats when the block is closed.
 	ErrUnableReportStatsBlockClosed = errors.New("unable to report stats, block is closed")
-	// ErrCancelledQuery is returned when the block processing is cancelled before finishing.
-	ErrCancelledQuery               = errors.New("query was cancelled")
+	// ErrCancelledQuery is returned when the block processing is canceled before finishing.
+	ErrCancelledQuery = errors.New("query was canceled")
 
 	errUnableToWriteBlockClosed     = errors.New("unable to write, index block is closed")
 	errUnableToWriteBlockSealed     = errors.New("unable to write, index block is sealed")

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -57,13 +57,14 @@ var (
 	ErrUnableToQueryBlockClosed = errors.New("unable to query, index block is closed")
 	// ErrUnableReportStatsBlockClosed is returned from Stats when the block is closed.
 	ErrUnableReportStatsBlockClosed = errors.New("unable to report stats, block is closed")
+	// ErrCancelledQuery is returned when the block processing is cancelled before finishing.
+	ErrCancelledQuery               = errors.New("query was cancelled")
 
 	errUnableToWriteBlockClosed     = errors.New("unable to write, index block is closed")
 	errUnableToWriteBlockSealed     = errors.New("unable to write, index block is sealed")
 	errUnableToBootstrapBlockClosed = errors.New("unable to bootstrap, block is closed")
 	errUnableToTickBlockClosed      = errors.New("unable to tick, block is closed")
 	errBlockAlreadyClosed           = errors.New("unable to close, block already closed")
-	errCancelledQuery               = errors.New("query was cancelled")
 
 	errUnableToSealBlockIllegalStateFmtString  = "unable to seal, index block state: %v"
 	errUnableToWriteBlockUnknownStateFmtString = "unable to write, unknown index block state: %v"
@@ -473,7 +474,7 @@ func (b *block) queryWithSpan(
 	// which means it can't be used for finalization any longer.
 	valid := cancellable.TryCheckout()
 	if !valid {
-		return false, errCancelledQuery
+		return false, ErrCancelledQuery
 	}
 	execCloseRegistered = true // Make sure to not locally close it.
 	ctx.RegisterFinalizer(xresource.FinalizerFn(func() {
@@ -560,7 +561,7 @@ func (b *block) addQueryResults(
 	queryValid := cancellable.TryCheckout()
 	if !queryValid {
 		// query not valid any longer, do not add results and return early.
-		return batch, 0, 0, errCancelledQuery
+		return batch, 0, 0, ErrCancelledQuery
 	}
 
 	// try to add the docs to the xresource.
@@ -824,7 +825,7 @@ func (b *block) addAggregateResults(
 	queryValid := cancellable.TryCheckout()
 	if !queryValid {
 		// query not valid any longer, do not add results and return early.
-		return batch, 0, 0, errCancelledQuery
+		return batch, 0, 0, ErrCancelledQuery
 	}
 
 	// try to add the docs to the xresource.

--- a/src/dbnode/storage/index/block_test.go
+++ b/src/dbnode/storage/index/block_test.go
@@ -399,7 +399,7 @@ func TestBlockQueryWithCancelledQuery(t *testing.T) {
 	_, err = b.Query(context.NewContext(), cancellable,
 		defaultQuery, QueryOptions{}, results, emptyLogFields)
 	require.Error(t, err)
-	require.Equal(t, errCancelledQuery, err)
+	require.Equal(t, ErrCancelledQuery, err)
 }
 
 func TestBlockQueryExecutorError(t *testing.T) {

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -379,7 +379,6 @@ func TestNamespaceIndexQueryNoMatchingBlocks(t *testing.T) {
 }
 
 func TestNamespaceIndexQueryTimeout(t *testing.T) {
-	
 }
 
 func verifyFlushForShards(
@@ -468,11 +467,11 @@ func verifyFlushForShards(
 			resultsTags1 := ident.NewTagsIterator(ident.NewTags())
 			resultsTags2 := ident.NewTagsIterator(ident.NewTags())
 			resultsInShard := []block.FetchBlocksMetadataResult{
-				block.FetchBlocksMetadataResult{
+				{
 					ID:   resultsID1,
 					Tags: resultsTags1,
 				},
-				block.FetchBlocksMetadataResult{
+				{
 					ID:   resultsID2,
 					Tags: resultsTags2,
 				},

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -378,6 +378,10 @@ func TestNamespaceIndexQueryNoMatchingBlocks(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNamespaceIndexQueryTimeout(t *testing.T) {
+	
+}
+
 func verifyFlushForShards(
 	t *testing.T,
 	ctrl *gomock.Controller,


### PR DESCRIPTION
Use a background monitor to cancel the index query after the timeout.
This prevents a race in the previous code that only checked the timeout
when scheduling a new worker. Once a worker was dispatched it could in
theory run forever since it would not recheck the timeout.

Now the background goroutine will cancel the worker after the timeout.
The worker checks the cancelation after each batch, so at worst a worker
will process one more additional batch after the timeout.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
