### PR TITLE
[aggregator] Checking if metadata is set to default should not cause …

### DIFF
--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -100,10 +100,10 @@ func (m PipelineMetadata) Equal(other PipelineMetadata) bool {
 
 // IsDefault returns whether this is the default standard pipeline metadata.
 func (m PipelineMetadata) IsDefault() bool {
-	return m.AggregationID.IsDefault() &&
-		m.StoragePolicies.IsDefault() &&
+	return m.AggregationID == aggregation.DefaultID &&
+		len(m.StoragePolicies) == 0 &&
 		m.Pipeline.IsEmpty() &&
-		m.DropPolicy.IsDefault()
+		m.DropPolicy == policy.DefaultDropPolicy
 }
 
 // IsMappingRule returns whether this is a rollup rule pipeline metadata.
@@ -435,7 +435,13 @@ func (sms StagedMetadatas) Equal(other StagedMetadatas) bool {
 
 // IsDefault determines whether the list of staged metadata is a default list.
 func (sms StagedMetadatas) IsDefault() bool {
-	return len(sms) == 1 && sms[0].IsDefault()
+	// very ugly but need to help out the go compiler here, as function calls have a high inlining cost
+	return len(sms) == 1 && len(sms[0].Pipelines) == 1 &&
+		sms[0].CutoverNanos == 0 && !sms[0].Tombstoned &&
+		sms[0].Pipelines[0].AggregationID == aggregation.DefaultID &&
+		len(sms[0].Pipelines[0].StoragePolicies) == 0 &&
+		sms[0].Pipelines[0].Pipeline.IsEmpty() &&
+		sms[0].Pipelines[0].DropPolicy == policy.DefaultDropPolicy
 }
 
 // IsDropPolicyApplied returns whether the list of staged metadata is the

--- a/src/metrics/metadata/metadata_benchmark_test.go
+++ b/src/metrics/metadata/metadata_benchmark_test.go
@@ -23,6 +23,9 @@ package metadata
 import (
 	"runtime"
 	"testing"
+
+	"github.com/m3db/m3/src/metrics/aggregation"
+	"github.com/m3db/m3/src/metrics/policy"
 )
 
 func isDefault(m StagedMetadatas) bool {
@@ -30,11 +33,22 @@ func isDefault(m StagedMetadatas) bool {
 }
 
 func BenchmarkMetadata_IsDefault(b *testing.B) {
-	m := testLargeStagedMetadatas
-	m = append(m, testLargeStagedMetadatas...)
+	m := StagedMetadatas{
+		StagedMetadata{
+			CutoverNanos: 0,
+			Tombstoned:   false,
+			Metadata: Metadata{
+				Pipelines: []PipelineMetadata{
+					{
+						AggregationID:   aggregation.DefaultID,
+						StoragePolicies: []policy.StoragePolicy{},
+					},
+				},
+			},
+		},
+	}
 	for i := 0; i < b.N; i++ {
-		m[0].CutoverNanos = int64(i)
-		if isDefault(m) {
+		if !isDefault(m) {
 			b.Fail()
 		}
 	}

--- a/src/metrics/metadata/metadata_test.go
+++ b/src/metrics/metadata/metadata_test.go
@@ -700,7 +700,10 @@ func TestStagedMetadatasIsDefault(t *testing.T) {
 	}
 
 	for _, input := range inputs {
-		require.Equal(t, input.expected, input.metadatas.IsDefault())
+		input := input
+		t.Run(fmt.Sprintf("%v", input.metadatas), func(t *testing.T) {
+			require.Equal(t, input.expected, input.metadatas.IsDefault())
+		})
 	}
 }
 

--- a/src/metrics/pipeline/applied/type.go
+++ b/src/metrics/pipeline/applied/type.go
@@ -180,7 +180,7 @@ func NewPipeline(ops []OpUnion) Pipeline {
 func (p Pipeline) Len() int { return len(p.operations) }
 
 // IsEmpty determines whether a pipeline is empty.
-func (p Pipeline) IsEmpty() bool { return p.Len() == 0 }
+func (p Pipeline) IsEmpty() bool { return len(p.operations) == 0 }
 
 // At returns the operation at a given step.
 func (p Pipeline) At(i int) OpUnion { return p.operations[i] }


### PR DESCRIPTION
…copying

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The microbenchmarks don't tell the entire story, as it's much harder the copying in real code. Metadata checks are actually contributing to overall copying and wasting cache bandwidth.
Again, all because compiler doesn't like inlining the rather deep call stacks.
```
benchmark                          old ns/op     new ns/op     delta
BenchmarkMetadata_IsDefault-12     6.86          2.58          -62.39%
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
