### PR TITLE
[dbnode] Update WriteShardsInitializing comment

### DIFF
--- a/src/dbnode/client/config.go
+++ b/src/dbnode/client/config.go
@@ -115,8 +115,8 @@ type Configuration struct {
 	// from the remote peer. Defaults to 4096.
 	FetchSeriesBlocksBatchSize *int `yaml:"fetchSeriesBlocksBatchSize"`
 
-	// WriteShardsInitializing sets whether or not writes to leaving shards
-	// count towards consistency, by default they do not.
+	// WriteShardsInitializing sets whether or not to write to shards that are initializing.
+	// Defaults to true.
 	WriteShardsInitializing *bool `yaml:"writeShardsInitializing"`
 
 	// ShardsLeavingCountTowardsConsistency sets whether or not writes to leaving shards


### PR DESCRIPTION
The comment for WriteShardsInitializing was a duplicate of the comment for ShardsLeavingCountTowardsConsistency, this PR adds a relevant comment.