### PR TITLE
Remove optional go ctx from m3 ctx

### DIFF
--- a/src/dbnode/integration/commitlog_bootstrap_helpers.go
+++ b/src/dbnode/integration/commitlog_bootstrap_helpers.go
@@ -166,7 +166,7 @@ func writeCommitLogDataBase(
 		} else {
 			s.SetNowFn(currTs.ToTime())
 		}
-		ctx := context.NewContext()
+		ctx := context.NewBackground()
 		defer ctx.Close()
 
 		m := map[xtime.UnixNano]generate.SeriesBlock{

--- a/src/dbnode/network/server/tchannelthrift/context.go
+++ b/src/dbnode/network/server/tchannelthrift/context.go
@@ -21,8 +21,8 @@
 package tchannelthrift
 
 import (
-	"time"
 	stdctx "context"
+	"time"
 
 	"github.com/m3db/m3/src/x/context"
 
@@ -42,7 +42,7 @@ func RegisterServer(channel *tchannel.Channel, service thrift.TChanServer, conte
 	server.SetContextFn(func(ctx stdctx.Context, method string, headers map[string]string) thrift.Context {
 		xCtx := contextPool.Get()
 		xCtx.SetGoContext(ctx)
-		ctxWithValue := stdctx.WithValue(ctx, contextKey, xCtx)
+		ctxWithValue := stdctx.WithValue(ctx, contextKey, xCtx) //nolint: staticcheck
 		return thrift.WithHeaders(ctxWithValue, headers)
 	})
 }
@@ -51,7 +51,7 @@ func RegisterServer(channel *tchannel.Channel, service thrift.TChanServer, conte
 func NewContext(timeout time.Duration) (thrift.Context, stdctx.CancelFunc) {
 	tctx, cancel := thrift.NewContext(timeout)
 	xCtx := context.NewWithGoContext(tctx)
-	ctxWithValue := stdctx.WithValue(tctx, contextKey, xCtx)
+	ctxWithValue := stdctx.WithValue(tctx, contextKey, xCtx) //nolint: staticcheck
 	return thrift.WithHeaders(ctxWithValue, nil), cancel
 }
 

--- a/src/dbnode/network/server/tchannelthrift/context.go
+++ b/src/dbnode/network/server/tchannelthrift/context.go
@@ -22,13 +22,13 @@ package tchannelthrift
 
 import (
 	"time"
+	stdctx "context"
 
 	"github.com/m3db/m3/src/x/context"
 
 	apachethrift "github.com/apache/thrift/lib/go/thrift"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/thrift"
-	xnetcontext "golang.org/x/net/context"
 )
 
 const (
@@ -39,18 +39,19 @@ const (
 func RegisterServer(channel *tchannel.Channel, service thrift.TChanServer, contextPool context.Pool) {
 	server := thrift.NewServer(channel)
 	server.Register(service, thrift.OptPostResponse(postResponseFn))
-	server.SetContextFn(func(ctx xnetcontext.Context, method string, headers map[string]string) thrift.Context {
+	server.SetContextFn(func(ctx stdctx.Context, method string, headers map[string]string) thrift.Context {
 		xCtx := contextPool.Get()
 		xCtx.SetGoContext(ctx)
-		ctxWithValue := xnetcontext.WithValue(ctx, contextKey, xCtx)
+		ctxWithValue := stdctx.WithValue(ctx, contextKey, xCtx)
 		return thrift.WithHeaders(ctxWithValue, headers)
 	})
 }
 
 // NewContext returns a new thrift context and cancel func with embedded M3DB context
-func NewContext(timeout time.Duration) (thrift.Context, xnetcontext.CancelFunc) {
+func NewContext(timeout time.Duration) (thrift.Context, stdctx.CancelFunc) {
 	tctx, cancel := thrift.NewContext(timeout)
-	ctxWithValue := xnetcontext.WithValue(tctx, contextKey, context.NewContext())
+	xCtx := context.NewWithGoContext(tctx)
+	ctxWithValue := stdctx.WithValue(tctx, contextKey, xCtx)
 	return thrift.WithHeaders(ctxWithValue, nil), cancel
 }
 
@@ -59,7 +60,7 @@ func Context(ctx thrift.Context) context.Context {
 	return ctx.Value(contextKey).(context.Context)
 }
 
-func postResponseFn(ctx xnetcontext.Context, method string, response apachethrift.TStruct) {
+func postResponseFn(ctx stdctx.Context, method string, response apachethrift.TStruct) {
 	value := ctx.Value(contextKey)
 	inner := value.(context.Context)
 	inner.Close()

--- a/src/dbnode/network/server/tchannelthrift/node/fetch_result_iter_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/fetch_result_iter_test.go
@@ -41,7 +41,7 @@ import (
 
 func TestFetchResultIterTest(t *testing.T) {
 	scope := tally.NewTestScope("", map[string]string{})
-	ctx := context.NewContext()
+	ctx := context.NewBackground()
 	mocks := gomock.NewController(t)
 	defer mocks.Finish()
 

--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -2862,12 +2862,7 @@ func addSourceToContext(tctx thrift.Context, source []byte) context.Context {
 
 func addSourceToM3Context(ctx context.Context, source []byte) context.Context {
 	if len(source) > 0 {
-		if base, ok := ctx.GoContext(); ok {
-			ctx.SetGoContext(goctx.WithValue(base, limits.SourceContextKey, source))
-		} else {
-			ctx.SetGoContext(goctx.WithValue(goctx.Background(), limits.SourceContextKey, source))
-		}
+		ctx.SetGoContext(goctx.WithValue(ctx.GoContext(), limits.SourceContextKey, source))
 	}
-
 	return ctx
 }

--- a/src/dbnode/persist/fs/retriever.go
+++ b/src/dbnode/persist/fs/retriever.go
@@ -661,11 +661,9 @@ func (r *blockRetriever) Stream(
 	req.onRetrieve = onRetrieve
 	req.streamReqType = streamDataReq
 
-	goCtx, found := ctx.GoContext()
-	if found {
-		if source, ok := goCtx.Value(limits.SourceContextKey).([]byte); ok {
-			req.source = source
-		}
+	goCtx := ctx.GoContext()
+	if source, ok := goCtx.Value(limits.SourceContextKey).([]byte); ok {
+		req.source = source
 	}
 
 	err = r.streamRequest(ctx, req, shard, id, startTime)

--- a/src/dbnode/storage/bootstrap.go
+++ b/src/dbnode/storage/bootstrap.go
@@ -194,7 +194,7 @@ func (m *bootstrapManager) Report() {
 }
 
 func (m *bootstrapManager) bootstrap() error {
-	ctx := context.NewContext()
+	ctx := context.NewBackground()
 	defer ctx.Close()
 
 	// NB(r): construct new instance of the bootstrap process to avoid

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/source.go
@@ -936,7 +936,7 @@ func (s *commitLogSource) readCommitLogFilePredicate(f commitlog.FileFilterInfo)
 }
 
 func (s *commitLogSource) startAccumulateWorker(worker *accumulateWorker) {
-	ctx := context.NewContext()
+	ctx := context.NewBackground()
 	defer ctx.Close()
 
 	for input := range worker.inputCh {

--- a/src/dbnode/storage/bootstrap/util.go
+++ b/src/dbnode/storage/bootstrap/util.go
@@ -240,7 +240,7 @@ func (a *TestDataAccumulator) checkoutSeriesWithLock(
 	mockSeries.EXPECT().
 		LoadBlock(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(bl block.DatabaseBlock, _ series.WriteType) error {
-			reader, err := bl.Stream(context.NewContext())
+			reader, err := bl.Stream(context.NewBackground())
 			if err != nil {
 				streamErr = err
 				return err
@@ -572,7 +572,7 @@ func (nt *NamespacesTester) ResultForNamespace(id ident.ID) NamespaceResult {
 // TestBootstrapWith bootstraps the current Namespaces with the
 // provided bootstrapper.
 func (nt *NamespacesTester) TestBootstrapWith(b Bootstrapper) {
-	ctx := context.NewContext()
+	ctx := context.NewBackground()
 	defer ctx.Close()
 	res, err := b.Bootstrap(ctx, nt.Namespaces, nt.Cache)
 	assert.NoError(nt.t, err)
@@ -582,7 +582,7 @@ func (nt *NamespacesTester) TestBootstrapWith(b Bootstrapper) {
 // TestReadWith reads the current Namespaces with the
 // provided bootstrap source.
 func (nt *NamespacesTester) TestReadWith(s Source) {
-	ctx := context.NewContext()
+	ctx := context.NewBackground()
 	defer ctx.Close()
 	res, err := s.Read(ctx, nt.Namespaces, nt.Cache)
 	require.NoError(nt.t, err)

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1581,7 +1581,7 @@ func (i *nsIndex) queryWithSpan(
 		}
 
 		wg.Add(1)
-		scheduleResult := i.queryWorkersPool.GoWithContext(ctx.MustGoContext(), func() {
+		scheduleResult := i.queryWorkersPool.GoWithContext(ctx.GoContext(), func() {
 			execBlockFn(ctx, block, query, opts, &state, results, logFields)
 			wg.Done()
 		})
@@ -2031,7 +2031,7 @@ func (i *nsIndex) DebugMemorySegments(opts DebugMemorySegmentsOptions) error {
 		return errDbIndexAlreadyClosed
 	}
 
-	ctx := context.NewContext()
+	ctx := context.NewBackground()
 	defer ctx.Close()
 
 	// Create a new set of file system options to output to new directory.

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -497,7 +497,7 @@ func (b *block) queryWithSpan(
 		// when includes the search time, and subsequent batch resets.
 		if len(batch) == 0 {
 			select {
-			case <-ctx.MustGoContext().Done():
+			case <-ctx.GoContext().Done():
 				// indexNs will log something useful.
 				return false, ErrCancelledQuery
 			default:
@@ -713,7 +713,7 @@ func (b *block) aggregateWithSpan(
 			// initial result when includes the search time, and subsequent batch resets.
 			if len(batch) == 0 {
 				select {
-				case <-ctx.MustGoContext().Done():
+				case <-ctx.GoContext().Done():
 					return false, ErrCancelledQuery
 				default:
 				}

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -414,7 +414,7 @@ func TestNamespaceIndexQueryTimeout(t *testing.T) {
 			r index.QueryResults,
 			logFields []opentracinglog.Field,
 		) (bool, error) {
-			<-ctx.MustGoContext().Done()
+			<-ctx.GoContext().Done()
 			return false, index.ErrCancelledQuery
 		})
 	mockBlock.EXPECT().Close().Return(nil)

--- a/src/dbnode/storage/limits/permits/lookback_limit_permit.go
+++ b/src/dbnode/storage/limits/permits/lookback_limit_permit.go
@@ -90,12 +90,7 @@ func (p *lookbackLimitPermit) Release() {
 }
 
 func sourceFromContext(ctx context.Context) []byte {
-	goctx, ok := ctx.GoContext()
-	if !ok {
-		return nil
-	}
-
-	val := goctx.Value(limits.SourceContextKey)
+	val := ctx.GoContext().Value(limits.SourceContextKey)
 	parsed, ok := val.([]byte)
 	if !ok {
 		return nil

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -570,7 +570,7 @@ func testNamespaceBootstrapUnfulfilledShards(
 ) {
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
-	ctx := context.NewContext()
+	ctx := context.NewBackground()
 	defer ctx.Close()
 
 	var (

--- a/src/x/context/context.go
+++ b/src/x/context/context.go
@@ -56,11 +56,6 @@ type finalizeable struct {
 	closer    xresource.SimpleCloser
 }
 
-// NewContext creates a new context.
-func NewContext() Context {
-	return newContext()
-}
-
 // NewWithGoContext creates a new context with the provided go ctx.
 func NewWithGoContext(goCtx stdctx.Context) Context {
 	ctx := newContext()
@@ -83,20 +78,8 @@ func newContext() *ctx {
 	return &ctx{}
 }
 
-func (c *ctx) GoContext() (stdctx.Context, bool) {
-	if c.goCtx == nil {
-		return nil, false
-	}
-
-	return c.goCtx, true
-}
-
-func (c *ctx) MustGoContext() stdctx.Context {
-	goCtx, found := c.GoContext()
-	if !found {
-		panic("no go ctx set")
-	}
-	return goCtx
+func (c *ctx) GoContext() stdctx.Context {
+	return c.goCtx
 }
 
 func (c *ctx) SetGoContext(v stdctx.Context) {
@@ -299,7 +282,7 @@ func (c *ctx) Reset() {
 	}
 
 	c.Lock()
-	c.done, c.finalizeables, c.goCtx, c.checkedAndNotSampled = false, nil, nil, false
+	c.done, c.finalizeables, c.goCtx, c.checkedAndNotSampled = false, nil, stdctx.Background(), false
 	c.Unlock()
 }
 
@@ -344,10 +327,10 @@ func (c *ctx) parentCtx() Context {
 }
 
 func (c *ctx) StartSampledTraceSpan(name string) (Context, opentracing.Span, bool) {
-	goCtx, exists := c.GoContext()
-	if !exists || c.checkedAndNotSampled {
+	if  c.checkedAndNotSampled {
 		return c, noopTracer.StartSpan(name), false
 	}
+	goCtx := c.GoContext()
 
 	childGoCtx, span, sampled := StartSampledTraceSpan(goCtx, name)
 	if !sampled {

--- a/src/x/context/context.go
+++ b/src/x/context/context.go
@@ -327,7 +327,7 @@ func (c *ctx) parentCtx() Context {
 }
 
 func (c *ctx) StartSampledTraceSpan(name string) (Context, opentracing.Span, bool) {
-	if  c.checkedAndNotSampled {
+	if c.checkedAndNotSampled {
 		return c, noopTracer.StartSpan(name), false
 	}
 	goCtx := c.GoContext()

--- a/src/x/context/context_test.go
+++ b/src/x/context/context_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestRegisterFinalizerWithChild(t *testing.T) {
-	xCtx := NewContext().(*ctx)
+	xCtx := NewBackground().(*ctx)
 	assert.Nil(t, xCtx.parentCtx())
 
 	childCtx := xCtx.newChildContext().(*ctx)
@@ -67,7 +67,7 @@ func TestRegisterFinalizer(t *testing.T) {
 	var (
 		wg     sync.WaitGroup
 		closed = false
-		ctx    = NewContext().(*ctx)
+		ctx    = NewBackground().(*ctx)
 	)
 
 	wg.Add(1)
@@ -85,7 +85,7 @@ func TestRegisterFinalizer(t *testing.T) {
 }
 
 func TestRegisterCloserWithChild(t *testing.T) {
-	xCtx := NewContext().(*ctx)
+	xCtx := NewBackground().(*ctx)
 	assert.Nil(t, xCtx.parentCtx())
 
 	childCtx := xCtx.newChildContext().(*ctx)
@@ -116,7 +116,7 @@ func TestRegisterCloser(t *testing.T) {
 	var (
 		wg     sync.WaitGroup
 		closed = false
-		ctx    = NewContext().(*ctx)
+		ctx    = NewBackground().(*ctx)
 	)
 
 	wg.Add(1)
@@ -134,7 +134,7 @@ func TestRegisterCloser(t *testing.T) {
 }
 
 func TestDoesNotRegisterFinalizerWhenClosed(t *testing.T) {
-	ctx := NewContext().(*ctx)
+	ctx := NewBackground().(*ctx)
 	ctx.Close()
 	ctx.RegisterFinalizer(xresource.FinalizerFn(func() {}))
 
@@ -142,7 +142,7 @@ func TestDoesNotRegisterFinalizerWhenClosed(t *testing.T) {
 }
 
 func TestDoesNotCloseTwice(t *testing.T) {
-	ctx := NewContext().(*ctx)
+	ctx := NewBackground().(*ctx)
 
 	var closed int32
 	ctx.RegisterFinalizer(xresource.FinalizerFn(func() {
@@ -159,18 +159,18 @@ func TestDoesNotCloseTwice(t *testing.T) {
 }
 
 func TestDependsOnNoCloserAllocation(t *testing.T) {
-	ctx := NewContext().(*ctx)
-	ctx.DependsOn(NewContext())
+	ctx := NewBackground().(*ctx)
+	ctx.DependsOn(NewBackground())
 	assert.Equal(t, 0, ctx.numFinalizeables())
 }
 
 func TestDependsOn(t *testing.T) {
-	ctx := NewContext().(*ctx)
+	ctx := NewBackground().(*ctx)
 	testDependsOn(t, ctx)
 }
 
 func TestDependsOnWithReset(t *testing.T) {
-	ctx := NewContext().(*ctx)
+	ctx := NewBackground().(*ctx)
 
 	testDependsOn(t, ctx)
 
@@ -184,7 +184,7 @@ func testDependsOn(t *testing.T, c *ctx) {
 	var wg sync.WaitGroup
 	var closed int32
 
-	other := NewContext().(*ctx)
+	other := NewBackground().(*ctx)
 
 	wg.Add(1)
 	c.RegisterFinalizer(xresource.FinalizerFn(func() {
@@ -212,9 +212,9 @@ func testDependsOn(t *testing.T, c *ctx) {
 
 func TestDependsOnWithChild(t *testing.T) {
 	var (
-		c     = NewContext().(*ctx)
+		c     = NewBackground().(*ctx)
 		child = c.newChildContext().(*ctx)
-		other = NewContext().(*ctx)
+		other = NewBackground().(*ctx)
 
 		wg     sync.WaitGroup
 		closed int32
@@ -247,7 +247,7 @@ func TestDependsOnWithChild(t *testing.T) {
 
 func TestSampledTraceSpan(t *testing.T) {
 	var (
-		xCtx  = NewContext()
+		xCtx  = NewBackground()
 		goCtx = stdctx.Background()
 		sp    opentracing.Span
 		spCtx Context
@@ -275,26 +275,18 @@ func TestSampledTraceSpan(t *testing.T) {
 }
 
 func TestGoContext(t *testing.T) {
-	goCtx := stdctx.Background()
-	xCtx := NewContext()
+	goCtx, cancel  := stdctx.WithTimeout(stdctx.Background(), time.Minute)
+	defer cancel()
+	xCtx := NewWithGoContext(goCtx)
 
 	var (
-		exists    bool
 		returnCtx stdctx.Context
 	)
 
-	returnCtx, exists = xCtx.GoContext()
-	assert.False(t, exists)
-	assert.Nil(t, returnCtx)
-
-	xCtx.SetGoContext(goCtx)
-
-	returnCtx, exists = xCtx.GoContext()
-	assert.True(t, exists)
+	returnCtx = xCtx.GoContext()
 	assert.Equal(t, goCtx, returnCtx)
 
 	xCtx.Reset()
-	returnCtx, exists = xCtx.GoContext()
-	assert.False(t, exists)
-	assert.Nil(t, returnCtx)
+	returnCtx = xCtx.GoContext()
+	assert.Equal(t, stdctx.Background(), returnCtx)
 }

--- a/src/x/context/context_test.go
+++ b/src/x/context/context_test.go
@@ -275,7 +275,7 @@ func TestSampledTraceSpan(t *testing.T) {
 }
 
 func TestGoContext(t *testing.T) {
-	goCtx, cancel  := stdctx.WithTimeout(stdctx.Background(), time.Minute)
+	goCtx, cancel := stdctx.WithTimeout(stdctx.Background(), time.Minute)
 	defer cancel()
 	xCtx := NewWithGoContext(goCtx)
 

--- a/src/x/context/types.go
+++ b/src/x/context/types.go
@@ -76,11 +76,8 @@ type Context interface {
 	// will not be returned to a pool.
 	BlockingCloseReset()
 
-	// GoContext returns the Go std context.
-	GoContext() (stdctx.Context, bool)
-
-	// MustGoContext returns the std go context, or panics if not set.
-	MustGoContext() stdctx.Context
+	// GoContext returns the std go context.
+	GoContext() stdctx.Context
 
 	// SetGoContext sets the Go std context.
 	SetGoContext(stdctx.Context)


### PR DESCRIPTION
The go ctx was always being populated by the thrift server. A few
non-rpc processes, like the bootstrapper, needed to be updated to use
NewBackground instead of NewContext.

Now all m3 code can safely assume a go ctx is always present, instead of
having to check for it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
