### PR TITLE
[dbnode] Fix time ranges becoming obsolete during long bootstraps

### DIFF
--- a/src/dbnode/storage/bootstrap/process_test.go
+++ b/src/dbnode/storage/bootstrap/process_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bootstrap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
+	"github.com/m3db/m3/src/dbnode/retention"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	"github.com/m3db/m3/src/dbnode/topology"
+	xcontext "github.com/m3db/m3/src/x/context"
+	"github.com/m3db/m3/src/x/ident"
+)
+
+func TestBootstrapProcessRunActiveBlockAdvanced(t *testing.T) {
+	var (
+		ctrl = gomock.NewController(t)
+		ctx  = xcontext.NewBackground()
+
+		blockSize    = time.Hour
+		startTime    = time.Now().Truncate(blockSize)
+		bufferPast   = 30 * time.Minute
+		bufferFuture = 30 * time.Minute
+		// shift 'now' just enough so that after adding 'bufferFuture' it would reach the next block
+		now = startTime.Add(blockSize - bufferFuture)
+
+		retentionOpts = retention.NewOptions().
+				SetBlockSize(blockSize).
+				SetRetentionPeriod(12 * blockSize).
+				SetBufferPast(bufferPast).
+				SetBufferFuture(bufferFuture)
+		nsOptions = namespace.NewOptions().SetRetentionOptions(retentionOpts)
+		nsID      = ident.StringID("ns")
+		ns, err   = namespace.NewMetadata(nsID, nsOptions)
+	)
+	require.NoError(t, err)
+
+	processNs := []ProcessNamespace{
+		{
+			Metadata:        ns,
+			Shards:          []uint32{0},
+			DataAccumulator: NewMockNamespaceDataAccumulator(ctrl),
+		},
+	}
+
+	bootstrapper := NewMockBootstrapper(ctrl)
+	bootstrapper.EXPECT().String().Return("mock_bootstrapper").AnyTimes()
+	bootstrapper.EXPECT().
+		Bootstrap(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_, _, _ interface{}) (NamespaceResults, error) {
+			return NewNamespaceResults(NewNamespaces(processNs)), nil
+		}).
+		AnyTimes()
+
+	process := bootstrapProcess{
+		processOpts:          NewProcessOptions(),
+		resultOpts:           result.NewOptions(),
+		fsOpts:               fs.NewOptions(),
+		nowFn:                func() time.Time { return now },
+		log:                  zap.NewNop(),
+		bootstrapper:         bootstrapper,
+		initialTopologyState: &topology.StateSnapshot{},
+	}
+
+	_, err = process.Run(ctx, startTime, processNs)
+	require.Equal(t, ErrFileSetSnapshotTypeRangeAdvanced, err)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes an issue where bootstrap time ranges become obsolete during long bootstraps. Due to this bug, shards would be marked bootstrapped even if they don't have all blocks.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
