### PR TITLE
Fix data race in genny list Remove

### DIFF
--- a/src/dbnode/storage/id_list_gen.go
+++ b/src/dbnode/storage/id_list_gen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Uber Technologies, Inc.
+// Copyright (c) 2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -219,13 +219,16 @@ func (l *idList) remove(e *idElement) *idElement {
 // It returns the element value e.Value.
 // The element must not be nil.
 func (l *idList) Remove(e *idElement) doc.Metadata {
+	// read the value before returning to the pool to avoid a data race with another goroutine getting access to the
+	// list after it has been put back into the pool.
+	v := e.Value
 	if e.list == l {
 		// if e.list == l, l must have been initialized when e was inserted
 		// in l or l == nil (e is a zero Element) and l.remove will crash.
 		l.remove(e)
 		l.Pool.put(e)
 	}
-	return e.Value
+	return v
 }
 
 // PushFront inserts a new element e with value v at the front of list l and returns e.

--- a/src/x/context/finalizeable_list_gen.go
+++ b/src/x/context/finalizeable_list_gen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Uber Technologies, Inc.
+// Copyright (c) 2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -218,13 +218,16 @@ func (l *finalizeableList) remove(e *finalizeableElement) *finalizeableElement {
 // It returns the element value e.Value.
 // The element must not be nil.
 func (l *finalizeableList) Remove(e *finalizeableElement) finalizeable {
+	// read the value before returning to the pool to avoid a data race with another goroutine getting access to the
+	// list after it has been put back into the pool.
+	v := e.Value
 	if e.list == l {
 		// if e.list == l, l must have been initialized when e was inserted
 		// in l or l == nil (e is a zero Element) and l.remove will crash.
 		l.remove(e)
 		l.Pool.put(e)
 	}
-	return e.Value
+	return v
 }
 
 // PushFront inserts a new element e with value v at the front of list l and returns e.

--- a/src/x/generics/list/list.go
+++ b/src/x/generics/list/list.go
@@ -199,13 +199,16 @@ func (l *List) remove(e *Element) *Element {
 // It returns the element value e.Value.
 // The element must not be nil.
 func (l *List) Remove(e *Element) ValueType {
+	// read the value before returning to the pool to avoid a data race with another goroutine getting access to the
+	// list after it has been put back into the pool.
+	v := e.Value
 	if e.list == l {
 		// if e.list == l, l must have been initialized when e was inserted
 		// in l or l == nil (e is a zero Element) and l.remove will crash.
 		l.remove(e)
 		l.Pool.put(e)
 	}
-	return e.Value
+	return v
 }
 
 // PushFront inserts a new element e with value v at the front of list l and returns e.


### PR DESCRIPTION
The data race is reading the value after the element has been put back
in the pool. Another goroutine can get the element out of pool before
the value is read again.

This was not causing an actual production issue because no caller
actually uses the returned value from Remove. However, it did cause
data race failures in tests when run with -race.

```
WARNING: DATA RACE
Write at 0x00c063a621d8 by goroutine 3582:
  github.com/m3db/m3/src/x/context.(*finalizeableList).insertValue()
      /Users/rhall/go/src/github.com/m3db/m3/src/x/context/finalizeable_list_gen.go:202 +0xa8
  github.com/m3db/m3/src/x/context.(*finalizeableList).PushBack()
      /Users/rhall/go/src/github.com/m3db/m3/src/x/context/finalizeable_list_gen.go:239 +0x96
  github.com/m3db/m3/src/x/context.(*ctx).registerFinalizeable()
      /Users/rhall/go/src/github.com/m3db/m3/src/x/context/context.go:135 +0xce
  github.com/m3db/m3/src/x/context.(*ctx).RegisterFinalizer()
      /Users/rhall/go/src/github.com/m3db/m3/src/x/context/context.go:109 +0xa2
  github.com/m3db/m3/src/dbnode/storage/index.(*block).aggregateWithSpan()
      /Users/rhall/go/src/github.com/m3db/m3/src/dbnode/storage/index/block.go:703 +0x690
  github.com/m3db/m3/src/dbnode/storage/index.(*block).Aggregate()
      /Users/rhall/go/src/github.com/m3db/m3/src/dbnode/storage/index/block.go:607 +0x20a
  github.com/m3db/m3/src/dbnode/storage.(*nsIndex).execBlockAggregateQueryFn()
      /Users/rhall/go/src/github.com/m3db/m3/src/dbnode/storage/index.go:1763 +0x611
  github.com/m3db/m3/src/dbnode/storage.(*nsIndex).execBlockAggregateQueryFn-fm()
      /Users/rhall/go/src/github.com/m3db/m3/src/dbnode/storage/index.go:1736 +0x150
  github.com/m3db/m3/src/dbnode/storage.(*nsIndex).queryWithSpan.func1()
      /Users/rhall/go/src/github.com/m3db/m3/src/dbnode/storage/index.go:1589 +0x22f
  github.com/m3db/m3/src/x/sync.(*workerPool).GoWithContext.func1()
      /Users/rhall/go/src/github.com/m3db/m3/src/x/sync/worker_pool.go:128 +0x34
Previous read at 0x00c063a621d8 by goroutine 2940:
  [failed to restore the stack]
Goroutine 3582 (running) created at:
  github.com/m3db/m3/src/x/sync.(*workerPool).GoWithContext()
      /Users/rhall/go/src/github.com/m3db/m3/src/x/sync/worker_pool.go:127 +0x2e6
  github.com/m3db/m3/src/dbnode/storage.(*nsIndex).queryWithSpan()
      /Users/rhall/go/src/github.com/m3db/m3/src/dbnode/storage/index.go:1587 +0x8f2
  github.com/m3db/m3/src/dbnode/storage.(*nsIndex).query()
      /Users/rhall/go/src/github.com/m3db/m3/src/dbnode/storage/index.go:1467 +0x279
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
