### PR TITLE
[dbnode] Fix jagged metrics issue

### DIFF
--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -1594,11 +1594,10 @@ func TestServiceFetchTagged(t *testing.T) {
 			queryLimits, err := limits.NewQueryLimits(limitsOpts)
 			permitOpts := permits.NewOptions().
 				SetSeriesReadPermitsManager(permits.NewLookbackLimitPermitsManager(
-					testTChannelThriftOptions.InstrumentOptions(),
-					limitsOpts.DiskSeriesReadLimitOpts(),
 					"disk-series-read",
-					limitsOpts.SourceLoggerBuilder(),
-					map[string]string{}))
+					limitsOpts.DiskSeriesReadLimitOpts(),
+					testTChannelThriftOptions.InstrumentOptions(),
+					limitsOpts.SourceLoggerBuilder()))
 
 			require.NoError(t, err)
 			testTChannelThriftOptions = testTChannelThriftOptions.

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -466,12 +466,11 @@ func Run(runOpts RunOptions) {
 	}
 	queryLimits.Start()
 	defer queryLimits.Stop()
-	seriesReadPermits := permits.NewLookbackLimitPermitsManager(iOpts,
-		diskSeriesReadLimit,
+	seriesReadPermits := permits.NewLookbackLimitPermitsManager(
 		"disk-series-read",
+		diskSeriesReadLimit,
+		iOpts,
 		limitOpts.SourceLoggerBuilder(),
-		// TODO: Add appropriate tags here.
-		map[string]string{},
 	)
 	seriesReadPermits.Start()
 	defer seriesReadPermits.Stop()

--- a/src/dbnode/storage/limits/permits/lookback_limit_permit.go
+++ b/src/dbnode/storage/limits/permits/lookback_limit_permit.go
@@ -44,14 +44,12 @@ var _ Permits = (*lookbackLimitPermit)(nil)
 
 // NewLookbackLimitPermitsManager builds a new lookback limit permits manager.
 func NewLookbackLimitPermitsManager(
-	instrumentOpts instrument.Options,
-	opts limits.LookbackLimitOptions,
 	name string,
+	opts limits.LookbackLimitOptions,
+	instrumentOpts instrument.Options,
 	sourceLoggerBuilder limits.SourceLoggerBuilder,
-	tags map[string]string,
 ) *LookbackLimitPermitManager {
-	lookbackLimit := limits.NewLookbackLimit(
-		instrumentOpts, opts, name, sourceLoggerBuilder, tags)
+	lookbackLimit := limits.NewLookbackLimit(name, opts, instrumentOpts, sourceLoggerBuilder)
 
 	// We expose this implementation type to allow caller to use Start/Stop
 	// lookback functions which are not part of the Permits interface.

--- a/src/dbnode/storage/limits/permits/lookback_limit_permit_test.go
+++ b/src/dbnode/storage/limits/permits/lookback_limit_permit_test.go
@@ -50,11 +50,10 @@ func TestLookbackLimitPermitIncBy(t *testing.T) {
 func newManager(t *testing.T, limit limits.LookbackLimit, incBy int) *LookbackLimitPermitManager {
 	t.Helper()
 	mgr := NewLookbackLimitPermitsManager(
-		instrument.NewTestOptions(t),
-		limits.DefaultLookbackLimitOptions(),
 		"test-limit",
+		limits.DefaultLookbackLimitOptions(),
+		instrument.NewTestOptions(t),
 		limits.NewOptions().SourceLoggerBuilder(),
-		map[string]string{},
 		incBy,
 	)
 	mgr.Limit = limit

--- a/src/dbnode/storage/limits/query_limits.go
+++ b/src/dbnode/storage/limits/query_limits.go
@@ -98,16 +98,21 @@ func NewQueryLimits(options Options) (QueryLimits, error) {
 		docsMatched      = "docs-matched"
 		bytesRead        = "disk-bytes-read"
 		aggregateMatched = "aggregate-matched"
-		docsLimit        = newLookbackLimit(
-			iOpts, docsLimitOpts, docsMatched, docsMatched,
-			sourceLoggerBuilder, map[string]string{"type": "fetch"})
-		bytesReadLimit = newLookbackLimit(
-			iOpts, bytesReadLimitOpts, bytesRead, bytesRead,
-			sourceLoggerBuilder, nil)
-
-		aggregatedDocsLimit = newLookbackLimit(
-			iOpts, aggDocsLimitOpts, docsMatched, aggregateMatched,
-			sourceLoggerBuilder, map[string]string{"type": "aggregate"})
+		docsLimit        = newLookbackLimit(limitNames{
+			limitName:  docsMatched,
+			metricName: docsMatched,
+			metricType: "fetch",
+		}, docsLimitOpts, iOpts, sourceLoggerBuilder)
+		bytesReadLimit = newLookbackLimit(limitNames{
+			limitName:  bytesRead,
+			metricName: bytesRead,
+			metricType: "read",
+		}, bytesReadLimitOpts, iOpts, sourceLoggerBuilder)
+		aggregatedDocsLimit = newLookbackLimit(limitNames{
+			limitName:  aggregateMatched,
+			metricName: docsMatched,
+			metricType: "aggregate",
+		}, aggDocsLimitOpts, iOpts, sourceLoggerBuilder)
 	)
 
 	return &queryLimits{
@@ -119,32 +124,38 @@ func NewQueryLimits(options Options) (QueryLimits, error) {
 
 // NewLookbackLimit returns a new lookback limit.
 func NewLookbackLimit(
-	instrumentOpts instrument.Options,
-	opts LookbackLimitOptions,
 	name string,
+	opts LookbackLimitOptions,
+	instrumentOpts instrument.Options,
 	sourceLoggerBuilder SourceLoggerBuilder,
-	tags map[string]string,
 ) LookbackLimit {
-	return newLookbackLimit(instrumentOpts, opts, name, name, sourceLoggerBuilder, tags)
+	return newLookbackLimit(limitNames{
+		limitName:  name,
+		metricName: name,
+		metricType: name,
+	}, opts, instrumentOpts, sourceLoggerBuilder)
+}
+
+type limitNames struct {
+	limitName  string
+	metricName string
+	metricType string
 }
 
 func newLookbackLimit(
-	instrumentOpts instrument.Options,
+	limitNames limitNames,
 	opts LookbackLimitOptions,
-	metricName string,
-	name string,
+	instrumentOpts instrument.Options,
 	sourceLoggerBuilder SourceLoggerBuilder,
-	tags map[string]string,
 ) *lookbackLimit {
 	metrics := newLookbackLimitMetrics(
+		limitNames,
 		instrumentOpts,
-		metricName,
 		sourceLoggerBuilder,
-		tags,
 	)
 
 	return &lookbackLimit{
-		name:      name,
+		name:      limitNames.limitName,
 		options:   opts,
 		metrics:   metrics,
 		logger:    instrumentOpts.Logger(),
@@ -156,15 +167,14 @@ func newLookbackLimit(
 }
 
 func newLookbackLimitMetrics(
+	limitNames limitNames,
 	instrumentOpts instrument.Options,
-	name string,
 	sourceLoggerBuilder SourceLoggerBuilder,
-	tags map[string]string,
 ) lookbackLimitMetrics {
-	loggerScope := instrumentOpts.MetricsScope()
-	if tags != nil {
-		loggerScope = loggerScope.Tagged(tags)
-	}
+	metricName := limitNames.metricName
+	loggerScope := instrumentOpts.MetricsScope().Tagged(map[string]string{
+		"type": limitNames.metricType,
+	})
 
 	var (
 		loggerOpts  = instrumentOpts.SetMetricsScope(loggerScope)
@@ -172,14 +182,14 @@ func newLookbackLimitMetrics(
 	)
 
 	return lookbackLimitMetrics{
-		optionsLimit:    metricScope.Gauge(fmt.Sprintf("current-limit-%s", name)),
-		optionsLookback: metricScope.Gauge(fmt.Sprintf("current-lookback-%s", name)),
-		recentCount:     metricScope.Gauge(fmt.Sprintf("recent-count-%s", name)),
-		recentMax:       metricScope.Gauge(fmt.Sprintf("recent-max-%s", name)),
-		total:           metricScope.Counter(fmt.Sprintf("total-%s", name)),
-		exceeded:        metricScope.Tagged(map[string]string{"limit": name}).Counter("exceeded"),
+		optionsLimit:    metricScope.Gauge(fmt.Sprintf("current-limit-%s", metricName)),
+		optionsLookback: metricScope.Gauge(fmt.Sprintf("current-lookback-%s", metricName)),
+		recentCount:     metricScope.Gauge(fmt.Sprintf("recent-count-%s", metricName)),
+		recentMax:       metricScope.Gauge(fmt.Sprintf("recent-max-%s", metricName)),
+		total:           metricScope.Counter(fmt.Sprintf("total-%s", metricName)),
+		exceeded:        metricScope.Tagged(map[string]string{"limit": metricName}).Counter("exceeded"),
 
-		sourceLogger: sourceLoggerBuilder.NewSourceLogger(name, loggerOpts),
+		sourceLogger: sourceLoggerBuilder.NewSourceLogger(metricName, loggerOpts),
 	}
 }
 

--- a/src/dbnode/storage/limits/query_limits_test.go
+++ b/src/dbnode/storage/limits/query_limits_test.go
@@ -358,10 +358,6 @@ func verifyMetrics(t *testing.T,
 		fmt.Sprintf("query-limit.total-%s", name),
 		map[string]string{"type": "test"})
 
-	for _, c := range snapshot.Counters() {
-		fmt.Println(c.Name(), c.Tags())
-	}
-
 	tallytest.AssertCounterValue(
 		t, expectedExceeded, snapshot,
 		"query-limit.exceeded",


### PR DESCRIPTION
Bytes read limit was not being reported correctly because while tally allows metrics with the same `__name__` but different numbers of tags, prometheus does not, erroring silently.