### PR TITLE
[m3ninx] Fix uint underflow in segment.go

### DIFF
--- a/src/m3ninx/index/segment/fst/segment.go
+++ b/src/m3ninx/index/segment/fst/segment.go
@@ -753,7 +753,7 @@ func (r *fsSegment) retrieveTermsBytesWithRLock(base []byte, offset uint64) (pro
 	const sizeofUint64 = 8
 	var (
 		magicNumberEnd   = int64(offset) // to prevent underflows
-		magicNumberStart = offset - sizeofUint64
+		magicNumberStart = magicNumberEnd - sizeofUint64
 	)
 	if magicNumberEnd > int64(len(base)) || magicNumberStart < 0 {
 		return nil, nil, fmt.Errorf("base bytes too small, length: %d, base-offset: %d", len(base), magicNumberEnd)
@@ -784,7 +784,7 @@ func (r *fsSegment) retrieveTermsBytesWithRLock(base []byte, offset uint64) (pro
 
 	var (
 		payloadEnd   = sizeStart
-		payloadStart = payloadEnd - size
+		payloadStart = payloadEnd - int64(size)
 	)
 	if payloadStart < 0 {
 		return nil, nil, fmt.Errorf("base bytes too small, length: %d, payload-start: %d, payload-size: %d",
@@ -809,7 +809,7 @@ func (r *fsSegment) retrieveTermsBytesWithRLock(base []byte, offset uint64) (pro
 
 	var (
 		protoEnd   = protoSizeStart
-		protoStart = protoEnd - protoSize
+		protoStart = protoEnd - int64(protoSize)
 	)
 	if protoStart < 0 {
 		return nil, nil, fmt.Errorf("base bytes too small, length: %d, proto-start: %d", len(base), protoStart)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes a `uint` underflow in `fst/segment.go`. This was revealed by a panic in one of the BK builds: https://buildkite.com/uberopensource/m3-monorepo-public/builds/7365#e2f76bc7-6a2c-49ba-892a-899f9db9caf7/5333-5542

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
