### PR TITLE
[dbnode] Remove unused fs bootstrapper options

### DIFF
--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/options.go
@@ -47,18 +47,6 @@ var (
 	errFilesystemOptionsNotSet  = errors.New("filesystem options not set")
 	errMigrationOptionsNotSet   = errors.New("migration options not set")
 
-	// NB(r): Bootstrapping data doesn't use large amounts of memory
-	// that won't be released, so its fine to do this as fast as possible.
-	defaultBootstrapDataNumProcessors = int(math.Ceil(float64(goruntime.NumCPU()) / 2))
-	// NB(r): Bootstrapping index segments pulls a lot of data into memory
-	// since its across all shards, so we actually break up the
-	// number of segments we even create across the set of shards if
-	// we have to create an FST in place, this is to avoid OOMing a node.
-	// Because of this we only want to create one segment at a time otherwise
-	// us splitting an index block into smaller pieces is moot because we'll
-	// pull a lot more data into memory if we create more than one at a time.
-	defaultBootstrapIndexNumProcessors = 1
-
 	// DefaultIndexSegmentConcurrency defines the default index segment building concurrency.
 	DefaultIndexSegmentConcurrency = int(math.Min(2, float64(goruntime.NumCPU())))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes some unused options in fs bootstrapper code to reduce confusion.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE