### PR TITLE
[coordinator] add mapping rule m3 tag to drop timestamp

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsample_mock.go
+++ b/src/cmd/services/m3coordinator/downsample/downsample_mock.go
@@ -181,71 +181,85 @@ func (m *MockSamplesAppender) EXPECT() *MockSamplesAppenderMockRecorder {
 }
 
 // AppendCounterSample mocks base method
-func (m *MockSamplesAppender) AppendCounterSample(arg0 int64, arg1 []byte) error {
+func (m *MockSamplesAppender) AppendCounterSample(arg0 time.Time, arg1 int64, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendCounterSample", arg0, arg1)
+	ret := m.ctrl.Call(m, "AppendCounterSample", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AppendCounterSample indicates an expected call of AppendCounterSample
-func (mr *MockSamplesAppenderMockRecorder) AppendCounterSample(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSamplesAppenderMockRecorder) AppendCounterSample(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendCounterSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendCounterSample), arg0, arg1)
-}
-
-// AppendCounterTimedSample mocks base method
-func (m *MockSamplesAppender) AppendCounterTimedSample(arg0 time.Time, arg1 int64, arg2 []byte) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendCounterTimedSample", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AppendCounterTimedSample indicates an expected call of AppendCounterTimedSample
-func (mr *MockSamplesAppenderMockRecorder) AppendCounterTimedSample(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendCounterTimedSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendCounterTimedSample), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendCounterSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendCounterSample), arg0, arg1, arg2)
 }
 
 // AppendGaugeSample mocks base method
-func (m *MockSamplesAppender) AppendGaugeSample(arg0 float64, arg1 []byte) error {
+func (m *MockSamplesAppender) AppendGaugeSample(arg0 time.Time, arg1 float64, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendGaugeSample", arg0, arg1)
+	ret := m.ctrl.Call(m, "AppendGaugeSample", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AppendGaugeSample indicates an expected call of AppendGaugeSample
-func (mr *MockSamplesAppenderMockRecorder) AppendGaugeSample(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSamplesAppenderMockRecorder) AppendGaugeSample(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendGaugeSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendGaugeSample), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendGaugeSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendGaugeSample), arg0, arg1, arg2)
 }
 
-// AppendGaugeTimedSample mocks base method
-func (m *MockSamplesAppender) AppendGaugeTimedSample(arg0 time.Time, arg1 float64, arg2 []byte) error {
+// AppendTimerSample mocks base method
+func (m *MockSamplesAppender) AppendTimerSample(arg0 time.Time, arg1 float64, arg2 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendGaugeTimedSample", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AppendTimerSample", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AppendGaugeTimedSample indicates an expected call of AppendGaugeTimedSample
-func (mr *MockSamplesAppenderMockRecorder) AppendGaugeTimedSample(arg0, arg1, arg2 interface{}) *gomock.Call {
+// AppendTimerSample indicates an expected call of AppendTimerSample
+func (mr *MockSamplesAppenderMockRecorder) AppendTimerSample(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendGaugeTimedSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendGaugeTimedSample), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendTimerSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendTimerSample), arg0, arg1, arg2)
 }
 
-// AppendTimerTimedSample mocks base method
-func (m *MockSamplesAppender) AppendTimerTimedSample(arg0 time.Time, arg1 float64, arg2 []byte) error {
+// AppendUntimedCounterSample mocks base method
+func (m *MockSamplesAppender) AppendUntimedCounterSample(arg0 int64, arg1 []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendTimerTimedSample", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AppendUntimedCounterSample", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AppendTimerTimedSample indicates an expected call of AppendTimerTimedSample
-func (mr *MockSamplesAppenderMockRecorder) AppendTimerTimedSample(arg0, arg1, arg2 interface{}) *gomock.Call {
+// AppendUntimedCounterSample indicates an expected call of AppendUntimedCounterSample
+func (mr *MockSamplesAppenderMockRecorder) AppendUntimedCounterSample(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendTimerTimedSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendTimerTimedSample), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUntimedCounterSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendUntimedCounterSample), arg0, arg1)
+}
+
+// AppendUntimedGaugeSample mocks base method
+func (m *MockSamplesAppender) AppendUntimedGaugeSample(arg0 float64, arg1 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppendUntimedGaugeSample", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AppendUntimedGaugeSample indicates an expected call of AppendUntimedGaugeSample
+func (mr *MockSamplesAppenderMockRecorder) AppendUntimedGaugeSample(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUntimedGaugeSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendUntimedGaugeSample), arg0, arg1)
+}
+
+// AppendUntimedTimerSample mocks base method
+func (m *MockSamplesAppender) AppendUntimedTimerSample(arg0 float64, arg1 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppendUntimedTimerSample", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AppendUntimedTimerSample indicates an expected call of AppendUntimedTimerSample
+func (mr *MockSamplesAppenderMockRecorder) AppendUntimedTimerSample(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUntimedTimerSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendUntimedTimerSample), arg0, arg1)
 }

--- a/src/cmd/services/m3coordinator/downsample/downsample_mock.go
+++ b/src/cmd/services/m3coordinator/downsample/downsample_mock.go
@@ -263,3 +263,17 @@ func (mr *MockSamplesAppenderMockRecorder) AppendUntimedTimerSample(arg0, arg1 i
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUntimedTimerSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendUntimedTimerSample), arg0, arg1)
 }
+
+// DropTimestamp mocks base method
+func (m *MockSamplesAppender) DropTimestamp() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DropTimestamp")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DropTimestamp indicates an expected call of DropTimestamp
+func (mr *MockSamplesAppenderMockRecorder) DropTimestamp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropTimestamp", reflect.TypeOf((*MockSamplesAppender)(nil).DropTimestamp))
+}

--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -86,6 +86,7 @@ type SamplesAppender interface {
 	AppendCounterSample(t time.Time, value int64, annotation []byte) error
 	AppendGaugeSample(t time.Time, value float64, annotation []byte) error
 	AppendTimerSample(t time.Time, value float64, annotation []byte) error
+	DropTimestamp() bool
 }
 
 type downsampler struct {

--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -80,11 +80,12 @@ type SamplesAppenderOverrideRules struct {
 // SamplesAppender is a downsampling samples appender,
 // that can only be called by a single caller at a time.
 type SamplesAppender interface {
-	AppendCounterSample(value int64, annotation []byte) error
-	AppendGaugeSample(value float64, annotation []byte) error
-	AppendCounterTimedSample(t time.Time, value int64, annotation []byte) error
-	AppendGaugeTimedSample(t time.Time, value float64, annotation []byte) error
-	AppendTimerTimedSample(t time.Time, value float64, annotation []byte) error
+	AppendUntimedCounterSample(value int64, annotation []byte) error
+	AppendUntimedGaugeSample(value float64, annotation []byte) error
+	AppendUntimedTimerSample(value float64, annotation []byte) error
+	AppendCounterSample(t time.Time, value int64, annotation []byte) error
+	AppendGaugeSample(t time.Time, value float64, annotation []byte) error
+	AppendTimerSample(t time.Time, value float64, annotation []byte) error
 }
 
 type downsampler struct {

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1012,6 +1012,16 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesWithDropTSTag(t *testi
 					},
 					Tags: tags,
 				},
+				{
+					Filter:       "app:testapp",
+					Aggregations: []aggregation.Type{aggregation.Sum},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: 1 * time.Second,
+							Retention:  30 * 24 * time.Hour,
+						},
+					},
+				},
 			},
 		},
 		ingest: &testDownsamplerOptionsIngest{
@@ -1023,6 +1033,15 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesWithDropTSTag(t *testi
 				{
 					tags:   gaugeMetric.tags,
 					values: []expectedValue{{value: 30}},
+					attributes: &storagemetadata.Attributes{
+						MetricsType: storagemetadata.AggregatedMetricsType,
+						Resolution:  1 * time.Second,
+						Retention:   30 * 24 * time.Hour,
+					},
+				},
+				{
+					tags:   counterMetric.tags,
+					values: []expectedValue{{value: 6}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
 						Resolution:  1 * time.Second,

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1958,7 +1958,7 @@ func testDownsamplerAggregationIngest(
 
 		samplesAppender := samplesAppenderResult.SamplesAppender
 		for _, sample := range metric.samples {
-			err = samplesAppender.AppendCounterSample(sample, nil)
+			err = samplesAppender.AppendUntimedCounterSample(sample, nil)
 			require.NoError(t, err)
 		}
 		for _, sample := range metric.timedSamples {
@@ -1968,7 +1968,7 @@ func testDownsamplerAggregationIngest(
 			if sample.offset > 0 {
 				sample.time = sample.time.Add(sample.offset)
 			}
-			err = samplesAppender.AppendCounterTimedSample(sample.time, sample.value, nil)
+			err = samplesAppender.AppendCounterSample(sample.time, sample.value, nil)
 			require.NoError(t, err)
 		}
 	}
@@ -1986,7 +1986,7 @@ func testDownsamplerAggregationIngest(
 
 		samplesAppender := samplesAppenderResult.SamplesAppender
 		for _, sample := range metric.samples {
-			err = samplesAppender.AppendGaugeSample(sample, nil)
+			err = samplesAppender.AppendUntimedGaugeSample(sample, nil)
 			require.NoError(t, err)
 		}
 		for _, sample := range metric.timedSamples {
@@ -1996,7 +1996,7 @@ func testDownsamplerAggregationIngest(
 			if sample.offset > 0 {
 				sample.time = sample.time.Add(sample.offset)
 			}
-			err = samplesAppender.AppendGaugeTimedSample(sample.time, sample.value, nil)
+			err = samplesAppender.AppendGaugeSample(sample.time, sample.value, nil)
 			require.NoError(t, err)
 		}
 	}

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -476,12 +476,12 @@ func (a *metricsAppender) addSamplesAppenders(originalTags *tags, stagedMetadata
 			continue
 		}
 
-		tags, dropTs := a.processTags(originalTags, pipeline.GraphitePrefix, pipeline.Tags, pipeline.AggregationID)
+		tags, dropTS := a.processTags(originalTags, pipeline.GraphitePrefix, pipeline.Tags, pipeline.AggregationID)
 
 		sm := stagedMetadata
 		sm.Pipelines = []metadata.PipelineMetadata{pipeline}
 
-		appender, err := a.newSamplesAppender(tags, sm, dropTs)
+		appender, err := a.newSamplesAppender(tags, sm, dropTS)
 		if err != nil {
 			return err
 		}
@@ -506,7 +506,7 @@ func (a *metricsAppender) addSamplesAppenders(originalTags *tags, stagedMetadata
 func (a *metricsAppender) newSamplesAppender(
 	tags *tags,
 	sm metadata.StagedMetadata,
-	dropTs bool,
+	dropTS bool,
 ) (samplesAppender, error) {
 	tagEncoder := a.tagEncoder()
 	if err := tagEncoder.Encode(tags); err != nil {
@@ -519,7 +519,7 @@ func (a *metricsAppender) newSamplesAppender(
 	return samplesAppender{
 		agg:             a.agg,
 		clientRemote:    a.clientRemote,
-		dropTs:          dropTs,
+		dropTS:          dropTS,
 		unownedID:       data.Bytes(),
 		stagedMetadatas: []metadata.StagedMetadata{sm},
 	}, nil
@@ -534,7 +534,7 @@ func (a *metricsAppender) processTags(
 	// Create the prefix tags if any.
 	var (
 		tags   = a.tags()
-		dropTs bool
+		dropTS bool
 	)
 	for i, path := range graphitePrefix {
 		// Add the graphite prefix as the initial graphite tags.
@@ -585,10 +585,10 @@ func (a *metricsAppender) processTags(
 			)
 			tags.append(name, value)
 		} else if bytes.Equal(tag.Name, metric.M3MetricsDropTimestamp) {
-			dropTs = true
+			dropTS = true
 		}
 	}
-	return tags, dropTs
+	return tags, dropTS
 }
 
 func stagedMetadatasLogField(sm metadata.StagedMetadatas) zapcore.Field {

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
@@ -131,7 +131,7 @@ func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
 			},
 		)
 
-		require.NoError(t, a.SamplesAppender.AppendCounterSample(int64(i), nil))
+		require.NoError(t, a.SamplesAppender.AppendUntimedCounterSample(int64(i), nil))
 
 		assert.False(t, a.IsDropPolicyApplied)
 		appender.Finalize()

--- a/src/cmd/services/m3coordinator/ingest/write.go
+++ b/src/cmd/services/m3coordinator/ingest/write.go
@@ -275,7 +275,7 @@ func (d *downsamplerAndWriter) writeToDownsampler(
 	}
 
 	for _, dp := range datapoints {
-		err := result.SamplesAppender.AppendGaugeTimedSample(dp.Timestamp, dp.Value, annotation)
+		err := result.SamplesAppender.AppendGaugeSample(dp.Timestamp, dp.Value, annotation)
 		if err != nil {
 			return result.IsDropPolicyApplied, err
 		}
@@ -498,11 +498,11 @@ func (d *downsamplerAndWriter) writeAggregatedBatch(
 		for _, dp := range value.Datapoints {
 			switch value.Attributes.M3Type {
 			case ts.M3MetricTypeGauge:
-				err = result.SamplesAppender.AppendGaugeTimedSample(dp.Timestamp, dp.Value, value.Annotation)
+				err = result.SamplesAppender.AppendGaugeSample(dp.Timestamp, dp.Value, value.Annotation)
 			case ts.M3MetricTypeCounter:
-				err = result.SamplesAppender.AppendCounterTimedSample(dp.Timestamp, int64(dp.Value), value.Annotation)
+				err = result.SamplesAppender.AppendCounterSample(dp.Timestamp, int64(dp.Value), value.Annotation)
 			case ts.M3MetricTypeTimer:
-				err = result.SamplesAppender.AppendTimerTimedSample(dp.Timestamp, dp.Value, value.Annotation)
+				err = result.SamplesAppender.AppendTimerSample(dp.Timestamp, dp.Value, value.Annotation)
 			}
 			if err != nil {
 				// If we see an error break out so we can try processing the

--- a/src/cmd/services/m3coordinator/ingest/write_test.go
+++ b/src/cmd/services/m3coordinator/ingest/write_test.go
@@ -354,7 +354,7 @@ func TestDownsampleAndWriteWithDownsampleOverridesAndDropMappingRules(t *testing
 	}
 
 	for _, dp := range testDatapoints1 {
-		mockSamplesAppender.EXPECT().AppendGaugeTimedSample(dp.Timestamp, dp.Value, testAnnotation1)
+		mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation1)
 	}
 	downsampler.EXPECT().NewMetricsAppender().Return(mockMetricsAppender, nil)
 
@@ -467,13 +467,13 @@ func TestDownsampleAndWriteBatch(t *testing.T) {
 		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
 	}
 	for _, dp := range testDatapoints1 {
-		mockSamplesAppender.EXPECT().AppendGaugeTimedSample(dp.Timestamp, dp.Value, testAnnotation1)
+		mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation1)
 	}
 	for _, tag := range testTags2.Tags {
 		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
 	}
 	for _, dp := range testDatapoints2 {
-		mockSamplesAppender.EXPECT().AppendGaugeTimedSample(dp.Timestamp, dp.Value, testAnnotation2)
+		mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation2)
 	}
 	downsampler.EXPECT().NewMetricsAppender().Return(mockMetricsAppender, nil)
 
@@ -519,7 +519,7 @@ func TestDownsampleAndWriteBatchBadTags(t *testing.T) {
 		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
 	}
 	for _, dp := range testDatapoints2 {
-		mockSamplesAppender.EXPECT().AppendGaugeTimedSample(dp.Timestamp, dp.Value, testAnnotation2)
+		mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation2)
 	}
 	downsampler.EXPECT().NewMetricsAppender().Return(mockMetricsAppender, nil)
 
@@ -574,13 +574,13 @@ func TestDownsampleAndWriteBatchDifferentTypes(t *testing.T) {
 		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
 	}
 	for _, dp := range testDatapoints1 {
-		mockSamplesAppender.EXPECT().AppendCounterTimedSample(dp.Timestamp, int64(dp.Value), testAnnotation1)
+		mockSamplesAppender.EXPECT().AppendCounterSample(dp.Timestamp, int64(dp.Value), testAnnotation1)
 	}
 	for _, tag := range testTags2.Tags {
 		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
 	}
 	for _, dp := range testDatapoints2 {
-		mockSamplesAppender.EXPECT().AppendTimerTimedSample(dp.Timestamp, dp.Value, testAnnotation2)
+		mockSamplesAppender.EXPECT().AppendTimerSample(dp.Timestamp, dp.Value, testAnnotation2)
 	}
 	downsampler.EXPECT().NewMetricsAppender().Return(mockMetricsAppender, nil)
 
@@ -624,13 +624,13 @@ func TestDownsampleAndWriteBatchSingleDrop(t *testing.T) {
 		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
 	}
 	for _, dp := range testDatapoints1 {
-		mockSamplesAppender.EXPECT().AppendGaugeTimedSample(dp.Timestamp, dp.Value, testAnnotation1)
+		mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation1)
 	}
 	for _, tag := range testTags2.Tags {
 		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
 	}
 	for _, dp := range testDatapoints2 {
-		mockSamplesAppender.EXPECT().AppendGaugeTimedSample(dp.Timestamp, dp.Value, testAnnotation2)
+		mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation2)
 	}
 	downsampler.EXPECT().NewMetricsAppender().Return(mockMetricsAppender, nil)
 
@@ -707,7 +707,7 @@ func TestDownsampleAndWriteBatchOverrideDownsampleRules(t *testing.T) {
 		}
 		// We will also get the common gauge tag.
 		for _, dp := range entry.datapoints {
-			mockSamplesAppender.EXPECT().AppendGaugeTimedSample(dp.Timestamp, dp.Value, testAnnotation1)
+			mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation1)
 		}
 	}
 	downsampler.EXPECT().NewMetricsAppender().Return(mockMetricsAppender, nil)
@@ -787,7 +787,7 @@ func expectDefaultDownsampling(
 	}
 
 	for _, dp := range datapoints {
-		mockSamplesAppender.EXPECT().AppendGaugeTimedSample(dp.Timestamp, dp.Value, testAnnotation1)
+		mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation1)
 	}
 	downsampler.EXPECT().NewMetricsAppender().Return(mockMetricsAppender, nil)
 

--- a/src/metrics/metric/types.go
+++ b/src/metrics/metric/types.go
@@ -56,6 +56,7 @@ var (
 	M3TypeTag                    = []byte(M3MetricsPrefixString + "_type__")
 	M3MetricsGraphiteAggregation = []byte(M3MetricsPrefixString + "_graphite_aggregation__")
 	M3MetricsGraphitePrefix      = []byte(M3MetricsPrefixString + "_graphite_prefix__")
+	M3MetricsDropTimestamp       = []byte(M3MetricsPrefixString + "_drop_timestamp__")
 )
 
 func (t Type) String() string {

--- a/src/query/generated/mocks/generate.go
+++ b/src/query/generated/mocks/generate.go
@@ -20,5 +20,18 @@
 
 // mockgen rules for generating mocks for exported interfaces (reflection mode).
 //go:generate sh -c "mockgen -package=downsample $PACKAGE/src/cmd/services/m3coordinator/downsample Downsampler,MetricsAppender,SamplesAppender | genclean -pkg $PACKAGE/src/cmd/services/m3coordinator/downsample -out $GOPATH/src/$PACKAGE/src/cmd/services/m3coordinator/downsample/downsample_mock.go"
+//go:generate sh -c "mockgen -package=storage -destination=$GOPATH/src/$PACKAGE/src/query/storage/storage_mock.go $PACKAGE/src/query/storage Storage"
+//go:generate sh -c "mockgen -package=m3 -destination=$GOPATH/src/$PACKAGE/src/query/storage/m3/m3_mock.go $PACKAGE/src/query/storage/m3 Storage"
+//go:generate sh -c "mockgen -package=ts -destination=$GOPATH/src/$PACKAGE/src/query/ts/ts_mock.go $PACKAGE/src/query/ts Values"
+//go:generate sh -c "mockgen -package=block -destination=$GOPATH/src/$PACKAGE/src/query/block/block_mock.go $PACKAGE/src/query/block Block,StepIter,Builder,Step,SeriesIter"
+//go:generate sh -c "mockgen -package=ingest -destination=$GOPATH/src/$PACKAGE/src/cmd/services/m3coordinator/ingest/write_mock.go $PACKAGE/src/cmd/services/m3coordinator/ingest DownsamplerAndWriter"
+//go:generate sh -c "mockgen -package=transform -destination=$GOPATH/src/$PACKAGE/src/query/executor/transform/types_mock.go $PACKAGE/src/query/executor/transform OpNode"
+//go:generate sh -c "mockgen -package=executor -destination=$GOPATH/src/$PACKAGE/src/query/executor/types_mock.go $PACKAGE/src/query/executor Engine"
+//go:generate sh -c "mockgen -package=storage -destination=$GOPATH/src/$PACKAGE/src/query/graphite/storage/storage_mock.go $PACKAGE/src/query/graphite/storage Storage"
+
+// mockgen rules for generating mocks for unexported interfaces (file mode).
+//go:generate sh -c "mockgen -package=m3ql -destination=$GOPATH/src/github.com/m3db/m3/src/query/parser/m3ql/types_mock.go -source=$GOPATH/src/github.com/m3db/m3/src/query/parser/m3ql/types.go"
+//go:generate sh -c "mockgen -package=transform -destination=$GOPATH/src/github.com/m3db/m3/src/query/executor/transform/exec_mock.go -source=$GOPATH/src/github.com/m3db/m3/src/query/executor/transform/exec.go"
+//go:generate sh -c "mockgen -package=temporal -destination=$GOPATH/src/github.com/m3db/m3/src/query/functions/temporal/dependencies_mock.go -source=$GOPATH/src/github.com/m3db/m3/src/query/functions/temporal/dependencies.go" controller
 
 package mocks

--- a/src/query/generated/mocks/generate.go
+++ b/src/query/generated/mocks/generate.go
@@ -20,18 +20,5 @@
 
 // mockgen rules for generating mocks for exported interfaces (reflection mode).
 //go:generate sh -c "mockgen -package=downsample $PACKAGE/src/cmd/services/m3coordinator/downsample Downsampler,MetricsAppender,SamplesAppender | genclean -pkg $PACKAGE/src/cmd/services/m3coordinator/downsample -out $GOPATH/src/$PACKAGE/src/cmd/services/m3coordinator/downsample/downsample_mock.go"
-//go:generate sh -c "mockgen -package=storage -destination=$GOPATH/src/$PACKAGE/src/query/storage/storage_mock.go $PACKAGE/src/query/storage Storage"
-//go:generate sh -c "mockgen -package=m3 -destination=$GOPATH/src/$PACKAGE/src/query/storage/m3/m3_mock.go $PACKAGE/src/query/storage/m3 Storage"
-//go:generate sh -c "mockgen -package=ts -destination=$GOPATH/src/$PACKAGE/src/query/ts/ts_mock.go $PACKAGE/src/query/ts Values"
-//go:generate sh -c "mockgen -package=block -destination=$GOPATH/src/$PACKAGE/src/query/block/block_mock.go $PACKAGE/src/query/block Block,StepIter,Builder,Step,SeriesIter"
-//go:generate sh -c "mockgen -package=ingest -destination=$GOPATH/src/$PACKAGE/src/cmd/services/m3coordinator/ingest/write_mock.go $PACKAGE/src/cmd/services/m3coordinator/ingest DownsamplerAndWriter"
-//go:generate sh -c "mockgen -package=transform -destination=$GOPATH/src/$PACKAGE/src/query/executor/transform/types_mock.go $PACKAGE/src/query/executor/transform OpNode"
-//go:generate sh -c "mockgen -package=executor -destination=$GOPATH/src/$PACKAGE/src/query/executor/types_mock.go $PACKAGE/src/query/executor Engine"
-//go:generate sh -c "mockgen -package=storage -destination=$GOPATH/src/$PACKAGE/src/query/graphite/storage/storage_mock.go $PACKAGE/src/query/graphite/storage Storage"
-
-// mockgen rules for generating mocks for unexported interfaces (file mode).
-//go:generate sh -c "mockgen -package=m3ql -destination=$GOPATH/src/github.com/m3db/m3/src/query/parser/m3ql/types_mock.go -source=$GOPATH/src/github.com/m3db/m3/src/query/parser/m3ql/types.go"
-//go:generate sh -c "mockgen -package=transform -destination=$GOPATH/src/github.com/m3db/m3/src/query/executor/transform/exec_mock.go -source=$GOPATH/src/github.com/m3db/m3/src/query/executor/transform/exec.go"
-//go:generate sh -c "mockgen -package=temporal -destination=$GOPATH/src/github.com/m3db/m3/src/query/functions/temporal/dependencies_mock.go -source=$GOPATH/src/github.com/m3db/m3/src/query/functions/temporal/dependencies.go" controller
 
 package mocks


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds a new m3 special tag `__m3_drop_timestamp` supported by mapping rules that indicate we should drop the timestamp and send metrics to be aggregated untimed..

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
None

**Does this PR require updating code package or user-facing documentation?**:
None