### PR TITLE
[tests] Change default final bootstrapper to NoOpNoneBootstrapper

### DIFF
--- a/src/dbnode/integration/integration.go
+++ b/src/dbnode/integration/integration.go
@@ -181,7 +181,7 @@ func NewDefaultBootstrappableTestSetups( // nolint:gocyclo
 		)
 
 		if finalBootstrapperToUse == "" {
-			finalBootstrapperToUse = bootstrapper.NoOpAllBootstrapperName
+			finalBootstrapperToUse = bootstrapper.NoOpNoneBootstrapperName
 		}
 
 		if topologyInitializer == nil {
@@ -253,6 +253,8 @@ func NewDefaultBootstrappableTestSetups( // nolint:gocyclo
 		switch finalBootstrapperToUse {
 		case bootstrapper.NoOpAllBootstrapperName:
 			finalBootstrapper = bootstrapper.NewNoOpAllBootstrapperProvider()
+		case bootstrapper.NoOpNoneBootstrapperName:
+			finalBootstrapper = bootstrapper.NewNoOpNoneBootstrapperProvider()
 		case uninitialized.UninitializedTopologyBootstrapperName:
 			uninitialized.NewUninitializedTopologyBootstrapperProvider(
 				uninitialized.NewOptions().

--- a/src/dbnode/integration/peers_bootstrap_index_aggregate_test.go
+++ b/src/dbnode/integration/peers_bootstrap_index_aggregate_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/integration/generate"
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/retention"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/m3ninx/idx"
 	"github.com/m3db/m3/src/x/ident"
@@ -67,7 +68,10 @@ func TestPeersBootstrapIndexAggregateQuery(t *testing.T) {
 
 	setupOpts := []BootstrappableTestSetupOptions{
 		{DisablePeersBootstrapper: true},
-		{DisablePeersBootstrapper: false},
+		{
+			DisablePeersBootstrapper: false,
+			FinalBootstrapper:        bootstrapper.NoOpAllBootstrapperName,
+		},
 	}
 	setups, closeFn := NewDefaultBootstrappableTestSetups(t, opts, setupOpts)
 	defer closeFn()

--- a/src/dbnode/integration/peers_bootstrap_index_test.go
+++ b/src/dbnode/integration/peers_bootstrap_index_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/retention"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/m3ninx/generated/proto/fswriter"
 	"github.com/m3db/m3/src/m3ninx/idx"
@@ -72,7 +73,10 @@ func TestPeersBootstrapIndexWithIndexingEnabled(t *testing.T) {
 
 	setupOpts := []BootstrappableTestSetupOptions{
 		{DisablePeersBootstrapper: true},
-		{DisablePeersBootstrapper: false},
+		{
+			DisablePeersBootstrapper: false,
+			FinalBootstrapper:        bootstrapper.NoOpAllBootstrapperName,
+		},
 	}
 	setups, closeFn := NewDefaultBootstrappableTestSetups(t, opts, setupOpts)
 	defer closeFn()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Changes default final bootstrapper in integration tests to `NoOpNoneBootstrapper`, which propagates unfulfilled ranges from the previous steps. This makes it more likely that a regressions in bootstrap process will result in failing tests. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
