### PR TITLE
[dbnode] Permit limit exceeded error propagation

### DIFF
--- a/src/dbnode/network/server/tchannelthrift/node/service.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service.go
@@ -823,8 +823,11 @@ func (s *service) FetchTaggedIter(ctx context.Context, req *rpc.FetchTaggedReque
 	return iter, err
 }
 
-func (s *service) fetchTaggedIter(ctx context.Context, req *rpc.FetchTaggedRequest, instrumentClose func(error)) (
-	FetchTaggedResultsIter, error) {
+func (s *service) fetchTaggedIter(
+	ctx context.Context,
+	req *rpc.FetchTaggedRequest,
+	instrumentClose func(error),
+) (FetchTaggedResultsIter, error) {
 	db, err := s.startReadRPCWithDB()
 	if err != nil {
 		return nil, err
@@ -844,6 +847,11 @@ func (s *service) fetchTaggedIter(ctx context.Context, req *rpc.FetchTaggedReque
 		return nil, convert.ToRPCError(err)
 	}
 
+	permits, err := s.seriesReadPermits.NewPermits(ctx)
+	if err != nil {
+		return nil, convert.ToRPCError(err)
+	}
+
 	tagEncoder := s.pools.tagEncoder.Get()
 	ctx.RegisterFinalizer(tagEncoder)
 
@@ -857,7 +865,7 @@ func (s *service) fetchTaggedIter(ctx context.Context, req *rpc.FetchTaggedReque
 		tagEncoder:      tagEncoder,
 		iOpts:           s.opts.InstrumentOptions(),
 		instrumentClose: instrumentClose,
-		blockPermits:    s.seriesReadPermits.NewPermits(ctx),
+		blockPermits:    permits,
 		totalDocsCount:  queryResult.Results.TotalDocsCount(),
 		nowFn:           s.nowFn,
 		fetchStart:      startTime,

--- a/src/dbnode/storage/limits/permits/lookback_limit_permit.go
+++ b/src/dbnode/storage/limits/permits/lookback_limit_permit.go
@@ -63,12 +63,17 @@ func NewLookbackLimitPermitsManager(
 }
 
 // NewPermits returns a new set of permits.
-func (p *LookbackLimitPermitManager) NewPermits(ctx context.Context) Permits {
+func (p *LookbackLimitPermitManager) NewPermits(ctx context.Context) (Permits, error) {
 	s := sourceFromContext(ctx)
+	// Ensure currently under limit.
+	if err := p.Limit.Inc(0, s); err != nil {
+		return nil, err
+	}
+
 	return &LookbackLimitPermit{
 		limit:  p.Limit,
 		source: s,
-	}
+	}, nil
 }
 
 // Start starts background handling of the lookback limit for the permits.
@@ -82,13 +87,13 @@ func (p *LookbackLimitPermitManager) Stop() {
 }
 
 // Acquire increments the underlying querying limit.
-func (p *LookbackLimitPermit) Acquire(_ context.Context) error {
+func (p *LookbackLimitPermit) Acquire(context.Context) error {
 	return p.limit.Inc(1, p.source)
 }
 
 // TryAcquire increments the underlying querying limit. Functionally equivalent
 // to Acquire.
-func (p *LookbackLimitPermit) TryAcquire(_ context.Context) (bool, error) {
+func (p *LookbackLimitPermit) TryAcquire(context.Context) (bool, error) {
 	err := p.limit.Inc(1, p.source)
 	return err != nil, err
 }

--- a/src/dbnode/storage/limits/permits/lookback_limit_permit_test.go
+++ b/src/dbnode/storage/limits/permits/lookback_limit_permit_test.go
@@ -35,14 +35,15 @@ func TestLookbackLimitPermit(t *testing.T) {
 	manager := newManager(t, lookbackLimit)
 
 	ctx := context.NewBackground()
-	permits := manager.NewPermits(ctx)
+	permits, err := manager.NewPermits(ctx)
+	require.NoError(t, err)
 
 	require.Equal(t, 0, lookbackLimit.count)
 
 	require.NoError(t, permits.Acquire(ctx))
 	require.Equal(t, 1, lookbackLimit.count)
 
-	_, err := permits.TryAcquire(ctx)
+	_, err = permits.TryAcquire(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 2, lookbackLimit.count)
 }

--- a/src/dbnode/storage/limits/permits/noop_permit.go
+++ b/src/dbnode/storage/limits/permits/noop_permit.go
@@ -39,15 +39,15 @@ func NewNoOpPermits() Permits {
 	return &noOpPermits{}
 }
 
-func (p noOpPermits) NewPermits(_ context.Context) Permits {
-	return p
+func (p noOpPermits) NewPermits(context.Context) (Permits, error) {
+	return p, nil
 }
 
-func (p noOpPermits) Acquire(_ context.Context) error {
+func (p noOpPermits) Acquire(context.Context) error {
 	return nil
 }
 
-func (p noOpPermits) TryAcquire(_ context.Context) (bool, error) {
+func (p noOpPermits) TryAcquire(context.Context) (bool, error) {
 	return true, nil
 }
 

--- a/src/dbnode/storage/limits/permits/types.go
+++ b/src/dbnode/storage/limits/permits/types.go
@@ -34,7 +34,7 @@ type Options interface {
 // Manager manages a set of permits.
 type Manager interface {
 	// NewPermits builds a new set of permits.
-	NewPermits(ctx context.Context) Permits
+	NewPermits(ctx context.Context) (Permits, error)
 }
 
 // Permits are the set of permits that individual codepaths will utilize.


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks that limit has not been exceeded to short circuit