### PR TITLE
[aggregator] Reduce timer stream allocs

### DIFF
--- a/src/aggregator/aggregation/quantile/cm/heap.go
+++ b/src/aggregator/aggregation/quantile/cm/heap.go
@@ -56,16 +56,19 @@ func (h *minHeap) Push(value float64) {
 func (h *minHeap) ensureSize() {
 	heap := *h
 	targetCap := cap(heap) * 2
-
 	newHeap := sharedHeapPool.Get(targetCap)
 	(*newHeap) = append(*newHeap, heap...)
-	sharedHeapPool.Put(heap)
-	*h = *newHeap
+	if cap(heap) >= _initialHeapBucketSize {
+		sharedHeapPool.Put(heap)
+	}
+	(*h) = *newHeap
 }
 
 func (h *minHeap) Reset() {
 	heap := *h
-	sharedHeapPool.Put(heap)
+	if cap(heap) >= _initialHeapBucketSize {
+		sharedHeapPool.Put(heap)
+	}
 	(*h) = nil
 }
 

--- a/src/aggregator/aggregation/quantile/cm/heap.go
+++ b/src/aggregator/aggregation/quantile/cm/heap.go
@@ -65,8 +65,7 @@ func (h *minHeap) ensureSize() {
 }
 
 func (h *minHeap) Reset() {
-	heap := *h
-	if cap(heap) >= _initialHeapBucketSize {
+	if heap := *h; cap(heap) >= _initialHeapBucketSize {
 		sharedHeapPool.Put(heap)
 	}
 	(*h) = nil

--- a/src/aggregator/aggregation/quantile/cm/heap_pool.go
+++ b/src/aggregator/aggregation/quantile/cm/heap_pool.go
@@ -26,8 +26,8 @@ import (
 
 const (
 	// create buckets of 64, 256, 1024, 4096, 16484, 65536 floats
-	_initialHeapBucketSize      = 16
-	_heapSizeBuckets            = 7
+	_initialHeapBucketSize      = 64
+	_heapSizeBuckets            = 6
 	_heapSizeBucketGrowthFactor = 4
 )
 
@@ -85,21 +85,14 @@ makeNew:
 }
 
 func (p heapPool) Put(value minHeap) {
-	if value == nil {
-		return
-	}
 	size := cap(value)
-	if size == 0 {
-		return
-	}
-
-	for i := range p.sizes {
+	for i := 0; i < len(p.sizes); i++ {
 		if p.sizes[i] < size {
 			continue
 		}
-
+		pool := p.pools[i]
 		value = value[:0]
-		p.pools[i].Put(&value)
+		pool.Put(&value)
 		return
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Slightly reduce the need for allocations by actually sizing the pool as indented in the comment and other minor tweaks

```
╰─$ benchstat old.txt new.txt
name                                                              old time/op    new time/op    delta
TimerValues-12                                                      32.3ns ± 1%    32.5ns ± 3%     ~     (p=0.770 n=5+5)
TimerValueOf-12                                                     69.6ns ± 1%    66.3ns ± 7%     ~     (p=0.151 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size-12                       1.50ms ± 6%    1.53ms ± 8%     ~     (p=0.548 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..1,000,000_range-12    1.58ms ± 6%    1.56ms ±11%     ~     (p=0.548 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..100,000_range-12      1.59ms ± 3%    1.53ms ± 5%     ~     (p=0.056 n=5+5)
TimerAddBatch/10k_samples_1000_batch_size-12                         189µs ± 3%     186µs ± 5%     ~     (p=0.548 n=5+5)
TimerAddBatch/10k_samples_100_batch_size-12                          188µs ± 3%     186µs ± 2%     ~     (p=0.310 n=5+5)
TimerAddBatch/10k_samples_100_batch_size_with_negative_values-12     187µs ± 4%     186µs ± 1%     ~     (p=0.151 n=5+5)
TimerAddBatch/1k_samples_100_batch_size-12                          27.9µs ± 3%    27.1µs ± 4%     ~     (p=0.056 n=5+5)

name                                                              old alloc/op   new alloc/op   delta
TimerValues-12                                                       0.00B          0.00B          ~     (all equal)
TimerValueOf-12                                                      0.00B          0.00B          ~     (all equal)
TimerAddBatch/100k_samples_1000_batch_size-12                       1.58kB ±15%    1.50kB ±22%     ~     (p=0.548 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..1,000,000_range-12    1.55kB ± 1%    1.42kB ± 2%   -7.93%  (p=0.016 n=4+5)
TimerAddBatch/100k_samples_1000_batch_size_0..100,000_range-12      1.55kB ± 7%    1.47kB ± 5%     ~     (p=0.190 n=4+5)
TimerAddBatch/10k_samples_1000_batch_size-12                          701B ± 2%      557B ± 6%  -20.57%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size-12                           679B ± 2%      576B ± 7%  -15.14%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size_with_negative_values-12      575B ± 4%      435B ± 9%  -24.26%  (p=0.008 n=5+5)
TimerAddBatch/1k_samples_100_batch_size-12                            320B ± 2%      172B ± 4%  -46.28%  (p=0.008 n=5+5)

name                                                              old allocs/op  new allocs/op  delta
TimerValues-12                                                        0.00           0.00          ~     (all equal)
TimerValueOf-12                                                       0.00           0.00          ~     (all equal)
TimerAddBatch/100k_samples_1000_batch_size-12                         12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..1,000,000_range-12      12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..100,000_range-12        12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_1000_batch_size-12                          12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size-12                           12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size_with_negative_values-12      12.0 ± 0%       8.0 ± 0%  -33.33%  (p=0.008 n=5+5)
TimerAddBatch/1k_samples_100_batch_size-12                            8.00 ± 0%      4.00 ± 0%  -50.00%  (p=0.008 n=5+5)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
