### PR TITLE
[coordinator] make drop timestamp apply to the metric rather than specific rule

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1097,6 +1097,7 @@ go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.opencensus.io v0.22.2 h1:75k/FF0Q2YM8QYo07VPddOLBslDt1MZOdEslOHvmzAs=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/src/cmd/services/m3coordinator/downsample/downsample_mock.go
+++ b/src/cmd/services/m3coordinator/downsample/downsample_mock.go
@@ -263,17 +263,3 @@ func (mr *MockSamplesAppenderMockRecorder) AppendUntimedTimerSample(arg0, arg1 i
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendUntimedTimerSample", reflect.TypeOf((*MockSamplesAppender)(nil).AppendUntimedTimerSample), arg0, arg1)
 }
-
-// DropTimestamp mocks base method
-func (m *MockSamplesAppender) DropTimestamp() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DropTimestamp")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// DropTimestamp indicates an expected call of DropTimestamp
-func (mr *MockSamplesAppenderMockRecorder) DropTimestamp() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropTimestamp", reflect.TypeOf((*MockSamplesAppender)(nil).DropTimestamp))
-}

--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -60,6 +60,7 @@ type MetricsAppender interface {
 type SamplesAppenderResult struct {
 	SamplesAppender     SamplesAppender
 	IsDropPolicyApplied bool
+	ShouldDropTimestamp bool
 }
 
 // SampleAppenderOptions defines the options being used when constructing
@@ -86,7 +87,6 @@ type SamplesAppender interface {
 	AppendCounterSample(t time.Time, value int64, annotation []byte) error
 	AppendGaugeSample(t time.Time, value float64, annotation []byte) error
 	AppendTimerSample(t time.Time, value float64, annotation []byte) error
-	DropTimestamp() bool
 }
 
 type downsampler struct {

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1648,6 +1648,106 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleAndDropTimestamp(t *test
 	testDownsamplerAggregation(t, testDownsampler)
 }
 
+func TestDownsamplerAggregationWithRulesConfigRollupRuleAndDropPolicyAndDropTimestamp(t *testing.T) {
+	t.Parallel()
+
+	gaugeMetrics := []testGaugeMetric{
+		{
+			tags: map[string]string{
+				nameTag:         "http_requests",
+				"app":           "nginx_edge",
+				"status_code":   "500",
+				"endpoint":      "/foo/bar",
+				"not_rolled_up": "not_rolled_up_value_1",
+			},
+			timedSamples: []testGaugeMetricTimedSample{
+				{value: 42}, // +42 (should not be accounted since is a reset)
+				// Explicit no value.
+				{value: 12, offset: 2 * time.Second}, // +12 - simulate a reset (should not be accounted)
+			},
+			expectDropTimestamp:     true,
+			expectDropPolicyApplied: true,
+		},
+		{
+			tags: map[string]string{
+				nameTag:         "http_requests",
+				"app":           "nginx_edge",
+				"status_code":   "500",
+				"endpoint":      "/foo/bar",
+				"not_rolled_up": "not_rolled_up_value_2",
+			},
+			timedSamples: []testGaugeMetricTimedSample{
+				{value: 13},
+				{value: 27, offset: 2 * time.Second}, // +14
+			},
+			expectDropTimestamp:     true,
+			expectDropPolicyApplied: true,
+		},
+	}
+	tags := []Tag{
+		{Name: "__m3_drop_timestamp__", Value: ""},
+	}
+	res := 1 * time.Second
+	ret := 30 * 24 * time.Hour
+	filter := fmt.Sprintf("%s:http_requests app:* status_code:* endpoint:*", nameTag)
+	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
+		rulesConfig: &RulesConfiguration{
+			MappingRules: []MappingRuleConfiguration{
+				{
+					Filter: filter,
+					Drop:   true,
+					Tags:   tags,
+				},
+			},
+			RollupRules: []RollupRuleConfiguration{
+				{
+					Filter: filter,
+					Transforms: []TransformConfiguration{
+						{
+							Rollup: &RollupOperationConfiguration{
+								MetricName:   "http_requests_by_status_code",
+								GroupBy:      []string{"app", "status_code", "endpoint"},
+								Aggregations: []aggregation.Type{aggregation.Sum},
+							},
+						},
+					},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: res,
+							Retention:  ret,
+						},
+					},
+				},
+			},
+		},
+		ingest: &testDownsamplerOptionsIngest{
+			gaugeMetrics: gaugeMetrics,
+		},
+		expect: &testDownsamplerOptionsExpect{
+			writes: []testExpectedWrite{
+				{
+					tags: map[string]string{
+						nameTag:               "http_requests_by_status_code",
+						string(rollupTagName): string(rollupTagValue),
+						"app":                 "nginx_edge",
+						"status_code":         "500",
+						"endpoint":            "/foo/bar",
+					},
+					values: []expectedValue{{value: 55}, {value: 39}},
+					attributes: &storagemetadata.Attributes{
+						MetricsType: storagemetadata.AggregatedMetricsType,
+						Resolution:  res,
+						Retention:   ret,
+					},
+				},
+			},
+		},
+	})
+
+	// Test expected output
+	testDownsamplerAggregation(t, testDownsampler)
+}
+
 func TestDownsamplerAggregationWithTimedSamples(t *testing.T) {
 	counterMetrics, counterMetricsExpect := testCounterMetrics(testCounterMetricsOptions{
 		timedSamples: true,

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1083,6 +1083,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesWithDropTSTag(t *testi
 		timedSamples: []testCounterMetricTimedSample{
 			{value: 1}, {value: 2}, {value: 3},
 		},
+		expectDropTimestamp: true,
 	}
 	tags := []Tag{
 		{Name: "__m3_drop_timestamp__", Value: ""},
@@ -1099,7 +1100,6 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesWithDropTSTag(t *testi
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
-					Tags: tags,
 				},
 				{
 					Filter:       "app:testapp",
@@ -1110,6 +1110,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesWithDropTSTag(t *testi
 							Retention:  30 * 24 * time.Hour,
 						},
 					},
+					Tags: tags,
 				},
 			},
 		},
@@ -1138,7 +1139,6 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesWithDropTSTag(t *testi
 					},
 				},
 			},
-			gaugeDropTimestamp: true,
 		},
 	})
 
@@ -1544,6 +1544,110 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleAndDropPolicy(t *testing
 	testDownsamplerAggregation(t, testDownsampler)
 }
 
+func TestDownsamplerAggregationWithRulesConfigRollupRuleAndDropTimestamp(t *testing.T) {
+	t.Parallel()
+
+	gaugeMetrics := []testGaugeMetric{
+		{
+			tags: map[string]string{
+				nameTag:         "http_requests",
+				"app":           "nginx_edge",
+				"status_code":   "500",
+				"endpoint":      "/foo/bar",
+				"not_rolled_up": "not_rolled_up_value_1",
+			},
+			timedSamples: []testGaugeMetricTimedSample{
+				{value: 42}, // +42 (should not be accounted since is a reset)
+				// Explicit no value.
+				{value: 12, offset: 2 * time.Second}, // +12 - simulate a reset (should not be accounted)
+			},
+			expectDropTimestamp: true,
+		},
+		{
+			tags: map[string]string{
+				nameTag:         "http_requests",
+				"app":           "nginx_edge",
+				"status_code":   "500",
+				"endpoint":      "/foo/bar",
+				"not_rolled_up": "not_rolled_up_value_2",
+			},
+			timedSamples: []testGaugeMetricTimedSample{
+				{value: 13},
+				{value: 27, offset: 2 * time.Second}, // +14
+			},
+			expectDropTimestamp: true,
+		},
+	}
+	tags := []Tag{
+		{Name: "__m3_drop_timestamp__", Value: ""},
+	}
+	res := 1 * time.Second
+	ret := 30 * 24 * time.Hour
+	filter := fmt.Sprintf("%s:http_requests app:* status_code:* endpoint:*", nameTag)
+	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
+		rulesConfig: &RulesConfiguration{
+			MappingRules: []MappingRuleConfiguration{
+				{
+					Filter:       filter,
+					Tags:         tags,
+					Aggregations: []aggregation.Type{testAggregationType},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: res,
+							Retention:  ret,
+						},
+					},
+				},
+			},
+			RollupRules: []RollupRuleConfiguration{
+				{
+					Filter: filter,
+					Transforms: []TransformConfiguration{
+						{
+							Rollup: &RollupOperationConfiguration{
+								MetricName:   "http_requests_by_status_code",
+								GroupBy:      []string{"app", "status_code", "endpoint"},
+								Aggregations: []aggregation.Type{aggregation.Sum},
+							},
+						},
+					},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: res,
+							Retention:  ret,
+						},
+					},
+				},
+			},
+		},
+		ingest: &testDownsamplerOptionsIngest{
+			gaugeMetrics: gaugeMetrics,
+		},
+		expect: &testDownsamplerOptionsExpect{
+			writes: []testExpectedWrite{
+				{
+					tags: map[string]string{
+						nameTag:               "http_requests_by_status_code",
+						string(rollupTagName): string(rollupTagValue),
+						"app":                 "nginx_edge",
+						"status_code":         "500",
+						"endpoint":            "/foo/bar",
+					},
+					values: []expectedValue{{value: 55}, {value: 39}},
+					attributes: &storagemetadata.Attributes{
+						MetricsType: storagemetadata.AggregatedMetricsType,
+						Resolution:  res,
+						Retention:   ret,
+					},
+				},
+			},
+		},
+	})
+
+	// Test expected output
+	testDownsamplerAggregation(t, testDownsampler)
+}
+
 func TestDownsamplerAggregationWithTimedSamples(t *testing.T) {
 	counterMetrics, counterMetricsExpect := testCounterMetrics(testCounterMetricsOptions{
 		timedSamples: true,
@@ -1787,6 +1891,7 @@ type testCounterMetric struct {
 	samples                 []int64
 	timedSamples            []testCounterMetricTimedSample
 	expectDropPolicyApplied bool
+	expectDropTimestamp     bool
 }
 
 type testCounterMetricTimedSample struct {
@@ -1800,6 +1905,7 @@ type testGaugeMetric struct {
 	samples                 []float64
 	timedSamples            []testGaugeMetricTimedSample
 	expectDropPolicyApplied bool
+	expectDropTimestamp     bool
 }
 
 type testGaugeMetricTimedSample struct {
@@ -2128,6 +2234,8 @@ func testDownsamplerAggregationIngest(
 		require.NoError(t, err)
 		require.Equal(t, metric.expectDropPolicyApplied,
 			samplesAppenderResult.IsDropPolicyApplied)
+		require.Equal(t, metric.expectDropTimestamp,
+			samplesAppenderResult.ShouldDropTimestamp)
 
 		samplesAppender := samplesAppenderResult.SamplesAppender
 		for _, sample := range metric.samples {
@@ -2144,7 +2252,6 @@ func testDownsamplerAggregationIngest(
 			err = samplesAppender.AppendCounterSample(sample.time, sample.value, nil)
 			require.NoError(t, err)
 		}
-		require.Equal(t, testDownsampler.testOpts.expect.counterDropTimestamp, samplesAppender.DropTimestamp())
 	}
 	for _, metric := range testGaugeMetrics {
 		appender.NextMetric()
@@ -2157,6 +2264,8 @@ func testDownsamplerAggregationIngest(
 		require.NoError(t, err)
 		require.Equal(t, metric.expectDropPolicyApplied,
 			samplesAppenderResult.IsDropPolicyApplied)
+		require.Equal(t, metric.expectDropTimestamp,
+			samplesAppenderResult.ShouldDropTimestamp)
 
 		samplesAppender := samplesAppenderResult.SamplesAppender
 		for _, sample := range metric.samples {
@@ -2173,7 +2282,6 @@ func testDownsamplerAggregationIngest(
 			err = samplesAppender.AppendGaugeSample(sample.time, sample.value, nil)
 			require.NoError(t, err)
 		}
-		require.Equal(t, testDownsampler.testOpts.expect.gaugeDropTimestamp, samplesAppender.DropTimestamp())
 	}
 }
 
@@ -2234,9 +2342,7 @@ type testDownsamplerOptionsIngest struct {
 }
 
 type testDownsamplerOptionsExpect struct {
-	writes               []testExpectedWrite
-	counterDropTimestamp bool
-	gaugeDropTimestamp   bool
+	writes []testExpectedWrite
 }
 
 func newTestDownsampler(t *testing.T, opts testDownsamplerOptions) testDownsampler {

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -189,7 +189,10 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 	// filter out augmented metrics tags
 	tags.filterPrefix(metric.M3MetricsPrefix)
 
-	var dropApplyResult metadata.ApplyOrRemoveDropPoliciesResult
+	var (
+		dropApplyResult metadata.ApplyOrRemoveDropPoliciesResult
+		dropTimestamp   bool
+	)
 	if opts.Override {
 		// Reuse a slice to keep the current staged metadatas we will apply.
 		a.curr.Pipelines = a.curr.Pipelines[:0]
@@ -346,6 +349,9 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 		// Apply drop policies results
 		a.curr.Pipelines, dropApplyResult = a.curr.Pipelines.ApplyOrRemoveDropPolicies()
 
+		// Apply the customer tags after applying drop policies.
+		dropTimestamp = a.curr.Pipelines.ApplyCustomTags()
+
 		if len(a.curr.Pipelines) > 0 && !a.curr.IsDropPolicyApplied() {
 			// Send to downsampler if we have something in the pipeline.
 			a.debugLogMatch("downsampler using built mapping staged metadatas",
@@ -375,6 +381,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 	return SamplesAppenderResult{
 		SamplesAppender:     a.multiSamplesAppender,
 		IsDropPolicyApplied: dropPolicyApplied,
+		ShouldDropTimestamp: dropTimestamp,
 	}, nil
 }
 
@@ -476,12 +483,12 @@ func (a *metricsAppender) addSamplesAppenders(originalTags *tags, stagedMetadata
 			continue
 		}
 
-		tags, dropTS := a.processTags(originalTags, pipeline.GraphitePrefix, pipeline.Tags, pipeline.AggregationID)
+		tags := a.processTags(originalTags, pipeline.GraphitePrefix, pipeline.Tags, pipeline.AggregationID)
 
 		sm := stagedMetadata
 		sm.Pipelines = []metadata.PipelineMetadata{pipeline}
 
-		appender, err := a.newSamplesAppender(tags, sm, dropTS)
+		appender, err := a.newSamplesAppender(tags, sm)
 		if err != nil {
 			return err
 		}
@@ -495,7 +502,7 @@ func (a *metricsAppender) addSamplesAppenders(originalTags *tags, stagedMetadata
 	sm := stagedMetadata
 	sm.Pipelines = pipelines
 
-	appender, err := a.newSamplesAppender(originalTags, sm, false)
+	appender, err := a.newSamplesAppender(originalTags, sm)
 	if err != nil {
 		return err
 	}
@@ -506,7 +513,6 @@ func (a *metricsAppender) addSamplesAppenders(originalTags *tags, stagedMetadata
 func (a *metricsAppender) newSamplesAppender(
 	tags *tags,
 	sm metadata.StagedMetadata,
-	dropTS bool,
 ) (samplesAppender, error) {
 	tagEncoder := a.tagEncoder()
 	if err := tagEncoder.Encode(tags); err != nil {
@@ -519,7 +525,6 @@ func (a *metricsAppender) newSamplesAppender(
 	return samplesAppender{
 		agg:             a.agg,
 		clientRemote:    a.clientRemote,
-		dropTS:          dropTS,
 		unownedID:       data.Bytes(),
 		stagedMetadatas: []metadata.StagedMetadata{sm},
 	}, nil
@@ -530,12 +535,9 @@ func (a *metricsAppender) processTags(
 	graphitePrefix [][]byte,
 	t []models.Tag,
 	id aggregation.ID,
-) (*tags, bool) {
+) *tags {
 	// Create the prefix tags if any.
-	var (
-		tags   = a.tags()
-		dropTS bool
-	)
+	var tags = a.tags()
 	for i, path := range graphitePrefix {
 		// Add the graphite prefix as the initial graphite tags.
 		tags.append(graphite.TagName(i), path)
@@ -584,11 +586,9 @@ func (a *metricsAppender) processTags(
 				value = types[0].Name()
 			)
 			tags.append(name, value)
-		} else if bytes.Equal(tag.Name, metric.M3MetricsDropTimestamp) {
-			dropTS = true
 		}
 	}
-	return tags, dropTS
+	return tags
 }
 
 func stagedMetadatasLogField(sm metadata.StagedMetadatas) zapcore.Field {

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -346,11 +346,12 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 				append(a.curr.Pipelines, pipelines.Pipelines...)
 		}
 
+		// Apply the customer tags first so that they apply even if mapping
+		// rules drop the metric.
+		dropTimestamp = a.curr.Pipelines.ApplyCustomTags()
+
 		// Apply drop policies results
 		a.curr.Pipelines, dropApplyResult = a.curr.Pipelines.ApplyOrRemoveDropPolicies()
-
-		// Apply the customer tags after applying drop policies.
-		dropTimestamp = a.curr.Pipelines.ApplyCustomTags()
 
 		if len(a.curr.Pipelines) > 0 && !a.curr.IsDropPolicyApplied() {
 			// Send to downsampler if we have something in the pipeline.

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -346,7 +346,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 				append(a.curr.Pipelines, pipelines.Pipelines...)
 		}
 
-		// Apply the customer tags first so that they apply even if mapping
+		// Apply the custom tags first so that they apply even if mapping
 		// rules drop the metric.
 		dropTimestamp = a.curr.Pipelines.ApplyCustomTags()
 

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -537,7 +537,7 @@ func (a *metricsAppender) processTags(
 	id aggregation.ID,
 ) *tags {
 	// Create the prefix tags if any.
-	var tags = a.tags()
+	tags := a.tags()
 	for i, path := range graphitePrefix {
 		// Add the graphite prefix as the initial graphite tags.
 		tags.append(graphite.TagName(i), path)

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -343,6 +343,10 @@ type MappingRuleConfiguration struct {
 	// aggregation tag which is required for graphite. If a metric is of the
 	// form {__g0__:stats __g1__:metric __g2__:timer} and we have configured
 	// a P95 aggregation, this option will add __g3__:P95 to the metric.
+	// __m3_graphite_prefix__ as a tag will add the provided value as a prefix
+	// to graphite metrics.
+	// __m3_drop_timestamp__ as a tag will drop the timestamp from while
+	// writing the metric out. So effectively treat it as an untimed metric.
 	Tags []Tag `yaml:"tags"`
 
 	// Optional fields follow.

--- a/src/cmd/services/m3coordinator/downsample/samples_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/samples_appender.go
@@ -45,10 +45,6 @@ type samplesAppender struct {
 // Ensure samplesAppender implements SamplesAppender.
 var _ SamplesAppender = (*samplesAppender)(nil)
 
-func (a samplesAppender) DropTimestamp() bool {
-	return a.dropTS
-}
-
 func (a samplesAppender) AppendUntimedCounterSample(value int64, annotation []byte) error {
 	if a.clientRemote != nil {
 		// Remote client write instead of local aggregation.
@@ -110,9 +106,6 @@ func (a samplesAppender) AppendUntimedTimerSample(value float64, annotation []by
 }
 
 func (a *samplesAppender) AppendCounterSample(t time.Time, value int64, annotation []byte) error {
-	if a.dropTS {
-		return a.AppendUntimedCounterSample(value, annotation)
-	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.CounterType,
 		ID:         a.unownedID,
@@ -123,9 +116,6 @@ func (a *samplesAppender) AppendCounterSample(t time.Time, value int64, annotati
 }
 
 func (a *samplesAppender) AppendGaugeSample(t time.Time, value float64, annotation []byte) error {
-	if a.dropTS {
-		return a.AppendUntimedGaugeSample(value, annotation)
-	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.GaugeType,
 		ID:         a.unownedID,
@@ -136,9 +126,6 @@ func (a *samplesAppender) AppendGaugeSample(t time.Time, value float64, annotati
 }
 
 func (a *samplesAppender) AppendTimerSample(t time.Time, value float64, annotation []byte) error {
-	if a.dropTS {
-		return a.AppendUntimedTimerSample(value, annotation)
-	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.TimerType,
 		ID:         a.unownedID,
@@ -176,15 +163,6 @@ func (a *multiSamplesAppender) reset() {
 
 func (a *multiSamplesAppender) addSamplesAppender(v samplesAppender) {
 	a.appenders = append(a.appenders, v)
-}
-
-func (a *multiSamplesAppender) DropTimestamp() bool {
-	for _, appender := range a.appenders {
-		if appender.DropTimestamp() {
-			return true
-		}
-	}
-	return false
 }
 
 func (a *multiSamplesAppender) AppendUntimedCounterSample(value int64, annotation []byte) error {

--- a/src/cmd/services/m3coordinator/downsample/samples_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/samples_appender.go
@@ -37,7 +37,6 @@ type samplesAppender struct {
 	agg          aggregator.Aggregator
 	clientRemote client.Client
 
-	dropTS          bool
 	unownedID       []byte
 	stagedMetadatas metadata.StagedMetadatas
 }

--- a/src/cmd/services/m3coordinator/ingest/write.go
+++ b/src/cmd/services/m3coordinator/ingest/write.go
@@ -275,7 +275,11 @@ func (d *downsamplerAndWriter) writeToDownsampler(
 	}
 
 	for _, dp := range datapoints {
-		err := result.SamplesAppender.AppendGaugeSample(dp.Timestamp, dp.Value, annotation)
+		if result.ShouldDropTimestamp {
+			err = result.SamplesAppender.AppendUntimedGaugeSample(dp.Value, annotation)
+		} else {
+			err = result.SamplesAppender.AppendGaugeSample(dp.Timestamp, dp.Value, annotation)
+		}
 		if err != nil {
 			return result.IsDropPolicyApplied, err
 		}
@@ -498,11 +502,23 @@ func (d *downsamplerAndWriter) writeAggregatedBatch(
 		for _, dp := range value.Datapoints {
 			switch value.Attributes.M3Type {
 			case ts.M3MetricTypeGauge:
-				err = result.SamplesAppender.AppendGaugeSample(dp.Timestamp, dp.Value, value.Annotation)
+				if result.ShouldDropTimestamp {
+					err = result.SamplesAppender.AppendUntimedGaugeSample(dp.Value, value.Annotation)
+				} else {
+					err = result.SamplesAppender.AppendGaugeSample(dp.Timestamp, dp.Value, value.Annotation)
+				}
 			case ts.M3MetricTypeCounter:
-				err = result.SamplesAppender.AppendCounterSample(dp.Timestamp, int64(dp.Value), value.Annotation)
+				if result.ShouldDropTimestamp {
+					err = result.SamplesAppender.AppendUntimedCounterSample(int64(dp.Value), value.Annotation)
+				} else {
+					err = result.SamplesAppender.AppendCounterSample(dp.Timestamp, int64(dp.Value), value.Annotation)
+				}
 			case ts.M3MetricTypeTimer:
-				err = result.SamplesAppender.AppendTimerSample(dp.Timestamp, dp.Value, value.Annotation)
+				if result.ShouldDropTimestamp {
+					err = result.SamplesAppender.AppendUntimedTimerSample(dp.Value, value.Annotation)
+				} else {
+					err = result.SamplesAppender.AppendTimerSample(dp.Timestamp, dp.Value, value.Annotation)
+				}
 			}
 			if err != nil {
 				// If we see an error break out so we can try processing the

--- a/src/cmd/services/m3coordinator/ingest/write_test.go
+++ b/src/cmd/services/m3coordinator/ingest/write_test.go
@@ -648,6 +648,60 @@ func TestDownsampleAndWriteBatchSingleDrop(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDownsampleAndWriteBatchDropTimestamp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	downAndWrite, downsampler, session := newTestDownsamplerAndWriter(t, ctrl,
+		testDownsamplerAndWriterOptions{})
+
+	var (
+		mockSamplesAppender = downsample.NewMockSamplesAppender(ctrl)
+		mockMetricsAppender = downsample.NewMockMetricsAppender(ctrl)
+	)
+
+	mockMetricsAppender.
+		EXPECT().
+		SamplesAppender(zeroDownsamplerAppenderOpts).
+		Return(downsample.SamplesAppenderResult{SamplesAppender: mockSamplesAppender, ShouldDropTimestamp: true}, nil).Times(1)
+	mockMetricsAppender.
+		EXPECT().
+		SamplesAppender(zeroDownsamplerAppenderOpts).
+		Return(downsample.SamplesAppenderResult{SamplesAppender: mockSamplesAppender}, nil).Times(1)
+	for _, tag := range testTags1.Tags {
+		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
+	}
+	for _, dp := range testDatapoints1 {
+		mockSamplesAppender.EXPECT().AppendUntimedGaugeSample(dp.Value, testAnnotation1)
+	}
+	for _, tag := range testTags2.Tags {
+		mockMetricsAppender.EXPECT().AddTag(tag.Name, tag.Value)
+	}
+	for _, dp := range testDatapoints2 {
+		mockSamplesAppender.EXPECT().AppendGaugeSample(dp.Timestamp, dp.Value, testAnnotation2)
+	}
+	downsampler.EXPECT().NewMetricsAppender().Return(mockMetricsAppender, nil)
+
+	mockMetricsAppender.EXPECT().NextMetric().Times(2)
+	mockMetricsAppender.EXPECT().Finalize()
+
+	for _, dp := range testEntries[0].datapoints {
+		session.EXPECT().WriteTagged(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dp.Value, gomock.Any(), testEntries[0].annotation,
+		)
+	}
+
+	for _, dp := range testEntries[1].datapoints {
+		session.EXPECT().WriteTagged(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), dp.Value, gomock.Any(), testEntries[1].annotation,
+		)
+	}
+
+	iter := newTestIter(testEntries)
+	err := downAndWrite.WriteBatch(context.Background(), iter, WriteOptions{})
+	require.NoError(t, err)
+}
+
 func TestDownsampleAndWriteBatchNoDownsampler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/src/cmd/services/m3coordinator/ingest/write_test.go
+++ b/src/cmd/services/m3coordinator/ingest/write_test.go
@@ -663,7 +663,10 @@ func TestDownsampleAndWriteBatchDropTimestamp(t *testing.T) {
 	mockMetricsAppender.
 		EXPECT().
 		SamplesAppender(zeroDownsamplerAppenderOpts).
-		Return(downsample.SamplesAppenderResult{SamplesAppender: mockSamplesAppender, ShouldDropTimestamp: true}, nil).Times(1)
+		Return(downsample.SamplesAppenderResult{
+			SamplesAppender:     mockSamplesAppender,
+			ShouldDropTimestamp: true,
+		}, nil).Times(1)
 	mockMetricsAppender.
 		EXPECT().
 		SamplesAppender(zeroDownsamplerAppenderOpts).

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -22,7 +22,6 @@ package metadata
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/metrics/generated/proto/metricpb"
@@ -269,11 +268,10 @@ func (metadatas PipelineMetadatas) ApplyOrRemoveDropPolicies() (
 	return result, RemovedIneffectiveDropPoliciesResult
 }
 
-// ApplyCustomTags.applies custom M3 tags.
+// ApplyCustomTags applies custom M3 tags.
 func (metadatas PipelineMetadatas) ApplyCustomTags() (
 	dropTimestamp bool,
 ) {
-	fmt.Printf("applying custom tags\n")
 	// Go over metadatas and process M3 custom tags.
 	for i := range metadatas {
 		for j := range metadatas[i].Tags {

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -21,9 +21,13 @@
 package metadata
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/metrics/generated/proto/metricpb"
 	"github.com/m3db/m3/src/metrics/generated/proto/policypb"
+	"github.com/m3db/m3/src/metrics/metric"
 	"github.com/m3db/m3/src/metrics/pipeline/applied"
 	"github.com/m3db/m3/src/metrics/policy"
 	"github.com/m3db/m3/src/query/models"
@@ -263,6 +267,24 @@ func (metadatas PipelineMetadatas) ApplyOrRemoveDropPolicies() (
 	}
 
 	return result, RemovedIneffectiveDropPoliciesResult
+}
+
+// ApplyCustomTags.applies custom M3 tags.
+func (metadatas PipelineMetadatas) ApplyCustomTags() (
+	dropTimestamp bool,
+) {
+	fmt.Printf("applying custom tags\n")
+	// Go over metadatas and process M3 custom tags.
+	for i := range metadatas {
+		for j := range metadatas[i].Tags {
+			// If any metadata has the drop timestamp tag, then return that we
+			// should send untimed metrics to the aggregator.
+			if bytes.Equal(metadatas[i].Tags[j].Name, metric.M3MetricsDropTimestamp) {
+				dropTimestamp = true
+			}
+		}
+	}
+	return
 }
 
 // Metadata represents the metadata associated with a metric.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for the drop timestamp tag to universally drop the timestamp while sending the metric to the aggregator.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
