### PR TITLE
[dbnode] Namespace extended options mutable

### DIFF
--- a/src/query/api/v1/handler/namespace/update.go
+++ b/src/query/api/v1/handler/namespace/update.go
@@ -64,7 +64,7 @@ var (
 		fieldNameRetentionOptions:   {},
 		fieldNameRuntimeOptions:     {},
 		fieldNameAggregationOptions: {},
-		fieldNameExtendedOptions: 	 {},
+		fieldNameExtendedOptions:    {},
 	}
 )
 

--- a/src/query/api/v1/handler/namespace/update.go
+++ b/src/query/api/v1/handler/namespace/update.go
@@ -54,6 +54,7 @@ var (
 	fieldNameRetentionPeriod    = "RetentionPeriodNanos"
 	fieldNameRuntimeOptions     = "RuntimeOptions"
 	fieldNameAggregationOptions = "AggregationOptions"
+	fieldNameExtendedOptions    = "ExtendedOptions"
 
 	errEmptyNamespaceName      = errors.New("must specify namespace name")
 	errEmptyNamespaceOptions   = errors.New("update options cannot be empty")
@@ -63,6 +64,7 @@ var (
 		fieldNameRetentionOptions:   {},
 		fieldNameRuntimeOptions:     {},
 		fieldNameAggregationOptions: {},
+		fieldNameExtendedOptions: 	 {},
 	}
 )
 

--- a/src/query/api/v1/handler/namespace/update_test.go
+++ b/src/query/api/v1/handler/namespace/update_test.go
@@ -62,6 +62,12 @@ const (
 						}
 					}
 				]
+			},
+			"extendedOptions": {
+				"type": "testExtendedOptions",
+				"options": {
+					"value": "bar"
+				}
 			}
 		}
 }
@@ -196,7 +202,7 @@ func TestNamespaceUpdateHandler(t *testing.T) {
 						"schemaOptions":     nil,
 						"stagingState":      xjson.Map{"status": "UNKNOWN"},
 						"coldWritesEnabled": false,
-						"extendedOptions":   xtest.NewTestExtendedOptionsJSON("foo"),
+						"extendedOptions":   xtest.NewTestExtendedOptionsJSON("bar"),
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows updating `namespace.extendedOptions` field via the API.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE