### PR TITLE
[tests] Remove a few more usages of NoOpAllBootstrapper from tests

### DIFF
--- a/src/dbnode/integration/fetch_tagged_quorum_test.go
+++ b/src/dbnode/integration/fetch_tagged_quorum_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/namespace"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/uninitialized"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/m3ninx/idx"
@@ -251,7 +250,6 @@ func makeMultiNodeSetup(
 	numShards int,
 	indexingEnabled bool,
 	asyncInserts bool,
-	finalBootstrapperName string,
 	instances []services.ServiceInstance,
 ) (testSetups, closeFn, client.Options) {
 	nsOpts := namespace.NewOptions()
@@ -263,7 +261,7 @@ func makeMultiNodeSetup(
 	require.NoError(t, err)
 
 	nspaces := []namespace.Metadata{md1, md2}
-	nodes, topoInit, closeFn := newNodes(t, numShards, instances, nspaces, asyncInserts, finalBootstrapperName)
+	nodes, topoInit, closeFn := newNodes(t, numShards, instances, nspaces, asyncInserts)
 	for _, node := range nodes {
 		node.SetOpts(node.Opts().SetNumShards(numShards))
 	}
@@ -284,8 +282,7 @@ func makeTestFetchTagged(
 	numShards int,
 	instances []services.ServiceInstance,
 ) (testSetups, closeFn, testFetchFn) {
-	nodes, closeFn, clientopts := makeMultiNodeSetup(t, numShards, true, false,
-		uninitialized.UninitializedTopologyBootstrapperName, instances)
+	nodes, closeFn, clientopts := makeMultiNodeSetup(t, numShards, true, false, instances)
 	testFetch := func(cLevel topology.ReadConsistencyLevel) (encoding.SeriesIterators, bool, error) {
 		clientopts := clientopts.SetReadConsistencyLevel(cLevel)
 		c, err := client.NewClient(clientopts)

--- a/src/dbnode/integration/index_multiple_node_high_concurrency_test.go
+++ b/src/dbnode/integration/index_multiple_node_high_concurrency_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/cluster/shard"
 	"github.com/m3db/m3/src/dbnode/client"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/uninitialized"
 	"github.com/m3db/m3/src/dbnode/topology"
 	xclock "github.com/m3db/m3/src/x/clock"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -73,8 +72,7 @@ func TestIndexMultipleNodeHighConcurrency(t *testing.T) {
 					node(t, 2, newClusterShardsRange(minShard, maxShard, shard.Available)),
 				}
 				// nodes = m3db nodes
-				nodes, closeFn, clientopts := makeMultiNodeSetup(t, numShards, true, true,
-					uninitialized.UninitializedTopologyBootstrapperName, instances)
+				nodes, closeFn, clientopts := makeMultiNodeSetup(t, numShards, true, true, instances)
 				clientopts = clientopts.SetReadConsistencyLevel(lvl)
 
 				defer closeFn()

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -50,6 +50,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper"
 	bcl "github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/commitlog"
 	bfs "github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/fs"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/uninitialized"
 	"github.com/m3db/m3/src/dbnode/storage/cluster"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/storage/series"
@@ -1084,7 +1085,6 @@ func newNodes(
 	instances []services.ServiceInstance,
 	nspaces []namespace.Metadata,
 	asyncInserts bool,
-	finalBootstrapperName string,
 ) (testSetups, topology.Initializer, closeFn) {
 	var (
 		log  = zap.L()
@@ -1110,7 +1110,7 @@ func newNodes(
 
 	nodeOpt := BootstrappableTestSetupOptions{
 		DisablePeersBootstrapper: true,
-		FinalBootstrapper:        finalBootstrapperName,
+		FinalBootstrapper:        uninitialized.UninitializedTopologyBootstrapperName,
 		TopologyInitializer:      topoInit,
 	}
 

--- a/src/dbnode/integration/write_read_high_concurrency_test.go
+++ b/src/dbnode/integration/write_read_high_concurrency_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/cluster/shard"
 	"github.com/m3db/m3/src/dbnode/client"
-	"github.com/m3db/m3/src/dbnode/storage/bootstrap/bootstrapper/uninitialized"
 	"github.com/m3db/m3/src/dbnode/topology"
 	xclock "github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/ident"
@@ -61,8 +60,7 @@ func TestWriteReadHighConcurrencyTestMultiNS(t *testing.T) {
 			node(t, 2, newClusterShardsRange(minShard, maxShard, shard.Available)),
 		}
 	)
-	nodes, closeFn, clientopts := makeMultiNodeSetup(t, numShards, true, true,
-		uninitialized.UninitializedTopologyBootstrapperName, instances)
+	nodes, closeFn, clientopts := makeMultiNodeSetup(t, numShards, true, true, instances)
 	clientopts = clientopts.
 		SetWriteConsistencyLevel(topology.ConsistencyLevelAll).
 		SetReadConsistencyLevel(topology.ReadConsistencyLevelAll)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Removes a few more usages of `NoOpAllBootstrapper` from integration tests

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
