### PR TITLE
[coordinator] convert prom type to m3 metric type for prometheus counters

### DIFF
--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -134,6 +134,8 @@ func PromTimeSeriesToSeriesAttributes(series prompb.TimeSeries) (ts.SeriesAttrib
 		m3MetricType = ts.M3MetricTypeGauge
 		if promMetricType == ts.PromMetricTypeUnknown && series.Source == prompb.Source_GRAPHITE {
 			promMetricType = ts.PromMetricTypeGauge
+		} else if series.Type == prompb.MetricType_COUNTER && series.Source == prompb.Source_PROMETHEUS {
+			m3MetricType = ts.M3MetricTypeCounter
 		}
 	case prompb.M3Type_M3_TIMER:
 		m3MetricType = ts.M3MetricTypeTimer

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -372,6 +372,35 @@ func TestPromTimeSeriesToSeriesAttributesPromMetricsTypeFromGraphite(t *testing.
 	}
 }
 
+func TestPromTimeSeriesToSeriesAttributesMetricsTypeFromPromType(t *testing.T) {
+	for _, test := range []struct {
+		m3Type   prompb.M3Type
+		promType prompb.MetricType
+		expected ts.M3MetricType
+	}{
+		{
+			m3Type:   prompb.M3Type_M3_COUNTER,
+			expected: ts.M3MetricTypeCounter,
+		},
+		{
+			m3Type:   prompb.M3Type_M3_GAUGE,
+			promType: prompb.MetricType_COUNTER,
+			expected: ts.M3MetricTypeCounter,
+		},
+		{
+			m3Type:   prompb.M3Type_M3_GAUGE,
+			promType: prompb.MetricType_SUMMARY,
+			expected: ts.M3MetricTypeGauge,
+		},
+	} {
+		t.Run(test.m3Type.String(), func(t *testing.T) {
+			attrs, err := PromTimeSeriesToSeriesAttributes(prompb.TimeSeries{M3Type: test.m3Type, Source: prompb.Source_PROMETHEUS, Type: test.promType})
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, attrs.M3Type)
+		})
+	}
+}
+
 func TestSeriesAttributesToAnnotationPayload(t *testing.T) {
 	mapping := map[ts.PromMetricType]annotation.MetricType{
 		ts.PromMetricTypeUnknown:        annotation.MetricType_UNKNOWN,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR converts the prometheus metric types to m3 metric type for counters if m3 metric type is not present.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
