### PR TITLE
[aggregator] CanLead for unflushed window takes BufferPast into account

### DIFF
--- a/src/aggregator/aggregator/flush_mgr_options.go
+++ b/src/aggregator/aggregator/flush_mgr_options.go
@@ -122,6 +122,12 @@ type FlushManagerOptions interface {
 
 	// ForcedFlushWindowSize returns the window size for a forced flush.
 	ForcedFlushWindowSize() time.Duration
+
+	// SetBufferForPastTimedMetric sets the size of the buffer for timed metrics in the past.
+	SetBufferForPastTimedMetric(value time.Duration) FlushManagerOptions
+
+	// BufferForPastTimedMetric returns the size of the buffer for timed metrics in the past.
+	BufferForPastTimedMetric() time.Duration
 }
 
 type flushManagerOptions struct {
@@ -137,6 +143,8 @@ type flushManagerOptions struct {
 	flushTimesPersistEvery time.Duration
 	maxBufferSize          time.Duration
 	forcedFlushWindowSize  time.Duration
+
+	bufferForPastTimedMetric time.Duration
 }
 
 // NewFlushManagerOptions create a new set of flush manager options.
@@ -152,6 +160,8 @@ func NewFlushManagerOptions() FlushManagerOptions {
 		flushTimesPersistEvery: defaultFlushTimesPersistEvery,
 		maxBufferSize:          defaultMaxBufferSize,
 		forcedFlushWindowSize:  defaultForcedFlushWindowSize,
+
+		bufferForPastTimedMetric: defaultTimedMetricBuffer,
 	}
 }
 
@@ -273,4 +283,14 @@ func (o *flushManagerOptions) SetForcedFlushWindowSize(value time.Duration) Flus
 
 func (o *flushManagerOptions) ForcedFlushWindowSize() time.Duration {
 	return o.forcedFlushWindowSize
+}
+
+func (o *flushManagerOptions) SetBufferForPastTimedMetric(value time.Duration) FlushManagerOptions {
+	opts := *o
+	opts.bufferForPastTimedMetric = value
+	return &opts
+}
+
+func (o *flushManagerOptions) BufferForPastTimedMetric() time.Duration {
+	return o.bufferForPastTimedMetric
 }

--- a/src/aggregator/aggregator/leader_flush_mgr_test.go
+++ b/src/aggregator/aggregator/leader_flush_mgr_test.go
@@ -37,18 +37,18 @@ import (
 var (
 	testFlushTimes = &schema.ShardSetFlushTimes{
 		ByShard: map[uint32]*schema.ShardFlushTimes{
-			0: &schema.ShardFlushTimes{
+			0: {
 				StandardByResolution: map[int64]int64{
 					1000000000:  3663000000000,
 					60000000000: 3660000000000,
 				},
 				ForwardedByResolution: map[int64]*schema.ForwardedFlushTimesForResolution{
-					1000000000: &schema.ForwardedFlushTimesForResolution{
+					1000000000: {
 						ByNumForwardedTimes: map[int32]int64{
 							1: 3663000000000,
 						},
 					},
-					60000000000: &schema.ForwardedFlushTimesForResolution{
+					60000000000: {
 						ByNumForwardedTimes: map[int32]int64{
 							2: 3660000000000,
 							3: 3600000000000,
@@ -56,19 +56,19 @@ var (
 					},
 				},
 			},
-			1: &schema.ShardFlushTimes{
+			1: {
 				StandardByResolution: map[int64]int64{
 					1000000000: 3658000000000,
 				},
 				ForwardedByResolution: map[int64]*schema.ForwardedFlushTimesForResolution{
-					1000000000: &schema.ForwardedFlushTimesForResolution{
+					1000000000: {
 						ByNumForwardedTimes: map[int32]int64{
 							1: 3658000000000,
 						},
 					},
 				},
 			},
-			2: &schema.ShardFlushTimes{
+			2: {
 				StandardByResolution: map[int64]int64{
 					3600000000000: 3600000000000,
 				},
@@ -78,7 +78,7 @@ var (
 
 	testFlushTimes2 = &schema.ShardSetFlushTimes{
 		ByShard: map[uint32]*schema.ShardFlushTimes{
-			0: &schema.ShardFlushTimes{
+			0: {
 				StandardByResolution: map[int64]int64{
 					1000000000:  3669000000000,
 					60000000000: 3660000000000,
@@ -87,12 +87,12 @@ var (
 					1000000000: 3600000000000,
 				},
 				ForwardedByResolution: map[int64]*schema.ForwardedFlushTimesForResolution{
-					1000000000: &schema.ForwardedFlushTimesForResolution{
+					1000000000: {
 						ByNumForwardedTimes: map[int32]int64{
 							1: 3681000000000,
 						},
 					},
-					60000000000: &schema.ForwardedFlushTimesForResolution{
+					60000000000: {
 						ByNumForwardedTimes: map[int32]int64{
 							2: 3660000000000,
 							3: 3600000000000,
@@ -101,12 +101,12 @@ var (
 				},
 				Tombstoned: false,
 			},
-			1: &schema.ShardFlushTimes{
+			1: {
 				StandardByResolution: map[int64]int64{
 					1000000000: 3658000000000,
 				},
 				ForwardedByResolution: map[int64]*schema.ForwardedFlushTimesForResolution{
-					1000000000: &schema.ForwardedFlushTimesForResolution{
+					1000000000: {
 						ByNumForwardedTimes: map[int32]int64{
 							1: 3658000000000,
 						},
@@ -114,21 +114,21 @@ var (
 				},
 				Tombstoned: true,
 			},
-			2: &schema.ShardFlushTimes{
+			2: {
 				StandardByResolution: map[int64]int64{
 					3600000000000: 3600000000000,
 				},
 				Tombstoned: true,
 			},
-			3: &schema.ShardFlushTimes{
+			3: {
 				StandardByResolution: map[int64]int64{
 					3600000000000: 7200000000000,
 				},
 				Tombstoned: false,
 			},
-			4: &schema.ShardFlushTimes{
+			4: {
 				ForwardedByResolution: map[int64]*schema.ForwardedFlushTimesForResolution{
-					60000000000: &schema.ForwardedFlushTimesForResolution{
+					60000000000: {
 						ByNumForwardedTimes: map[int32]int64{
 							2: 3658000000000,
 						},
@@ -655,38 +655,38 @@ func testFlushBuckets(ctrl *gomock.Controller) []*flushBucket {
 
 	return []*flushBucket{
 		// Standard flushing metric lists.
-		&flushBucket{
+		{
 			bucketID: standardMetricListID{resolution: time.Second}.toMetricListID(),
 			interval: time.Second,
 			offset:   250 * time.Millisecond,
 			flushers: []flushingMetricList{standardFlusher1, standardFlusher2},
 		},
-		&flushBucket{
+		{
 			bucketID: standardMetricListID{resolution: time.Minute}.toMetricListID(),
 			interval: time.Minute,
 			offset:   12 * time.Second,
 			flushers: []flushingMetricList{standardFlusher3},
 		},
-		&flushBucket{
+		{
 			bucketID: standardMetricListID{resolution: time.Hour}.toMetricListID(),
 			interval: time.Hour,
 			offset:   time.Minute,
 			flushers: []flushingMetricList{standardFlusher4},
 		},
 		// Forwarded flushing metric lists.
-		&flushBucket{
+		{
 			bucketID: forwardedMetricListID{resolution: time.Second, numForwardedTimes: 1}.toMetricListID(),
 			interval: time.Second,
 			offset:   100 * time.Millisecond,
 			flushers: []flushingMetricList{forwardedFlusher1, forwardedFlusher2},
 		},
-		&flushBucket{
+		{
 			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 2}.toMetricListID(),
 			interval: time.Minute,
 			offset:   time.Second,
 			flushers: []flushingMetricList{forwardedFlusher3},
 		},
-		&flushBucket{
+		{
 			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 3}.toMetricListID(),
 			interval: time.Minute,
 			offset:   0,
@@ -722,31 +722,31 @@ func testFlushBuckets2(ctrl *gomock.Controller) []*flushBucket {
 	forwardedFlusher2.EXPECT().LastFlushedNanos().Return(int64(3658000000000)).AnyTimes()
 
 	return []*flushBucket{
-		&flushBucket{
+		{
 			bucketID: standardMetricListID{resolution: time.Second}.toMetricListID(),
 			interval: time.Second,
 			offset:   250 * time.Millisecond,
 			flushers: []flushingMetricList{standardFlusher1},
 		},
-		&flushBucket{
+		{
 			bucketID: standardMetricListID{resolution: time.Hour}.toMetricListID(),
 			interval: time.Hour,
 			offset:   time.Minute,
 			flushers: []flushingMetricList{standardFlusher2},
 		},
-		&flushBucket{
+		{
 			bucketID: timedMetricListID{resolution: time.Second}.toMetricListID(),
 			interval: time.Second,
 			offset:   250 * time.Millisecond,
 			flushers: []flushingMetricList{timedFlusher1},
 		},
-		&flushBucket{
+		{
 			bucketID: forwardedMetricListID{resolution: time.Second, numForwardedTimes: 1}.toMetricListID(),
 			interval: time.Second,
 			offset:   100 * time.Millisecond,
 			flushers: []flushingMetricList{forwardedFlusher1},
 		},
-		&flushBucket{
+		{
 			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 2}.toMetricListID(),
 			interval: time.Minute,
 			offset:   time.Second,

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -250,10 +250,16 @@ type Options interface {
 	// delay for given metric resolution and number of times the metric has been forwarded.
 	MaxAllowedForwardingDelayFn() MaxAllowedForwardingDelayFn
 
-	// SetBufferForPastTimedMetricFn sets the size of the buffer for timed metrics in the past.
+	// SetBufferForPastTimedMetric sets the size of the buffer for timed metrics in the past.
+	SetBufferForPastTimedMetric(value time.Duration) Options
+
+	// BufferForPastTimedMetric returns the size of the buffer for timed metrics in the past.
+	BufferForPastTimedMetric() time.Duration
+
+	// SetBufferForPastTimedMetricFn sets the size fn of the buffer for timed metrics in the past.
 	SetBufferForPastTimedMetricFn(value BufferForPastTimedMetricFn) Options
 
-	// BufferForPastTimedMetricFn returns the size of the buffer for timed metrics in the past.
+	// BufferForPastTimedMetricFn returns the size fn of the buffer for timed metrics in the past.
 	BufferForPastTimedMetricFn() BufferForPastTimedMetricFn
 
 	// SetBufferForFutureTimedMetric sets the size of the buffer for timed metrics in the future.
@@ -353,6 +359,7 @@ type options struct {
 	electionManager                  ElectionManager
 	resignTimeout                    time.Duration
 	maxAllowedForwardingDelayFn      MaxAllowedForwardingDelayFn
+	bufferForPastTimedMetric         time.Duration
 	bufferForPastTimedMetricFn       BufferForPastTimedMetricFn
 	bufferForFutureTimedMetric       time.Duration
 	maxNumCachedSourceSets           int
@@ -399,6 +406,7 @@ func NewOptions() Options {
 		defaultStoragePolicies:           defaultDefaultStoragePolicies,
 		resignTimeout:                    defaultResignTimeout,
 		maxAllowedForwardingDelayFn:      defaultMaxAllowedForwardingDelayFn,
+		bufferForPastTimedMetric:         defaultTimedMetricBuffer,
 		bufferForPastTimedMetricFn:       defaultBufferForPastTimedMetricFn,
 		bufferForFutureTimedMetric:       defaultTimedMetricBuffer,
 		maxNumCachedSourceSets:           defaultMaxNumCachedSourceSets,
@@ -687,6 +695,16 @@ func (o *options) SetMaxAllowedForwardingDelayFn(value MaxAllowedForwardingDelay
 
 func (o *options) MaxAllowedForwardingDelayFn() MaxAllowedForwardingDelayFn {
 	return o.maxAllowedForwardingDelayFn
+}
+
+func (o *options) SetBufferForPastTimedMetric(value time.Duration) Options {
+	opts := *o
+	opts.bufferForPastTimedMetric = value
+	return &opts
+}
+
+func (o *options) BufferForPastTimedMetric() time.Duration {
+	return o.bufferForPastTimedMetric
 }
 
 func (o *options) SetBufferForPastTimedMetricFn(value BufferForPastTimedMetricFn) Options {

--- a/src/aggregator/integration/setup.go
+++ b/src/aggregator/integration/setup.go
@@ -161,7 +161,8 @@ func newTestServerSetup(t *testing.T, opts testServerOptions) *testServerSetup {
 		SetFlushTimesManager(flushTimesManager).
 		SetElectionManager(electionManager).
 		SetJitterEnabled(opts.JitterEnabled()).
-		SetMaxJitterFn(opts.MaxJitterFn())
+		SetMaxJitterFn(opts.MaxJitterFn()).
+		SetBufferForPastTimedMetric(aggregatorOpts.BufferForPastTimedMetric())
 	flushManager := aggregator.NewFlushManager(flushManagerOpts)
 	aggregatorOpts = aggregatorOpts.SetFlushManager(flushManager)
 

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -332,7 +332,8 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 		opts = opts.SetBufferDurationAfterShardCutoff(c.BufferDurationAfterShardCutoff)
 	}
 	if c.BufferDurationForPastTimedMetric != 0 {
-		opts = opts.SetBufferForPastTimedMetricFn(bufferForPastTimedMetricFn(c.BufferDurationForPastTimedMetric))
+		opts = opts.SetBufferForPastTimedMetric(c.BufferDurationForPastTimedMetric).
+			SetBufferForPastTimedMetricFn(bufferForPastTimedMetricFn(c.BufferDurationForPastTimedMetric))
 	}
 	if c.BufferDurationForFutureTimedMetric != 0 {
 		opts = opts.SetBufferForFutureTimedMetric(c.BufferDurationForFutureTimedMetric)
@@ -374,6 +375,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 		electionManager,
 		flushTimesManager,
 		iOpts,
+		opts.BufferForPastTimedMetric(),
 	)
 	if err != nil {
 		return nil, err
@@ -779,12 +781,14 @@ func (c flushManagerConfiguration) NewFlushManagerOptions(
 	electionManager aggregator.ElectionManager,
 	flushTimesManager aggregator.FlushTimesManager,
 	instrumentOpts instrument.Options,
+	bufferForPastTimedMetric time.Duration,
 ) (aggregator.FlushManagerOptions, error) {
 	opts := aggregator.NewFlushManagerOptions().
 		SetInstrumentOptions(instrumentOpts).
 		SetPlacementManager(placementManager).
 		SetElectionManager(electionManager).
-		SetFlushTimesManager(flushTimesManager)
+		SetFlushTimesManager(flushTimesManager).
+		SetBufferForPastTimedMetric(bufferForPastTimedMetric)
 	if c.CheckEvery != 0 {
 		opts = opts.SetCheckEvery(c.CheckEvery)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/m3db/m3/pull/2818 introduced a special case handling for resolution windows that have not been flushed yet by the leader, but it did not take `BufferPast` into account for timed metrics.
This PR adds the logics to  take `BufferPast` into account for timed metrics.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
