### PR TITLE
Optimize StagedMetadatas conversion

### DIFF
--- a/src/metrics/aggregation/id.go
+++ b/src/metrics/aggregation/id.go
@@ -141,21 +141,13 @@ func (id *ID) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // ToProto converts the aggregation id to a protobuf message in place.
-func (id ID) ToProto(pb *aggregationpb.AggregationID) error {
-	if IDLen != 1 {
-		return fmt.Errorf("id length %d cannot be represented by a single integer", IDLen)
-	}
+func (id ID) ToProto(pb *aggregationpb.AggregationID) {
 	pb.Id = id[0]
-	return nil
 }
 
 // FromProto converts the protobuf message to an aggregation id in place.
-func (id *ID) FromProto(pb aggregationpb.AggregationID) error {
-	if IDLen != 1 {
-		return fmt.Errorf("id length %d cannot be represented by a single integer", IDLen)
-	}
+func (id *ID) FromProto(pb aggregationpb.AggregationID) {
 	(*id)[0] = pb.Id
-	return nil
 }
 
 // CompressTypes compresses a list of aggregation types to an ID.
@@ -171,4 +163,11 @@ func MustCompressTypes(aggTypes ...Type) ID {
 		panic(err)
 	}
 	return res
+}
+
+func init() {
+	if IDLen != 1 {
+		// changing this const requires extensive surgery
+		panic(fmt.Sprintf("id length %d cannot be represented by a single integer", IDLen))
+	}
 }

--- a/src/metrics/aggregation/id_test.go
+++ b/src/metrics/aggregation/id_test.go
@@ -39,13 +39,13 @@ var (
 
 func TestIDToProto(t *testing.T) {
 	var pb aggregationpb.AggregationID
-	require.NoError(t, testID.ToProto(&pb))
+	testID.ToProto(&pb)
 	require.Equal(t, testIDProto, pb)
 }
 
 func TestIDFromProto(t *testing.T) {
 	var res ID
-	require.NoError(t, res.FromProto(testIDProto))
+	res.FromProto(testIDProto)
 	require.Equal(t, testID, res)
 }
 
@@ -54,8 +54,8 @@ func TestIDRoundTrip(t *testing.T) {
 		pb  aggregationpb.AggregationID
 		res ID
 	)
-	require.NoError(t, testID.ToProto(&pb))
-	require.NoError(t, res.FromProto(pb))
+	testID.ToProto(&pb)
+	res.FromProto(pb)
 	require.Equal(t, testID, res)
 }
 

--- a/src/metrics/encoding/protobuf/unaggregated_encoder_test.go
+++ b/src/metrics/encoding/protobuf/unaggregated_encoder_test.go
@@ -253,7 +253,7 @@ var (
 	}
 	testPassthroughMetadata1 = policy.NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour)
 	testPassthroughMetadata2 = policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour)
-	testCounter1Proto = metricpb.Counter{
+	testCounter1Proto        = metricpb.Counter{
 		Id:    []byte("testCounter1"),
 		Value: 123,
 	}
@@ -673,11 +673,11 @@ func TestUnaggregatedEncoderEncodeBatchTimerWithMetadatas(t *testing.T) {
 	enc.(*unaggregatedEncoder).encodeMessageFn = func(pb metricpb.MetricWithMetadatas) error { pbRes = pb; return nil }
 	for i, input := range inputs {
 		require.NoError(t, enc.EncodeMessage(encoding.UnaggregatedMessageUnion{
-			Type: encoding.BatchTimerWithMetadatasType,
+			Type:                    encoding.BatchTimerWithMetadatasType,
 			BatchTimerWithMetadatas: input,
 		}))
 		expectedProto := metricpb.MetricWithMetadatas{
-			Type: metricpb.MetricWithMetadatas_BATCH_TIMER_WITH_METADATAS,
+			Type:                    metricpb.MetricWithMetadatas_BATCH_TIMER_WITH_METADATAS,
 			BatchTimerWithMetadatas: &expected[i],
 		}
 		expectedMsgSize := expectedProto.Size()
@@ -793,11 +793,11 @@ func TestUnaggregatedEncoderEncodeForwardedMetricWithMetadata(t *testing.T) {
 	enc.(*unaggregatedEncoder).encodeMessageFn = func(pb metricpb.MetricWithMetadatas) error { pbRes = pb; return nil }
 	for i, input := range inputs {
 		require.NoError(t, enc.EncodeMessage(encoding.UnaggregatedMessageUnion{
-			Type: encoding.ForwardedMetricWithMetadataType,
+			Type:                        encoding.ForwardedMetricWithMetadataType,
 			ForwardedMetricWithMetadata: input,
 		}))
 		expectedProto := metricpb.MetricWithMetadatas{
-			Type: metricpb.MetricWithMetadatas_FORWARDED_METRIC_WITH_METADATA,
+			Type:                        metricpb.MetricWithMetadatas_FORWARDED_METRIC_WITH_METADATA,
 			ForwardedMetricWithMetadata: &expected[i],
 		}
 		expectedMsgSize := expectedProto.Size()
@@ -853,11 +853,11 @@ func TestUnaggregatedEncoderEncodeTimedMetricWithMetadata(t *testing.T) {
 	enc.(*unaggregatedEncoder).encodeMessageFn = func(pb metricpb.MetricWithMetadatas) error { pbRes = pb; return nil }
 	for i, input := range inputs {
 		require.NoError(t, enc.EncodeMessage(encoding.UnaggregatedMessageUnion{
-			Type: encoding.TimedMetricWithMetadataType,
+			Type:                    encoding.TimedMetricWithMetadataType,
 			TimedMetricWithMetadata: input,
 		}))
 		expectedProto := metricpb.MetricWithMetadatas{
-			Type: metricpb.MetricWithMetadatas_TIMED_METRIC_WITH_METADATA,
+			Type:                    metricpb.MetricWithMetadatas_TIMED_METRIC_WITH_METADATA,
 			TimedMetricWithMetadata: &expected[i],
 		}
 		expectedMsgSize := expectedProto.Size()
@@ -1121,12 +1121,12 @@ func TestUnaggregatedEncoderStress(t *testing.T) {
 				}
 			case unaggregated.BatchTimerWithMetadatas:
 				msg = encoding.UnaggregatedMessageUnion{
-					Type: encoding.BatchTimerWithMetadatasType,
+					Type:                    encoding.BatchTimerWithMetadatasType,
 					BatchTimerWithMetadatas: input,
 				}
 				res := expected[i].(metricpb.BatchTimerWithMetadatas)
 				expectedProto = metricpb.MetricWithMetadatas{
-					Type: metricpb.MetricWithMetadatas_BATCH_TIMER_WITH_METADATAS,
+					Type:                    metricpb.MetricWithMetadatas_BATCH_TIMER_WITH_METADATAS,
 					BatchTimerWithMetadatas: &res,
 				}
 			case unaggregated.GaugeWithMetadatas:
@@ -1141,32 +1141,32 @@ func TestUnaggregatedEncoderStress(t *testing.T) {
 				}
 			case aggregated.ForwardedMetricWithMetadata:
 				msg = encoding.UnaggregatedMessageUnion{
-					Type: encoding.ForwardedMetricWithMetadataType,
+					Type:                        encoding.ForwardedMetricWithMetadataType,
 					ForwardedMetricWithMetadata: input,
 				}
 				res := expected[i].(metricpb.ForwardedMetricWithMetadata)
 				expectedProto = metricpb.MetricWithMetadatas{
-					Type: metricpb.MetricWithMetadatas_FORWARDED_METRIC_WITH_METADATA,
+					Type:                        metricpb.MetricWithMetadatas_FORWARDED_METRIC_WITH_METADATA,
 					ForwardedMetricWithMetadata: &res,
 				}
 			case aggregated.TimedMetricWithMetadata:
 				msg = encoding.UnaggregatedMessageUnion{
-					Type: encoding.TimedMetricWithMetadataType,
+					Type:                    encoding.TimedMetricWithMetadataType,
 					TimedMetricWithMetadata: input,
 				}
 				res := expected[i].(metricpb.TimedMetricWithMetadata)
 				expectedProto = metricpb.MetricWithMetadatas{
-					Type: metricpb.MetricWithMetadatas_TIMED_METRIC_WITH_METADATA,
+					Type:                    metricpb.MetricWithMetadatas_TIMED_METRIC_WITH_METADATA,
 					TimedMetricWithMetadata: &res,
 				}
 			case aggregated.PassthroughMetricWithMetadata:
 				msg = encoding.UnaggregatedMessageUnion{
-					Type: encoding.PassthroughMetricWithMetadataType,
+					Type:                          encoding.PassthroughMetricWithMetadataType,
 					PassthroughMetricWithMetadata: input,
 				}
 				res := expected[i].(metricpb.TimedMetricWithStoragePolicy)
 				expectedProto = metricpb.MetricWithMetadatas{
-					Type: metricpb.MetricWithMetadatas_TIMED_METRIC_WITH_STORAGE_POLICY,
+					Type:                         metricpb.MetricWithMetadatas_TIMED_METRIC_WITH_STORAGE_POLICY,
 					TimedMetricWithStoragePolicy: &res,
 				}
 			default:

--- a/src/metrics/generated/proto/metricpb/composite.pb.go
+++ b/src/metrics/generated/proto/metricpb/composite.pb.go
@@ -143,10 +143,12 @@ type BatchTimerWithMetadatas struct {
 	Metadatas  StagedMetadatas `protobuf:"bytes,2,opt,name=metadatas" json:"metadatas"`
 }
 
-func (m *BatchTimerWithMetadatas) Reset()                    { *m = BatchTimerWithMetadatas{} }
-func (m *BatchTimerWithMetadatas) String() string            { return proto.CompactTextString(m) }
-func (*BatchTimerWithMetadatas) ProtoMessage()               {}
-func (*BatchTimerWithMetadatas) Descriptor() ([]byte, []int) { return fileDescriptorComposite, []int{1} }
+func (m *BatchTimerWithMetadatas) Reset()         { *m = BatchTimerWithMetadatas{} }
+func (m *BatchTimerWithMetadatas) String() string { return proto.CompactTextString(m) }
+func (*BatchTimerWithMetadatas) ProtoMessage()    {}
+func (*BatchTimerWithMetadatas) Descriptor() ([]byte, []int) {
+	return fileDescriptorComposite, []int{1}
+}
 
 func (m *BatchTimerWithMetadatas) GetBatchTimer() BatchTimer {
 	if m != nil {
@@ -217,10 +219,12 @@ type TimedMetricWithMetadata struct {
 	Metadata TimedMetadata `protobuf:"bytes,2,opt,name=metadata" json:"metadata"`
 }
 
-func (m *TimedMetricWithMetadata) Reset()                    { *m = TimedMetricWithMetadata{} }
-func (m *TimedMetricWithMetadata) String() string            { return proto.CompactTextString(m) }
-func (*TimedMetricWithMetadata) ProtoMessage()               {}
-func (*TimedMetricWithMetadata) Descriptor() ([]byte, []int) { return fileDescriptorComposite, []int{4} }
+func (m *TimedMetricWithMetadata) Reset()         { *m = TimedMetricWithMetadata{} }
+func (m *TimedMetricWithMetadata) String() string { return proto.CompactTextString(m) }
+func (*TimedMetricWithMetadata) ProtoMessage()    {}
+func (*TimedMetricWithMetadata) Descriptor() ([]byte, []int) {
+	return fileDescriptorComposite, []int{4}
+}
 
 func (m *TimedMetricWithMetadata) GetMetric() TimedMetric {
 	if m != nil {

--- a/src/metrics/generated/proto/metricpb/composite.pb.go
+++ b/src/metrics/generated/proto/metricpb/composite.pb.go
@@ -143,12 +143,10 @@ type BatchTimerWithMetadatas struct {
 	Metadatas  StagedMetadatas `protobuf:"bytes,2,opt,name=metadatas" json:"metadatas"`
 }
 
-func (m *BatchTimerWithMetadatas) Reset()         { *m = BatchTimerWithMetadatas{} }
-func (m *BatchTimerWithMetadatas) String() string { return proto.CompactTextString(m) }
-func (*BatchTimerWithMetadatas) ProtoMessage()    {}
-func (*BatchTimerWithMetadatas) Descriptor() ([]byte, []int) {
-	return fileDescriptorComposite, []int{1}
-}
+func (m *BatchTimerWithMetadatas) Reset()                    { *m = BatchTimerWithMetadatas{} }
+func (m *BatchTimerWithMetadatas) String() string            { return proto.CompactTextString(m) }
+func (*BatchTimerWithMetadatas) ProtoMessage()               {}
+func (*BatchTimerWithMetadatas) Descriptor() ([]byte, []int) { return fileDescriptorComposite, []int{1} }
 
 func (m *BatchTimerWithMetadatas) GetBatchTimer() BatchTimer {
 	if m != nil {
@@ -219,12 +217,10 @@ type TimedMetricWithMetadata struct {
 	Metadata TimedMetadata `protobuf:"bytes,2,opt,name=metadata" json:"metadata"`
 }
 
-func (m *TimedMetricWithMetadata) Reset()         { *m = TimedMetricWithMetadata{} }
-func (m *TimedMetricWithMetadata) String() string { return proto.CompactTextString(m) }
-func (*TimedMetricWithMetadata) ProtoMessage()    {}
-func (*TimedMetricWithMetadata) Descriptor() ([]byte, []int) {
-	return fileDescriptorComposite, []int{4}
-}
+func (m *TimedMetricWithMetadata) Reset()                    { *m = TimedMetricWithMetadata{} }
+func (m *TimedMetricWithMetadata) String() string            { return proto.CompactTextString(m) }
+func (*TimedMetricWithMetadata) ProtoMessage()               {}
+func (*TimedMetricWithMetadata) Descriptor() ([]byte, []int) { return fileDescriptorComposite, []int{4} }
 
 func (m *TimedMetricWithMetadata) GetMetric() TimedMetric {
 	if m != nil {

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -135,9 +135,7 @@ func (m PipelineMetadata) Clone() PipelineMetadata {
 
 // ToProto converts the pipeline metadata to a protobuf message in place.
 func (m PipelineMetadata) ToProto(pb *metricpb.PipelineMetadata) error {
-	if err := m.AggregationID.ToProto(&pb.AggregationId); err != nil {
-		return err
-	}
+	m.AggregationID.ToProto(&pb.AggregationId)
 	if err := m.Pipeline.ToProto(&pb.Pipeline); err != nil {
 		return err
 	}
@@ -158,9 +156,7 @@ func (m PipelineMetadata) ToProto(pb *metricpb.PipelineMetadata) error {
 
 // FromProto converts the protobuf message to a pipeline metadata in place.
 func (m *PipelineMetadata) FromProto(pb metricpb.PipelineMetadata) error {
-	if err := m.AggregationID.FromProto(pb.AggregationId); err != nil {
-		return err
-	}
+	m.AggregationID.FromProto(pb.AggregationId)
 	if err := m.Pipeline.FromProto(pb.Pipeline); err != nil {
 		return err
 	}
@@ -358,9 +354,7 @@ type ForwardMetadata struct {
 
 // ToProto converts the forward metadata to a protobuf message in place.
 func (m ForwardMetadata) ToProto(pb *metricpb.ForwardMetadata) error {
-	if err := m.AggregationID.ToProto(&pb.AggregationId); err != nil {
-		return err
-	}
+	m.AggregationID.ToProto(&pb.AggregationId)
 	if err := m.StoragePolicy.ToProto(&pb.StoragePolicy); err != nil {
 		return err
 	}
@@ -374,9 +368,7 @@ func (m ForwardMetadata) ToProto(pb *metricpb.ForwardMetadata) error {
 
 // FromProto converts the protobuf message to a forward metadata in place.
 func (m *ForwardMetadata) FromProto(pb metricpb.ForwardMetadata) error {
-	if err := m.AggregationID.FromProto(pb.AggregationId); err != nil {
-		return err
-	}
+	m.AggregationID.FromProto(pb.AggregationId)
 	if err := m.StoragePolicy.FromProto(pb.StoragePolicy); err != nil {
 		return err
 	}
@@ -487,7 +479,77 @@ func (sms StagedMetadatas) ToProto(pb *metricpb.StagedMetadatas) error {
 }
 
 // FromProto converts the protobuf message to a staged metadatas in place.
+// This is an optimized method that merges some nested steps.
 func (sms *StagedMetadatas) FromProto(pb metricpb.StagedMetadatas) error {
+	numMetadatas := len(pb.Metadatas)
+	if cap(*sms) >= numMetadatas {
+		*sms = (*sms)[:numMetadatas]
+	} else {
+		*sms = make([]StagedMetadata, numMetadatas)
+	}
+
+	for i := 0; i < numMetadatas; i++ {
+		metadata := &(*sms)[i]
+		metadataPb := &pb.Metadatas[i]
+		numPipelines := len(metadataPb.Metadata.Pipelines)
+
+		metadata.CutoverNanos = metadataPb.CutoverNanos
+		metadata.Tombstoned = metadataPb.Tombstoned
+
+		if cap(metadata.Pipelines) >= numPipelines {
+			metadata.Pipelines = metadata.Pipelines[:numPipelines]
+		} else {
+			metadata.Pipelines = make(PipelineMetadatas, numPipelines)
+		}
+
+		for j := 0; j < numPipelines; j++ {
+			var (
+				pipelinePb         = &metadataPb.Metadata.Pipelines[j]
+				pipeline           = &metadata.Pipelines[j]
+				numStoragePolicies = len(pipelinePb.StoragePolicies)
+				numOps             = len(pipelinePb.Pipeline.Ops)
+				err                error
+			)
+
+			pipeline.AggregationID[0] = pipelinePb.AggregationId.Id
+			pipeline.DropPolicy = policy.DropPolicy(pipelinePb.DropPolicy)
+
+			if len(pipeline.Tags) > 0 {
+				pipeline.Tags = pipeline.Tags[:0]
+			}
+			if len(pipeline.GraphitePrefix) > 0 {
+				pipeline.GraphitePrefix = pipeline.GraphitePrefix[:0]
+			}
+
+			if cap(pipeline.StoragePolicies) >= numStoragePolicies {
+				pipeline.StoragePolicies = pipeline.StoragePolicies[:numStoragePolicies]
+			} else {
+				pipeline.StoragePolicies = make([]policy.StoragePolicy, numStoragePolicies)
+			}
+
+			if cap(pipeline.Pipeline.Operations) >= numOps {
+				pipeline.Pipeline.Operations = pipeline.Pipeline.Operations[:numOps]
+			} else {
+				pipeline.Pipeline.Operations = make([]applied.OpUnion, numOps)
+			}
+
+			err = applied.OperationsFromProto(pipelinePb.Pipeline.Ops, pipeline.Pipeline.Operations)
+			if err != nil {
+				return err
+			}
+
+			err = policy.StoragePoliciesFromProto(pipelinePb.StoragePolicies, pipeline.StoragePolicies)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// fromProto is a non-optimized in place protobuf conversion method, used as a reference for tests.
+func (sms *StagedMetadatas) fromProto(pb metricpb.StagedMetadatas) error {
 	numMetadatas := len(pb.Metadatas)
 	if cap(*sms) >= numMetadatas {
 		*sms = (*sms)[:numMetadatas]
@@ -519,9 +581,7 @@ type TimedMetadata struct {
 
 // ToProto converts the timed metadata to a protobuf message in place.
 func (m TimedMetadata) ToProto(pb *metricpb.TimedMetadata) error {
-	if err := m.AggregationID.ToProto(&pb.AggregationId); err != nil {
-		return err
-	}
+	m.AggregationID.ToProto(&pb.AggregationId)
 	if err := m.StoragePolicy.ToProto(&pb.StoragePolicy); err != nil {
 		return err
 	}
@@ -530,9 +590,7 @@ func (m TimedMetadata) ToProto(pb *metricpb.TimedMetadata) error {
 
 // FromProto converts the protobuf message to a timed metadata in place.
 func (m *TimedMetadata) FromProto(pb metricpb.TimedMetadata) error {
-	if err := m.AggregationID.FromProto(pb.AggregationId); err != nil {
-		return err
-	}
+	m.AggregationID.FromProto(pb.AggregationId)
 	if err := m.StoragePolicy.FromProto(pb.StoragePolicy); err != nil {
 		return err
 	}

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -533,14 +533,17 @@ func (sms *StagedMetadatas) FromProto(pb metricpb.StagedMetadatas) error {
 				pipeline.Pipeline.Operations = make([]applied.OpUnion, numOps)
 			}
 
-			err = applied.OperationsFromProto(pipelinePb.Pipeline.Ops, pipeline.Pipeline.Operations)
-			if err != nil {
-				return err
+			if len(pipelinePb.Pipeline.Ops) > 0 {
+				err = applied.OperationsFromProto(pipelinePb.Pipeline.Ops, pipeline.Pipeline.Operations)
+				if err != nil {
+					return err
+				}
 			}
-
-			err = policy.StoragePoliciesFromProto(pipelinePb.StoragePolicies, pipeline.StoragePolicies)
-			if err != nil {
-				return err
+			if len(pipelinePb.StoragePolicies) > 0 {
+				err = policy.StoragePoliciesFromProto(pipelinePb.StoragePolicies, pipeline.StoragePolicies)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/src/metrics/metadata/metadata_benchmark_test.go
+++ b/src/metrics/metadata/metadata_benchmark_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3/src/metrics/aggregation"
+	"github.com/m3db/m3/src/metrics/generated/proto/metricpb"
 	"github.com/m3db/m3/src/metrics/policy"
 )
 
@@ -52,5 +53,87 @@ func BenchmarkMetadata_IsDefault(b *testing.B) {
 			b.Fail()
 		}
 	}
+	runtime.KeepAlive(m)
+}
+
+func BenchmarkMetadata_FromProto(b *testing.B) {
+	var (
+		testAllPayload metricpb.StagedMetadatas
+		m              StagedMetadatas
+	)
+
+	testAllPayload.Metadatas = append(testAllPayload.Metadatas,
+		testSmallStagedMetadatasProto.Metadatas...)
+	testAllPayload.Metadatas = append(testAllPayload.Metadatas,
+		testLargeStagedMetadatasProto.Metadatas...)
+	testAllPayload.Metadatas = append(testAllPayload.Metadatas,
+		testSmallStagedMetadatasWithLargeStoragePoliciesProto.Metadatas...)
+
+	b.Run("large metadatas", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := m.FromProto(testLargeStagedMetadatasProto); err != nil {
+				b.Fail()
+			}
+		}
+	})
+
+	b.Run("small metadatas", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := m.FromProto(testSmallStagedMetadatasProto); err != nil {
+				b.Fail()
+			}
+		}
+	})
+
+	b.Run("storage policies", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := m.FromProto(
+				testSmallStagedMetadatasWithLargeStoragePoliciesProto,
+			); err != nil {
+				b.Fail()
+			}
+		}
+	})
+
+	b.Run("all", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := m.FromProto(testAllPayload); err != nil {
+				b.Fail()
+			}
+		}
+	})
+
+	b.Run("reference, large metadatas", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := m.fromProto(testLargeStagedMetadatasProto); err != nil {
+				b.Fail()
+			}
+		}
+	})
+
+	b.Run("reference, small metadatas", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := m.fromProto(testSmallStagedMetadatasProto); err != nil {
+				b.Fail()
+			}
+		}
+	})
+
+	b.Run("reference, storage policies", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := m.fromProto(testSmallStagedMetadatasWithLargeStoragePoliciesProto); err != nil {
+				b.Fail()
+			}
+		}
+	})
+
+	b.Run("reference, all", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if err := m.fromProto(testAllPayload); err != nil {
+				b.Fail()
+			}
+		}
+	})
+
 	runtime.KeepAlive(m)
 }

--- a/src/metrics/metadata/metadata_test.go
+++ b/src/metrics/metadata/metadata_test.go
@@ -413,6 +413,68 @@ var (
 			},
 		},
 	}
+	testSmallStagedMetadatasWithLargeStoragePoliciesProto = metricpb.StagedMetadatas{
+		Metadatas: []metricpb.StagedMetadata{
+			{
+				CutoverNanos: 4567,
+				Tombstoned:   true,
+				Metadata: metricpb.Metadata{
+					Pipelines: []metricpb.PipelineMetadata{
+						{
+							AggregationId: aggregationpb.AggregationID{Id: aggregation.MustCompressTypes(aggregation.Sum)[0]},
+							StoragePolicies: []policypb.StoragePolicy{
+								{
+									Resolution: policypb.Resolution{
+										WindowSize: time.Second.Nanoseconds(),
+										Precision:  time.Second.Nanoseconds(),
+									},
+									Retention: policypb.Retention{
+										Period: 10 * time.Second.Nanoseconds(),
+									},
+								},
+								{
+									Resolution: policypb.Resolution{
+										WindowSize: 10 * time.Second.Nanoseconds(),
+										Precision:  time.Second.Nanoseconds(),
+									},
+									Retention: policypb.Retention{
+										Period: time.Hour.Nanoseconds(),
+									},
+								},
+								{
+									Resolution: policypb.Resolution{
+										WindowSize: 10 * time.Minute.Nanoseconds(),
+										Precision:  time.Second.Nanoseconds(),
+									},
+									Retention: policypb.Retention{
+										Period: time.Minute.Nanoseconds(),
+									},
+								},
+								{
+									Resolution: policypb.Resolution{
+										WindowSize: 10 * time.Minute.Nanoseconds(),
+										Precision:  time.Second.Nanoseconds(),
+									},
+									Retention: policypb.Retention{
+										Period: time.Second.Nanoseconds(),
+									},
+								},
+								{
+									Resolution: policypb.Resolution{
+										WindowSize: 10 * time.Hour.Nanoseconds(),
+										Precision:  time.Second.Nanoseconds(),
+									},
+									Retention: policypb.Retention{
+										Period: time.Second.Nanoseconds(),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	testLargeStagedMetadatasProto = metricpb.StagedMetadatas{
 		Metadatas: []metricpb.StagedMetadata{
 			{
@@ -1013,10 +1075,13 @@ func TestStagedMetadatasFromProto(t *testing.T) {
 	}
 
 	for _, input := range inputs {
-		var res StagedMetadatas
+		var resOpt, resReference StagedMetadatas
 		for i, pb := range input.sequence {
-			require.NoError(t, res.FromProto(pb))
-			require.Equal(t, input.expected[i], res)
+			require.NoError(t, resReference.fromProto(pb))
+			require.NoError(t, resOpt.FromProto(pb))
+			require.Equal(t, input.expected[i], resOpt)
+			require.Equal(t, input.expected[i], resReference)
+			require.Equal(t, resOpt, resReference)
 		}
 	}
 }

--- a/src/metrics/metric/aggregated/types_test.go
+++ b/src/metrics/metric/aggregated/types_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/m3db/m3/src/metrics/transformation"
 	xtime "github.com/m3db/m3/src/x/time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -365,13 +366,18 @@ func TestForwardedMetricWithMetadataFromProto(t *testing.T) {
 	}
 
 	var res ForwardedMetricWithMetadata
+	comparer := cmp.Comparer(spComparer)
 	for _, input := range inputs {
 		require.NoError(t, res.FromProto(&input.data))
 		expected := ForwardedMetricWithMetadata{
 			ForwardedMetric: input.expectedMetric,
 			ForwardMetadata: input.expectedMetadata,
 		}
-		require.Equal(t, expected, res)
+
+		if !cmp.Equal(expected, res, comparer) {
+			t.Log(cmp.Diff(expected, res, comparer))
+			t.Fail()
+		}
 	}
 }
 
@@ -416,6 +422,7 @@ func TestForwardedMetricWithMetadataRoundtrip(t *testing.T) {
 		res ForwardedMetricWithMetadata
 		pb  metricpb.ForwardedMetricWithMetadata
 	)
+	comparer := cmp.Comparer(spComparer)
 	for _, input := range inputs {
 		data := ForwardedMetricWithMetadata{
 			ForwardedMetric: input.metric,
@@ -423,6 +430,13 @@ func TestForwardedMetricWithMetadataRoundtrip(t *testing.T) {
 		}
 		require.NoError(t, data.ToProto(&pb))
 		require.NoError(t, res.FromProto(&pb))
-		require.Equal(t, data, res)
+		if !cmp.Equal(data, res, comparer) {
+			t.Log(cmp.Diff(data, res, comparer))
+			t.Fail()
+		}
 	}
+}
+
+func spComparer(x, y policy.StoragePolicy) bool {
+	return x.Equivalent(y)
 }

--- a/src/metrics/pipeline/applied/type.go
+++ b/src/metrics/pipeline/applied/type.go
@@ -28,13 +28,17 @@ import (
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/metrics/generated/proto/pipelinepb"
 	"github.com/m3db/m3/src/metrics/pipeline"
+	"github.com/m3db/m3/src/metrics/transformation"
 )
 
 var (
 	// DefaultPipeline is a default pipeline.
 	DefaultPipeline Pipeline
 
-	errNilAppliedRollupOpProto = errors.New("nil applied rollup op proto message")
+	errNilAppliedRollupOpProto  = errors.New("nil applied rollup op proto message")
+	errUnknownOpType            = errors.New("unknown op type")
+	errOperationsLengthMismatch = errors.New("operations list length does not match proto")
+	errNilTransformationOpProto = errors.New("nil transformation op proto message")
 )
 
 // RollupOp captures the rollup metadata after the operation is applied against a metric ID.
@@ -45,7 +49,7 @@ type RollupOp struct {
 	AggregationID aggregation.ID
 }
 
-// Equal determines whether two rollup operations are equal.
+// Equal determines whether two rollup Operations are equal.
 func (op RollupOp) Equal(other RollupOp) bool {
 	return op.AggregationID == other.AggregationID && bytes.Equal(op.ID, other.ID)
 }
@@ -63,9 +67,7 @@ func (op RollupOp) String() string {
 
 // ToProto converts the applied rollup op to a protobuf message in place.
 func (op RollupOp) ToProto(pb *pipelinepb.AppliedRollupOp) error {
-	if err := op.AggregationID.ToProto(&pb.AggregationId); err != nil {
-		return err
-	}
+	op.AggregationID.ToProto(&pb.AggregationId)
 	pb.Id = op.ID
 	return nil
 }
@@ -75,9 +77,7 @@ func (op *RollupOp) FromProto(pb *pipelinepb.AppliedRollupOp) error {
 	if pb == nil {
 		return errNilAppliedRollupOpProto
 	}
-	if err := op.AggregationID.FromProto(pb.AggregationId); err != nil {
-		return err
-	}
+	op.AggregationID.FromProto(pb.AggregationId)
 	op.ID = pb.Id
 	return nil
 }
@@ -143,7 +143,7 @@ func (u OpUnion) ToProto(pb *pipelinepb.AppliedPipelineOp) error {
 		pb.Rollup = &pipelinepb.AppliedRollupOp{}
 		return u.Rollup.ToProto(pb.Rollup)
 	default:
-		return fmt.Errorf("unknown op type: %v", u.Type)
+		return errUnknownOpType
 	}
 }
 
@@ -152,58 +152,62 @@ func (u *OpUnion) Reset() { *u = OpUnion{} }
 
 // FromProto converts the protobuf message to an applied pipeline op in place.
 func (u *OpUnion) FromProto(pb pipelinepb.AppliedPipelineOp) error {
-	u.Reset()
 	switch pb.Type {
 	case pipelinepb.AppliedPipelineOp_TRANSFORMATION:
 		u.Type = pipeline.TransformationOpType
+		if u.Rollup.ID != nil {
+			u.Rollup.ID = u.Rollup.ID[:0]
+		}
+		u.Rollup.AggregationID[0] = aggregation.DefaultID[0]
 		return u.Transformation.FromProto(pb.Transformation)
 	case pipelinepb.AppliedPipelineOp_ROLLUP:
 		u.Type = pipeline.RollupOpType
+		u.Transformation.Type = transformation.UnknownType
 		return u.Rollup.FromProto(pb.Rollup)
 	default:
-		return fmt.Errorf("unknown op type in proto: %v", pb.Type)
+		return errUnknownOpType
 	}
 }
 
 // Pipeline is a pipeline of operations.
 type Pipeline struct {
-	// a list of pipeline operations.
-	operations []OpUnion
+	// a list of pipeline Operations.
+	Operations []OpUnion
 }
 
 // NewPipeline creates a new pipeline.
 func NewPipeline(ops []OpUnion) Pipeline {
-	return Pipeline{operations: ops}
+	return Pipeline{Operations: ops}
 }
 
 // Len returns the number of steps in a pipeline.
-func (p Pipeline) Len() int { return len(p.operations) }
+func (p Pipeline) Len() int { return len(p.Operations) }
 
 // IsEmpty determines whether a pipeline is empty.
-func (p Pipeline) IsEmpty() bool { return len(p.operations) == 0 }
+func (p Pipeline) IsEmpty() bool { return len(p.Operations) == 0 }
 
 // At returns the operation at a given step.
-func (p Pipeline) At(i int) OpUnion { return p.operations[i] }
+func (p Pipeline) At(i int) OpUnion { return p.Operations[i] }
 
 // Equal determines whether two pipelines are equal.
 func (p Pipeline) Equal(other Pipeline) bool {
 	// keep in sync with OpUnion.Equal as go is terrible at inlining anything with a loop
-	if len(p.operations) != len(other.operations) {
+	if len(p.Operations) != len(other.Operations) {
 		return false
 	}
 
-	for i := 0; i < len(p.operations); i++ {
-		if p.operations[i].Type != other.operations[i].Type {
+	for i := 0; i < len(p.Operations); i++ {
+		if p.Operations[i].Type != other.Operations[i].Type {
 			return false
 		}
 		//nolint:exhaustive
-		switch p.operations[i].Type {
+		switch p.Operations[i].Type {
 		case pipeline.RollupOpType:
-			if !p.operations[i].Rollup.Equal(other.operations[i].Rollup) {
+			if !p.Operations[i].Rollup.Equal(other.Operations[i].Rollup) {
 				return false
 			}
 		case pipeline.TransformationOpType:
-			if p.operations[i].Transformation.Type != other.operations[i].Transformation.Type {
+			if p.Operations[i].Transformation.Type != other.Operations[i].Transformation.Type {
 				return false
 			}
 		}
@@ -214,25 +218,25 @@ func (p Pipeline) Equal(other Pipeline) bool {
 
 // Clone clones the pipeline.
 func (p Pipeline) Clone() Pipeline {
-	clone := make([]OpUnion, len(p.operations))
-	for i := range p.operations {
-		clone[i] = p.operations[i].Clone()
+	clone := make([]OpUnion, len(p.Operations))
+	for i := range p.Operations {
+		clone[i] = p.Operations[i].Clone()
 	}
-	return Pipeline{operations: clone}
+	return Pipeline{Operations: clone}
 }
 
-// SubPipeline returns a sub-pipeline containing operations between step `startInclusive`
+// SubPipeline returns a sub-pipeline containing Operations between step `startInclusive`
 // and step `endExclusive` of the current pipeline.
 func (p Pipeline) SubPipeline(startInclusive int, endExclusive int) Pipeline {
-	return Pipeline{operations: p.operations[startInclusive:endExclusive]}
+	return Pipeline{Operations: p.Operations[startInclusive:endExclusive]}
 }
 
 func (p Pipeline) String() string {
 	var b bytes.Buffer
 	b.WriteString("{operations: [")
-	for i, op := range p.operations {
+	for i, op := range p.Operations {
 		b.WriteString(op.String())
-		if i < len(p.operations)-1 {
+		if i < len(p.Operations)-1 {
 			b.WriteString(", ")
 		}
 	}
@@ -242,14 +246,14 @@ func (p Pipeline) String() string {
 
 // ToProto converts the applied pipeline to a protobuf message in place.
 func (p Pipeline) ToProto(pb *pipelinepb.AppliedPipeline) error {
-	numOps := len(p.operations)
+	numOps := len(p.Operations)
 	if cap(pb.Ops) >= numOps {
 		pb.Ops = pb.Ops[:numOps]
 	} else {
 		pb.Ops = make([]pipelinepb.AppliedPipelineOp, numOps)
 	}
 	for i := 0; i < numOps; i++ {
-		if err := p.operations[i].ToProto(&pb.Ops[i]); err != nil {
+		if err := p.Operations[i].ToProto(&pb.Ops[i]); err != nil {
 			return err
 		}
 	}
@@ -259,13 +263,13 @@ func (p Pipeline) ToProto(pb *pipelinepb.AppliedPipeline) error {
 // FromProto converts the protobuf message to an applied pipeline in place.
 func (p *Pipeline) FromProto(pb pipelinepb.AppliedPipeline) error {
 	numOps := len(pb.Ops)
-	if cap(p.operations) >= numOps {
-		p.operations = p.operations[:numOps]
+	if cap(p.Operations) >= numOps {
+		p.Operations = p.Operations[:numOps]
 	} else {
-		p.operations = make([]OpUnion, numOps)
+		p.Operations = make([]OpUnion, numOps)
 	}
 	for i := 0; i < numOps; i++ {
-		if err := p.operations[i].FromProto(pb.Ops[i]); err != nil {
+		if err := p.Operations[i].FromProto(pb.Ops[i]); err != nil {
 			return err
 		}
 	}
@@ -275,10 +279,45 @@ func (p *Pipeline) FromProto(pb pipelinepb.AppliedPipeline) error {
 // IsMappingRule returns whether this is a mapping rule, determined by
 // if any rollup pipelines are included.
 func (p Pipeline) IsMappingRule() bool {
-	for _, op := range p.operations {
+	for _, op := range p.Operations {
 		if op.Rollup.ID != nil {
 			return false
 		}
 	}
 	return true
+}
+
+// OperationsFromProto converts a list of protobuf AppliedPipelineOps, used in optimized staged metadata methods.
+func OperationsFromProto(pb []pipelinepb.AppliedPipelineOp, ops []OpUnion) error {
+	numOps := len(pb)
+	if numOps != len(ops) {
+		return errOperationsLengthMismatch
+	}
+	for i := 0; i < numOps; i++ {
+		u := &ops[i]
+		u.Type = pipeline.OpType(pb[i].Type + 1)
+		switch u.Type {
+		case pipeline.TransformationOpType:
+			if u.Rollup.ID != nil {
+				u.Rollup.ID = u.Rollup.ID[:0]
+			}
+			u.Rollup.AggregationID[0] = aggregation.DefaultID[0]
+			if pb[i].Transformation == nil {
+				return errNilTransformationOpProto
+			}
+			if err := u.Transformation.Type.FromProto(pb[i].Transformation.Type); err != nil {
+				return err
+			}
+		case pipeline.RollupOpType:
+			u.Transformation.Type = transformation.UnknownType
+			if pb == nil {
+				return errNilAppliedRollupOpProto
+			}
+			u.Rollup.AggregationID[0] = pb[i].Rollup.AggregationId.Id
+			u.Rollup.ID = pb[i].Rollup.Id
+		default:
+			return errUnknownOpType
+		}
+	}
+	return nil
 }

--- a/src/metrics/pipeline/applied/type_test.go
+++ b/src/metrics/pipeline/applied/type_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/m3db/m3/src/metrics/pipeline"
 	"github.com/m3db/m3/src/metrics/transformation"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -367,18 +368,18 @@ func TestPipelineEqual(t *testing.T) {
 			require.Equal(t, input.expected, input.p2.Equal(input.p1))
 			// assert implementation is equal to OpUnion
 			if input.expected {
-				for i, op := range input.p1.operations {
-					require.True(t, op.Equal(input.p2.operations[i]))
+				for i, op := range input.p1.Operations {
+					require.True(t, op.Equal(input.p2.Operations[i]))
 				}
-				for i, op := range input.p2.operations {
-					require.True(t, op.Equal(input.p1.operations[i]))
+				for i, op := range input.p2.Operations {
+					require.True(t, op.Equal(input.p1.Operations[i]))
 				}
-			} else if len(input.p1.operations) == len(input.p2.operations) {
-				for i, op := range input.p1.operations {
-					require.False(t, op.Equal(input.p2.operations[i]))
+			} else if len(input.p1.Operations) == len(input.p2.Operations) {
+				for i, op := range input.p1.Operations {
+					require.False(t, op.Equal(input.p2.Operations[i]))
 				}
-				for i, op := range input.p2.operations {
-					require.False(t, op.Equal(input.p1.operations[i]))
+				for i, op := range input.p2.Operations {
+					require.False(t, op.Equal(input.p1.Operations[i]))
 				}
 			}
 		})
@@ -392,7 +393,7 @@ func TestPipelineCloneEmptyPipeline(t *testing.T) {
 	p2 := p1.Clone()
 	require.True(t, p1.Equal(p2))
 
-	p2.operations = append(p2.operations, OpUnion{
+	p2.Operations = append(p2.Operations, OpUnion{
 		Type: pipeline.RollupOpType,
 		Rollup: RollupOp{
 			ID:            []byte("foo"),
@@ -438,9 +439,9 @@ func TestPipelineCloneMultiLevelPipeline(t *testing.T) {
 	require.True(t, p1.Equal(p3))
 
 	// Mutate the operations of a cloned pipeline.
-	p2.operations[0].Transformation.Type = transformation.PerSecond
-	p2.operations[1].Rollup.ID[0] = 'z'
-	p2.operations[3].Rollup.AggregationID = aggregation.MustCompressTypes(aggregation.Count)
+	p2.Operations[0].Transformation.Type = transformation.PerSecond
+	p2.Operations[1].Rollup.ID[0] = 'z'
+	p2.Operations[3].Rollup.AggregationID = aggregation.MustCompressTypes(aggregation.Count)
 
 	// Verify the mutations do not affect the source pipeline or other clones.
 	require.False(t, p1.Equal(p2))
@@ -616,7 +617,10 @@ func TestPipelineFromProto(t *testing.T) {
 		var res Pipeline
 		for i, pb := range input.sequence {
 			require.NoError(t, res.FromProto(pb))
-			require.Equal(t, input.expected[i], res)
+			if !cmp.Equal(input.expected[i], res) {
+				t.Log(cmp.Diff(input.expected[i], res))
+				t.Fail()
+			}
 		}
 	}
 }
@@ -646,7 +650,10 @@ func TestPipelineRoundTrip(t *testing.T) {
 		for _, pipeline := range input {
 			require.NoError(t, pipeline.ToProto(&pb))
 			require.NoError(t, res.FromProto(pb))
-			require.Equal(t, pipeline, res)
+			if !cmp.Equal(pipeline, res) {
+				t.Log(cmp.Diff(pipeline, res))
+				t.Fail()
+			}
 		}
 	}
 }

--- a/src/metrics/policy/storage_policy.go
+++ b/src/metrics/policy/storage_policy.go
@@ -39,8 +39,9 @@ var (
 	// EmptyStoragePolicy represents an empty storage policy.
 	EmptyStoragePolicy StoragePolicy
 
-	errNilStoragePolicyProto      = errors.New("nil storage policy proto")
-	errInvalidStoragePolicyString = errors.New("invalid storage policy string")
+	errNilStoragePolicyProto       = errors.New("nil storage policy proto")
+	errInvalidStoragePolicyString  = errors.New("invalid storage policy string")
+	errStoragePolicyLengthMismatch = errors.New("storage policy list length does not match proto")
 )
 
 // StoragePolicy represents the resolution and retention period metric datapoints
@@ -264,4 +265,23 @@ func (sp ByRetentionAscResolutionAsc) Less(i, j int) bool {
 		return rw1 < rw2
 	}
 	return sp[i].Resolution().Precision < sp[j].Resolution().Precision
+}
+
+// StoragePoliciesFromProto converts a list of protobuf storage policies to a storage policy in place.
+func StoragePoliciesFromProto(src []policypb.StoragePolicy, dst []StoragePolicy) error {
+	if len(src) != len(dst) {
+		return errStoragePolicyLengthMismatch
+	}
+	for i := 0; i < len(src); i++ {
+		d := &dst[i]
+		if err := d.resolution.FromProto(src[i].Resolution); err != nil {
+			return err
+		}
+
+		if err := d.retention.FromProto(src[i].Retention); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/src/x/time/unit.go
+++ b/src/x/time/unit.go
@@ -108,11 +108,18 @@ func (tu Unit) String() string {
 
 // UnitFromDuration creates a time unit from a time duration.
 func UnitFromDuration(d time.Duration) (Unit, error) {
-	if unit, found := durationsToUnit[d]; found {
-		return unit, nil
+	i := 0
+	// TODO: remove this once we're on go 1.16+, as for loops prevent inlining with older compilers
+For:
+	if i >= len(unitLookupArray) {
+		return None, errConvertDurationToUnit
 	}
 
-	return None, errConvertDurationToUnit
+	if unitLookupArray[i].duration == d {
+		return unitLookupArray[i].unit, nil
+	}
+	i++
+	goto For
 }
 
 // DurationFromUnit creates a time duration from a time unit.
@@ -184,12 +191,18 @@ var (
 		Day:         time.Hour * 24,
 		Year:        time.Hour * 24 * 365,
 	}
-	durationsToUnit = make(map[time.Duration]Unit)
 
 	unitCount = len(unitsToDuration)
 
 	unitsByDurationDesc []Unit
 )
+
+type unitLookupEntry struct {
+	duration time.Duration
+	unit     Unit
+}
+
+var unitLookupArray []unitLookupEntry
 
 // byDurationDesc sorts time units by their durations in descending order.
 // The order is undefined if the units are invalid.
@@ -206,13 +219,15 @@ func (b byDurationDesc) Less(i, j int) bool {
 
 func init() {
 	unitsByDurationDesc = make([]Unit, 0, unitCount)
+	unitLookupArray = make([]unitLookupEntry, 0, unitCount)
+
 	for u, d := range unitsToDuration {
 		unit := Unit(u)
 		if unit == None {
 			continue
 		}
 
-		durationsToUnit[d] = unit
+		unitLookupArray = append(unitLookupArray, unitLookupEntry{unit: unit, duration: d})
 		unitsByDurationDesc = append(unitsByDurationDesc, unit)
 	}
 	sort.Sort(byDurationDesc(unitsByDurationDesc))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This is a ton of ugly code to speed up metadata mapping from proto to domain level structs, and is on very hot path.
```
name                                    old time/op    new time/op    delta
Metadata_FromProto/large_metadatas-12      101ns ± 1%      55ns ± 4%  -46.22%  (p=0.000 n=9+10)
Metadata_FromProto/small_metadatas-12     46.9ns ± 1%    28.9ns ± 2%  -38.28%  (p=0.000 n=9+10)
Metadata_FromProto/storage_policies-12    56.8ns ± 2%    26.3ns ± 1%  -53.64%  (p=0.000 n=10+9)
Metadata_FromProto/all-12                  200ns ± 1%     105ns ± 1%  -47.80%  (p=0.000 n=8+10)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
