### PR TITLE
[aggregator] Sort heap in one go, instead of iterating one-by-one

### DIFF
--- a/src/aggregator/aggregation/quantile/cm/heap.go
+++ b/src/aggregator/aggregation/quantile/cm/heap.go
@@ -121,9 +121,11 @@ func (h minHeap) SortDesc() {
 }
 
 func (h *minHeap) ensureSize() {
-	heap := *h
-	targetCap := cap(heap) * 2
-	newHeap := sharedHeapPool.Get(targetCap)
+	var (
+		heap      = *h
+		targetCap = cap(heap) * 2
+		newHeap   = sharedHeapPool.Get(targetCap)
+	)
 	(*newHeap) = append(*newHeap, heap...)
 	if cap(heap) >= _initialHeapBucketSize {
 		sharedHeapPool.Put(heap)

--- a/src/aggregator/aggregation/quantile/cm/heap.go
+++ b/src/aggregator/aggregation/quantile/cm/heap.go
@@ -43,25 +43,14 @@ func (h *minHeap) Push(value float64) {
 	heap := *h
 	n := len(heap)
 	i := n - 1
-	for {
+	for i < n && i >= 0 {
 		parent := (i - 1) / 2
-		if parent == i || heap[parent] <= heap[i] {
+		if parent == i || parent >= n || parent < 0 || heap[parent] <= heap[i] {
 			break
 		}
 		heap[parent], heap[i] = heap[i], heap[parent]
 		i = parent
 	}
-}
-
-func (h *minHeap) ensureSize() {
-	heap := *h
-	targetCap := cap(heap) * 2
-	newHeap := sharedHeapPool.Get(targetCap)
-	(*newHeap) = append(*newHeap, heap...)
-	if cap(heap) >= _initialHeapBucketSize {
-		sharedHeapPool.Put(heap)
-	}
-	(*h) = *newHeap
 }
 
 func (h *minHeap) Reset() {
@@ -98,4 +87,46 @@ func (h *minHeap) Pop() float64 {
 	}
 	*h = old[0:n]
 	return val
+}
+
+func (h minHeap) SortDesc() {
+	heap := h
+	// this is equivalent to Pop() in a loop (heapsort)
+	// all the redundant-looking conditions are there to eliminate bounds-checks
+	for n := len(heap) - 1; n > 0 && n < len(heap); n = len(heap) - 1 {
+		var (
+			i        int
+			smallest int
+		)
+		heap[0], heap[n] = heap[n], heap[0]
+		for smallest >= 0 && smallest <= n {
+			var (
+				left  = smallest*2 + 1
+				right = left + 1
+			)
+			if left < n && left >= 0 && heap[left] < heap[smallest] {
+				smallest = left
+			}
+			if right < n && right >= 0 && heap[right] < heap[smallest] {
+				smallest = right
+			}
+			if smallest == i {
+				break
+			}
+			heap[i], heap[smallest] = heap[smallest], heap[i]
+			i = smallest
+		}
+		heap = heap[0:n]
+	}
+}
+
+func (h *minHeap) ensureSize() {
+	heap := *h
+	targetCap := cap(heap) * 2
+	newHeap := sharedHeapPool.Get(targetCap)
+	(*newHeap) = append(*newHeap, heap...)
+	if cap(heap) >= _initialHeapBucketSize {
+		sharedHeapPool.Put(heap)
+	}
+	(*h) = *newHeap
 }

--- a/src/aggregator/aggregation/quantile/cm/heap_test.go
+++ b/src/aggregator/aggregation/quantile/cm/heap_test.go
@@ -21,6 +21,8 @@
 package cm
 
 import (
+	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,6 +35,7 @@ func TestMinHeapPushInDecreasingOrder(t *testing.T) {
 		h.Push(float64(i))
 		require.Equal(t, iter-i, h.Len())
 	}
+	validateSort(t, *h)
 	for i := 0; i < iter; i++ {
 		require.Equal(t, float64(i), h.Min())
 		require.Equal(t, float64(i), h.Pop())
@@ -47,11 +50,35 @@ func TestMinHeapPushInIncreasingOrder(t *testing.T) {
 		h.Push(float64(i))
 		require.Equal(t, i+1, h.Len())
 	}
+	validateSort(t, *h)
 	for i := 0; i < iter; i++ {
 		require.Equal(t, float64(i), h.Min())
 		require.Equal(t, float64(i), h.Pop())
 		validateInvariant(t, *h, 0)
 	}
+}
+
+func TestMinHeapPushInRandomOrderAndSort(t *testing.T) {
+	h := &minHeap{}
+	iter := 42
+	for i := 0; i < iter; i++ {
+		h.Push(rand.ExpFloat64())
+	}
+	validateSort(t, *h)
+}
+
+func validateSort(t *testing.T, h minHeap) {
+	t.Helper()
+	// copy heap before applying reference sort and minheap-sort
+	a := make([]float64, h.Len())
+	b := make([]float64, h.Len())
+	for i := 0; i < len(h); i++ {
+		a[i], b[i] = h[i], h[i]
+	}
+	sort.Sort(sort.Reverse(sort.Float64Slice(a)))
+	heap := (*minHeap)(&b)
+	heap.SortDesc()
+	require.Equal(t, a, b)
 }
 
 func validateInvariant(t *testing.T, h minHeap, i int) {

--- a/src/aggregator/aggregation/quantile/cm/stream.go
+++ b/src/aggregator/aggregation/quantile/cm/stream.go
@@ -357,13 +357,13 @@ func (s *Stream) compress() {
 	)
 
 	for s.compressCursor != s.samples.Front() {
-		curr := s.compressCursor
-		next := curr.next
-		prev := curr.prev
-
-		maxRank := s.compressMinRank + curr.numRanks + curr.delta
-
 		var (
+			curr = s.compressCursor
+			next = curr.next
+			prev = curr.prev
+
+			maxRank = s.compressMinRank + curr.numRanks + curr.delta
+
 			threshold   = int64(math.MaxInt64)
 			quantileMin int64
 		)

--- a/src/aggregator/aggregation/quantile/cm/stream.go
+++ b/src/aggregator/aggregation/quantile/cm/stream.go
@@ -253,10 +253,7 @@ func (s *Stream) calcQuantiles() {
 		)
 	}
 
-	for curr != nil {
-		if idx == len(s.quantiles) {
-			break
-		}
+	for curr != nil && idx < len(s.computedQuantiles) {
 		maxRank = minRank + curr.numRanks + curr.delta
 		rank, threshold := s.thresholdBuf[idx].rank, s.thresholdBuf[idx].threshold
 
@@ -271,7 +268,7 @@ func (s *Stream) calcQuantiles() {
 	}
 
 	// check if the last sample value should satisfy unprocessed quantiles
-	for i := idx; i < len(s.quantiles); i++ {
+	for i := idx; i < len(s.thresholdBuf); i++ {
 		rank, threshold := s.thresholdBuf[i].rank, s.thresholdBuf[i].threshold
 		if maxRank >= rank+threshold || minRank > rank {
 			s.computedQuantiles[i] = prev.value
@@ -284,6 +281,7 @@ func (s *Stream) insert() {
 	var (
 		compCur          = s.compressCursor
 		compValue        = math.NaN()
+		samples          = &s.samples
 		insertPointValue float64
 		sample           *Sample
 	)
@@ -292,15 +290,22 @@ func (s *Stream) insert() {
 		compValue = compCur.value
 	}
 
-	samples := &s.samples
+	// break heap invariant and just sort all the times, as we'll consume all of them in one go
+	s.bufMore.SortDesc()
 
-	for s.insertCursor != nil {
+	var (
+		vals = []float64(s.bufMore)
+		idx  = len(vals) - 1
+	)
+
+	for s.insertCursor != nil && idx < len(vals) {
 		curr := s.insertCursor
 		insertPointValue = curr.value
 
-		for s.bufMore.Len() > 0 && s.bufMore.Min() <= insertPointValue {
+		for idx >= 0 && vals[idx] <= insertPointValue {
+			val := vals[idx]
+			idx--
 			sample = s.samples.Acquire()
-			val := s.bufMore.Pop()
 			sample.value = val
 			sample.numRanks = 1
 			sample.delta = curr.numRanks + curr.delta - 1
@@ -316,19 +321,20 @@ func (s *Stream) insert() {
 		s.insertCursor = s.insertCursor.next
 	}
 
-	if s.insertCursor != nil {
-		return
+	if s.insertCursor == nil && idx < len(vals) {
+		for idx >= 0 && vals[idx] >= samples.Back().value {
+			val := vals[idx]
+			idx--
+			sample = s.samples.Acquire()
+			sample.value = val
+			sample.numRanks = 1
+			sample.delta = 0
+			samples.PushBack(sample)
+			s.numValues++
+		}
 	}
 
-	for s.bufMore.Len() > 0 && s.bufMore.Min() >= samples.Back().value {
-		sample = s.samples.Acquire()
-		sample.value = s.bufMore.Pop()
-		sample.numRanks = 1
-		sample.delta = 0
-		samples.PushBack(sample)
-		s.numValues++
-	}
-
+	s.bufMore = s.bufMore[:0]
 	s.resetInsertCursor()
 }
 
@@ -345,27 +351,48 @@ func (s *Stream) compress() {
 		s.compressCursor = s.compressCursor.prev
 	}
 
+	var (
+		numVals = s.numValues
+		eps     = 2.0 * s.eps
+	)
+
 	for s.compressCursor != s.samples.Front() {
-		next := s.compressCursor.next
-		maxRank := s.compressMinRank + s.compressCursor.numRanks + s.compressCursor.delta
-		threshold := s.threshold(maxRank)
-		s.compressMinRank -= s.compressCursor.numRanks
-		testVal := s.compressCursor.numRanks + next.numRanks + next.delta
+		curr := s.compressCursor
+		next := curr.next
+		prev := curr.prev
+
+		maxRank := s.compressMinRank + curr.numRanks + curr.delta
+
+		var (
+			threshold   = int64(math.MaxInt64)
+			quantileMin int64
+		)
+
+		for i := range s.quantiles {
+			if maxRank >= int64(s.quantiles[i]*float64(numVals)) {
+				quantileMin = int64(eps * float64(maxRank) / s.quantiles[i])
+			} else {
+				quantileMin = int64(eps * float64(numVals-maxRank) / (1.0 - s.quantiles[i]))
+			}
+			if quantileMin < threshold {
+				threshold = quantileMin
+			}
+		}
+
+		s.compressMinRank -= curr.numRanks
+		testVal := curr.numRanks + next.numRanks + next.delta
 
 		if testVal <= threshold {
-			if s.insertCursor == s.compressCursor {
+			if s.insertCursor == curr {
 				s.insertCursor = next
 			}
 
-			next.numRanks += s.compressCursor.numRanks
+			next.numRanks += curr.numRanks
 
-			prev := s.compressCursor.prev
 			// no need to release sample here
-			s.samples.Remove(s.compressCursor)
-			s.compressCursor = prev
-		} else {
-			s.compressCursor = s.compressCursor.prev
+			s.samples.Remove(curr)
 		}
+		s.compressCursor = prev
 	}
 
 	if s.compressCursor == s.samples.Front() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
A few more small timer aggregation tweaks.
Total throughput with 12 concurrent streams:
```
name                                                              old speed      new speed      delta
TimerAddBatch/100k_samples_1000_batch_size-12                      604MB/s ± 3%   633MB/s ± 0%   +4.84%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..1,000,000_range-12   555MB/s ± 5%   635MB/s ± 0%  +14.50%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..100,000_range-12     567MB/s ± 1%   584MB/s ± 5%     ~     (p=0.151 n=5+5)
TimerAddBatch/10k_samples_1000_batch_size-12                       543MB/s ± 2%   590MB/s ± 2%   +8.54%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size-12                        536MB/s ± 1%   583MB/s ± 2%   +8.83%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size_with_negative_values-12   537MB/s ± 1%   575MB/s ± 2%   +7.09%  (p=0.008 n=5+5)
TimerAddBatch/1k_samples_100_batch_size-12                         621MB/s ± 1%   652MB/s ± 2%   +4.92%  (p=0.008 n=5+5)
```
Single CPU only:
```
name                                                           old speed      new speed      delta
TimerAddBatch/100k_samples_1000_batch_size                     74.2MB/s ± 0%  80.0MB/s ± 0%  +7.74%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..1,000,000_range  74.3MB/s ± 0%  79.6MB/s ± 1%  +7.17%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..100,000_range    74.1MB/s ± 0%  79.9MB/s ± 1%  +7.87%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_1000_batch_size                      75.8MB/s ± 0%  80.9MB/s ± 1%  +6.78%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size                       76.0MB/s ± 1%  81.5MB/s ± 0%  +7.22%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size_with_negative_values  75.6MB/s ± 0%  81.2MB/s ± 1%  +7.42%  (p=0.008 n=5+5)
TimerAddBatch/1k_samples_100_batch_size                        91.7MB/s ± 0%  97.1MB/s ± 1%  +5.80%  (p=0.008 n=5+5)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
