### PR TITLE
[pool] Add support for dynamic, sync.Pool backed, object pools

### DIFF
--- a/src/cmd/services/m3dbnode/config/pooling.go
+++ b/src/cmd/services/m3dbnode/config/pooling.go
@@ -20,7 +20,11 @@
 
 package config
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/m3db/m3/src/x/pool"
+)
 
 // PoolingType is a type of pooling, using runtime or mmap'd bytes pooling.
 type PoolingType string
@@ -39,7 +43,7 @@ const (
 )
 
 type poolPolicyDefault struct {
-	size                int
+	size                pool.Size
 	refillLowWaterMark  float64
 	refillHighWaterMark float64
 
@@ -214,7 +218,7 @@ var (
 				{
 					Capacity: intPtr(16),
 					PoolPolicy: PoolPolicy{
-						Size:                intPtr(524288),
+						Size:                poolSizePtr(524288),
 						RefillLowWaterMark:  &defaultRefillLowWaterMark,
 						RefillHighWaterMark: &defaultRefillHighWaterMark,
 					},
@@ -222,7 +226,7 @@ var (
 				{
 					Capacity: intPtr(32),
 					PoolPolicy: PoolPolicy{
-						Size:                intPtr(262144),
+						Size:                poolSizePtr(262144),
 						RefillLowWaterMark:  &defaultRefillLowWaterMark,
 						RefillHighWaterMark: &defaultRefillHighWaterMark,
 					},
@@ -230,7 +234,7 @@ var (
 				{
 					Capacity: intPtr(64),
 					PoolPolicy: PoolPolicy{
-						Size:                intPtr(131072),
+						Size:                poolSizePtr(131072),
 						RefillLowWaterMark:  &defaultRefillLowWaterMark,
 						RefillHighWaterMark: &defaultRefillHighWaterMark,
 					},
@@ -238,7 +242,7 @@ var (
 				{
 					Capacity: intPtr(128),
 					PoolPolicy: PoolPolicy{
-						Size:                intPtr(65536),
+						Size:                poolSizePtr(65536),
 						RefillLowWaterMark:  &defaultRefillLowWaterMark,
 						RefillHighWaterMark: &defaultRefillHighWaterMark,
 					},
@@ -246,7 +250,7 @@ var (
 				{
 					Capacity: intPtr(256),
 					PoolPolicy: PoolPolicy{
-						Size:                intPtr(65536),
+						Size:                poolSizePtr(65536),
 						RefillLowWaterMark:  &defaultRefillLowWaterMark,
 						RefillHighWaterMark: &defaultRefillHighWaterMark,
 					},
@@ -254,7 +258,7 @@ var (
 				{
 					Capacity: intPtr(1440),
 					PoolPolicy: PoolPolicy{
-						Size:                intPtr(16384),
+						Size:                poolSizePtr(16384),
 						RefillLowWaterMark:  &defaultRefillLowWaterMark,
 						RefillHighWaterMark: &defaultRefillHighWaterMark,
 					},
@@ -262,7 +266,7 @@ var (
 				{
 					Capacity: intPtr(4096),
 					PoolPolicy: PoolPolicy{
-						Size:                intPtr(8192),
+						Size:                poolSizePtr(8192),
 						RefillLowWaterMark:  &defaultRefillLowWaterMark,
 						RefillHighWaterMark: &defaultRefillHighWaterMark,
 					},
@@ -486,7 +490,7 @@ func (p *PoolingPolicy) TypeOrDefault() PoolingType {
 // PoolPolicy specifies a single pool policy.
 type PoolPolicy struct {
 	// The size of the pool.
-	Size *int `yaml:"size"`
+	Size *pool.Size `yaml:"size"`
 
 	// The low watermark to start refilling the pool, if zero none.
 	RefillLowWaterMark *float64 `yaml:"lowWatermark"`
@@ -525,7 +529,7 @@ func (p *PoolPolicy) initDefaultsAndValidate(poolName string) error {
 }
 
 // SizeOrDefault returns the configured size if present, or a default value otherwise.
-func (p *PoolPolicy) SizeOrDefault() int {
+func (p *PoolPolicy) SizeOrDefault() pool.Size {
 	return *p.Size
 }
 
@@ -667,4 +671,9 @@ type WriteBatchPoolPolicy struct {
 
 func intPtr(x int) *int {
 	return &x
+}
+
+func poolSizePtr(x int) *pool.Size {
+	sz := pool.Size(x)
+	return &sz
 }

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -1005,7 +1005,7 @@ func (s *session) setTopologyWithLock(topoMap topology.Map, queues []hostQueue, 
 		s.pools.multiReaderIteratorArray = encoding.NewMultiReaderIteratorArrayPool([]pool.Bucket{
 			{
 				Capacity: replicas,
-				Count:    s.opts.SeriesIteratorPoolSize(),
+				Count:    pool.Size(s.opts.SeriesIteratorPoolSize()),
 			},
 		})
 		s.pools.multiReaderIteratorArray.Init()

--- a/src/dbnode/encoding/multi_reader_iterator_array_pool.go
+++ b/src/dbnode/encoding/multi_reader_iterator_array_pool.go
@@ -66,7 +66,7 @@ func (p *multiReaderIteratorArrayPool) Init() {
 	for i := range p.sizesAsc {
 		buckets[i].capacity = p.sizesAsc[i].Capacity
 		buckets[i].values = make(chan []MultiReaderIterator, p.sizesAsc[i].Count)
-		for j := 0; j < p.sizesAsc[i].Count; j++ {
+		for j := 0; pool.Size(j) < p.sizesAsc[i].Count; j++ {
 			buckets[i].values <- p.alloc(p.sizesAsc[i].Capacity)
 		}
 	}

--- a/src/dbnode/encoding/mutable_series_iterators_pool.go
+++ b/src/dbnode/encoding/mutable_series_iterators_pool.go
@@ -59,7 +59,7 @@ func (p *seriesIteratorsPool) Init() {
 	for i := range p.sizesAsc {
 		buckets[i].capacity = p.sizesAsc[i].Capacity
 		buckets[i].values = make(chan MutableSeriesIterators, p.sizesAsc[i].Count)
-		for j := 0; j < p.sizesAsc[i].Count; j++ {
+		for j := 0; pool.Size(j) < p.sizesAsc[i].Count; j++ {
 			buckets[i].values <- p.alloc(p.sizesAsc[i].Capacity)
 		}
 	}

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -1533,7 +1533,7 @@ func withEncodingAndPoolingOptions(
 
 		logger.Info("bytes pool configured",
 			zap.Int("capacity", bucket.CapacityOrDefault()),
-			zap.Int("size", bucket.SizeOrDefault()),
+			zap.Int("size", int(bucket.SizeOrDefault())),
 			zap.Float64("refillLowWaterMark", bucket.RefillLowWaterMarkOrDefault()),
 			zap.Float64("refillHighWaterMark", bucket.RefillHighWaterMarkOrDefault()))
 	}
@@ -1920,7 +1920,7 @@ func poolOptions(
 	)
 
 	if size > 0 {
-		opts = opts.SetSize(size)
+		opts = opts.SetSize(int(size))
 		if refillLowWaterMark > 0 &&
 			refillHighWaterMark > 0 &&
 			refillHighWaterMark > refillLowWaterMark {
@@ -1929,6 +1929,8 @@ func poolOptions(
 				SetRefillHighWatermark(refillHighWaterMark)
 		}
 	}
+	opts = opts.SetDynamic(size.IsDynamic())
+
 	if scope != nil {
 		opts = opts.SetInstrumentOptions(opts.InstrumentOptions().
 			SetMetricsScope(scope))
@@ -1948,7 +1950,7 @@ func capacityPoolOptions(
 	)
 
 	if size > 0 {
-		opts = opts.SetSize(size)
+		opts = opts.SetSize(int(size))
 		if refillLowWaterMark > 0 &&
 			refillHighWaterMark > 0 &&
 			refillHighWaterMark > refillLowWaterMark {
@@ -1956,6 +1958,8 @@ func capacityPoolOptions(
 			opts = opts.SetRefillHighWatermark(refillHighWaterMark)
 		}
 	}
+	opts = opts.SetDynamic(size.IsDynamic())
+
 	if scope != nil {
 		opts = opts.SetInstrumentOptions(opts.InstrumentOptions().
 			SetMetricsScope(scope))
@@ -1975,7 +1979,7 @@ func maxCapacityPoolOptions(
 	)
 
 	if size > 0 {
-		opts = opts.SetSize(size)
+		opts = opts.SetSize(int(size))
 		if refillLowWaterMark > 0 &&
 			refillHighWaterMark > 0 &&
 			refillHighWaterMark > refillLowWaterMark {
@@ -1983,6 +1987,8 @@ func maxCapacityPoolOptions(
 			opts = opts.SetRefillHighWatermark(refillHighWaterMark)
 		}
 	}
+	opts = opts.SetDynamic(size.IsDynamic())
+
 	if scope != nil {
 		opts = opts.SetInstrumentOptions(opts.InstrumentOptions().
 			SetMetricsScope(scope))

--- a/src/msg/consumer/config.go
+++ b/src/msg/consumer/config.go
@@ -44,7 +44,7 @@ type Configuration struct {
 // options, which extends the default object pool configuration.
 type MessagePoolConfiguration struct {
 	// Size is the size of the pool.
-	Size int `yaml:"size"`
+	Size pool.Size `yaml:"size"`
 
 	// Watermark is the object pool watermark configuration.
 	Watermark pool.WatermarkConfiguration `yaml:"watermark"`

--- a/src/msg/protocol/proto/roundtrip_test.go
+++ b/src/msg/protocol/proto/roundtrip_test.go
@@ -197,7 +197,7 @@ func getBytesPool(bucketSizes int, bucketCaps []int) pool.BytesPool {
 	buckets := make([]pool.Bucket, len(bucketCaps))
 	for i, cap := range bucketCaps {
 		buckets[i] = pool.Bucket{
-			Count:    bucketSizes,
+			Count:    pool.Size(bucketSizes),
 			Capacity: cap,
 		}
 	}

--- a/src/query/ts/m3db/options.go
+++ b/src/query/ts/m3db/options.go
@@ -70,7 +70,7 @@ type encodedBlockOptions struct {
 func NewOptions() Options {
 	bytesPool := pool.NewCheckedBytesPool([]pool.Bucket{{
 		Capacity: defaultCapacity,
-		Count:    defaultCount,
+		Count:    pool.Size(defaultCount),
 	}}, nil, func(s []pool.Bucket) pool.BytesPool {
 		return pool.NewBytesPool(s, nil)
 	})

--- a/src/x/pool/bucketized.go
+++ b/src/x/pool/bucketized.go
@@ -77,8 +77,10 @@ func (p *bucketizedObjectPool) Init(alloc BucketizedAllocator) {
 			opts = perBucketOpts
 		}
 
-		if !opts.Dynamic() {
-			opts = opts.SetSize(size)
+		if size > 0 {
+			opts = opts.SetSize(int(size))
+		} else if size == _dynamicPoolSize {
+			opts.SetDynamic(true)
 		}
 		iopts := opts.InstrumentOptions()
 

--- a/src/x/pool/bucketized.go
+++ b/src/x/pool/bucketized.go
@@ -79,9 +79,9 @@ func (p *bucketizedObjectPool) Init(alloc BucketizedAllocator) {
 
 		if size > 0 {
 			opts = opts.SetSize(int(size))
-		} else if size == _dynamicPoolSize {
-			opts.SetDynamic(true)
 		}
+		opts = opts.SetDynamic(size.IsDynamic())
+
 		iopts := opts.InstrumentOptions()
 
 		if iopts.MetricsScope() != nil {

--- a/src/x/pool/bucketized.go
+++ b/src/x/pool/bucketized.go
@@ -21,8 +21,8 @@
 package pool
 
 import (
-	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/uber-go/tally"
 )
@@ -77,13 +77,19 @@ func (p *bucketizedObjectPool) Init(alloc BucketizedAllocator) {
 			opts = perBucketOpts
 		}
 
-		opts = opts.SetSize(size)
+		if !opts.Dynamic() {
+			opts = opts.SetSize(size)
+		}
 		iopts := opts.InstrumentOptions()
 
 		if iopts.MetricsScope() != nil {
+			sz := strconv.Itoa(capacity)
+			if capacity <= 0 {
+				sz = "dynamic"
+			}
 			opts = opts.SetInstrumentOptions(iopts.SetMetricsScope(
 				iopts.MetricsScope().Tagged(map[string]string{
-					"bucket-capacity": fmt.Sprintf("%d", capacity),
+					"bucket-capacity": sz,
 				})))
 		}
 

--- a/src/x/pool/bytes_test.go
+++ b/src/x/pool/bytes_test.go
@@ -89,7 +89,7 @@ func getBytesPool(bucketSizes int, bucketCaps []int) *bytesPool {
 	buckets := make([]Bucket, len(bucketCaps))
 	for i, cap := range bucketCaps {
 		buckets[i] = Bucket{
-			Count:    bucketSizes,
+			Count:    Size(bucketSizes),
 			Capacity: cap,
 		}
 	}

--- a/src/x/pool/checked_bytes_test.go
+++ b/src/x/pool/checked_bytes_test.go
@@ -109,7 +109,7 @@ func getCheckedBytesPool(
 	buckets := make([]Bucket, len(bucketCaps))
 	for i, cap := range bucketCaps {
 		buckets[i] = Bucket{
-			Count:    bucketSizes,
+			Count:    Size(bucketSizes),
 			Capacity: cap,
 		}
 	}

--- a/src/x/pool/config.go
+++ b/src/x/pool/config.go
@@ -20,12 +20,17 @@
 
 package pool
 
-import "github.com/m3db/m3/src/x/instrument"
+import (
+	"errors"
+	"strconv"
+
+	"github.com/m3db/m3/src/x/instrument"
+)
 
 // ObjectPoolConfiguration contains configuration for object pools.
 type ObjectPoolConfiguration struct {
 	// The size of the pool.
-	Size int `yaml:"size"`
+	Size Size `yaml:"size"`
 
 	// The watermark configuration.
 	Watermark WatermarkConfiguration `yaml:"watermark"`
@@ -35,13 +40,22 @@ type ObjectPoolConfiguration struct {
 func (c *ObjectPoolConfiguration) NewObjectPoolOptions(
 	instrumentOpts instrument.Options,
 ) ObjectPoolOptions {
-	size := defaultSize
-	if c.Size != 0 {
-		size = c.Size
+	var (
+		size    = _defaultSize
+		dynamic bool
+	)
+
+	switch {
+	case c.Size > 0:
+		size = int(c.Size)
+	case c.Size == _dynamicPoolSize:
+		dynamic = true
 	}
+
 	return NewObjectPoolOptions().
 		SetInstrumentOptions(instrumentOpts).
 		SetSize(size).
+		SetDynamic(dynamic).
 		SetRefillLowWatermark(c.Watermark.RefillLowWatermark).
 		SetRefillHighWatermark(c.Watermark.RefillHighWatermark)
 }
@@ -99,4 +113,28 @@ type WatermarkConfiguration struct {
 
 	// The high watermark to stop refilling the pool, if zero none.
 	RefillHighWatermark float64 `yaml:"high" validate:"min=0.0,max=1.0"`
+}
+
+// Size stores pool capacity for pools that can be either dynamic or pre-allocated
+type Size int
+
+// UnmarshalText unmarshals Size.
+func (s *Size) UnmarshalText(b []byte) error {
+	if string(b) == "dynamic" {
+		*s = _dynamicPoolSize
+		return nil
+	}
+
+	i, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	if i < 0 {
+		return errors.New("pool capacity cannot be negative")
+	}
+
+	*s = Size(i)
+
+	return nil
 }

--- a/src/x/pool/config.go
+++ b/src/x/pool/config.go
@@ -92,7 +92,7 @@ func (c *BucketizedPoolConfiguration) NewBuckets() []Bucket {
 // BucketConfiguration contains configuration for a pool bucket.
 type BucketConfiguration struct {
 	// The count of the items in the bucket.
-	Count int `yaml:"count"`
+	Count Size `yaml:"count"`
 
 	// The capacity of each item in the bucket.
 	Capacity int `yaml:"capacity"`

--- a/src/x/pool/config.go
+++ b/src/x/pool/config.go
@@ -40,22 +40,15 @@ type ObjectPoolConfiguration struct {
 func (c *ObjectPoolConfiguration) NewObjectPoolOptions(
 	instrumentOpts instrument.Options,
 ) ObjectPoolOptions {
-	var (
-		size    = _defaultSize
-		dynamic bool
-	)
-
-	switch {
-	case c.Size > 0:
+	size := _defaultSize
+	if c.Size > 0 {
 		size = int(c.Size)
-	case c.Size == _dynamicPoolSize:
-		dynamic = true
 	}
 
 	return NewObjectPoolOptions().
 		SetInstrumentOptions(instrumentOpts).
 		SetSize(size).
-		SetDynamic(dynamic).
+		SetDynamic(c.Size.IsDynamic()).
 		SetRefillLowWatermark(c.Watermark.RefillLowWatermark).
 		SetRefillHighWatermark(c.Watermark.RefillHighWatermark)
 }
@@ -137,4 +130,9 @@ func (s *Size) UnmarshalText(b []byte) error {
 	*s = Size(i)
 
 	return nil
+}
+
+// IsDynamic returns whether the pool should be fixed size or not.
+func (s Size) IsDynamic() bool {
+	return s == _dynamicPoolSize
 }

--- a/src/x/pool/floats_test.go
+++ b/src/x/pool/floats_test.go
@@ -53,7 +53,7 @@ func getFloatsPool(bucketSizes int, bucketCaps []int) *floatsPool {
 	buckets := make([]Bucket, len(bucketCaps))
 	for i, cap := range bucketCaps {
 		buckets[i] = Bucket{
-			Count:    bucketSizes,
+			Count:    Size(bucketSizes),
 			Capacity: cap,
 		}
 	}

--- a/src/x/pool/object_test.go
+++ b/src/x/pool/object_test.go
@@ -193,6 +193,7 @@ func BenchmarkObjectPoolParallelGetMultiPutContended(b *testing.B) {
 				o := bufs[i]
 				buf := *o
 				buf = strconv.AppendInt(buf[:0], 12344321, 10)
+				runtime.KeepAlive(buf)
 				p.Put(o)
 			}
 		}

--- a/src/x/pool/object_test.go
+++ b/src/x/pool/object_test.go
@@ -21,6 +21,7 @@
 package pool
 
 import (
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -192,6 +193,39 @@ func BenchmarkObjectPoolParallelGetMultiPutContended(b *testing.B) {
 				o := bufs[i]
 				buf := *o
 				buf = strconv.AppendInt(buf[:0], 12344321, 10)
+				p.Put(o)
+			}
+		}
+	})
+}
+
+//nolint:dupl
+func BenchmarkObjectPoolParallelGetMultiPutContendedDynamic(b *testing.B) {
+	opts := NewObjectPoolOptions().
+		SetDynamic(true)
+
+	p := NewObjectPool(opts)
+	p.Init(func() interface{} {
+		b := make([]byte, 0, 64)
+		return &b
+	})
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			bufs := make([]*[]byte, 16)
+			for i := 0; i < len(bufs); i++ {
+				o, ok := p.Get().(*[]byte)
+				if !ok {
+					b.Fail()
+				}
+				bufs[i] = o
+			}
+			for i := 0; i < len(bufs); i++ {
+				o := bufs[i]
+				buf := *o
+				buf = strconv.AppendInt(buf[:0], 12344321, 10)
+				runtime.KeepAlive(buf)
 				p.Put(o)
 			}
 		}

--- a/src/x/pool/options.go
+++ b/src/x/pool/options.go
@@ -23,9 +23,11 @@ package pool
 import "github.com/m3db/m3/src/x/instrument"
 
 const (
-	defaultSize                = 4096
-	defaultRefillLowWatermark  = 0.0
-	defaultRefillHighWatermark = 0.0
+	_defaultSize                = 4096
+	_defaultRefillLowWatermark  = 0.0
+	_defaultRefillHighWatermark = 0.0
+
+	_dynamicPoolSize = -1
 )
 
 type objectPoolOptions struct {
@@ -34,14 +36,16 @@ type objectPoolOptions struct {
 	refillHighWatermark float64
 	instrumentOpts      instrument.Options
 	onPoolAccessErrorFn OnPoolAccessErrorFn
+	dynamic             bool
 }
 
 // NewObjectPoolOptions creates a new set of object pool options
 func NewObjectPoolOptions() ObjectPoolOptions {
 	return &objectPoolOptions{
-		size:                defaultSize,
-		refillLowWatermark:  defaultRefillLowWatermark,
-		refillHighWatermark: defaultRefillHighWatermark,
+		size:                _defaultSize,
+		dynamic:             false,
+		refillLowWatermark:  _defaultRefillLowWatermark,
+		refillHighWatermark: _defaultRefillHighWatermark,
 		instrumentOpts:      instrument.NewOptions(),
 		onPoolAccessErrorFn: func(err error) { panic(err) },
 	}
@@ -54,7 +58,20 @@ func (o *objectPoolOptions) SetSize(value int) ObjectPoolOptions {
 }
 
 func (o *objectPoolOptions) Size() int {
+	if o.dynamic {
+		return _dynamicPoolSize
+	}
 	return o.size
+}
+
+func (o *objectPoolOptions) SetDynamic(dynamic bool) ObjectPoolOptions {
+	opts := *o
+	opts.dynamic = dynamic
+	return &opts
+}
+
+func (o *objectPoolOptions) Dynamic() bool {
+	return o.dynamic
 }
 
 func (o *objectPoolOptions) SetRefillLowWatermark(value float64) ObjectPoolOptions {

--- a/src/x/pool/types.go
+++ b/src/x/pool/types.go
@@ -53,6 +53,12 @@ type ObjectPoolOptions interface {
 	// Size returns the size of the object pool.
 	Size() int
 
+	// SetDynamic creates a dynamically-sized, non-preallocated pool.
+	SetDynamic(value bool) ObjectPoolOptions
+
+	// Dynamic returns if the pool is dynamic.
+	Dynamic() bool
+
 	// SetRefillLowWatermark sets the refill low watermark value between [0, 1),
 	// if zero then no refills occur.
 	SetRefillLowWatermark(value float64) ObjectPoolOptions

--- a/src/x/pool/types.go
+++ b/src/x/pool/types.go
@@ -96,7 +96,7 @@ type Bucket struct {
 	Capacity int
 
 	// Count is the number of fixed elements in the bucket.
-	Count int
+	Count Size
 
 	// Options is an optional override to specify options to use for a bucket,
 	// specify nil to use the options specified to the bucketized pool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
If pool size in config is set to `dynamic`, the backing pool will be simply a wrapped `sync.Pool`.
```
name                                                 time/op
ObjectPoolParallelGetMultiPutContended               1.24µs ± 0%
ObjectPoolParallelGetMultiPutContended-12            2.98µs ± 0%
ObjectPoolParallelGetMultiPutContendedDynamic         818ns ± 0%
ObjectPoolParallelGetMultiPutContendedDynamic-12      203ns ± 5%
ObjectPoolParallelGetMultiPutContendedWithRefill     1.23µs ± 1%
ObjectPoolParallelGetMultiPutContendedWithRefill-12  3.10µs ± 5%
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
