### PR TITLE
[coordinator] Fix panic in Ready endpoint for admin coordinator

### DIFF
--- a/src/query/api/v1/handler/ready.go
+++ b/src/query/api/v1/handler/ready.go
@@ -90,10 +90,12 @@ func (h *ReadyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var (
+	var namespaces m3.ClusterNamespaces
+	if h.clusters != nil {
 		namespaces = h.clusters.ClusterNamespaces()
-		result     = &readyResult{}
-	)
+	}
+
+	result := &readyResult{}
 	for _, ns := range namespaces {
 		attrs := ns.Options().Attributes()
 		nsResult := readyResultNamespace{

--- a/src/query/api/v1/handler/ready_test.go
+++ b/src/query/api/v1/handler/ready_test.go
@@ -211,3 +211,28 @@ func TestReadyHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestReadyHandlerNoClusters(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	opts := options.EmptyHandlerOptions()
+	readyHandler := NewReadyHandler(opts)
+
+	w := httptest.NewRecorder()
+	url := ReadyURL
+	req := httptest.NewRequest(ReadyHTTPMethod, url, nil)
+
+	readyHandler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	expected := "{}"
+	actual := xtest.MustPrettyJSONString(t, string(body))
+
+	assert.Equal(t, expected, actual, xtest.Diff(expected, actual))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
`ready` endpoint was panicking when `cluster/namespaces` was not configured (which can be the case for the admin coordinator).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
