### PR TITLE
[coordinator] Add config option to make rollup rules untimed

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -137,6 +137,7 @@ func defaultMetricsAppenderOptions(opts DownsamplerOptions, agg agg) metricsAppe
 		metricTagsIteratorPool: agg.pools.metricTagsIteratorPool,
 		debugLogging:           debugLogging,
 		logger:                 logger,
+		untimedRollups:         agg.untimedRollups,
 	}
 }
 

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -2844,6 +2844,9 @@ func testDownsamplerAggregationIngest(
 			if sample.offset > 0 {
 				sample.time = sample.time.Add(sample.offset)
 			}
+			if testOpts.waitForOffset {
+				time.Sleep(sample.offset)
+			}
 			err = samplesAppender.AppendCounterSample(sample.time, sample.value, nil)
 			require.NoError(t, err)
 		}

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1844,7 +1844,6 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollups(t *testin
 				{value: 42},
 				{value: 12, offset: 2 * time.Second},
 			},
-			expectDropPolicyApplied: true,
 		},
 		{
 			tags: map[string]string{
@@ -1858,7 +1857,6 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollups(t *testin
 				{value: 13},
 				{value: 27, offset: 2 * time.Second},
 			},
-			expectDropPolicyApplied: true,
 		},
 	}
 	res := 1 * time.Second
@@ -1869,8 +1867,14 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollups(t *testin
 		rulesConfig: &RulesConfiguration{
 			MappingRules: []MappingRuleConfiguration{
 				{
-					Filter: filter,
-					Drop:   true,
+					Filter:       "app:nginx*",
+					Aggregations: []aggregation.Type{aggregation.Max},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: 1 * time.Second,
+							Retention:  30 * 24 * time.Hour,
+						},
+					},
 				},
 			},
 			RollupRules: []RollupRuleConfiguration{

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1813,7 +1813,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleAndDropPolicyAndDropTime
 						"status_code":         "500",
 						"endpoint":            "/foo/bar",
 					},
-					values: []expectedValue{{value: 55}, {value: 39}},
+					values: []expectedValue{{value: 94}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
 						Resolution:  res,
@@ -1844,6 +1844,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollups(t *testin
 				{value: 42},
 				{value: 12, offset: 2 * time.Second},
 			},
+			expectDropTimestamp: true,
 		},
 		{
 			tags: map[string]string{
@@ -1857,6 +1858,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollups(t *testin
 				{value: 13},
 				{value: 27, offset: 2 * time.Second},
 			},
+			expectDropTimestamp: true,
 		},
 	}
 	res := 1 * time.Second
@@ -1942,6 +1944,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollupsWaitForOff
 				{value: 42},
 			},
 			expectDropPolicyApplied: true,
+			expectDropTimestamp:     true,
 		},
 		{
 			tags: map[string]string{
@@ -1955,6 +1958,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollupsWaitForOff
 				{value: 12, offset: 2 * time.Second},
 			},
 			expectDropPolicyApplied: true,
+			expectDropTimestamp:     true,
 		},
 		{
 			tags: map[string]string{
@@ -1968,6 +1972,7 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollupsWaitForOff
 				{value: 13},
 			},
 			expectDropPolicyApplied: true,
+			expectDropTimestamp:     true,
 		},
 	}
 	res := 1 * time.Second
@@ -2018,6 +2023,111 @@ func TestDownsamplerAggregationWithRulesConfigRollupRuleUntimedRollupsWaitForOff
 						"endpoint":            "/foo/bar",
 					},
 					values: []expectedValue{{value: 42}, {value: 25}},
+					attributes: &storagemetadata.Attributes{
+						MetricsType: storagemetadata.AggregatedMetricsType,
+						Resolution:  res,
+						Retention:   ret,
+					},
+				},
+			},
+		},
+	})
+
+	// Test expected output
+	testDownsamplerAggregation(t, testDownsampler)
+}
+
+func TestDownsamplerAggregationWithRulesConfigRollupRuleRollupLaterUntimedRollups(t *testing.T) {
+	t.Parallel()
+
+	gaugeMetrics := []testGaugeMetric{
+		{
+			tags: map[string]string{
+				nameTag:         "http_requests",
+				"app":           "nginx_edge",
+				"status_code":   "500",
+				"endpoint":      "/foo/bar",
+				"not_rolled_up": "not_rolled_up_value_1",
+			},
+			timedSamples: []testGaugeMetricTimedSample{
+				{value: 42},
+				{value: 12, offset: 2 * time.Second},
+			},
+			expectDropTimestamp: true,
+		},
+		{
+			tags: map[string]string{
+				nameTag:         "http_requests",
+				"app":           "nginx_edge",
+				"status_code":   "500",
+				"endpoint":      "/foo/bar",
+				"not_rolled_up": "not_rolled_up_value_2",
+			},
+			timedSamples: []testGaugeMetricTimedSample{
+				{value: 13},
+				{value: 27, offset: 2 * time.Second},
+			},
+			expectDropTimestamp: true,
+		},
+	}
+	res := 1 * time.Second
+	ret := 30 * 24 * time.Hour
+	filter := fmt.Sprintf("%s:http_requests app:* status_code:* endpoint:*", nameTag)
+	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
+		untimedRollups: true,
+		rulesConfig: &RulesConfiguration{
+			MappingRules: []MappingRuleConfiguration{
+				{
+					Filter:       "app:nginx*",
+					Aggregations: []aggregation.Type{aggregation.Max},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: 1 * time.Second,
+							Retention:  30 * 24 * time.Hour,
+						},
+					},
+				},
+			},
+			RollupRules: []RollupRuleConfiguration{
+				{
+					Filter: filter,
+					Transforms: []TransformConfiguration{
+						{
+							Transform: &TransformOperationConfiguration{
+								Type: transformation.Add,
+							},
+						},
+						{
+							Rollup: &RollupOperationConfiguration{
+								MetricName:   "http_requests_by_status_code",
+								GroupBy:      []string{"app", "status_code", "endpoint"},
+								Aggregations: []aggregation.Type{aggregation.Sum},
+							},
+						},
+					},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: res,
+							Retention:  ret,
+						},
+					},
+				},
+			},
+		},
+		ingest: &testDownsamplerOptionsIngest{
+			gaugeMetrics: gaugeMetrics,
+		},
+		expect: &testDownsamplerOptionsExpect{
+			writes: []testExpectedWrite{
+				{
+					tags: map[string]string{
+						nameTag:               "http_requests_by_status_code",
+						string(rollupTagName): string(rollupTagValue),
+						"app":                 "nginx_edge",
+						"status_code":         "500",
+						"endpoint":            "/foo/bar",
+					},
+					values: []expectedValue{{value: 39}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
 						Resolution:  res,
@@ -2851,7 +2961,11 @@ func testDownsamplerAggregationIngest(
 			if testOpts.waitForOffset {
 				time.Sleep(sample.offset)
 			}
-			err = samplesAppender.AppendCounterSample(sample.time, sample.value, nil)
+			if samplesAppenderResult.ShouldDropTimestamp {
+				err = samplesAppender.AppendUntimedCounterSample(sample.value, nil)
+			} else {
+				err = samplesAppender.AppendCounterSample(sample.time, sample.value, nil)
+			}
 			require.NoError(t, err)
 		}
 	}
@@ -2884,7 +2998,11 @@ func testDownsamplerAggregationIngest(
 			if testOpts.waitForOffset {
 				time.Sleep(sample.offset)
 			}
-			err = samplesAppender.AppendGaugeSample(sample.time, sample.value, nil)
+			if samplesAppenderResult.ShouldDropTimestamp {
+				err = samplesAppender.AppendUntimedGaugeSample(sample.value, nil)
+			} else {
+				err = samplesAppender.AppendGaugeSample(sample.time, sample.value, nil)
+			}
 			require.NoError(t, err)
 		}
 	}

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -378,7 +378,10 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 
 	// Apply the custom tags first so that they apply even if mapping
 	// rules drop the metric.
-	dropTimestamp = a.curr.Pipelines.ShouldDropTimestamp(a.untimedRollups)
+	dropTimestamp = a.curr.Pipelines.ShouldDropTimestamp(
+		metadata.ShouldDropTimestampOptions{
+			UntimedRollups: a.untimedRollups,
+		})
 
 	// Apply drop policies results
 	a.curr.Pipelines, dropApplyResult = a.curr.Pipelines.ApplyOrRemoveDropPolicies()

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -102,6 +102,7 @@ type metricsAppenderOptions struct {
 	matcher                      matcher.Matcher
 	tagEncoderPool               serialize.TagEncoderPool
 	metricTagsIteratorPool       serialize.MetricTagsIteratorPool
+	untimedRollups               bool
 
 	clockOpts    clock.Options
 	debugLogging bool
@@ -403,6 +404,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			clientRemote:    a.clientRemote,
 			unownedID:       rollup.ID,
 			stagedMetadatas: rollup.Metadatas,
+			dropTs:          a.untimedRollups,
 		})
 	}
 

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -378,7 +378,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 
 	// Apply the custom tags first so that they apply even if mapping
 	// rules drop the metric.
-	dropTimestamp = a.curr.Pipelines.ApplyCustomTags()
+	dropTimestamp = a.curr.Pipelines.ShouldDropTimestamp(a.untimedRollups)
 
 	// Apply drop policies results
 	a.curr.Pipelines, dropApplyResult = a.curr.Pipelines.ApplyOrRemoveDropPolicies()
@@ -404,8 +404,10 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			clientRemote:    a.clientRemote,
 			unownedID:       rollup.ID,
 			stagedMetadatas: rollup.Metadatas,
-			dropTS:          a.untimedRollups,
 		})
+		if a.untimedRollups {
+			dropTimestamp = true
+		}
 	}
 
 	dropPolicyApplied := dropApplyResult != metadata.NoDropPolicyPresentResult

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -404,7 +404,7 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 			clientRemote:    a.clientRemote,
 			unownedID:       rollup.ID,
 			stagedMetadatas: rollup.Metadatas,
-			dropTs:          a.untimedRollups,
+			dropTS:          a.untimedRollups,
 		})
 	}
 

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -234,9 +234,10 @@ type agg struct {
 	aggregator   aggregator.Aggregator
 	clientRemote client.Client
 
-	clockOpts clock.Options
-	matcher   matcher.Matcher
-	pools     aggPools
+	clockOpts      clock.Options
+	matcher        matcher.Matcher
+	pools          aggPools
+	untimedRollups bool
 }
 
 // Configuration configurates a downsampler.
@@ -268,8 +269,12 @@ type Configuration struct {
 	// BufferPastLimits specifies the buffer past limits.
 	BufferPastLimits []BufferPastLimitConfiguration `yaml:"bufferPastLimits"`
 
-	// EntryTTL determines how long an entry remains alive before it may be expired due to inactivity.
+	// EntryTTL determines how long an entry remains alive before it may be
+	// expired due to inactivity.
 	EntryTTL time.Duration `yaml:"entryTTL"`
+
+	// UntimedRollups indicates rollup rules should be untimed.
+	UntimedRollups bool `yaml:"untimedRollups"`
 }
 
 // MatcherConfiguration is the configuration for the rule matcher.
@@ -808,9 +813,10 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		}
 
 		return agg{
-			clientRemote: client,
-			matcher:      matcher,
-			pools:        pools,
+			clientRemote:   client,
+			matcher:        matcher,
+			pools:          pools,
+			untimedRollups: cfg.UntimedRollups,
 		}, nil
 	}
 
@@ -972,9 +978,10 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	}
 
 	return agg{
-		aggregator: aggregatorInstance,
-		matcher:    matcher,
-		pools:      pools,
+		aggregator:     aggregatorInstance,
+		matcher:        matcher,
+		pools:          pools,
+		untimedRollups: cfg.UntimedRollups,
 	}, nil
 }
 

--- a/src/cmd/services/m3coordinator/downsample/samples_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/samples_appender.go
@@ -36,7 +36,7 @@ import (
 type samplesAppender struct {
 	agg          aggregator.Aggregator
 	clientRemote client.Client
-	dropTs       bool
+	dropTS       bool
 
 	unownedID       []byte
 	stagedMetadatas metadata.StagedMetadatas
@@ -106,7 +106,7 @@ func (a samplesAppender) AppendUntimedTimerSample(value float64, annotation []by
 }
 
 func (a *samplesAppender) AppendCounterSample(t time.Time, value int64, annotation []byte) error {
-	if a.dropTs {
+	if a.dropTS {
 		return a.AppendUntimedCounterSample(value, annotation)
 	}
 	return a.appendTimedSample(aggregated.Metric{
@@ -119,7 +119,7 @@ func (a *samplesAppender) AppendCounterSample(t time.Time, value int64, annotati
 }
 
 func (a *samplesAppender) AppendGaugeSample(t time.Time, value float64, annotation []byte) error {
-	if a.dropTs {
+	if a.dropTS {
 		return a.AppendUntimedGaugeSample(value, annotation)
 	}
 	return a.appendTimedSample(aggregated.Metric{
@@ -132,7 +132,7 @@ func (a *samplesAppender) AppendGaugeSample(t time.Time, value float64, annotati
 }
 
 func (a *samplesAppender) AppendTimerSample(t time.Time, value float64, annotation []byte) error {
-	if a.dropTs {
+	if a.dropTS {
 		return a.AppendUntimedTimerSample(value, annotation)
 	}
 	return a.appendTimedSample(aggregated.Metric{

--- a/src/cmd/services/m3coordinator/downsample/samples_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/samples_appender.go
@@ -36,7 +36,6 @@ import (
 type samplesAppender struct {
 	agg          aggregator.Aggregator
 	clientRemote client.Client
-	dropTS       bool
 
 	unownedID       []byte
 	stagedMetadatas metadata.StagedMetadatas
@@ -106,9 +105,6 @@ func (a samplesAppender) AppendUntimedTimerSample(value float64, annotation []by
 }
 
 func (a *samplesAppender) AppendCounterSample(t time.Time, value int64, annotation []byte) error {
-	if a.dropTS {
-		return a.AppendUntimedCounterSample(value, annotation)
-	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.CounterType,
 		ID:         a.unownedID,
@@ -119,9 +115,6 @@ func (a *samplesAppender) AppendCounterSample(t time.Time, value int64, annotati
 }
 
 func (a *samplesAppender) AppendGaugeSample(t time.Time, value float64, annotation []byte) error {
-	if a.dropTS {
-		return a.AppendUntimedGaugeSample(value, annotation)
-	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.GaugeType,
 		ID:         a.unownedID,
@@ -132,9 +125,6 @@ func (a *samplesAppender) AppendGaugeSample(t time.Time, value float64, annotati
 }
 
 func (a *samplesAppender) AppendTimerSample(t time.Time, value float64, annotation []byte) error {
-	if a.dropTS {
-		return a.AppendUntimedTimerSample(value, annotation)
-	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.TimerType,
 		ID:         a.unownedID,

--- a/src/cmd/services/m3coordinator/downsample/samples_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/samples_appender.go
@@ -36,6 +36,7 @@ import (
 type samplesAppender struct {
 	agg          aggregator.Aggregator
 	clientRemote client.Client
+	dropTs       bool
 
 	unownedID       []byte
 	stagedMetadatas metadata.StagedMetadatas
@@ -105,6 +106,9 @@ func (a samplesAppender) AppendUntimedTimerSample(value float64, annotation []by
 }
 
 func (a *samplesAppender) AppendCounterSample(t time.Time, value int64, annotation []byte) error {
+	if a.dropTs {
+		return a.AppendUntimedCounterSample(value, annotation)
+	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.CounterType,
 		ID:         a.unownedID,
@@ -115,6 +119,9 @@ func (a *samplesAppender) AppendCounterSample(t time.Time, value int64, annotati
 }
 
 func (a *samplesAppender) AppendGaugeSample(t time.Time, value float64, annotation []byte) error {
+	if a.dropTs {
+		return a.AppendUntimedGaugeSample(value, annotation)
+	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.GaugeType,
 		ID:         a.unownedID,
@@ -125,6 +132,9 @@ func (a *samplesAppender) AppendGaugeSample(t time.Time, value float64, annotati
 }
 
 func (a *samplesAppender) AppendTimerSample(t time.Time, value float64, annotation []byte) error {
+	if a.dropTs {
+		return a.AppendUntimedTimerSample(value, annotation)
+	}
 	return a.appendTimedSample(aggregated.Metric{
 		Type:       metric.TimerType,
 		ID:         a.unownedID,

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -23,8 +23,6 @@ package metadata
 import (
 	"bytes"
 
-	"github.com/m3db/m3/src/metrics/pipeline"
-
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/metrics/generated/proto/metricpb"
 	"github.com/m3db/m3/src/metrics/generated/proto/policypb"
@@ -287,10 +285,8 @@ func (metadatas PipelineMetadatas) ShouldDropTimestamp(untimedRollups bool) bool
 	// Go over metadatas and and look for drop timestamp tag.
 	for i := range metadatas {
 		if untimedRollups {
-			for j := range metadatas[i].Pipeline.Operations {
-				if metadatas[i].Pipeline.Operations[j].Type == pipeline.RollupOpType {
-					return true
-				}
+			if !metadatas[i].IsMappingRule() {
+				return true
 			}
 		}
 		for j := range metadatas[i].Tags {

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -115,6 +115,11 @@ func (m PipelineMetadata) IsMappingRule() bool {
 	return m.Pipeline.IsMappingRule()
 }
 
+// IsAnyRollupRules returns whether any of the rules have rollups.
+func (m PipelineMetadata) IsAnyRollupRules() bool {
+	return !m.Pipeline.IsMappingRule()
+}
+
 // IsDropPolicyApplied returns whether this is the default standard pipeline
 // but with the drop policy applied.
 func (m PipelineMetadata) IsDropPolicyApplied() bool {
@@ -280,12 +285,17 @@ func (metadatas PipelineMetadatas) ApplyOrRemoveDropPolicies() (
 	return result, RemovedIneffectiveDropPoliciesResult
 }
 
+// ShouldDropTimestampOptions are options for the should drop timestamp method.
+type ShouldDropTimestampOptions struct {
+	UntimedRollups bool
+}
+
 // ShouldDropTimestamp applies custom M3 tags.
-func (metadatas PipelineMetadatas) ShouldDropTimestamp(untimedRollups bool) bool {
+func (metadatas PipelineMetadatas) ShouldDropTimestamp(opts ShouldDropTimestampOptions) bool {
 	// Go over metadatas and and look for drop timestamp tag.
 	for i := range metadatas {
-		if untimedRollups {
-			if !metadatas[i].IsMappingRule() {
+		if opts.UntimedRollups {
+			if metadatas[i].IsAnyRollupRules() {
 				return true
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds a coordinator config option to force all rollup rules to be considered as untimed.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
