### PR TITLE
[x] Add OffsetClock constructor that uses given time delta

### DIFF
--- a/src/x/clock/offset_clock.go
+++ b/src/x/clock/offset_clock.go
@@ -35,7 +35,12 @@ func NewOffsetClock(offsetTime time.Time, nowFn NowFn) OffsetClock {
 	return OffsetClock{nowFn: nowFn, timeDelta: offsetTime.Sub(nowFn())}
 }
 
-// Now returns current time from the initial seed time value.
+// NewOffsetClock returns new offset clock that has time shifted by timeDelta duration.
+func NewOffsetClockFromTimeDelta(timeDelta time.Duration, nowFn NowFn) OffsetClock {
+	return OffsetClock{nowFn: nowFn, timeDelta: timeDelta}
+}
+
+// Now returns current time with time offset taken into account.
 func (c OffsetClock) Now() time.Time {
 	now := c.nowFn()
 	return now.Add(c.timeDelta)

--- a/src/x/clock/offset_clock.go
+++ b/src/x/clock/offset_clock.go
@@ -35,7 +35,7 @@ func NewOffsetClock(offsetTime time.Time, nowFn NowFn) OffsetClock {
 	return OffsetClock{nowFn: nowFn, timeDelta: offsetTime.Sub(nowFn())}
 }
 
-// NewOffsetClock returns new offset clock that has time shifted by timeDelta duration.
+// NewOffsetClockFromTimeDelta returns new offset clock that has time shifted by timeDelta duration.
 func NewOffsetClockFromTimeDelta(timeDelta time.Duration, nowFn NowFn) OffsetClock {
 	return OffsetClock{nowFn: nowFn, timeDelta: timeDelta}
 }

--- a/src/x/clock/offset_clock_test.go
+++ b/src/x/clock/offset_clock_test.go
@@ -30,6 +30,13 @@ import (
 func TestOffsetClockNow(t *testing.T) {
 	OneYearFromNow := time.Now().Add(365 * 24 * time.Hour).Truncate(time.Nanosecond)
 
+	initialSeedTime := time.Now()
+
+	advanceByOneSec := func() time.Time {
+		initialSeedTime = initialSeedTime.Add(1 * time.Second)
+		return initialSeedTime
+	}
+
 	tests := []struct {
 		name       string
 		offsetTime time.Time
@@ -74,9 +81,31 @@ func TestOffsetClockNow(t *testing.T) {
 	}
 }
 
-var initialSeedTime = time.Now()
+func TestNewOffsetClockFromTimeDelta(t *testing.T) {
+	nowFn := func() time.Time {
+		return time.Date(2021, 1, 1, 0, 0, 0, 0, time.Local)
+	}
 
-func advanceByOneSec() time.Time {
-	initialSeedTime = initialSeedTime.Add(1 * time.Second)
-	return initialSeedTime
+	tests := []struct {
+		name      string
+		timeDelta time.Duration
+		expected  time.Time
+	}{
+		{
+			name:      "positive offset",
+			timeDelta: time.Hour,
+			expected:  time.Date(2021, 1, 1, 1, 0, 0, 0, time.Local),
+		},
+		{
+			name:      "negative offset",
+			timeDelta: -24 * time.Hour,
+			expected:  time.Date(2020, 12, 31, 0, 0, 0, 0, time.Local),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, NewOffsetClockFromTimeDelta(tt.timeDelta, nowFn).Now())
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds `OffsetClock` constructor that uses given time delta instead of a particular `time.Time` in the past/future.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
