### PR TITLE
[tools] read_commitlog util

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ TOOLS :=               \
 	read_data_files      \
 	read_index_files     \
 	read_index_segments  \
+	read_commitlog       \
 	query_index_segments \
 	clone_fileset        \
 	dtest                \

--- a/src/cmd/tools/read_commitlog/README.md
+++ b/src/cmd/tools/read_commitlog/README.md
@@ -1,0 +1,18 @@
+# read_commitlog
+
+`read_commitlog` is a utility to extract data from a commitlog file.
+
+# Usage
+```
+$ git clone git@github.com:m3db/m3.git
+$ make read_commitlog
+$ ./bin/read_commitlog
+Usage: read_commitlog [-p value] [-f value]
+ -p, --path=value
+       Commitlog file path [e.g. /var/lib/m3db/commitlogs/commitlog-0-161023.db]
+ -f, --id-filter=value
+       ID Contains Filter [e.g. xyz]
+
+# example usage
+# read_commitlog -p /var/lib/m3db/commitlogs/commitlog-0-161023.db -f 'metric-name' > /tmp/sample-data.out
+```

--- a/src/cmd/tools/read_commitlog/main/main.go
+++ b/src/cmd/tools/read_commitlog/main/main.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -58,8 +59,8 @@ func main() {
 
 	entryCount := 0
 
-	opts := commitlog.NewCommitLogReaderOptions(commitlog.NewOptions(), false)
-	reader := commitlog.NewCommitLogReader(opts)
+	opts := commitlog.NewReaderOptions(commitlog.NewOptions(), false)
+	reader := commitlog.NewReader(opts)
 
 	_, err = reader.Open(*path)
 	if err != nil {
@@ -68,26 +69,26 @@ func main() {
 
 	for {
 		entry, err := reader.Read()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
 			logger.Fatalf("err reading commitlog: %v", err)
 		}
 
-		var id = entry.Series.ID
+		id := entry.Series.ID
 		if *idFilter != "" && !strings.Contains(id.String(), *idFilter) {
 			continue
 		}
 
-		fmt.Printf("{id: %s, dp: %+v", id, entry.Datapoint)
+		fmt.Printf("{id: %s, dp: %+v", id, entry.Datapoint) // nolint: forbidigo
 		if len(entry.Annotation) > 0 {
-			fmt.Printf(", annotation: %s", base64.StdEncoding.EncodeToString(entry.Annotation))
+			fmt.Printf(", annotation: %s", base64.StdEncoding.EncodeToString(entry.Annotation)) // nolint: forbidigo
 		}
-		fmt.Println("}")
+		fmt.Println("}") // nolint: forbidigo
 
 		entryCount++
 	}
 
-	fmt.Printf("\n%d entries read\n", entryCount)
+	fmt.Printf("\n%d entries read\n", entryCount) // nolint: forbidigo
 }

--- a/src/cmd/tools/read_commitlog/main/main.go
+++ b/src/cmd/tools/read_commitlog/main/main.go
@@ -89,7 +89,8 @@ func main() {
 		fmt.Printf("{id: %s, dp: %+v, ns: %s, shard: %d", // nolint: forbidigo
 			series.ID, entry.Datapoint, entry.Series.Namespace, entry.Series.Shard)
 		if len(entry.Annotation) > 0 {
-			fmt.Printf(", annotation: %s", base64.StdEncoding.EncodeToString(entry.Annotation)) // nolint: forbidigo
+			fmt.Printf(", annotation: %s", // nolint: forbidigo
+				base64.StdEncoding.EncodeToString(entry.Annotation))
 			annotationSizeTotal += uint64(len(entry.Annotation))
 		}
 		fmt.Println("}") // nolint: forbidigo
@@ -98,6 +99,7 @@ func main() {
 	}
 
 	runTime := time.Since(start)
+
 	fmt.Printf("\nRunning time: %s\n", runTime)                          // nolint: forbidigo
 	fmt.Printf("%d entries read\n", entryCount)                          // nolint: forbidigo
 	fmt.Printf("Total annotation size: %d bytes\n", annotationSizeTotal) // nolint: forbidigo

--- a/src/cmd/tools/read_commitlog/main/main.go
+++ b/src/cmd/tools/read_commitlog/main/main.go
@@ -76,12 +76,13 @@ func main() {
 			logger.Fatalf("err reading commitlog: %v", err)
 		}
 
-		id := entry.Series.ID
-		if *idFilter != "" && !strings.Contains(id.String(), *idFilter) {
+		series := entry.Series
+		if *idFilter != "" && !strings.Contains(series.ID.String(), *idFilter) {
 			continue
 		}
 
-		fmt.Printf("{id: %s, dp: %+v", id, entry.Datapoint) // nolint: forbidigo
+		fmt.Printf("{id: %s, dp: %+v, ns: %s, shard: %d",
+			series.ID, entry.Datapoint, entry.Series.Namespace, entry.Series.Shard) // nolint: forbidigo
 		if len(entry.Annotation) > 0 {
 			fmt.Printf(", annotation: %s", base64.StdEncoding.EncodeToString(entry.Annotation)) // nolint: forbidigo
 		}

--- a/src/cmd/tools/read_commitlog/main/main.go
+++ b/src/cmd/tools/read_commitlog/main/main.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/pborman/getopt"
+	"go.uber.org/zap"
+
+	"github.com/m3db/m3/src/cmd/tools"
+	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
+)
+
+func main() {
+	var (
+		path     = getopt.StringLong("path", 'p', "", "file path [e.g. /var/lib/m3db/commitlogs/commitlog-0-161023.db]")
+		idFilter = getopt.StringLong("id-filter", 'f', "", "ID Contains Filter (optional)")
+	)
+	getopt.Parse()
+
+	rawLogger, err := zap.NewDevelopment()
+	if err != nil {
+		log.Fatalf("unable to create logger: %+v", err)
+	}
+	logger := rawLogger.Sugar()
+
+	if *path == "" {
+		getopt.Usage()
+		os.Exit(1)
+	}
+
+	bytesPool := tools.NewCheckedBytesPool()
+	bytesPool.Init()
+
+	entryCount := 0
+
+	opts := commitlog.NewCommitLogReaderOptions(commitlog.NewOptions(), false)
+	reader := commitlog.NewCommitLogReader(opts)
+
+	_, err = reader.Open(*path)
+	if err != nil {
+		logger.Fatalf("unable to open reader: %v", err)
+	}
+
+	for {
+		entry, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			logger.Fatalf("err reading commitlog: %v", err)
+		}
+
+		var id = entry.Series.ID
+		if *idFilter != "" && !strings.Contains(id.String(), *idFilter) {
+			continue
+		}
+
+		fmt.Printf("{id: %s, dp: %+v", id, entry.Datapoint)
+		if len(entry.Annotation) > 0 {
+			fmt.Printf(", annotation: %s", base64.StdEncoding.EncodeToString(entry.Annotation))
+		}
+		fmt.Println("}")
+
+		entryCount++
+	}
+
+	fmt.Printf("\n%d entries read\n", entryCount)
+}

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -189,7 +189,7 @@ func main() {
 
 	if benchMode != benchmarkNone {
 		runTime := time.Since(start)
-		fmt.Printf("Running time: %s\n", runTime) // nolint: forbidigo
+		fmt.Printf("Running time: %s\n", runTime)     // nolint: forbidigo
 		fmt.Printf("\n%d series read\n", seriesCount) // nolint: forbidigo
 		if runTime > 0 {
 			fmt.Printf("(%.2f series/second)\n", float64(seriesCount)/runTime.Seconds()) // nolint: forbidigo

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -69,7 +69,7 @@ func main() {
 		fileSetTypeArg = getopt.StringLong("fileset-type", 't', flushType, fmt.Sprintf("%s|%s", flushType, snapshotType))
 		idFilter       = getopt.StringLong("id-filter", 'f', "", "ID Contains Filter (optional)")
 		benchmark      = getopt.StringLong(
-			"benchmark", 'B', "", "benchmark mode (optional), [series/datapoints]")
+			"benchmark", 'B', "", "benchmark mode (optional), [series|datapoints]")
 	)
 	getopt.Parse()
 
@@ -118,9 +118,10 @@ func main() {
 	fsOpts := fs.NewOptions().SetFilePathPrefix(*optPathPrefix)
 
 	var (
-		seriesCount    = 0
-		datapointCount = 0
-		start          = time.Now()
+		seriesCount         = 0
+		datapointCount      = 0
+		annotationSizeTotal uint64
+		start               = time.Now()
 	)
 
 	reader, err := fs.NewReader(bytesPool, fsOpts)
@@ -164,12 +165,14 @@ func main() {
 				dp, _, annotation := iter.Current()
 				if benchMode == benchmarkNone {
 					// Use fmt package so it goes to stdout instead of stderr
-					fmt.Printf("{id: %s, dp: %+v", id.String(), dp)
+					fmt.Printf("{id: %s, dp: %+v", id.String(), dp) // nolint: forbidigo
 					if len(annotation) > 0 {
-						fmt.Printf(", annotation: %s", base64.StdEncoding.EncodeToString(annotation))
+						fmt.Printf(", annotation: %s", // nolint: forbidigo
+							base64.StdEncoding.EncodeToString(annotation))
 					}
-					fmt.Println("}")
+					fmt.Println("}") // nolint: forbidigo
 				}
+				annotationSizeTotal += uint64(len(annotation))
 				datapointCount++
 			}
 			if err := iter.Err(); err != nil {
@@ -186,15 +189,19 @@ func main() {
 
 	if benchMode != benchmarkNone {
 		runTime := time.Since(start)
-		fmt.Printf("Running time: %s\n", runTime)
-		fmt.Printf("\n%d series read\n", seriesCount)
+		fmt.Printf("Running time: %s\n", runTime) // nolint: forbidigo
+		fmt.Printf("\n%d series read\n", seriesCount) // nolint: forbidigo
 		if runTime > 0 {
-			fmt.Printf("(%.2f series/second)\n", float64(seriesCount)/runTime.Seconds())
+			fmt.Printf("(%.2f series/second)\n", float64(seriesCount)/runTime.Seconds()) // nolint: forbidigo
 		}
 
 		if benchMode == benchmarkDatapoints {
-			fmt.Printf("\n%d datapoints decoded\n", datapointCount)
-			fmt.Printf("(%.2f datapoints/second)\n", float64(datapointCount)/runTime.Seconds())
+			fmt.Printf("\n%d datapoints decoded\n", datapointCount) // nolint: forbidigo
+			if runTime > 0 {
+				fmt.Printf("(%.2f datapoints/second)\n", float64(datapointCount)/runTime.Seconds()) // nolint: forbidigo
+			}
+
+			fmt.Printf("\nTotal annotation size: %d bytes\n", annotationSizeTotal) // nolint: forbidigo
 		}
 	}
 }

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -553,7 +553,7 @@ func TestCommitLogReaderIsNotReusable(t *testing.T) {
 	require.Equal(t, 2, len(files))
 
 	// Assert commitlog cannot be opened more than once
-	reader := newCommitLogReader(commitLogReaderOptions{commitLogOptions: opts})
+	reader := NewCommitLogReader(CommitLogReaderOptions{commitLogOptions: opts})
 	_, err = reader.Open(files[0])
 	require.NoError(t, err)
 	reader.Close()

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -553,7 +553,7 @@ func TestCommitLogReaderIsNotReusable(t *testing.T) {
 	require.Equal(t, 2, len(files))
 
 	// Assert commitlog cannot be opened more than once
-	reader := NewCommitLogReader(CommitLogReaderOptions{commitLogOptions: opts})
+	reader := NewReader(ReaderOptions{commitLogOptions: opts})
 	_, err = reader.Open(files[0])
 	require.NoError(t, err)
 	reader.Close()

--- a/src/dbnode/persist/fs/commitlog/iterator.go
+++ b/src/dbnode/persist/fs/commitlog/iterator.go
@@ -47,7 +47,7 @@ type iterator struct {
 	metrics  iteratorMetrics
 	log      *zap.Logger
 	files    []persist.CommitLogFile
-	reader   CommitLogReader
+	reader   Reader
 	read     LogEntry
 	err      error
 	setRead  bool
@@ -163,7 +163,7 @@ func (i *iterator) nextReader() bool {
 	file := i.files[0]
 	i.files = i.files[1:]
 
-	reader := NewCommitLogReader(CommitLogReaderOptions{
+	reader := NewReader(ReaderOptions{
 		commitLogOptions:    i.opts,
 		returnMetadataAsRef: i.iterOpts.ReturnMetadataAsRef,
 	})

--- a/src/dbnode/persist/fs/commitlog/iterator.go
+++ b/src/dbnode/persist/fs/commitlog/iterator.go
@@ -47,7 +47,7 @@ type iterator struct {
 	metrics  iteratorMetrics
 	log      *zap.Logger
 	files    []persist.CommitLogFile
-	reader   commitLogReader
+	reader   CommitLogReader
 	read     LogEntry
 	err      error
 	setRead  bool
@@ -163,7 +163,7 @@ func (i *iterator) nextReader() bool {
 	file := i.files[0]
 	i.files = i.files[1:]
 
-	reader := newCommitLogReader(commitLogReaderOptions{
+	reader := NewCommitLogReader(CommitLogReaderOptions{
 		commitLogOptions:    i.opts,
 		returnMetadataAsRef: i.iterOpts.ReturnMetadataAsRef,
 	})

--- a/src/dbnode/persist/fs/commitlog/reader.go
+++ b/src/dbnode/persist/fs/commitlog/reader.go
@@ -58,8 +58,8 @@ var (
 	errCommitLogReaderMissingMetadata           = errors.New("commit log reader encountered a datapoint without corresponding metadata")
 )
 
-// CommitLogReader reads a commit log file.
-type CommitLogReader interface {
+// Reader reads a commit log file.
+type Reader interface {
 	// Open opens the commit log for reading
 	Open(filePath string) (int64, error)
 
@@ -71,7 +71,7 @@ type CommitLogReader interface {
 }
 
 type reader struct {
-	opts CommitLogReaderOptions
+	opts ReaderOptions
 
 	logEntryBytes          []byte
 	tagDecoder             serialize.TagDecoder
@@ -93,23 +93,23 @@ type namespaceRead struct {
 	namespaceIDRef   ident.ID
 }
 
-// CommitLogReaderOptions are the options for CommitLogReader.
-type CommitLogReaderOptions struct {
+// ReaderOptions are the options for Reader.
+type ReaderOptions struct {
 	commitLogOptions Options
 	// returnMetadataAsRef indicates to not allocate metadata results.
 	returnMetadataAsRef bool
 }
 
-// CommitLogReaderOptions returns new CommitLogReaderOptions.
-func NewCommitLogReaderOptions(opts Options, returnMetadataAsRef bool) CommitLogReaderOptions {
-	return CommitLogReaderOptions {
+// NewReaderOptions returns new ReaderOptions.
+func NewReaderOptions(opts Options, returnMetadataAsRef bool) ReaderOptions {
+	return ReaderOptions{
 		commitLogOptions:    opts,
 		returnMetadataAsRef: returnMetadataAsRef,
 	}
 }
 
-// NewCommitLogReader returns a new CommitLogReader.
-func NewCommitLogReader(opts CommitLogReaderOptions) CommitLogReader {
+// NewReader returns a new Reader.
+func NewReader(opts ReaderOptions) Reader {
 	tagDecoderCheckedBytes := checked.NewBytes(nil, nil)
 	tagDecoderCheckedBytes.IncRef()
 	return &reader{

--- a/src/dbnode/persist/fs/commitlog/reader.go
+++ b/src/dbnode/persist/fs/commitlog/reader.go
@@ -58,7 +58,8 @@ var (
 	errCommitLogReaderMissingMetadata           = errors.New("commit log reader encountered a datapoint without corresponding metadata")
 )
 
-type commitLogReader interface {
+// CommitLogReader reads a commit log file.
+type CommitLogReader interface {
 	// Open opens the commit log for reading
 	Open(filePath string) (int64, error)
 
@@ -70,7 +71,7 @@ type commitLogReader interface {
 }
 
 type reader struct {
-	opts commitLogReaderOptions
+	opts CommitLogReaderOptions
 
 	logEntryBytes          []byte
 	tagDecoder             serialize.TagDecoder
@@ -92,13 +93,23 @@ type namespaceRead struct {
 	namespaceIDRef   ident.ID
 }
 
-type commitLogReaderOptions struct {
+// CommitLogReaderOptions are the options for CommitLogReader.
+type CommitLogReaderOptions struct {
 	commitLogOptions Options
 	// returnMetadataAsRef indicates to not allocate metadata results.
 	returnMetadataAsRef bool
 }
 
-func newCommitLogReader(opts commitLogReaderOptions) commitLogReader {
+// CommitLogReaderOptions returns new CommitLogReaderOptions.
+func NewCommitLogReaderOptions(opts Options, returnMetadataAsRef bool) CommitLogReaderOptions {
+	return CommitLogReaderOptions {
+		commitLogOptions:    opts,
+		returnMetadataAsRef: returnMetadataAsRef,
+	}
+}
+
+// NewCommitLogReader returns a new CommitLogReader.
+func NewCommitLogReader(opts CommitLogReaderOptions) CommitLogReader {
 	tagDecoderCheckedBytes := checked.NewBytes(nil, nil)
 	tagDecoderCheckedBytes.IncRef()
 	return &reader{


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements a new command line utility for reading M3DB commit log files.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE