### PR TITLE
[aggregator] A flag to enable FlushOffset for timed metrics

### DIFF
--- a/src/aggregator/aggregator/list.go
+++ b/src/aggregator/aggregator/list.go
@@ -761,7 +761,10 @@ func (l *timedMetricList) ID() metricListID {
 }
 
 func (l *timedMetricList) FixedFlushOffset() (time.Duration, bool) {
-	return l.flushOffset, true
+	if l.opts.TimedMetricsFlushOffsetEnabled() {
+		return l.flushOffset, true
+	}
+	return 0, false
 }
 
 func (l *timedMetricList) Close() {

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -328,6 +328,12 @@ type Options interface {
 	// This is a temporary option to help with the seamless rollout of changing Add transforms to Reset transforms for
 	// resetting aggregate counters. Once rollup rules have changed to use Reset explicitly, this can be removed.
 	AddToReset() bool
+
+	// TimedMetricsFlushOffsetEnabled returns true if using of FlushOffset for timed metrics is enabled.
+	TimedMetricsFlushOffsetEnabled() bool
+
+	// SetTimedMetricsFlushOffsetEnabled controls using of FlushOffset for timed metrics.
+	SetTimedMetricsFlushOffsetEnabled(bool) Options
 }
 
 type options struct {
@@ -370,6 +376,7 @@ type options struct {
 	gaugeElemPool                    GaugeElemPool
 	verboseErrors                    bool
 	addToReset                       bool
+	timedMetricsFlushOffsetEnabled   bool
 
 	// Derived options.
 	fullCounterPrefix []byte
@@ -875,6 +882,16 @@ func (o *options) AddToReset() bool {
 func (o *options) SetAddToReset(value bool) Options {
 	opts := *o
 	opts.addToReset = value
+	return &opts
+}
+
+func (o *options) TimedMetricsFlushOffsetEnabled() bool {
+	return o.timedMetricsFlushOffsetEnabled
+}
+
+func (o *options) SetTimedMetricsFlushOffsetEnabled(value bool) Options {
+	opts := *o
+	opts.timedMetricsFlushOffsetEnabled = value
 	return &opts
 }
 

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -174,6 +174,9 @@ type AggregatorConfiguration struct {
 
 	// AddToReset is the yaml config for aggregator.Options.AddToReset
 	AddToReset bool `yaml:"addToReset"`
+
+	// TimedMetricsFlushOffsetEnabled enables using FlushOffset for timed metrics.
+	TimedMetricsFlushOffsetEnabled bool `yaml:"timedMetricsFlushOffsetEnabled"`
 }
 
 // InstanceIDType is the instance ID type that defines how the
@@ -258,7 +261,8 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 		SetInstrumentOptions(instrumentOpts).
 		SetRuntimeOptionsManager(runtimeOptsManager).
 		SetVerboseErrors(c.VerboseErrors).
-		SetAddToReset(c.AddToReset)
+		SetAddToReset(c.AddToReset).
+		SetTimedMetricsFlushOffsetEnabled(c.TimedMetricsFlushOffsetEnabled)
 
 	rwOpts := serveOpts.RWOptions()
 	if rwOpts == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds configuration flag (`timedMetricsFlushOffsetEnabled`) to aggregator config, to control the use of flush offset for timed metrics. The default is `false` to preserve the original behaviour (before https://github.com/m3db/m3/pull/3292).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE