### PR TITLE
[query] Match graphite-web Graphite ** to allow for empty segment path selector to match elements

### DIFF
--- a/src/query/graphite/graphite/glob.go
+++ b/src/query/graphite/graphite/glob.go
@@ -90,11 +90,11 @@ func (p *pattern) UnwriteLast() {
 
 func globToRegexPattern(glob string, opts GlobOptions) ([]byte, bool, error) {
 	var (
-		pattern      pattern
-		escaping     = false
-		regexed      = false
-		matchAll     = false
-		prevMatchAll = false
+		p            pattern
+		escaping     bool
+		regexed      bool
+		matchAll     bool
+		prevMatchAll bool
 	)
 
 	groupStartStack := []rune{rune(0)} // rune(0) indicates pattern is not in a group
@@ -103,11 +103,11 @@ func globToRegexPattern(glob string, opts GlobOptions) ([]byte, bool, error) {
 		prevMatchAll = matchAll
 		matchAll = false
 
-		prevEval := pattern.LastEvaluate()
-		pattern.Evaluate(r)
+		prevEval := p.LastEvaluate()
+		p.Evaluate(r)
 
 		if escaping {
-			pattern.WriteRune(r)
+			p.WriteRune(r)
 			escaping = false
 			continue
 		}
@@ -115,7 +115,7 @@ func globToRegexPattern(glob string, opts GlobOptions) ([]byte, bool, error) {
 		switch r {
 		case '\\':
 			escaping = true
-			pattern.WriteRune('\\')
+			p.WriteRune('\\')
 		case '.':
 			// Check that previous rune was not the match all statement
 			// since we need to skip adding a trailing dot to pattern if so.
@@ -126,27 +126,27 @@ func globToRegexPattern(glob string, opts GlobOptions) ([]byte, bool, error) {
 			// - foo.bar.baz
 			if !prevMatchAll {
 				// Match hierarchy separator
-				pattern.WriteString("\\.+")
+				p.WriteString("\\.+")
 				regexed = true
 			}
 		case '?':
 			// Match anything except the hierarchy separator
-			pattern.WriteString("[^\\.]")
+			p.WriteString("[^\\.]")
 			regexed = true
 		case '*':
 			if opts.AllowMatchAll && prevEval == '*' {
-				pattern.UnwriteLast()
-				pattern.WriteString(".*")
+				p.UnwriteLast()
+				p.WriteString(".*")
 				regexed = true
 				matchAll = true
 			} else {
 				// Match everything up to the next hierarchy separator
-				pattern.WriteString("[^\\.]*")
+				p.WriteString("[^\\.]*")
 				regexed = true
 			}
 		case '{':
 			// Begin non-capturing group
-			pattern.WriteString("(")
+			p.WriteString("(")
 			groupStartStack = append(groupStartStack, r)
 			regexed = true
 		case '}':
@@ -156,11 +156,11 @@ func globToRegexPattern(glob string, opts GlobOptions) ([]byte, bool, error) {
 				return nil, false, errors.NewInvalidParamsError(fmt.Errorf("invalid '}' at %d, no prior for '{' in %s", i, glob))
 			}
 
-			pattern.WriteRune(')')
+			p.WriteRune(')')
 			groupStartStack = groupStartStack[:len(groupStartStack)-1]
 		case '[':
 			// Begin character range
-			pattern.WriteRune('[')
+			p.WriteRune('[')
 			groupStartStack = append(groupStartStack, r)
 			regexed = true
 		case ']':
@@ -170,15 +170,15 @@ func globToRegexPattern(glob string, opts GlobOptions) ([]byte, bool, error) {
 				return nil, false, errors.NewInvalidParamsError(fmt.Errorf("invalid ']' at %d, no prior for '[' in %s", i, glob))
 			}
 
-			pattern.WriteRune(']')
+			p.WriteRune(']')
 			groupStartStack = groupStartStack[:len(groupStartStack)-1]
 		case '<', '>', '\'', '$':
-			pattern.WriteRune('\\')
-			pattern.WriteRune(r)
+			p.WriteRune('\\')
+			p.WriteRune(r)
 		case ',':
 			// Commas are part of the pattern if they appear in a group
 			if groupStartStack[len(groupStartStack)-1] == '{' {
-				pattern.WriteRune('|')
+				p.WriteRune('|')
 			} else {
 				return nil, false, errors.NewInvalidParamsError(fmt.Errorf("invalid ',' outside of matching group at pos %d in %s", i, glob))
 			}
@@ -186,7 +186,7 @@ func globToRegexPattern(glob string, opts GlobOptions) ([]byte, bool, error) {
 			if !strings.ContainsRune(ValidIdentifierRunes, r) {
 				return nil, false, errors.NewInvalidParamsError(fmt.Errorf("invalid character %c at pos %d in %s", r, i, glob))
 			}
-			pattern.WriteRune(r)
+			p.WriteRune(r)
 		}
 	}
 
@@ -194,5 +194,5 @@ func globToRegexPattern(glob string, opts GlobOptions) ([]byte, bool, error) {
 		return nil, false, errors.NewInvalidParamsError(fmt.Errorf("unbalanced '%c' in %s", groupStartStack[len(groupStartStack)-1], glob))
 	}
 
-	return pattern.buff.Bytes(), regexed, nil
+	return p.buff.Bytes(), regexed, nil
 }

--- a/src/query/graphite/graphite/glob_test.go
+++ b/src/query/graphite/graphite/glob_test.go
@@ -33,50 +33,63 @@ func TestGlobToRegexPattern(t *testing.T) {
 	tests := []struct {
 		glob    string
 		isRegex bool
-		regex   []byte
+		regex   string
+		opts    GlobOptions
 	}{
 		{
 			glob:    "barbaz",
 			isRegex: false,
-			regex:   []byte("barbaz"),
+			regex:   "barbaz",
 		},
 		{
 			glob:    "barbaz:quxqaz",
 			isRegex: false,
-			regex:   []byte("barbaz:quxqaz"),
+			regex:   "barbaz:quxqaz",
 		},
 		{
 			glob:    "foo\\+bar.'baz<1001>'.qux",
 			isRegex: true,
-			regex:   []byte("foo\\+bar\\.+\\'baz\\<1001\\>\\'\\.+qux"),
+			regex:   "foo\\+bar\\.+\\'baz\\<1001\\>\\'\\.+qux",
 		},
 		{
 			glob:    "foo.host.me{1,2,3}.*",
 			isRegex: true,
-			regex:   []byte("foo\\.+host\\.+me(1|2|3)\\.+[^\\.]*"),
+			regex:   "foo\\.+host\\.+me(1|2|3)\\.+[^\\.]*",
 		},
 		{
 			glob:    "bar.zed.whatever[0-9].*.*.bar",
 			isRegex: true,
-			regex:   []byte("bar\\.+zed\\.+whatever[0-9]\\.+[^\\.]*\\.+[^\\.]*\\.+bar"),
+			regex:   "bar\\.+zed\\.+whatever[0-9]\\.+[^\\.]*\\.+[^\\.]*\\.+bar",
 		},
 		{
 			glob:    "foo{0[3-9],1[0-9],20}",
 			isRegex: true,
-			regex:   []byte("foo(0[3-9]|1[0-9]|20)"),
+			regex:   "foo(0[3-9]|1[0-9]|20)",
 		},
 		{
 			glob:    "foo{0[3-9],1[0-9],20}:bar",
 			isRegex: true,
-			regex:   []byte("foo(0[3-9]|1[0-9]|20):bar"),
+			regex:   "foo(0[3-9]|1[0-9]|20):bar",
+		},
+		{
+			glob:    "foo.**.bar.baz",
+			isRegex: true,
+			regex:   "foo\\.+.*bar\\.+baz",
+			opts:    GlobOptions{AllowMatchAll: true},
+		},
+		{
+			glob:    "foo**bar.baz",
+			isRegex: true,
+			regex:   "foo.*bar\\.+baz",
+			opts:    GlobOptions{AllowMatchAll: true},
 		},
 	}
 
 	for _, test := range tests {
-		pattern, isRegex, err := GlobToRegexPattern(test.glob)
+		pattern, isRegex, err := ExtendedGlobToRegexPattern(test.glob, test.opts)
 		require.NoError(t, err)
 		assert.Equal(t, test.isRegex, isRegex)
-		assert.Equal(t, test.regex, pattern, "bad pattern for %s", test.glob)
+		assert.Equal(t, test.regex, string(pattern), "bad pattern for %s", test.glob)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This matches the behavior of graphite-web to allow ** to match empty path segments (i.e. `foo.**.bar` should match both `foo.abc.bar` and `foo.bar`).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
