### PR TITLE
[aggregator] Limit size of written buffers in rawtcp client

### DIFF
--- a/src/aggregator/client/queue.go
+++ b/src/aggregator/client/queue.go
@@ -223,7 +223,7 @@ func (q *queue) Flush() {
 		n += processed
 	}
 
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		q.log.Error("error writing data",
 			zap.String("target_instance_id", q.instance.ID()),
 			zap.String("target_instance", q.instance.Endpoint()),

--- a/src/aggregator/client/queue.go
+++ b/src/aggregator/client/queue.go
@@ -273,9 +273,7 @@ func (q *queue) flush(tmpWriteBuf *[]byte) (int, error) {
 	// mutex is not held while doing IO
 	q.mtx.Unlock()
 
-	size := len(*tmpWriteBuf)
-	if size == 0 {
-		_queueConnWriteBufPool.Put(tmpWriteBuf)
+	if n == 0 {
 		return n, io.EOF
 	}
 

--- a/src/aggregator/client/queue_test.go
+++ b/src/aggregator/client/queue_test.go
@@ -23,11 +23,11 @@ package client
 import (
 	"testing"
 
-	"github.com/m3db/m3/src/metrics/encoding/protobuf"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	"github.com/m3db/m3/src/metrics/encoding/protobuf"
 )
 
 func TestInstanceQueueEnqueueClosed(t *testing.T) {

--- a/src/aggregator/client/queue_test.go
+++ b/src/aggregator/client/queue_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 func TestInstanceQueueEnqueueClosed(t *testing.T) {
@@ -123,7 +123,6 @@ func TestInstanceQueueEnqueueLargeBuffers(t *testing.T) {
 	queue.Flush()
 	require.Equal(t, len(largeBuf), bytesWritten)
 	require.Equal(t, 1, timesWritten)
-
 }
 
 func TestInstanceQueueEnqueueSuccessDrainSuccess(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
It's not always a good idea to write everything in one go, as calls may time out just because the buffer is in the megabytes+ range - we should write it out in parts instead. It also should make the buffer allocs bounded, as right now we can end up doing a lot of throwaway work if a shard is really hot, etc.:
<img width="879" alt="Screen Shot 2021-03-17 at 2 49 14 PM" src="https://user-images.githubusercontent.com/1634068/111530658-f0563800-8739-11eb-9163-487432cf6830.png">


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
