### PR TITLE
[aggregator] Split out errArrivedTooLate out of not-categorized

### DIFF
--- a/src/aggregator/aggregator/aggregator.go
+++ b/src/aggregator/aggregator/aggregator.go
@@ -767,21 +767,19 @@ func (m *aggregatorAddMetricMetrics) ReportError(err error) {
 	if err == nil {
 		return
 	}
-	switch err {
-	case errShardNotOwned:
+	switch {
+	case xerrors.Is(err, errShardNotOwned):
 		m.shardNotOwned.Inc(1)
-	case errAggregatorShardNotWriteable:
+	case xerrors.Is(err, errAggregatorShardNotWriteable):
 		m.shardNotWriteable.Inc(1)
-	case errWriteNewMetricRateLimitExceeded:
+	case xerrors.Is(err, errWriteNewMetricRateLimitExceeded):
 		m.newMetricRateLimitExceeded.Inc(1)
-	case errWriteValueRateLimitExceeded:
+	case xerrors.Is(err, errWriteValueRateLimitExceeded):
 		m.valueRateLimitExceeded.Inc(1)
+	case xerrors.Is(err, errArrivedTooLate):
+		m.arrivedTooLate.Inc(1)
 	default:
-		if xerrors.Is(err, errArrivedTooLate) {
-			m.arrivedTooLate.Inc(1)
-		} else {
-			m.uncategorizedErrors.Inc(1)
-		}
+		m.uncategorizedErrors.Inc(1)
 	}
 }
 

--- a/src/aggregator/aggregator/aggregator_test.go
+++ b/src/aggregator/aggregator/aggregator_test.go
@@ -22,6 +22,7 @@ package aggregator
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"sort"
 	"testing"
@@ -44,6 +45,7 @@ import (
 	"github.com/m3db/m3/src/metrics/pipeline"
 	"github.com/m3db/m3/src/metrics/pipeline/applied"
 	"github.com/m3db/m3/src/metrics/policy"
+	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
 
@@ -955,13 +957,14 @@ func TestAggregatorAddMetricMetrics(t *testing.T) {
 	m.ReportError(errAggregatorShardNotWriteable)
 	m.ReportError(errWriteNewMetricRateLimitExceeded)
 	m.ReportError(errWriteValueRateLimitExceeded)
+	m.ReportError(xerrors.NewRenamedError(errArrivedTooLate, fmt.Errorf("errorrr")))
 	m.ReportError(errors.New("foo"))
 
 	snapshot := s.Snapshot()
 	counters, timers, gauges := snapshot.Counters(), snapshot.Timers(), snapshot.Gauges()
 
 	// Validate we count successes and errors correctly.
-	require.Equal(t, 7, len(counters))
+	require.Equal(t, 8, len(counters))
 	for _, id := range []string{
 		"testScope.success+",
 		"testScope.errors+reason=invalid-metric-types",
@@ -969,6 +972,7 @@ func TestAggregatorAddMetricMetrics(t *testing.T) {
 		"testScope.errors+reason=shard-not-writeable",
 		"testScope.errors+reason=value-rate-limit-exceeded",
 		"testScope.errors+reason=new-metric-rate-limit-exceeded",
+		"testScope.errors+reason=arrived-too-late",
 		"testScope.errors+reason=not-categorized",
 	} {
 		c, exists := counters[id]
@@ -1001,13 +1005,14 @@ func TestAggregatorAddTimedMetrics(t *testing.T) {
 	m.ReportError(errWriteValueRateLimitExceeded)
 	m.ReportError(errTooFarInTheFuture)
 	m.ReportError(errTooFarInThePast)
+	m.ReportError(xerrors.NewRenamedError(errArrivedTooLate, fmt.Errorf("errorrr")))
 	m.ReportError(errors.New("foo"))
 
 	snapshot := s.Snapshot()
 	counters, timers, gauges := snapshot.Counters(), snapshot.Timers(), snapshot.Gauges()
 
 	// Validate we count successes and errors correctly.
-	require.Equal(t, 8, len(counters))
+	require.Equal(t, 9, len(counters))
 	for _, id := range []string{
 		"testScope.success+",
 		"testScope.errors+reason=shard-not-owned",
@@ -1016,6 +1021,7 @@ func TestAggregatorAddTimedMetrics(t *testing.T) {
 		"testScope.errors+reason=new-metric-rate-limit-exceeded",
 		"testScope.errors+reason=too-far-in-the-future",
 		"testScope.errors+reason=too-far-in-the-past",
+		"testScope.errors+reason=arrived-too-late",
 		"testScope.errors+reason=not-categorized",
 	} {
 		c, exists := counters[id]


### PR DESCRIPTION
Right now, errors due to data points arriving too
late from forwarding get grouped into not-categorized.
This change splits it into its own value, arrived-too-late.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
