### PR TITLE
[query] Use optional ptr ints for per query limits to allow for specifying zero to disable limits

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -361,12 +361,12 @@ type PerQueryLimitsConfiguration struct {
 	// MaxFetchedSeries limits the number of time series returned for any given
 	// individual storage node per query, before returning result to query
 	// service.
-	MaxFetchedSeries int `yaml:"maxFetchedSeries"`
+	MaxFetchedSeries *int `yaml:"maxFetchedSeries"`
 
 	// MaxFetchedDocs limits the number of index documents matched for any given
 	// individual storage node per query, before returning result to query
 	// service.
-	MaxFetchedDocs int `yaml:"maxFetchedDocs"`
+	MaxFetchedDocs *int `yaml:"maxFetchedDocs"`
 
 	// RequireExhaustive results in an error if the query exceeds any limit.
 	RequireExhaustive *bool `yaml:"requireExhaustive"`
@@ -376,13 +376,13 @@ type PerQueryLimitsConfiguration struct {
 // handleroptions.FetchOptionsBuilderLimitsOptions.
 func (l *PerQueryLimitsConfiguration) AsFetchOptionsBuilderLimitsOptions() handleroptions.FetchOptionsBuilderLimitsOptions {
 	seriesLimit := defaultStorageQuerySeriesLimit
-	if v := l.MaxFetchedSeries; v > 0 {
-		seriesLimit = v
+	if v := l.MaxFetchedSeries; v != nil {
+		seriesLimit = *v
 	}
 
 	docsLimit := defaultStorageQueryDocsLimit
-	if v := l.MaxFetchedDocs; v > 0 {
-		docsLimit = v
+	if v := l.MaxFetchedDocs; v != nil {
+		docsLimit = *v
 	}
 
 	requireExhaustive := defaultRequireExhaustive

--- a/src/cmd/services/m3query/config/config_test.go
+++ b/src/cmd/services/m3query/config/config_test.go
@@ -94,12 +94,16 @@ func TestConfigLoading(t *testing.T) {
 	requireExhaustive = true
 	assert.Equal(t, &LimitsConfiguration{
 		PerQuery: PerQueryLimitsConfiguration{
-			MaxFetchedSeries:  12000,
-			MaxFetchedDocs:    11000,
+			MaxFetchedSeries:  intPtrValue(12000),
+			MaxFetchedDocs:    intPtrValue(11000),
 			RequireExhaustive: &requireExhaustive,
 		},
 	}, &cfg.Limits)
 	// TODO: assert on more fields here.
+}
+
+func intPtrValue(i int) *int {
+	return &i
 }
 
 func TestConfigValidation(t *testing.T) {
@@ -131,7 +135,7 @@ func TestConfigValidation(t *testing.T) {
 			cfg := baseCfg(t)
 			cfg.Limits = LimitsConfiguration{
 				PerQuery: PerQueryLimitsConfiguration{
-					MaxFetchedSeries: tc.limit,
+					MaxFetchedSeries: intPtrValue(tc.limit),
 				}}
 
 			assert.NoError(t, validator.Validate(cfg))


### PR DESCRIPTION
\<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Previously setting zero would default to the 100k default max series limit which conflicts with how the header works (setting zero disables limit). This makes both behave consistently (config + headers now act the same, zero disables, omitting uses default and setting explicit number enables at that number).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
