### PR TITLE
[coordinator] add a processed counter metric

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -127,6 +127,10 @@ func defaultMetricsAppenderOptions(opts DownsamplerOptions, agg agg) metricsAppe
 	if logger.Check(zapcore.DebugLevel, "debug") != nil {
 		debugLogging = true
 	}
+	scope := opts.InstrumentOptions.MetricsScope().SubScope("metrics_appender")
+	metrics := metricsAppenderMetrics{
+		processedCount: scope.Counter("processed_count"),
+	}
 
 	return metricsAppenderOptions{
 		agg:                    agg.aggregator,
@@ -138,6 +142,7 @@ func defaultMetricsAppenderOptions(opts DownsamplerOptions, agg agg) metricsAppe
 		debugLogging:           debugLogging,
 		logger:                 logger,
 		untimedRollups:         agg.untimedRollups,
+		metrics:                metrics,
 	}
 }
 

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 )
 
 func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
@@ -105,6 +106,9 @@ func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
 			metricTagsIteratorPool: metricTagsIteratorPool,
 			matcher:                matcher,
 			agg:                    agg,
+			metrics: metricsAppenderMetrics{
+				processedCount: tally.NoopScope.Counter("test-counter"),
+			},
 		})
 		name := []byte(fmt.Sprint("foo", i))
 		value := []byte(fmt.Sprint("bar", i))


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds a processed counter metric in the coordinator that tracks the number of times a metric is processed by the aggregator.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
