### PR TITLE
[dbnode] Fix clock not being propagated where needed

### DIFF
--- a/src/aggregator/aggregator/aggregator_test.go
+++ b/src/aggregator/aggregator/aggregator_test.go
@@ -45,7 +45,6 @@ import (
 	"github.com/m3db/m3/src/metrics/pipeline"
 	"github.com/m3db/m3/src/metrics/pipeline/applied"
 	"github.com/m3db/m3/src/metrics/policy"
-	"github.com/m3db/m3/src/x/clock"
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -1168,7 +1167,7 @@ func testOptions(ctrl *gomock.Controller) Options {
 	infiniteBufferForPastTimedMetricFn := func(time.Duration) time.Duration {
 		return math.MaxInt64
 	}
-	return NewOptions(clock.NewOptions()).
+	return newTestOptions().
 		SetPlacementManager(placementManager).
 		SetFlushTimesManager(flushTimesManager).
 		SetElectionManager(electionMgr).

--- a/src/aggregator/aggregator/aggregator_test.go
+++ b/src/aggregator/aggregator/aggregator_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/m3db/m3/src/metrics/pipeline"
 	"github.com/m3db/m3/src/metrics/pipeline/applied"
 	"github.com/m3db/m3/src/metrics/policy"
+	"github.com/m3db/m3/src/x/clock"
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -1167,7 +1168,7 @@ func testOptions(ctrl *gomock.Controller) Options {
 	infiniteBufferForPastTimedMetricFn := func(time.Duration) time.Duration {
 		return math.MaxInt64
 	}
-	return NewOptions().
+	return NewOptions(clock.NewOptions()).
 		SetPlacementManager(placementManager).
 		SetFlushTimesManager(flushTimesManager).
 		SetElectionManager(electionMgr).

--- a/src/aggregator/aggregator/elem_base_test.go
+++ b/src/aggregator/aggregator/elem_base_test.go
@@ -115,7 +115,7 @@ func TestElemBaseResetSetDataNoRollup(t *testing.T) {
 }
 
 func TestElemBaseForwardedIDWithDefaultPipeline(t *testing.T) {
-	e := newElemBase(NewOptions())
+	e := newElemBase(newTestOptions())
 	_, ok := e.ForwardedID()
 	require.False(t, ok)
 }
@@ -129,7 +129,7 @@ func TestElemBaseForwardedIDWithCustomPipeline(t *testing.T) {
 }
 
 func TestElemBaseForwardedAggregationKeyWithDefaultPipeline(t *testing.T) {
-	e := newElemBase(NewOptions())
+	e := newElemBase(newTestOptions())
 	_, ok := e.ForwardedAggregationKey()
 	require.False(t, ok)
 }
@@ -171,7 +171,7 @@ func TestElemBaseMarkAsTombStoned(t *testing.T) {
 }
 
 func TestCounterElemBase(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	aggTypesOpts := opts.AggregationTypesOptions()
 	e := counterElemBase{}
 	require.Equal(t, []byte("stats.counts."), e.FullPrefix(opts))
@@ -222,7 +222,7 @@ func TestTimerElemBase(t *testing.T) {
 		maggregation.P95,
 		maggregation.P99,
 	}
-	opts := NewOptions()
+	opts := newTestOptions()
 	aggTypesOpts := opts.AggregationTypesOptions()
 	e := timerElemBase{}
 	require.Equal(t, []byte("stats.timers."), e.FullPrefix(opts))
@@ -233,7 +233,7 @@ func TestTimerElemBase(t *testing.T) {
 
 func TestTimerElemBaseNewAggregation(t *testing.T) {
 	e := timerElemBase{}
-	la := e.NewAggregation(NewOptions(), raggregation.Options{})
+	la := e.NewAggregation(newTestOptions(), raggregation.Options{})
 	la.AddUnion(time.Now(), unaggregated.MetricUnion{
 		Type:          metric.TimerType,
 		BatchTimerVal: []float64{100.0, 200.0},
@@ -280,7 +280,7 @@ func TestTimerElemBaseResetSetDataInvalidTypes(t *testing.T) {
 }
 
 func TestGaugeElemBase(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	aggTypesOpts := opts.AggregationTypesOptions()
 	e := gaugeElemBase{}
 	require.Equal(t, []byte("stats.gauges."), e.FullPrefix(opts))
@@ -584,12 +584,12 @@ func TestAddToRestOption(t *testing.T) {
 			Transformation: pipeline.TransformationOp{Type: transformation.Increase},
 		},
 	})
-	e := newElemBase(NewOptions().SetAddToReset(false))
+	e := newElemBase(newTestOptions().SetAddToReset(false))
 	e.resetSetData(testCounterID, testStoragePolicy, testAggregationTypesExpensive, false, p, 3, WithPrefixWithSuffix)
 	require.Equal(t, transformation.Add, e.parsedPipeline.Transformations[0].Type())
 	require.Equal(t, transformation.Increase, e.parsedPipeline.Transformations[1].Type())
 
-	e = newElemBase(NewOptions().SetAddToReset(true))
+	e = newElemBase(newTestOptions().SetAddToReset(true))
 	e.resetSetData(testCounterID, testStoragePolicy, testAggregationTypesExpensive, false, p, 3, WithPrefixWithSuffix)
 	require.Equal(t, transformation.Reset, e.parsedPipeline.Transformations[0].Type())
 	require.Equal(t, transformation.Increase, e.parsedPipeline.Transformations[1].Type())

--- a/src/aggregator/aggregator/elem_pool_test.go
+++ b/src/aggregator/aggregator/elem_pool_test.go
@@ -34,7 +34,8 @@ import (
 func TestCounterElemPool(t *testing.T) {
 	p := NewCounterElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *CounterElem {
-		return MustNewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, NoPrefixNoSuffix, NewOptions())
+		return MustNewCounterElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes,
+			applied.DefaultPipeline, 0, NoPrefixNoSuffix, newTestOptions())
 	})
 
 	// Retrieve an element from the pool.
@@ -55,7 +56,8 @@ func TestCounterElemPool(t *testing.T) {
 func TestTimerElemPool(t *testing.T) {
 	p := NewTimerElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *TimerElem {
-		return MustNewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, NoPrefixNoSuffix, NewOptions())
+		return MustNewTimerElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes,
+			applied.DefaultPipeline, 0, NoPrefixNoSuffix, newTestOptions())
 	})
 
 	// Retrieve an element from the pool.
@@ -76,7 +78,8 @@ func TestTimerElemPool(t *testing.T) {
 func TestGaugeElemPool(t *testing.T) {
 	p := NewGaugeElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *GaugeElem {
-		return MustNewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes, applied.DefaultPipeline, 0, NoPrefixNoSuffix, NewOptions())
+		return MustNewGaugeElem(nil, policy.EmptyStoragePolicy, aggregation.DefaultTypes,
+			applied.DefaultPipeline, 0, NoPrefixNoSuffix, newTestOptions())
 	})
 
 	// Retrieve an element from the pool.

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -90,7 +90,7 @@ var (
 		},
 	})
 	testNumForwardedTimes = 0
-	testOpts              = NewOptions()
+	testOpts              = newTestOptions()
 	testTimestamps        = []time.Time{
 		time.Unix(216, 0), time.Unix(217, 0), time.Unix(221, 0),
 	}
@@ -103,7 +103,7 @@ var (
 )
 
 func TestCounterResetSetData(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	ce, err := NewCounterElem(nil, policy.EmptyStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, 1, NoPrefixNoSuffix, opts)
 	require.NoError(t, err)
 	require.Equal(t, opts.AggregationTypesOptions().DefaultCounterAggregationTypes(), ce.aggTypes)
@@ -157,7 +157,7 @@ func TestCounterResetSetData(t *testing.T) {
 }
 
 func TestCounterResetSetDataInvalidAggregationType(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	ce := MustNewCounterElem(nil, policy.EmptyStoragePolicy,
 		maggregation.DefaultTypes, applied.DefaultPipeline,
 		testNumForwardedTimes, NoPrefixNoSuffix, opts)
@@ -168,7 +168,7 @@ func TestCounterResetSetDataInvalidAggregationType(t *testing.T) {
 }
 
 func TestCounterResetSetDataNoRollup(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	ce := MustNewCounterElem(nil, policy.EmptyStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, opts)
 
 	pipelineNoRollup := applied.NewPipeline([]applied.OpUnion{
@@ -182,7 +182,8 @@ func TestCounterResetSetDataNoRollup(t *testing.T) {
 }
 
 func TestCounterElemAddUnion(t *testing.T) {
-	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a counter metric.
@@ -224,7 +225,8 @@ func TestCounterElemAddUnion(t *testing.T) {
 }
 
 func TestCounterElemAddUnionWithCustomAggregation(t *testing.T) {
-	e, err := NewCounterElem(testCounterID, testStoragePolicy, testAggregationTypesExpensive, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewCounterElem(testCounterID, testStoragePolicy, testAggregationTypesExpensive,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a counter metric.
@@ -262,7 +264,8 @@ func TestCounterElemAddUnionWithCustomAggregation(t *testing.T) {
 }
 
 func TestCounterElemAddUnique(t *testing.T) {
-	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a metric.
@@ -318,7 +321,8 @@ func TestCounterElemAddUnique(t *testing.T) {
 }
 
 func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
-	e, err := NewCounterElem(testCounterID, testStoragePolicy, testAggregationTypesExpensive, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewCounterElem(testCounterID, testStoragePolicy, testAggregationTypesExpensive,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a counter metric.
@@ -370,7 +374,7 @@ func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
 func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions()
+	opts := newTestOptions()
 	e := testCounterElem(testAlignedStarts[:len(testAlignedStarts)-1], testCounterVals, maggregation.DefaultTypes, applied.DefaultPipeline, opts)
 
 	// Consume values before an early-enough time.
@@ -429,7 +433,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions()
+	opts := newTestOptions()
 	e := testCounterElem(testAlignedStarts[:len(testAlignedStarts)-1], testCounterVals, testAggregationTypes, applied.DefaultPipeline, opts)
 
 	// Consume values before an early-enough time.
@@ -496,7 +500,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Sum}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
+	opts := newTestOptions().SetDiscardNaNAggregatedValues(false)
 	e := testCounterElem(alignedstartAtNanos[:3], counterVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{
@@ -598,7 +602,8 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 }
 
 func TestCounterElemClose(t *testing.T) {
-	e := testCounterElem(testAlignedStarts[:len(testAlignedStarts)-1], testCounterVals, maggregation.DefaultTypes, applied.DefaultPipeline, NewOptions())
+	e := testCounterElem(testAlignedStarts[:len(testAlignedStarts)-1], testCounterVals,
+		maggregation.DefaultTypes, applied.DefaultPipeline, newTestOptions())
 	require.False(t, e.closed)
 
 	// Closing the element.
@@ -620,7 +625,8 @@ func TestCounterElemClose(t *testing.T) {
 }
 
 func TestCounterFindOrCreateNoSourceSet(t *testing.T) {
-	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	inputs := []int64{10, 10, 20, 10, 15}
@@ -645,7 +651,8 @@ func TestCounterFindOrCreateNoSourceSet(t *testing.T) {
 }
 
 func TestCounterFindOrCreateWithSourceSet(t *testing.T) {
-	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewCounterElem(testCounterID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 	e.cachedSourceSets = []*bitset.BitSet{bitset.New(0)}
 
@@ -669,7 +676,7 @@ func TestCounterFindOrCreateWithSourceSet(t *testing.T) {
 }
 
 func TestTimerResetSetData(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	te, err := NewTimerElem(nil, policy.EmptyStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, opts)
 	require.NoError(t, err)
 	require.Nil(t, te.quantilesPool)
@@ -725,14 +732,14 @@ func TestTimerResetSetData(t *testing.T) {
 }
 
 func TestTimerResetSetDataInvalidAggregationType(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	te := MustNewTimerElem(nil, policy.EmptyStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, opts)
 	err := te.ResetSetData(testBatchTimerID, testStoragePolicy, maggregation.Types{maggregation.Last}, applied.DefaultPipeline, 0, NoPrefixNoSuffix)
 	require.Error(t, err)
 }
 
 func TestTimerResetSetDataNoRollup(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	te := MustNewTimerElem(nil, policy.EmptyStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, opts)
 
 	pipelineNoRollup := applied.NewPipeline([]applied.OpUnion{
@@ -746,7 +753,8 @@ func TestTimerResetSetDataNoRollup(t *testing.T) {
 }
 
 func TestTimerElemAddUnion(t *testing.T) {
-	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a timer metric.
@@ -792,7 +800,8 @@ func TestTimerElemAddUnion(t *testing.T) {
 }
 
 func TestTimerElemAddUnique(t *testing.T) {
-	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a metric.
@@ -849,7 +858,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	timestampNanosFn := standardMetricTimestampNanos
 
 	// Verify the pool is big enough to supply all the streams.
-	opts := NewOptions().SetStreamOptions(streamOpts)
+	opts := newTestOptions().SetStreamOptions(streamOpts)
 	e := testTimerElem(testAlignedStarts[:len(testAlignedStarts)-1], testBatchTimerVals, maggregation.DefaultTypes, applied.DefaultPipeline, opts)
 
 	// Consume values before an early-enough time.
@@ -912,7 +921,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	timestampNanosFn := standardMetricTimestampNanos
 
 	// Verify the pool is big enough to supply all the streams.
-	opts := NewOptions().SetStreamOptions(streamOpts)
+	opts := newTestOptions().SetStreamOptions(streamOpts)
 	e := testTimerElem(testAlignedStarts[:len(testAlignedStarts)-1], testBatchTimerVals, testTimerAggregationTypes, applied.DefaultPipeline, opts)
 
 	// Consume values before an early-enough time.
@@ -984,7 +993,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Min}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
+	opts := newTestOptions().SetDiscardNaNAggregatedValues(false)
 	e := testTimerElem(alignedstartAtNanos[:3], timerVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{
@@ -1090,7 +1099,7 @@ func TestTimerElemClose(t *testing.T) {
 	streamOpts := cm.NewOptions()
 
 	// Verify the pool is big enough to supply all the streams.
-	opts := NewOptions().SetStreamOptions(streamOpts)
+	opts := newTestOptions().SetStreamOptions(streamOpts)
 	e := testTimerElem(testAlignedStarts[:len(testAlignedStarts)-1], testBatchTimerVals, maggregation.DefaultTypes, applied.DefaultPipeline, opts)
 
 	require.False(t, e.closed)
@@ -1114,7 +1123,8 @@ func TestTimerElemClose(t *testing.T) {
 }
 
 func TestTimerFindOrCreateNoSourceSet(t *testing.T) {
-	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	inputs := []int64{10, 10, 20, 10, 15}
@@ -1138,7 +1148,8 @@ func TestTimerFindOrCreateNoSourceSet(t *testing.T) {
 }
 
 func TestTimerFindOrCreateWithSourceSet(t *testing.T) {
-	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewTimerElem(testBatchTimerID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 	e.cachedSourceSets = []*bitset.BitSet{bitset.New(0)}
 
@@ -1162,7 +1173,7 @@ func TestTimerFindOrCreateWithSourceSet(t *testing.T) {
 }
 
 func TestGaugeResetSetData(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	ge, err := NewGaugeElem(nil, policy.EmptyStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, opts)
 	require.NoError(t, err)
 	require.Equal(t, opts.AggregationTypesOptions().DefaultGaugeAggregationTypes(), ge.aggTypes)
@@ -1214,7 +1225,8 @@ func TestGaugeResetSetData(t *testing.T) {
 }
 
 func TestGaugeElemAddUnion(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a gauge metric.
@@ -1250,7 +1262,8 @@ func TestGaugeElemAddUnion(t *testing.T) {
 }
 
 func TestGaugeElemAddUnionWithCustomAggregation(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, testAggregationTypesExpensive, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, testAggregationTypesExpensive,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a gauge metric.
@@ -1288,7 +1301,8 @@ func TestGaugeElemAddUnionWithCustomAggregation(t *testing.T) {
 }
 
 func TestGaugeElemAddUnique(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a metric.
@@ -1344,7 +1358,8 @@ func TestGaugeElemAddUnique(t *testing.T) {
 }
 
 func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, testAggregationTypesExpensive, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, testAggregationTypesExpensive,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	// Add a gauge metric.
@@ -1396,7 +1411,7 @@ func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
 func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions()
+	opts := newTestOptions()
 	e := testGaugeElem(testAlignedStarts[:len(testAlignedStarts)-1], testGaugeVals, maggregation.DefaultTypes, applied.DefaultPipeline, opts)
 
 	// Consume values before an early-enough time.
@@ -1453,7 +1468,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 }
 
 func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
-	opts := NewOptions()
+	opts := newTestOptions()
 	e := testGaugeElem(testAlignedStarts[:len(testAlignedStarts)-1], testGaugeVals, testAggregationTypes, applied.DefaultPipeline, opts)
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
@@ -1522,7 +1537,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Last}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
+	opts := newTestOptions().SetDiscardNaNAggregatedValues(false)
 	e := testGaugeElem(alignedstartAtNanos[:3], gaugeVals, aggregationTypes, testPipeline, opts)
 
 	aggKey := aggregationKey{
@@ -1634,7 +1649,7 @@ func TestGaugeElemReset(t *testing.T) {
 	aggregationTypes := maggregation.Types{maggregation.Sum}
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos
-	opts := NewOptions().SetDiscardNaNAggregatedValues(false)
+	opts := newTestOptions().SetDiscardNaNAggregatedValues(false)
 
 	testPipeline := applied.NewPipeline([]applied.OpUnion{
 		{
@@ -1714,7 +1729,8 @@ func TestGaugeElemReset(t *testing.T) {
 }
 
 func TestGaugeElemClose(t *testing.T) {
-	e := testGaugeElem(testAlignedStarts[:len(testAlignedStarts)-1], testGaugeVals, maggregation.DefaultTypes, applied.DefaultPipeline, NewOptions())
+	e := testGaugeElem(testAlignedStarts[:len(testAlignedStarts)-1], testGaugeVals,
+		maggregation.DefaultTypes, applied.DefaultPipeline, newTestOptions())
 	require.False(t, e.closed)
 
 	// Closing the element.
@@ -1736,7 +1752,8 @@ func TestGaugeElemClose(t *testing.T) {
 }
 
 func TestGaugeFindOrCreateNoSourceSet(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 
 	inputs := []int64{10, 10, 20, 10, 15}
@@ -1760,7 +1777,8 @@ func TestGaugeFindOrCreateNoSourceSet(t *testing.T) {
 }
 
 func TestGaugeFindOrCreateWithSourceSet(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes, applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, NewOptions())
+	e, err := NewGaugeElem(testGaugeID, testStoragePolicy, maggregation.DefaultTypes,
+		applied.DefaultPipeline, testNumForwardedTimes, NoPrefixNoSuffix, newTestOptions())
 	require.NoError(t, err)
 	e.cachedSourceSets = []*bitset.BitSet{bitset.New(0)}
 

--- a/src/aggregator/aggregator/entry_pool_test.go
+++ b/src/aggregator/aggregator/entry_pool_test.go
@@ -33,13 +33,13 @@ func TestEntryPool(t *testing.T) {
 	runtimeOpts := runtime.NewOptions()
 	p := NewEntryPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *Entry {
-		return NewEntry(nil, runtimeOpts, NewOptions())
+		return NewEntry(nil, runtimeOpts, newTestOptions())
 	})
 
 	// Retrieve an entry from the pool.
 	entry := p.Get()
 	lists := &metricLists{}
-	entry.ResetSetData(&metricLists{}, runtimeOpts, NewOptions())
+	entry.ResetSetData(&metricLists{}, runtimeOpts, newTestOptions())
 	require.Equal(t, lists, entry.lists)
 
 	// Put the entry back to pool.

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -386,12 +386,7 @@ type options struct {
 }
 
 // NewOptions create a new set of options.
-func NewOptions() Options {
-	return NewOptionsWithClock(clock.NewOptions())
-}
-
-// NewOptionsWithClock create a new set of options using the supplied clock options.
-func NewOptionsWithClock(clockOpts clock.Options) Options {
+func NewOptions(clockOpts clock.Options) Options {
 	aggTypesOptions := aggregation.NewTypesOptions().
 		SetCounterTypeStringTransformFn(aggregation.EmptyTransform).
 		SetTimerTypeStringTransformFn(aggregation.SuffixTransform).

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -387,6 +387,11 @@ type options struct {
 
 // NewOptions create a new set of options.
 func NewOptions() Options {
+	return NewOptionsWithClock(clock.NewOptions())
+}
+
+// NewOptionsWithClock create a new set of options using the supplied clock options.
+func NewOptionsWithClock(clockOpts clock.Options) Options {
 	aggTypesOptions := aggregation.NewTypesOptions().
 		SetCounterTypeStringTransformFn(aggregation.EmptyTransform).
 		SetTimerTypeStringTransformFn(aggregation.SuffixTransform).
@@ -398,7 +403,7 @@ func NewOptions() Options {
 		timerPrefix:                      defaultTimerPrefix,
 		gaugePrefix:                      defaultGaugePrefix,
 		timeLock:                         &sync.RWMutex{},
-		clockOpts:                        clock.NewOptions(),
+		clockOpts:                        clockOpts,
 		instrumentOpts:                   instrument.NewOptions(),
 		streamOpts:                       cm.NewOptions(),
 		runtimeOptsManager:               runtime.NewOptionsManager(runtime.NewOptions()),

--- a/src/aggregator/aggregator/options_test.go
+++ b/src/aggregator/aggregator/options_test.go
@@ -50,7 +50,7 @@ func validateDerivedPrefix(
 }
 
 func TestOptionsValidateDefault(t *testing.T) {
-	o := NewOptions()
+	o := newTestOptions()
 
 	// Validate base options.
 	require.Equal(t, defaultMetricPrefix, o.MetricPrefix())
@@ -77,7 +77,7 @@ func TestOptionsValidateDefault(t *testing.T) {
 
 func TestOptionsSetMetricPrefix(t *testing.T) {
 	newPrefix := []byte("testMetricPrefix")
-	o := NewOptions().SetMetricPrefix(newPrefix)
+	o := newTestOptions().SetMetricPrefix(newPrefix)
 	require.Equal(t, newPrefix, o.MetricPrefix())
 	validateDerivedPrefix(t, o.FullCounterPrefix(), o.MetricPrefix(), o.CounterPrefix())
 	validateDerivedPrefix(t, o.FullTimerPrefix(), o.MetricPrefix(), o.TimerPrefix())
@@ -86,58 +86,58 @@ func TestOptionsSetMetricPrefix(t *testing.T) {
 
 func TestOptionsSetCounterPrefix(t *testing.T) {
 	newPrefix := []byte("testCounterPrefix")
-	o := NewOptions().SetCounterPrefix(newPrefix)
+	o := newTestOptions().SetCounterPrefix(newPrefix)
 	require.Equal(t, newPrefix, o.CounterPrefix())
 	validateDerivedPrefix(t, o.FullCounterPrefix(), o.MetricPrefix(), o.CounterPrefix())
 }
 
 func TestOptionsSetTimerPrefix(t *testing.T) {
 	newPrefix := []byte("testTimerPrefix")
-	o := NewOptions().SetTimerPrefix(newPrefix)
+	o := newTestOptions().SetTimerPrefix(newPrefix)
 	require.Equal(t, newPrefix, o.TimerPrefix())
 	validateDerivedPrefix(t, o.FullTimerPrefix(), o.MetricPrefix(), o.TimerPrefix())
 }
 
 func TestOptionsSetGaugePrefix(t *testing.T) {
 	newPrefix := []byte("testGaugePrefix")
-	o := NewOptions().SetGaugePrefix(newPrefix)
+	o := newTestOptions().SetGaugePrefix(newPrefix)
 	require.Equal(t, newPrefix, o.GaugePrefix())
 	validateDerivedPrefix(t, o.FullGaugePrefix(), o.MetricPrefix(), o.GaugePrefix())
 }
 
 func TestSetClockOptions(t *testing.T) {
 	value := clock.NewOptions()
-	o := NewOptions().SetClockOptions(value)
+	o := newTestOptions().SetClockOptions(value)
 	require.Equal(t, value, o.ClockOptions())
 }
 
 func TestSetInstrumentOptions(t *testing.T) {
 	value := instrument.NewOptions()
-	o := NewOptions().SetInstrumentOptions(value)
+	o := newTestOptions().SetInstrumentOptions(value)
 	require.Equal(t, value, o.InstrumentOptions())
 }
 
 func TestSetStreamOptions(t *testing.T) {
 	value := cm.NewOptions()
-	o := NewOptions().SetStreamOptions(value)
+	o := newTestOptions().SetStreamOptions(value)
 	require.Equal(t, value, o.StreamOptions())
 }
 
 func TestSetAdminClient(t *testing.T) {
 	var c client.AdminClient = &client.M3MsgClient{}
-	o := NewOptions().SetAdminClient(c)
+	o := newTestOptions().SetAdminClient(c)
 	require.True(t, c == o.AdminClient())
 }
 
 func TestSetRuntimeOptionsManager(t *testing.T) {
 	value := runtime.NewOptionsManager(runtime.NewOptions())
-	o := NewOptions().SetRuntimeOptionsManager(value)
+	o := newTestOptions().SetRuntimeOptionsManager(value)
 	require.Equal(t, value, o.RuntimeOptionsManager())
 }
 
 func TestSetTimeLock(t *testing.T) {
 	value := &sync.RWMutex{}
-	o := NewOptions().SetTimeLock(value)
+	o := newTestOptions().SetTimeLock(value)
 	require.Equal(t, value, o.TimeLock())
 }
 
@@ -146,7 +146,7 @@ func TestSetFlushHandler(t *testing.T) {
 	defer ctrl.Finish()
 
 	h := handler.NewMockHandler(ctrl)
-	o := NewOptions().SetFlushHandler(h)
+	o := newTestOptions().SetFlushHandler(h)
 	require.Equal(t, h, o.FlushHandler())
 }
 
@@ -155,13 +155,13 @@ func TestSetPassthroughWriter(t *testing.T) {
 	defer ctrl.Finish()
 
 	w := writer.NewMockWriter(ctrl)
-	o := NewOptions().SetPassthroughWriter(w)
+	o := newTestOptions().SetPassthroughWriter(w)
 	require.Equal(t, w, o.PassthroughWriter())
 }
 
 func TestSetEntryTTL(t *testing.T) {
 	value := time.Minute
-	o := NewOptions().SetEntryTTL(value)
+	o := newTestOptions().SetEntryTTL(value)
 	require.Equal(t, value, o.EntryTTL())
 }
 
@@ -169,7 +169,7 @@ func TestSetMaxAllowedForwardingDelayFn(t *testing.T) {
 	value := func(resolution time.Duration, numForwardedTimes int) time.Duration {
 		return resolution + time.Second*time.Duration(numForwardedTimes)
 	}
-	o := NewOptions().SetMaxAllowedForwardingDelayFn(value)
+	o := newTestOptions().SetMaxAllowedForwardingDelayFn(value)
 	fn := o.MaxAllowedForwardingDelayFn()
 	require.Equal(t, 72*time.Second, fn(time.Minute, 12))
 }
@@ -178,60 +178,64 @@ func TestSetTimedAggregationBufferPastFn(t *testing.T) {
 	value := func(resolution time.Duration) time.Duration {
 		return resolution * 2
 	}
-	o := NewOptions().SetBufferForPastTimedMetricFn(value)
+	o := newTestOptions().SetBufferForPastTimedMetricFn(value)
 	fn := o.BufferForPastTimedMetricFn()
 	require.Equal(t, 2*time.Minute, fn(time.Minute))
 }
 
 func TestSetTimedAggregationBufferFutureFn(t *testing.T) {
-	o := NewOptions().SetBufferForFutureTimedMetric(3 * time.Minute)
+	o := newTestOptions().SetBufferForFutureTimedMetric(3 * time.Minute)
 	require.Equal(t, 3*time.Minute, o.BufferForFutureTimedMetric())
 }
 
 func TestSetEntryCheckInterval(t *testing.T) {
 	value := time.Minute
-	o := NewOptions().SetEntryCheckInterval(value)
+	o := newTestOptions().SetEntryCheckInterval(value)
 	require.Equal(t, value, o.EntryCheckInterval())
 }
 
 func TestSetEntryCheckBatchPercent(t *testing.T) {
 	value := 0.05
-	o := NewOptions().SetEntryCheckBatchPercent(value)
+	o := newTestOptions().SetEntryCheckBatchPercent(value)
 	require.Equal(t, value, o.EntryCheckBatchPercent())
 }
 
 func TestSetEntryPool(t *testing.T) {
 	value := NewEntryPool(nil)
-	o := NewOptions().SetEntryPool(value)
+	o := newTestOptions().SetEntryPool(value)
 	require.Equal(t, value, o.EntryPool())
 }
 
 func TestSetMaxNumCachedSourceSets(t *testing.T) {
 	value := 4
-	o := NewOptions().SetMaxNumCachedSourceSets(value)
+	o := newTestOptions().SetMaxNumCachedSourceSets(value)
 	require.Equal(t, value, o.MaxNumCachedSourceSets())
 }
 
 func TestSetDiscardNaNAggregatedValues(t *testing.T) {
 	value := false
-	o := NewOptions().SetDiscardNaNAggregatedValues(value)
+	o := newTestOptions().SetDiscardNaNAggregatedValues(value)
 	require.Equal(t, value, o.DiscardNaNAggregatedValues())
 }
 
 func TestSetCounterElemPool(t *testing.T) {
 	value := NewCounterElemPool(nil)
-	o := NewOptions().SetCounterElemPool(value)
+	o := newTestOptions().SetCounterElemPool(value)
 	require.Equal(t, value, o.CounterElemPool())
 }
 
 func TestSetTimerElemPool(t *testing.T) {
 	value := NewTimerElemPool(nil)
-	o := NewOptions().SetTimerElemPool(value)
+	o := newTestOptions().SetTimerElemPool(value)
 	require.Equal(t, value, o.TimerElemPool())
 }
 
 func TestSetGaugeElemPool(t *testing.T) {
 	value := NewGaugeElemPool(nil)
-	o := NewOptions().SetGaugeElemPool(value)
+	o := newTestOptions().SetGaugeElemPool(value)
 	require.Equal(t, value, o.GaugeElemPool())
+}
+
+func newTestOptions() Options {
+	return NewOptions(clock.NewOptions())
 }

--- a/src/aggregator/aggregator/shard_test.go
+++ b/src/aggregator/aggregator/shard_test.go
@@ -37,7 +37,7 @@ var (
 )
 
 func TestAggregatorShardCutoffNanos(t *testing.T) {
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	inputs := []int64{0, 12345, math.MaxInt64}
 	for _, input := range inputs {
 		shard.cutoffNanos = input
@@ -47,7 +47,7 @@ func TestAggregatorShardCutoffNanos(t *testing.T) {
 
 func TestAggregatorShardIsWriteable(t *testing.T) {
 	now := time.Unix(0, 12345)
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	shard.nowFn = func() time.Time { return now }
 
 	inputs := []struct {
@@ -69,7 +69,7 @@ func TestAggregatorShardIsWriteable(t *testing.T) {
 
 func TestAggregatorShardIsCutoff(t *testing.T) {
 	now := time.Unix(0, 12345)
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	shard.nowFn = func() time.Time { return now }
 
 	inputs := []struct {
@@ -89,7 +89,7 @@ func TestAggregatorShardIsCutoff(t *testing.T) {
 
 func TestAggregatorShardSetWritableRange(t *testing.T) {
 	testNanos := int64(1234)
-	opts := NewOptions().
+	opts := newTestOptions().
 		SetEntryCheckInterval(0).
 		SetBufferDurationBeforeShardCutover(time.Duration(500)).
 		SetBufferDurationAfterShardCutoff(time.Duration(1000))
@@ -124,7 +124,7 @@ func TestAggregatorShardSetWritableRange(t *testing.T) {
 }
 
 func TestAggregatorShardAddUntimedShardClosed(t *testing.T) {
-	shard := newAggregatorShard(testShard, NewOptions().SetEntryCheckInterval(0))
+	shard := newAggregatorShard(testShard, newTestOptions().SetEntryCheckInterval(0))
 	shard.closed = true
 	err := shard.AddUntimed(testUntimedMetric, testStagedMetadatas)
 	require.Equal(t, errAggregatorShardClosed, err)
@@ -132,7 +132,7 @@ func TestAggregatorShardAddUntimedShardClosed(t *testing.T) {
 
 func TestAggregatorShardAddUntimedShardNotWriteable(t *testing.T) {
 	now := time.Unix(0, 12345)
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	shard.nowFn = func() time.Time { return now }
 
 	inputs := []struct {
@@ -153,7 +153,7 @@ func TestAggregatorShardAddUntimedShardNotWriteable(t *testing.T) {
 }
 
 func TestAggregatorShardAddUntimedSuccess(t *testing.T) {
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	require.Equal(t, testShard, shard.ID())
 
 	var (
@@ -177,7 +177,7 @@ func TestAggregatorShardAddUntimedSuccess(t *testing.T) {
 
 func TestAggregatorShardAddTimedShardNotWriteable(t *testing.T) {
 	now := time.Unix(0, 12345)
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	shard.nowFn = func() time.Time { return now }
 
 	inputs := []struct {
@@ -198,7 +198,7 @@ func TestAggregatorShardAddTimedShardNotWriteable(t *testing.T) {
 }
 
 func TestAggregatorShardAddTimedSuccess(t *testing.T) {
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	require.Equal(t, testShard, shard.ID())
 
 	var (
@@ -222,7 +222,7 @@ func TestAggregatorShardAddTimedSuccess(t *testing.T) {
 
 func TestAggregatorShardAddForwardedShardNotWriteable(t *testing.T) {
 	now := time.Unix(0, 12345)
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	shard.nowFn = func() time.Time { return now }
 
 	inputs := []struct {
@@ -243,7 +243,7 @@ func TestAggregatorShardAddForwardedShardNotWriteable(t *testing.T) {
 }
 
 func TestAggregatorShardAddForwardedSuccess(t *testing.T) {
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 	require.Equal(t, testShard, shard.ID())
 
 	var (
@@ -266,7 +266,7 @@ func TestAggregatorShardAddForwardedSuccess(t *testing.T) {
 }
 
 func TestAggregatorShardClose(t *testing.T) {
-	shard := newAggregatorShard(testShard, NewOptions())
+	shard := newAggregatorShard(testShard, newTestOptions())
 
 	// Close the shard.
 	shard.Close()

--- a/src/aggregator/integration/setup.go
+++ b/src/aggregator/integration/setup.go
@@ -105,8 +105,7 @@ func newTestServerSetup(t *testing.T, opts testServerOptions) *testServerSetup {
 
 	// Creating the aggregator options.
 	clockOpts := opts.ClockOptions()
-	aggregatorOpts := aggregator.NewOptions().
-		SetClockOptions(clockOpts).
+	aggregatorOpts := aggregator.NewOptions(clockOpts).
 		SetInstrumentOptions(opts.InstrumentOptions()).
 		SetAggregationTypesOptions(opts.AggregationTypesOptions()).
 		SetEntryCheckInterval(opts.EntryCheckInterval()).

--- a/src/aggregator/server/server.go
+++ b/src/aggregator/server/server.go
@@ -31,6 +31,7 @@ import (
 	m3aggregator "github.com/m3db/m3/src/aggregator/aggregator"
 	"github.com/m3db/m3/src/cmd/services/m3aggregator/config"
 	"github.com/m3db/m3/src/cmd/services/m3aggregator/serve"
+	"github.com/m3db/m3/src/x/clock"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/instrument"
 
@@ -149,7 +150,7 @@ func Run(opts RunOptions) {
 	// Create the aggregator.
 	aggregatorOpts, err := cfg.Aggregator.NewAggregatorOptions(
 		serverOptions.RawTCPAddr(),
-		client, serverOptions, runtimeOptsManager,
+		client, serverOptions, runtimeOptsManager, clock.NewOptions(),
 		instrumentOpts.SetMetricsScope(scope.SubScope("aggregator")))
 	if err != nil {
 		logger.Fatal("error creating aggregator options", zap.Error(err))

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -255,6 +255,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	client client.Client,
 	serveOpts serve.Options,
 	runtimeOptsManager aggruntime.OptionsManager,
+	clockOpts clock.Options,
 	instrumentOpts instrument.Options,
 ) (aggregator.Options, error) {
 	opts := aggregator.NewOptions().
@@ -365,6 +366,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 		placementNamespace,
 		placementManager,
 		flushTimesManager,
+		clockOpts,
 		iOpts,
 	)
 	if err != nil {
@@ -665,6 +667,7 @@ func (c electionManagerConfiguration) NewElectionManager(
 	placementNamespace string,
 	placementManager aggregator.PlacementManager,
 	flushTimesManager aggregator.FlushTimesManager,
+	clockOpts clock.Options,
 	instrumentOpts instrument.Options,
 ) (aggregator.ElectionManager, error) {
 	electionOpts, err := c.Election.NewElectionOptions()
@@ -696,6 +699,7 @@ func (c electionManagerConfiguration) NewElectionManager(
 	changeRetryOpts := c.ChangeRetrier.NewOptions(scope.SubScope("change-retrier"))
 	resignRetryOpts := c.ResignRetrier.NewOptions(scope.SubScope("resign-retrier"))
 	opts := aggregator.NewElectionManagerOptions().
+		SetClockOptions(clockOpts).
 		SetInstrumentOptions(instrumentOpts).
 		SetElectionOptions(electionOpts).
 		SetCampaignOptions(campaignOpts).

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -258,7 +258,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	clockOpts clock.Options,
 	instrumentOpts instrument.Options,
 ) (aggregator.Options, error) {
-	opts := aggregator.NewOptions().
+	opts := aggregator.NewOptions(clockOpts).
 		SetInstrumentOptions(instrumentOpts).
 		SetRuntimeOptionsManager(runtimeOptsManager).
 		SetVerboseErrors(c.VerboseErrors).

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -867,7 +867,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	}
 
 	// Finally construct all options.
-	aggregatorOpts := aggregator.NewOptionsWithClock(clockOpts).
+	aggregatorOpts := aggregator.NewOptions(clockOpts).
 		SetInstrumentOptions(instrumentOpts).
 		SetDefaultStoragePolicies(nil).
 		SetMetricPrefix(nil).

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -867,8 +867,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	}
 
 	// Finally construct all options.
-	aggregatorOpts := aggregator.NewOptions().
-		SetClockOptions(clockOpts).
+	aggregatorOpts := aggregator.NewOptionsWithClock(clockOpts).
 		SetInstrumentOptions(instrumentOpts).
 		SetDefaultStoragePolicies(nil).
 		SetMetricPrefix(nil).

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -837,7 +837,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 			SetFlushTimesStore(localKVStore))
 
 	electionManager, err := o.newAggregatorElectionManager(serviceID,
-		placementManager, flushTimesManager)
+		placementManager, flushTimesManager, clockOpts)
 	if err != nil {
 		return agg{}, err
 	}
@@ -1135,6 +1135,7 @@ func (o DownsamplerOptions) newAggregatorElectionManager(
 	serviceID services.ServiceID,
 	placementManager aggregator.PlacementManager,
 	flushTimesManager aggregator.FlushTimesManager,
+	clockOpts clock.Options,
 ) (aggregator.ElectionManager, error) {
 	leaderValue := instanceID
 	campaignOpts, err := services.NewCampaignOptions()
@@ -1147,6 +1148,7 @@ func (o DownsamplerOptions) newAggregatorElectionManager(
 	leaderService := newLocalLeaderService(serviceID)
 
 	electionManagerOpts := aggregator.NewElectionManagerOptions().
+		SetClockOptions(clockOpts).
 		SetCampaignOptions(campaignOpts).
 		SetLeaderService(leaderService).
 		SetPlacementManager(placementManager).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Yet another code fix for clock not being propagated where needed.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
