### PR TITLE
[pool] Enable dynamic pool sizing in uses that don't expose pool options

### DIFF
--- a/src/x/pool/config.go
+++ b/src/x/pool/config.go
@@ -114,7 +114,7 @@ type Size int
 // UnmarshalText unmarshals Size.
 func (s *Size) UnmarshalText(b []byte) error {
 	if string(b) == "dynamic" {
-		*s = _dynamicPoolSize
+		*s = DynamicPoolSize
 		return nil
 	}
 
@@ -134,5 +134,5 @@ func (s *Size) UnmarshalText(b []byte) error {
 
 // IsDynamic returns whether the pool should be fixed size or not.
 func (s Size) IsDynamic() bool {
-	return s == _dynamicPoolSize
+	return s == DynamicPoolSize
 }

--- a/src/x/pool/config_test.go
+++ b/src/x/pool/config_test.go
@@ -42,6 +42,11 @@ func TestObjectPoolConfiguration(t *testing.T) {
 	require.False(t, opts.Dynamic())
 	require.Equal(t, 0.1, opts.refillLowWatermark)
 	require.Equal(t, 0.5, opts.refillHighWatermark)
+
+	dynamicOpts := cfg.NewObjectPoolOptions(instrument.NewOptions())
+	require.False(t, dynamicOpts.Dynamic())
+	dynamicOpts = dynamicOpts.SetSize(-1)
+	require.True(t, dynamicOpts.Dynamic())
 }
 
 func TestDynamicObjectPoolConfiguration(t *testing.T) {

--- a/src/x/pool/config_test.go
+++ b/src/x/pool/config_test.go
@@ -51,10 +51,10 @@ func TestObjectPoolConfiguration(t *testing.T) {
 
 func TestDynamicObjectPoolConfiguration(t *testing.T) {
 	cfg := ObjectPoolConfiguration{
-		Size: _dynamicPoolSize,
+		Size: DynamicPoolSize,
 	}
 	opts := cfg.NewObjectPoolOptions(instrument.NewOptions()).(*objectPoolOptions)
-	require.Equal(t, _dynamicPoolSize, opts.Size())
+	require.Equal(t, DynamicPoolSize, opts.Size())
 	require.True(t, opts.Dynamic())
 
 	cfg, err := cfgFromStr(`
@@ -63,7 +63,7 @@ size: dynamic
 	require.NoError(t, err)
 
 	opts = cfg.NewObjectPoolOptions(instrument.NewOptions()).(*objectPoolOptions)
-	require.Equal(t, _dynamicPoolSize, opts.Size())
+	require.Equal(t, DynamicPoolSize, opts.Size())
 	require.True(t, opts.Dynamic())
 
 	_, err = cfgFromStr(`

--- a/src/x/pool/options.go
+++ b/src/x/pool/options.go
@@ -27,7 +27,8 @@ const (
 	_defaultRefillLowWatermark  = 0.0
 	_defaultRefillHighWatermark = 0.0
 
-	_dynamicPoolSize = -1
+	// DynamicPoolSize is a magic size value that will force use of sync.Pool-backed pool implementation.
+	DynamicPoolSize = -1
 )
 
 type objectPoolOptions struct {
@@ -59,7 +60,7 @@ func (o *objectPoolOptions) SetSize(value int) ObjectPoolOptions {
 
 func (o *objectPoolOptions) Size() int {
 	if o.dynamic {
-		return _dynamicPoolSize
+		return DynamicPoolSize
 	}
 	return o.size
 }
@@ -72,7 +73,7 @@ func (o *objectPoolOptions) SetDynamic(dynamic bool) ObjectPoolOptions {
 
 func (o *objectPoolOptions) Dynamic() bool {
 	// support enabling dynamic pools, even if a user does not expose pool options directly.
-	if o.size == _dynamicPoolSize {
+	if o.size == DynamicPoolSize {
 		return true
 	}
 	return o.dynamic

--- a/src/x/pool/options.go
+++ b/src/x/pool/options.go
@@ -58,9 +58,6 @@ func (o *objectPoolOptions) SetSize(value int) ObjectPoolOptions {
 }
 
 func (o *objectPoolOptions) Size() int {
-	if o.dynamic {
-		return _dynamicPoolSize
-	}
 	return o.size
 }
 
@@ -71,6 +68,10 @@ func (o *objectPoolOptions) SetDynamic(dynamic bool) ObjectPoolOptions {
 }
 
 func (o *objectPoolOptions) Dynamic() bool {
+	// support enabling dynamic pools, even if a user does not expose pool options directly.
+	if o.size == _dynamicPoolSize {
+		return true
+	}
 	return o.dynamic
 }
 

--- a/src/x/pool/options.go
+++ b/src/x/pool/options.go
@@ -58,6 +58,9 @@ func (o *objectPoolOptions) SetSize(value int) ObjectPoolOptions {
 }
 
 func (o *objectPoolOptions) Size() int {
+	if o.dynamic {
+		return _dynamicPoolSize
+	}
 	return o.size
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds support to various places that don't take object pool options directly, like m3db node client.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
