### PR TITLE
[dbnode] Avoid allocating small annotations from TimestampIterator

### DIFF
--- a/src/dbnode/encoding/m3tsz/roundtrip_test.go
+++ b/src/dbnode/encoding/m3tsz/roundtrip_test.go
@@ -123,7 +123,7 @@ func validateRoundTrip(t *testing.T, input []ts.Datapoint, intOpt bool) {
 		} else if i < 7 {
 			annotation = ts.Annotation("bar")
 		} else if i == 10 {
-			annotation = ts.Annotation("baz")
+			annotation = ts.Annotation("long annotation long annotation long annotation long annotation")
 		}
 
 		if annotation != nil {

--- a/src/dbnode/encoding/m3tsz/timestamp_iterator.go
+++ b/src/dbnode/encoding/m3tsz/timestamp_iterator.go
@@ -42,7 +42,7 @@ type TimestampIterator struct {
 	PrevTime      xtime.UnixNano
 	PrevTimeDelta time.Duration
 	PrevAnt       ts.Annotation
-	prevAntBytes  [16]byte
+	prevAntBytes  [ts.OptimizedAnnotationLen]byte
 
 	TimeUnit        xtime.Unit
 	defaultTimeUnit xtime.Unit

--- a/src/dbnode/encoding/m3tsz/timestamp_iterator.go
+++ b/src/dbnode/encoding/m3tsz/timestamp_iterator.go
@@ -42,6 +42,7 @@ type TimestampIterator struct {
 	PrevTime      xtime.UnixNano
 	PrevTimeDelta time.Duration
 	PrevAnt       ts.Annotation
+	prevAntBytes  [16]byte
 
 	TimeUnit        xtime.Unit
 	defaultTimeUnit xtime.Unit
@@ -335,8 +336,13 @@ func (it *TimestampIterator) readAnnotation(stream *encoding.IStream) error {
 		return errUnexpectedAnnotationLength
 	}
 
-	// TODO(xichen): use pool to allocate the buffer once the pool diff lands.
-	buf := make([]byte, antLen)
+	var buf []byte
+	if antLen <= len(it.prevAntBytes) {
+		buf = it.prevAntBytes[:antLen]
+	} else {
+		buf = make([]byte, antLen)
+	}
+
 	n, err := stream.Read(buf)
 	if err != nil {
 		return err

--- a/src/dbnode/ts/types.go
+++ b/src/dbnode/ts/types.go
@@ -62,5 +62,9 @@ func (d Datapoint) Equal(x Datapoint) bool {
 // EncodedTags represents the encoded tags for the series.
 type EncodedTags []byte
 
+// OptimizedAnnotationLen specifies the limit of length of annotations for which
+// we avoid allocations by using fixed backing memory where possible.
+const OptimizedAnnotationLen = 16
+
 // Annotation represents information used to annotate datapoints.
 type Annotation []byte


### PR DESCRIPTION
**What this PR does / why we need it**:
Typical annotation size is only few bytes. This change avoids allocating annotation slices in `TimestampIterator` for anything that fits in 16 bytes, reducing memory pressure during time series decoding.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE