### PR TITLE
[query] Fix Graphite moving fns not evaluating bootstrapped series when current time window has no series

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -231,6 +231,8 @@ linters:
     - dogsled
     # There are functions with complexity required.
     - gocyclo
+    # Doesn't buy us much being super opinionated on how to name test functions.
+    - thelper
   disable-all: false
   presets:
     # bodyclose, errcheck, gosec, govet, scopelint, staticcheck, typecheck

--- a/src/dbnode/storage/index/fields_terms_iterator_test.go
+++ b/src/dbnode/storage/index/fields_terms_iterator_test.go
@@ -461,7 +461,7 @@ func (s *fieldsTermsIterSetup) asSegment(t *testing.T) segment.Segment {
 	return fst.ToTestSegment(t, memSeg, testFstOptions)
 }
 
-func (s *fieldsTermsIterSetup) requireEquals(t *testing.T, iter fieldsAndTermsIterator) { //nolint:thelper
+func (s *fieldsTermsIterSetup) requireEquals(t *testing.T, iter fieldsAndTermsIterator) {
 	pending := s.fields
 	for len(pending) > 0 {
 		require.True(t, iter.Next())

--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -564,7 +564,6 @@ func TestNamespaceBootstrapUnfulfilledShards(t *testing.T) {
 	}
 }
 
-// nolint:thelper
 func testNamespaceBootstrapUnfulfilledShards(
 	t *testing.T,
 	shardIDs, unfulfilledShardIDs []uint32,

--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -1657,7 +1657,8 @@ func combineBootstrapWithOriginal(
 	for i, bootstrap := range bootstrapList {
 		original := seriesList.Values[i]
 		if bootstrap.MillisPerStep() < original.MillisPerStep() {
-			bootstrap, err = bootstrap.IntersectAndResize(bootstrap.StartTime(), bootstrap.EndTime(), original.MillisPerStep(), original.ConsolidationFunc())
+			bootstrap, err = bootstrap.IntersectAndResize(bootstrap.StartTime(), bootstrap.EndTime(),
+				original.MillisPerStep(), original.ConsolidationFunc())
 			if err != nil {
 				return ts.NewSeriesList(), err
 			}
@@ -2192,10 +2193,6 @@ func newMovingBinaryTransform(
 	xFilesFactor float64,
 	impl movingImpl,
 ) (*binaryContextShifter, error) {
-	if len(input.Values) == 0 {
-		return nil, nil
-	}
-
 	windowSize, err := parseWindowSize(windowSizeValue, input)
 	if err != nil {
 		return nil, err

--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -826,6 +826,13 @@ func parseWindowSize(windowSizeValue genericInterface, input singlePathSpec) (wi
 		windowSize.stringValue = fmt.Sprintf("%q", windowSizeValue)
 		windowSize.deltaValue = interval
 	case float64:
+		if len(input.Values) == 0 {
+			err := xerrors.NewInvalidParamsError(fmt.Errorf(
+				"windowSize is an int but no timeseries in time window to multiply resolution by %T",
+				windowSizeValue))
+			return windowSize, err
+		}
+
 		windowSizeInt := int(windowSizeValue)
 		if windowSizeInt <= 0 {
 			err := xerrors.NewInvalidParamsError(fmt.Errorf(

--- a/src/query/graphite/native/builtin_functions_test.go
+++ b/src/query/graphite/native/builtin_functions_test.go
@@ -2286,7 +2286,6 @@ func TestAsPercentWithSeriesList(t *testing.T) {
 	requireEqual(t, expected, r.Values)
 }
 
-// nolint: thelper
 func requireEqual(t *testing.T, expected, results []*ts.Series) {
 	require.Equal(t, len(expected), len(results))
 	for i := 0; i < len(results); i++ {
@@ -2644,7 +2643,6 @@ func TestAsPercentWithNodesAndTotalSeriesList(t *testing.T) {
 	requireEqual(t, expected, r.Values)
 }
 
-// nolint: thelper
 func testLogarithm(t *testing.T, base float64, asserts func(*ts.Series)) {
 	ctx := common.NewTestContext()
 	defer func() { _ = ctx.Close() }()

--- a/src/query/graphite/native/engine_test.go
+++ b/src/query/graphite/native/engine_test.go
@@ -191,20 +191,20 @@ func TestTracing(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedTraces := []common.Trace{
-		common.Trace{
+		{
 			ActivityName: "fetch foo.bar.*.zed",
 			Outputs:      common.TraceStats{NumSeries: 3}},
-		common.Trace{
+		{
 			ActivityName: "aliasByNode",
-			Inputs:       []common.TraceStats{common.TraceStats{NumSeries: 3}},
+			Inputs:       []common.TraceStats{{NumSeries: 3}},
 			Outputs:      common.TraceStats{NumSeries: 3}},
-		common.Trace{
+		{
 			ActivityName: "sortByName",
-			Inputs:       []common.TraceStats{common.TraceStats{NumSeries: 3}},
+			Inputs:       []common.TraceStats{{NumSeries: 3}},
 			Outputs:      common.TraceStats{NumSeries: 3}},
-		common.Trace{
+		{
 			ActivityName: "groupByNode",
-			Inputs:       []common.TraceStats{common.TraceStats{NumSeries: 3}},
+			Inputs:       []common.TraceStats{{NumSeries: 3}},
 			Outputs:      common.TraceStats{NumSeries: 1}},
 	}
 	require.Equal(t, len(expectedTraces), len(traces))
@@ -236,7 +236,7 @@ func TestNilBinaryContextShifter(t *testing.T) {
 	store.EXPECT().FetchByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		buildEmptyTestSeriesFn()).AnyTimes()
 
-	expr, err := engine.Compile("movingSum(foo.bar.q.zed, 30s)")
+	expr, err := engine.Compile("movingSum(foo.bar.q.zed, '30s')")
 	require.NoError(t, err)
 
 	_, err = expr.Execute(ctx)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes case when the original start/end time returns no series but the bootstrapped time range should evaluate the historical data captured by the "moving" time window specified.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
