### PR TITLE
[dbnode] Use multiple thrift byte slice pools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,8 +122,8 @@ require (
 	gotest.tools v2.2.0+incompatible
 )
 
-// branch 0.9.3-pool-read-binary-3
-replace github.com/apache/thrift => github.com/m3db/thrift v0.0.0-20190820191926-05b5a2227fe4
+// branch 0.9.3-patch
+replace github.com/apache/thrift => github.com/m3dbx/thrift v0.0.0-20210326170526-6e3eef8b4a26
 
 // NB(nate): upgrading to the latest msgpack is not backwards compatibile as msgpack will no longer attempt to automatically
 // write an integer into the smallest number of bytes it will fit in. We rely on this behavior by having helper methods

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,6 @@ github.com/m3db/stackmurmur3 v1.0.1 h1:ASTdJ6Bd2m34dgsnOBZHrwWdKGcpaavP3MokiKL/E
 github.com/m3db/stackmurmur3 v1.0.1/go.mod h1:hkR/F91aDUfPxDv5Jw55ifIXV6ZW1jzNHW0d8GP02rw=
 github.com/m3db/stackmurmur3/v2 v2.0.2 h1:q/kOlC12PwOib9XziHUTM/jsCQULHnRxBz/H4hT/Aro=
 github.com/m3db/stackmurmur3/v2 v2.0.2/go.mod h1:HnguA9wfEbTqYdTT/5klUlhxSDPRMGaWyvLzugxW+MA=
-github.com/m3db/thrift v0.0.0-20190820191926-05b5a2227fe4 h1:1x3mMuURd3wqKJ2qVjhRYOAmL9g4EA9JTagWB/y/3xo=
-github.com/m3db/thrift v0.0.0-20190820191926-05b5a2227fe4/go.mod h1:xVfRinGzD3cYDRvMjy6RkIwM+iNL2KHNLZjT0VpVZT8=
 github.com/m3db/tools v0.0.0-20181008195521-c6ded3f34878 h1:kww0LtVVfGrXR7Ofpbi/9bvc2EGYMQC0LCH/gQXoolE=
 github.com/m3db/tools v0.0.0-20181008195521-c6ded3f34878/go.mod h1:TxroQUZzb1wzOsq+4+TfVtT7z89YTz3v2UJAYfLNfLE=
 github.com/m3dbx/pilosa v1.4.1 h1:/Cpp1XAHSd6orpjceXGiKpCoDdYBP5BD/6NoqGG9eVg=

--- a/go.sum
+++ b/go.sum
@@ -635,6 +635,8 @@ github.com/m3db/tools v0.0.0-20181008195521-c6ded3f34878 h1:kww0LtVVfGrXR7Ofpbi/
 github.com/m3db/tools v0.0.0-20181008195521-c6ded3f34878/go.mod h1:TxroQUZzb1wzOsq+4+TfVtT7z89YTz3v2UJAYfLNfLE=
 github.com/m3dbx/pilosa v1.4.1 h1:/Cpp1XAHSd6orpjceXGiKpCoDdYBP5BD/6NoqGG9eVg=
 github.com/m3dbx/pilosa v1.4.1/go.mod h1:Jt0+w9O08sa7qWDeRC58VBjb4OeOTDMOhfvVmyeVCO8=
+github.com/m3dbx/thrift v0.0.0-20210326170526-6e3eef8b4a26 h1:4qw8juBzxIiD1g2XS7rDJEZ3FGZKn1giTeFZSRPtozA=
+github.com/m3dbx/thrift v0.0.0-20210326170526-6e3eef8b4a26/go.mod h1:01NnKywm1VUGvVw3DQrt4SsfK+7V90Rg2IZW4UqYYwk=
 github.com/m3dbx/vellum v0.0.0-20201119082309-5b47f7a70f69 h1:dANuca0xuYlZR7qWdPIIAZKG0YHvsbLTzdenj53yQvc=
 github.com/m3dbx/vellum v0.0.0-20201119082309-5b47f7a70f69/go.mod h1:DOTAUfV4bzK6Nrb0dboT/oCG0DnQuX+/n0jfZPh6xxI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/src/cmd/services/m3dbnode/config/pooling.go
+++ b/src/cmd/services/m3dbnode/config/pooling.go
@@ -37,7 +37,7 @@ const (
 )
 
 const (
-	defaultBlockAllocSize           = 16
+	defaultBlockAllocSize = 16
 )
 
 var (

--- a/src/cmd/services/m3dbnode/config/pooling.go
+++ b/src/cmd/services/m3dbnode/config/pooling.go
@@ -37,9 +37,11 @@ const (
 )
 
 const (
-	defaultMaxFinalizerCapacity     = 4
 	defaultBlockAllocSize           = 16
-	defaultThriftBytesPoolAllocSize = 2048
+)
+
+var (
+	defaultThriftBytesPoolAllocSizes = []int{16, 64, 256, 512, 1024, 2048}
 )
 
 type poolPolicyDefault struct {
@@ -467,14 +469,14 @@ func (p *PoolingPolicy) BlockAllocSizeOrDefault() int {
 	return defaultBlockAllocSize
 }
 
-// ThriftBytesPoolAllocSizeOrDefault returns the configured thrift bytes pool
+// ThriftBytesPoolAllocSizesOrDefault returns the configured thrift bytes pool
 // max alloc size if provided, or a default value otherwise.
-func (p *PoolingPolicy) ThriftBytesPoolAllocSizeOrDefault() int {
+func (p *PoolingPolicy) ThriftBytesPoolAllocSizesOrDefault() []int {
 	if p.ThriftBytesPoolAllocSize != nil {
-		return *p.ThriftBytesPoolAllocSize
+		return []int{*p.ThriftBytesPoolAllocSize}
 	}
 
-	return defaultThriftBytesPoolAllocSize
+	return defaultThriftBytesPoolAllocSizes
 }
 
 // TypeOrDefault returns the configured pooling type if provided, or a default

--- a/src/cmd/services/m3dbnode/config/pooling.go
+++ b/src/cmd/services/m3dbnode/config/pooling.go
@@ -34,15 +34,11 @@ const (
 	SimplePooling PoolingType = "simple"
 
 	defaultPoolingType = SimplePooling
-)
 
-const (
 	defaultBlockAllocSize = 16
 )
 
-var (
-	defaultThriftBytesPoolAllocSizes = []int{16, 64, 256, 512, 1024, 2048}
-)
+var defaultThriftBytesPoolAllocSizes = []int{16, 64, 256, 512, 1024, 2048}
 
 type poolPolicyDefault struct {
 	size                pool.Size

--- a/src/cmd/services/m3dbnode/config/pooling_test.go
+++ b/src/cmd/services/m3dbnode/config/pooling_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPoolingPolicyThriftBytesPoolAllocSizeOrDefault(t *testing.T) {
+func TestPoolingPolicyThriftBytesPoolAllocSizesOrDefault(t *testing.T) {
 	policy := PoolingPolicy{}
-	require.Equal(t, defaultThriftBytesPoolAllocSize,
-		policy.ThriftBytesPoolAllocSizeOrDefault())
+	require.Equal(t, defaultThriftBytesPoolAllocSizes,
+		policy.ThriftBytesPoolAllocSizesOrDefault())
 
-	value := 42
-	policy.ThriftBytesPoolAllocSize = &value
-	require.Equal(t, 42, policy.ThriftBytesPoolAllocSizeOrDefault())
+	values := []int{42}
+	policy.ThriftBytesPoolAllocSize = &values[0]
+	require.Equal(t, values, policy.ThriftBytesPoolAllocSizesOrDefault())
 }

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -1512,11 +1512,11 @@ func withEncodingAndPoolingOptions(
 	iOpts := opts.InstrumentOptions()
 	scope := opts.InstrumentOptions().MetricsScope()
 
-	// Set the max bytes pool byte slice alloc size for the thrift pooling.
-	thriftBytesAllocSize := policy.ThriftBytesPoolAllocSizeOrDefault()
-	logger.Info("set thrift bytes pool alloc size",
-		zap.Int("size", thriftBytesAllocSize))
-	apachethrift.SetMaxBytesPoolAlloc(thriftBytesAllocSize)
+	// Set the byte slice capacities for the thrift pooling.
+	thriftBytesAllocSizes := policy.ThriftBytesPoolAllocSizesOrDefault()
+	logger.Info("set thrift bytes pool slice sizes",
+		zap.Ints("sizes", thriftBytesAllocSizes))
+	apachethrift.SetMaxBytesPoolAlloc(thriftBytesAllocSizes...)
 
 	bytesPoolOpts := pool.NewObjectPoolOptions().
 		SetInstrumentOptions(iOpts.SetMetricsScope(scope.SubScope("bytes-pool")))


### PR DESCRIPTION
**What this PR does / why we need it**:
A single byte slice pool was used for incoming thrift requests, with default capacity of 2048 bytes. This was wasteful as many of the slices are much shorter than that. This change updates thrift dependency to the version with multiple capacity pooling, and configures it to use capacities of {16, 64, 256, 512, 1024, 2048} bytes.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
