### PR TITLE
[dbnode] Avoid crashing on stackoverflow

### DIFF
--- a/scripts/run-ci-lint.sh
+++ b/scripts/run-ci-lint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -eo pipefail
-set -x
 
 BIN="$1"
 TARGET="$2"

--- a/scripts/run-ci-lint.sh
+++ b/scripts/run-ci-lint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eo pipefail
+set -x
 
 BIN="$1"
 TARGET="$2"

--- a/src/x/context/context.go
+++ b/src/x/context/context.go
@@ -23,7 +23,6 @@ package context
 import (
 	stdctx "context"
 	"fmt"
-	"github.com/opentracing/opentracing-go/ext"
 	"sync"
 
 	xopentracing "github.com/m3db/m3/src/x/opentracing"
@@ -31,6 +30,7 @@ import (
 
 	lightstep "github.com/lightstep/lightstep-tracer-go"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/uber/jaeger-client-go"
 )
@@ -291,7 +291,8 @@ func (c *ctx) Reset() {
 	}
 
 	c.Lock()
-	c.done, c.finalizeables, c.goCtx, c.checkedAndNotSampled, c.distanceFromRoot = false, nil, stdctx.Background(), false, 0
+	c.done, c.finalizeables, c.goCtx, c.checkedAndNotSampled = false, nil, stdctx.Background(), false
+	c.distanceFromRoot = 0
 	c.Unlock()
 }
 

--- a/src/x/context/context_test.go
+++ b/src/x/context/context_test.go
@@ -23,7 +23,6 @@ package context
 import (
 	stdctx "context"
 	"fmt"
-	"github.com/m3db/m3/vendor/github.com/opentracing/opentracing-go"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -302,8 +301,7 @@ func TestTooDeepSpanTreeIsPreventedAndMarked(t *testing.T) {
 	span := tracer.StartSpan("root-span")
 	defer span.Finish()
 
-	context := NewContext()
-	context.SetGoContext(opentracing.ContextWithSpan(stdctx.Background(), span))
+	context := NewWithGoContext(opentracing.ContextWithSpan(stdctx.Background(), span))
 
 	var (
 		lastChildSpanCreated    opentracing.Span = nil

--- a/src/x/context/context_test.go
+++ b/src/x/context/context_test.go
@@ -293,7 +293,7 @@ func TestGoContext(t *testing.T) {
 }
 
 // Test that too deep span tree created is prevented
-// Span is signalled as error in that case that which is well defined
+// Span is marked as error in that case that which is well defined
 func TestTooDeepSpanTreeIsPreventedAndMarked(t *testing.T) {
 	// use a mock tracer to ensure sampling rate is set to 1.
 	tracer := mocktracer.New()
@@ -304,8 +304,8 @@ func TestTooDeepSpanTreeIsPreventedAndMarked(t *testing.T) {
 	context := NewWithGoContext(opentracing.ContextWithSpan(stdctx.Background(), span))
 
 	var (
-		lastChildSpanCreated    opentracing.Span = nil
-		lastChildContextCreated                  = context
+		lastChildSpanCreated    opentracing.Span
+		lastChildContextCreated = context
 	)
 	for i := 1; i <= maxDistanceFromRootContext; i++ {
 		lastChildContextCreated, lastChildSpanCreated, _ =
@@ -323,7 +323,7 @@ func TestTooDeepSpanTreeIsPreventedAndMarked(t *testing.T) {
 	assert.True(t, fieldsContains(spanLog.Fields, "event", "error") &&
 		fieldsContains(spanLog.Fields, "error.object", errSpanTooDeep.Error()))
 
-	childContext, span, _ := lastChildContextCreated.StartSampledTraceSpan("another-span-beyond-max-depth")
+	childContext, _, _ := lastChildContextCreated.StartSampledTraceSpan("another-span-beyond-max-depth")
 	assert.Equal(t, lastChildContextCreated, childContext)
 }
 

--- a/src/x/context/types.go
+++ b/src/x/context/types.go
@@ -22,7 +22,6 @@ package context
 
 import (
 	stdctx "context"
-	"github.com/m3db/m3/vendor/github.com/opentracing/opentracing-go"
 
 	"github.com/m3db/m3/src/x/pool"
 	xresource "github.com/m3db/m3/src/x/resource"

--- a/src/x/context/types.go
+++ b/src/x/context/types.go
@@ -22,6 +22,7 @@ package context
 
 import (
 	stdctx "context"
+	"github.com/m3db/m3/vendor/github.com/opentracing/opentracing-go"
 
 	"github.com/m3db/m3/src/x/pool"
 	xresource "github.com/m3db/m3/src/x/resource"
@@ -89,6 +90,9 @@ type Context interface {
 	// and a bool if the span is being sampled. This is used over StartTraceSpan()
 	// for hot paths where performance is crucial.
 	StartSampledTraceSpan(string) (Context, opentracing.Span, bool)
+
+	// DistanceFromRootContext returns the distance from root context (root context tree)
+	DistanceFromRootContext() uint16
 }
 
 // Pool provides a pool for contexts.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #3312 

When tracing is enabled, in a situation unknown yet, the server crashes on stack overflow, due to very deep parent-child relationship of Context object - i.e. very deep trace transaction. 

This PR adds will help detect when such a case occurs and present the call-stack to help pinpoint the real bug by: 
1. Adds a `depth` property to Context to know how deep the context object is.
2. When creating a parent-child relationship (only happens in `StartSampledTraceSpan`), prevent creating trace "chains" deeper than 100 (seems like reasonably high depth), by marking a special error on the 100th trace span, which we can search for in our traces back-end, avoid creating a child context and return No Op span on any subsequent span (deeper than 100)

The error marked on the 100th span, will be easily searchable and in effect details the call stack leading to creating this odd long chain, making it easier to detect and pin point the problem. 

The motivation and more details are described in detail in the issue #3312 

**Does this PR require updating code package or user-facing documentation?**:
I'm not sure yet if documentation is required for this change
