### PR TITLE
[dbnode] Decoder: fix handling of values requiring 64bit precision

### DIFF
--- a/src/dbnode/encoding/m3tsz/iterator_test.go
+++ b/src/dbnode/encoding/m3tsz/iterator_test.go
@@ -366,7 +366,6 @@ func TestReaderIteratorNextWithUnexpectedTimeUnit(t *testing.T) {
 }
 
 func TestReaderIteratorDecodingRegression(t *testing.T) {
-	t.Skip("to be removed in a follow-up PR")
 	// This reproduces the regression that was introduced in
 	// https://github.com/m3db/m3/commit/abad1bb2e9a4de18afcb9a29e87fa3a39a694ef4
 	// by failing decoding (returns unexpected EOF error after the first call to Next()).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Depends on #3405
Perf impact is negligible.
```
name            old time/op  new time/op  delta
M3TSZDecode-12  29.6µs ± 0%  29.8µs ± 0%  +0.54%  (p=0.008 n=5+5)
M3TSZEncode-12  69.6µs ± 1%  70.0µs ± 1%    ~     (p=0.151 n=5+5)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
