### PR TITLE
[query] Restore optimization to skip initial fetch for timeShift and unary fns

### DIFF
--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -2202,6 +2202,9 @@ func movingMinHelper(window []float64, vals ts.MutableValues, windowPoints int, 
 	}
 }
 
+// newMovingBinaryTransform requires that functions are registered with
+// WithoutUnaryContextShifterSkipFetchOptimization() during function
+// registration.
 func newMovingBinaryTransform(
 	ctx *common.Context,
 	input singlePathSpec,
@@ -2589,7 +2592,8 @@ func init() {
 	MustRegisterFunction(divideSeries)
 	MustRegisterFunction(divideSeriesLists)
 	MustRegisterFunction(exclude)
-	MustRegisterFunction(exponentialMovingAverage)
+	MustRegisterFunction(exponentialMovingAverage).
+		WithoutUnaryContextShifterSkipFetchOptimization()
 	MustRegisterFunction(fallbackSeries)
 	MustRegisterFunction(grep)
 	MustRegisterFunction(group)
@@ -2634,21 +2638,31 @@ func init() {
 	MustRegisterFunction(minSeries)
 	MustRegisterFunction(minimumAbove)
 	MustRegisterFunction(mostDeviant)
-	MustRegisterFunction(movingAverage).WithDefaultParams(map[uint8]interface{}{
-		3: defaultXFilesFactor, // XFilesFactor
-	})
-	MustRegisterFunction(movingMedian).WithDefaultParams(map[uint8]interface{}{
-		3: defaultXFilesFactor, // XFilesFactor
-	})
-	MustRegisterFunction(movingSum).WithDefaultParams(map[uint8]interface{}{
-		3: defaultXFilesFactor, // XFilesFactor
-	})
-	MustRegisterFunction(movingMax).WithDefaultParams(map[uint8]interface{}{
-		3: defaultXFilesFactor, // XFilesFactor
-	})
-	MustRegisterFunction(movingMin).WithDefaultParams(map[uint8]interface{}{
-		3: defaultXFilesFactor, // XFilesFactor
-	})
+	MustRegisterFunction(movingAverage).
+		WithDefaultParams(map[uint8]interface{}{
+			3: defaultXFilesFactor, // XFilesFactor
+		}).
+		WithoutUnaryContextShifterSkipFetchOptimization()
+	MustRegisterFunction(movingMedian).
+		WithDefaultParams(map[uint8]interface{}{
+			3: defaultXFilesFactor, // XFilesFactor
+		}).
+		WithoutUnaryContextShifterSkipFetchOptimization()
+	MustRegisterFunction(movingSum).
+		WithDefaultParams(map[uint8]interface{}{
+			3: defaultXFilesFactor, // XFilesFactor
+		}).
+		WithoutUnaryContextShifterSkipFetchOptimization()
+	MustRegisterFunction(movingMax).
+		WithDefaultParams(map[uint8]interface{}{
+			3: defaultXFilesFactor, // XFilesFactor
+		}).
+		WithoutUnaryContextShifterSkipFetchOptimization()
+	MustRegisterFunction(movingMin).
+		WithDefaultParams(map[uint8]interface{}{
+			3: defaultXFilesFactor, // XFilesFactor
+		}).
+		WithoutUnaryContextShifterSkipFetchOptimization()
 	MustRegisterFunction(multiplySeries)
 	MustRegisterFunction(nonNegativeDerivative).WithDefaultParams(map[uint8]interface{}{
 		2: math.NaN(), // maxValue

--- a/src/query/graphite/native/functions.go
+++ b/src/query/graphite/native/functions.go
@@ -538,6 +538,11 @@ func (call *functionCall) Arguments() []ArgumentASTNode {
 func (call *functionCall) Evaluate(ctx *common.Context) (reflect.Value, error) {
 	values := make([]reflect.Value, len(call.in))
 	for i, param := range call.in {
+		// Optimization to skip fetching series for a unary context shift
+		// operation since they'll refetch after shifting.
+		// Note: You can call WithoutUnaryContextShifterSkipFetchOptimization()
+		// after registering a function if you need a unary context shift
+		// operation to have series for the initial time window fetched.
 		if call.f.out == unaryContextShifterPtrType &&
 			!call.f.disableUnaryContextShiftFetchOptimization &&
 			(call.f.in[i] == singlePathSpecType || call.f.in[i] == multiplePathSpecsType) {

--- a/src/query/graphite/native/functions.go
+++ b/src/query/graphite/native/functions.go
@@ -235,6 +235,8 @@ type Function struct {
 	defaults map[uint8]interface{}
 	out      reflect.Type
 	variadic bool
+
+	disableUnaryContextShiftFetchOptimization bool
 }
 
 // WithDefaultParams provides default parameters for functions
@@ -245,6 +247,23 @@ func (f *Function) WithDefaultParams(defaultParams map[uint8]interface{}) *Funct
 		}
 	}
 	f.defaults = defaultParams
+	return f
+}
+
+// WithoutUnaryContextShifterSkipFetchOptimization allows a function to skip
+// the optimization that avoids fetching data for the first execution phase
+// of a unary context shifted function (where it is called the first time
+// without any series populated as input to the function and relies on
+// execution of the unary context shifter with the shifted series solely).
+// Note: This is useful for the "movingX" family of functions that require
+// that require actually seeing what the step size is sometimes of the series
+// from the first phase of execution to determine how much to look back for the
+// context shift phase.
+func (f *Function) WithoutUnaryContextShifterSkipFetchOptimization() *Function {
+	if f.out != unaryContextShifterPtrType {
+		panic("Skip fetch optimization only available to unary context shifters")
+	}
+	f.disableUnaryContextShiftFetchOptimization = true
 	return f
 }
 
@@ -519,6 +538,12 @@ func (call *functionCall) Arguments() []ArgumentASTNode {
 func (call *functionCall) Evaluate(ctx *common.Context) (reflect.Value, error) {
 	values := make([]reflect.Value, len(call.in))
 	for i, param := range call.in {
+		if call.f.out == unaryContextShifterPtrType &&
+			!call.f.disableUnaryContextShiftFetchOptimization &&
+			(call.f.in[i] == singlePathSpecType || call.f.in[i] == multiplePathSpecsType) {
+			values[i] = reflect.ValueOf(singlePathSpec{}) // fake parameter
+			continue
+		}
 		value, err := param.Evaluate(ctx)
 		if err != nil {
 			return reflect.Value{}, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Previously this optimization was removed since moving functions which started using the unary context shifter actually needed access to the initial fetch of data, but this does add considerable load when timeShift is used extensively with a lot of alerts.

Restoring this optimization for that use case.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
