### PR TITLE
[dbnode] Update the logic of index fileset volume cleanup

### DIFF
--- a/src/dbnode/storage/bootstrap/result/shard_ranges.go
+++ b/src/dbnode/storage/bootstrap/result/shard_ranges.go
@@ -206,6 +206,17 @@ func (r shardTimeRanges) AddRanges(other ShardTimeRanges) {
 	}
 }
 
+// FilterShards returns the shard time ranges after omitting shard not in the list.
+func (r shardTimeRanges) FilterShards(shards []uint32) ShardTimeRanges {
+	filtered := NewShardTimeRanges()
+	for _, s := range shards {
+		if ranges, ok := r.Get(s); ok {
+			filtered.Set(s, ranges)
+		}
+	}
+	return filtered
+}
+
 // ToUnfulfilledDataResult will return a result that is comprised of wholly
 // unfufilled time ranges from the set of shard time ranges.
 func (r shardTimeRanges) ToUnfulfilledDataResult() DataBootstrapResult {

--- a/src/dbnode/storage/bootstrap/result/types.go
+++ b/src/dbnode/storage/bootstrap/result/types.go
@@ -163,6 +163,9 @@ type ShardTimeRanges interface {
 	// GetOrAdd gets or adds time ranges for a shard.
 	GetOrAdd(shard uint32) xtime.Ranges
 
+	// FilterShards returns the shard time ranges after omitting shard not in the list.
+	FilterShards(shards []uint32) ShardTimeRanges
+
 	// AddRanges adds other shard time ranges to the current shard time ranges.
 	AddRanges(ranges ShardTimeRanges)
 

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -313,7 +313,11 @@ func (m *cleanupManager) cleanupDuplicateIndexFiles(namespaces []databaseNamespa
 			multiErr = multiErr.Add(err)
 			continue
 		}
-		multiErr = multiErr.Add(idx.CleanupDuplicateFileSets())
+		activeShards := make([]uint32, 0)
+		for _, s := range n.OwnedShards() {
+			activeShards = append(activeShards, s.ID())
+		}
+		multiErr = multiErr.Add(idx.CleanupDuplicateFileSets(activeShards))
 	}
 	return multiErr.FinalError()
 }

--- a/src/dbnode/storage/cleanup_test.go
+++ b/src/dbnode/storage/cleanup_test.go
@@ -348,6 +348,7 @@ func TestCleanupManagerNamespaceCleanupBootstrapped(t *testing.T) {
 
 	shard := NewMockdatabaseShard(ctrl)
 	shard.EXPECT().ID().Return(uint32(42)).AnyTimes()
+	shard.EXPECT().IsBootstrapped().Return(true).AnyTimes()
 	shard.EXPECT().CleanupExpiredFileSets(gomock.Eq(ts.Add(-rOpts.RetentionPeriod()))).Return(nil)
 	shard.EXPECT().CleanupCompactedFileSets().Return(nil)
 
@@ -385,11 +386,16 @@ func TestCleanupManagerNamespaceCleanupNotBootstrapped(t *testing.T) {
 			SetEnabled(true).
 			SetBlockSize(7200 * time.Second))
 
+	idx := NewMockNamespaceIndex(ctrl)
+	idx.EXPECT().CleanupExpiredFileSets(gomock.Any()).Return(nil)
+	idx.EXPECT().CleanupDuplicateFileSets(gomock.Any()).Return(nil)
+
 	ns := NewMockdatabaseNamespace(ctrl)
 	ns.EXPECT().ID().Return(ident.StringID("ns")).AnyTimes()
 	ns.EXPECT().Options().Return(nsOpts).AnyTimes()
 	ns.EXPECT().NeedsFlush(gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 	ns.EXPECT().OwnedShards().Return(nil).AnyTimes()
+	ns.EXPECT().Index().Return(idx, nil).AnyTimes()
 
 	nses := []databaseNamespace{ns}
 	db := newMockdatabase(ctrl, ns)

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -2141,7 +2141,7 @@ func (i *nsIndex) CleanupDuplicateFileSets(activeShards []uint32) error {
 			for _, seg := range segmentsOrderByVolumeIndex {
 				for len(segmentsToKeep) > 0 {
 					idx := len(segmentsToKeep) - 1
-					if previous := segmentsToKeep[idx]; seg.ShardTimeRanges().FilterShards(activeShards).IsSuperset(
+					if previous := segmentsToKeep[idx]; seg.ShardTimeRanges().IsSuperset(
 						previous.ShardTimeRanges().FilterShards(activeShards)) {
 						filesToDelete = append(filesToDelete, previous.AbsoluteFilePaths()...)
 						segmentsToKeep = segmentsToKeep[:idx]

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -2098,7 +2098,7 @@ func (i *nsIndex) CleanupExpiredFileSets(t time.Time) error {
 	return i.deleteFilesFn(filesets)
 }
 
-func (i *nsIndex) CleanupDuplicateFileSets() error {
+func (i *nsIndex) CleanupDuplicateFileSets(activeShards []uint32) error {
 	fsOpts := i.opts.CommitLogOptions().FilesystemOptions()
 	infoFiles := i.readIndexInfoFilesFn(
 		fsOpts.FilePathPrefix(),
@@ -2141,7 +2141,8 @@ func (i *nsIndex) CleanupDuplicateFileSets() error {
 			for _, seg := range segmentsOrderByVolumeIndex {
 				for len(segmentsToKeep) > 0 {
 					idx := len(segmentsToKeep) - 1
-					if previous := segmentsToKeep[idx]; seg.ShardTimeRanges().IsSuperset(previous.ShardTimeRanges()) {
+					if previous := segmentsToKeep[idx]; seg.ShardTimeRanges().FilterShards(activeShards).IsSuperset(
+						previous.ShardTimeRanges().FilterShards(activeShards)) {
 						filesToDelete = append(filesToDelete, previous.AbsoluteFilePaths()...)
 						segmentsToKeep = segmentsToKeep[:idx]
 					} else {

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -874,6 +874,7 @@ func newReadIndexInfoFileResult(
 		},
 		Info: indexpb.IndexVolumeInfo{
 			BlockStart: blockStart.UnixNano(),
+			BlockSize:  int64(2 * time.Hour),
 			Shards:     shards,
 			IndexVolumeType: &protobuftypes.StringValue{
 				Value: volumeType,

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -156,7 +156,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 	require.NoError(t, idx.CleanupDuplicateFileSets())
 }
 
-func TestNamespaceIndexCleanupDuplicateFilesets_SortingByBlockStartAndVolume(t *testing.T) {
+func TestNamespaceIndexCleanupDuplicateFilesets_SortingByBlockStartAndVolumeType(t *testing.T) {
 	blockStart1 := time.Now().Truncate(2 * time.Hour)
 	blockStart2 := blockStart1.Add(-2 * time.Hour)
 

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -156,7 +156,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 	require.NoError(t, idx.CleanupDuplicateFileSets())
 }
 
-func TestNamespaceIndexCleanupDuplicateFilesets_GroupingByBlockStartAndVolume(t *testing.T) {
+func TestNamespaceIndexCleanupDuplicateFilesets_SortingByBlockStartAndVolume(t *testing.T) {
 	blockStart1 := time.Now().Truncate(2 * time.Hour)
 	blockStart2 := blockStart1.Add(-2 * time.Hour)
 
@@ -208,7 +208,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets_GroupingByBlockStartAndVolume(t 
 	infoFiles := make([]fs.ReadIndexInfoFileResult, 0)
 	for _, fileset := range filesets {
 		shards := []uint32{1, 2}
-		infoFile := readIndexInfoFileResult(fileset.blockStart, fileset.volumeType, fileset.volumeIndex, shards)
+		infoFile := newReadIndexInfoFileResult(fileset.blockStart, fileset.volumeType, fileset.volumeIndex, shards)
 		infoFiles = append(infoFiles, infoFile)
 		if fileset.shouldRemove {
 			expectedFilesToRemove = append(expectedFilesToRemove, infoFile.AbsoluteFilePaths...)
@@ -273,7 +273,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets_ChangingShardList(t *testing.T) 
 	expectedFilesToRemove := make([]string, 0)
 	infoFiles := make([]fs.ReadIndexInfoFileResult, 0)
 	for i, shardList := range shardLists {
-		infoFile := readIndexInfoFileResult(blockStart, "default", i, shardList.shards)
+		infoFile := newReadIndexInfoFileResult(blockStart, "default", i, shardList.shards)
 		infoFiles = append(infoFiles, infoFile)
 		if shardList.shouldRemove {
 			expectedFilesToRemove = append(expectedFilesToRemove, infoFile.AbsoluteFilePaths...)
@@ -756,7 +756,7 @@ func verifyFlushForShards(
 	require.Equal(t, expectedDocs, actualDocs)
 }
 
-func readIndexInfoFileResult(
+func newReadIndexInfoFileResult(
 	blockStart time.Time,
 	volumeType string,
 	volumeIndex int,

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -2622,17 +2622,17 @@ func (mr *MockNamespaceIndexMockRecorder) CleanupExpiredFileSets(t interface{}) 
 }
 
 // CleanupDuplicateFileSets mocks base method
-func (m *MockNamespaceIndex) CleanupDuplicateFileSets() error {
+func (m *MockNamespaceIndex) CleanupDuplicateFileSets(activeShards []uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CleanupDuplicateFileSets")
+	ret := m.ctrl.Call(m, "CleanupDuplicateFileSets", activeShards)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CleanupDuplicateFileSets indicates an expected call of CleanupDuplicateFileSets
-func (mr *MockNamespaceIndexMockRecorder) CleanupDuplicateFileSets() *gomock.Call {
+func (mr *MockNamespaceIndexMockRecorder) CleanupDuplicateFileSets(activeShards interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupDuplicateFileSets", reflect.TypeOf((*MockNamespaceIndex)(nil).CleanupDuplicateFileSets))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupDuplicateFileSets", reflect.TypeOf((*MockNamespaceIndex)(nil).CleanupDuplicateFileSets), activeShards)
 }
 
 // Tick mocks base method

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -738,7 +738,7 @@ type NamespaceIndex interface {
 	CleanupExpiredFileSets(t time.Time) error
 
 	// CleanupDuplicateFileSets removes duplicate fileset files.
-	CleanupDuplicateFileSets() error
+	CleanupDuplicateFileSets(activeShards []uint32) error
 
 	// Tick performs internal house keeping in the index, including block rotation,
 	// data eviction, and so on.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Updates the logic of index fileset volume cleanup. This change mitigates the cases where recent volumes were not cleaned up after the shards owned by the dbnode changes.

For example, if we have following volumes:
```
volume index | shard list
0            | 0, 1
1            | 0, 1   // shard ownership changes due to modified topology
2            | 0
3            | 0
4            | 0
``` 

Previous cleanup logic would fail to delete some redundant volumes:
```
volume index | shard list
1            | 0, 1
2            | 0
3            | 0
4            | 0
```

After this change, the cleanup would leave following volumes
```
volume index | shard list
1            | 0, 1
4            | 0
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
