### PR TITLE
[dbnode] Fix TestSeriesWriteReadParallel datapoints too far in past with -race flag

### DIFF
--- a/src/dbnode/storage/series/series_test.go
+++ b/src/dbnode/storage/series/series_test.go
@@ -71,8 +71,8 @@ func newSeriesTestOptions() Options {
 		SetRetentionOptions(opts.
 			RetentionOptions().
 			SetBlockSize(2 * time.Minute).
-			SetBufferFuture(10 * time.Second).
-			SetBufferPast(10 * time.Second).
+			SetBufferFuture(90 * time.Second).
+			SetBufferPast(90 * time.Second).
 			SetRetentionPeriod(time.Hour)).
 		SetDatabaseBlockOptions(opts.
 			DatabaseBlockOptions().
@@ -325,10 +325,10 @@ func TestSeriesBootstrapAndLoad(t *testing.T) {
 				blockStates                  = BootstrappedBlockStateSnapshot{
 					Snapshot: map[xtime.UnixNano]BlockState{
 						// Exercise both code paths.
-						xtime.ToUnixNano(alreadyWarmFlushedBlockStart): BlockState{
+						xtime.ToUnixNano(alreadyWarmFlushedBlockStart): {
 							WarmRetrievable: true,
 						},
-						xtime.ToUnixNano(notYetWarmFlushedBlockStart): BlockState{
+						xtime.ToUnixNano(notYetWarmFlushedBlockStart): {
 							WarmRetrievable: false,
 						},
 					},
@@ -641,11 +641,11 @@ func TestSeriesTickNeedsBlockExpiry(t *testing.T) {
 	buffer.EXPECT().Stats().Return(bufferStats{wiredBlocks: 1})
 	blockStates := BootstrappedBlockStateSnapshot{
 		Snapshot: map[xtime.UnixNano]BlockState{
-			xtime.ToUnixNano(blockStart): BlockState{
+			xtime.ToUnixNano(blockStart): {
 				WarmRetrievable: false,
 				ColdVersion:     0,
 			},
-			xtime.ToUnixNano(curr): BlockState{
+			xtime.ToUnixNano(curr): {
 				WarmRetrievable: false,
 				ColdVersion:     0,
 			},
@@ -704,7 +704,7 @@ func TestSeriesTickRecentlyRead(t *testing.T) {
 
 	blockStates := BootstrappedBlockStateSnapshot{
 		Snapshot: map[xtime.UnixNano]BlockState{
-			xtime.ToUnixNano(curr): BlockState{
+			xtime.ToUnixNano(curr): {
 				WarmRetrievable: true,
 				ColdVersion:     1,
 			},
@@ -737,7 +737,7 @@ func TestSeriesTickRecentlyRead(t *testing.T) {
 
 	blockStates = BootstrappedBlockStateSnapshot{
 		Snapshot: map[xtime.UnixNano]BlockState{
-			xtime.ToUnixNano(curr): BlockState{
+			xtime.ToUnixNano(curr): {
 				WarmRetrievable: false,
 				ColdVersion:     0,
 			},
@@ -792,7 +792,7 @@ func TestSeriesTickCacheLRU(t *testing.T) {
 
 	blockStates := BootstrappedBlockStateSnapshot{
 		Snapshot: map[xtime.UnixNano]BlockState{
-			xtime.ToUnixNano(curr): BlockState{
+			xtime.ToUnixNano(curr): {
 				WarmRetrievable: true,
 				ColdVersion:     1,
 			},
@@ -832,7 +832,7 @@ func TestSeriesTickCacheLRU(t *testing.T) {
 
 	blockStates = BootstrappedBlockStateSnapshot{
 		Snapshot: map[xtime.UnixNano]BlockState{
-			xtime.ToUnixNano(curr): BlockState{
+			xtime.ToUnixNano(curr): {
 				WarmRetrievable: false,
 				ColdVersion:     0,
 			},
@@ -887,7 +887,7 @@ func TestSeriesTickCacheNone(t *testing.T) {
 
 	blockStates := BootstrappedBlockStateSnapshot{
 		Snapshot: map[xtime.UnixNano]BlockState{
-			xtime.ToUnixNano(curr): BlockState{
+			xtime.ToUnixNano(curr): {
 				WarmRetrievable: true,
 				ColdVersion:     1,
 			},
@@ -907,7 +907,7 @@ func TestSeriesTickCacheNone(t *testing.T) {
 
 	blockStates = BootstrappedBlockStateSnapshot{
 		Snapshot: map[xtime.UnixNano]BlockState{
-			xtime.ToUnixNano(curr): BlockState{
+			xtime.ToUnixNano(curr): {
 				WarmRetrievable: false,
 				ColdVersion:     0,
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This is a timing issue and the buffer past was only set to 1 second in the test options, increasing to 90 seconds is much more lenient for this intensive unit test (marked as "big" since it's more integration like).

Before:
```
go test -v -failfast -run TestSeriesWriteReadParallel -count 100 -tags big -race
=== RUN   TestSeriesWriteReadParallel
panic: datapoint too far in past: id=foo, off_by=134.750835ms, timestamp=13 Apr 21 13:48 -0400, past_limit=13 Apr 21 13:48 -0400, timestamp_unix_nanos=1618336092865249165, past_limit_unix_nanos=1618336093000000000

goroutine 8 [running]:
github.com/m3db/m3/src/dbnode/storage/series.TestSeriesWriteReadParallel.func1(0x2710, 0xc002259a40, 0x20d19a0, 0xc002e41490, 0xc015943733929748, 0x12571266, 0x2821ec0, 0xc0002ca1f0)
        /Users/r/go/src/github.com/m3db/m3/src/dbnode/storage/series/series_parallel_test.go:83 +0x226
created by github.com/m3db/m3/src/dbnode/storage/series.TestSeriesWriteReadParallel
        /Users/r/go/src/github.com/m3db/m3/src/dbnode/storage/series/series_parallel_test.go:78 +0x961
exit status 2
FAIL    github.com/m3db/m3/src/dbnode/storage/series    11.054s
```

After:
```
go test -v -failfast -run TestSeriesWriteReadParallel -count 100 -tags big -race
=== RUN   TestSeriesWriteReadParallel
--- PASS: TestSeriesWriteReadParallel (23.52s)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
