### PR TITLE
Do not use buffer channels if growOnDemand is true

### DIFF
--- a/src/x/sync/pooled_worker_pool.go
+++ b/src/x/sync/pooled_worker_pool.go
@@ -61,8 +61,14 @@ func NewPooledWorkerPool(size int, opts PooledWorkerPoolOptions) (PooledWorkerPo
 	}
 
 	workChs := make([]chan Work, numShards)
+	bufSize := int64(size) / numShards
+	if opts.GrowOnDemand() {
+		// Do not use buffered channels if the pool can grow on demand. This ensures a new worker is spawned if all
+		// workers are currently busy.
+		bufSize = 0
+	}
 	for i := range workChs {
-		workChs[i] = make(chan Work, int64(size)/numShards)
+		workChs[i] = make(chan Work, bufSize)
 	}
 
 	return &pooledWorkerPool{


### PR DESCRIPTION
This ensures a new worker is spawned if all workers are currently busy.
With buffered channels, a unit of work might get scheduled on a channel
where the worker is currently processing a long request. That unit of
work will get starved until the long request is complete.

For example in the host_queue worker pool, a long query request might
take 2 mins to complete. An unrelated request might get buffered on that
same chanel and won't get processed for 2 mins.

Also fixed a bug in the host_queue that did not cleanup if the work was
never scheduled due to a context timeout.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
