### PR TITLE
[coordinator] add more information to processed count metric

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -129,8 +129,9 @@ func defaultMetricsAppenderOptions(opts DownsamplerOptions, agg agg) metricsAppe
 	}
 	scope := opts.InstrumentOptions.MetricsScope().SubScope("metrics_appender")
 	metrics := metricsAppenderMetrics{
-		processedCountNonRollup: scope.Tagged(map[string]string{"aggType": "non_rollup"}).Counter("processed_count"),
-		processedCountRollup:    scope.Tagged(map[string]string{"aggType": "rollup"}).Counter("processed_count"),
+		processedCountNonRollup: scope.Tagged(map[string]string{"agg_type": "non_rollup"}).Counter("processed"),
+		processedCountRollup:    scope.Tagged(map[string]string{"agg_type": "rollup"}).Counter("processed"),
+		operationsCount:         scope.Counter("operations_processed"),
 	}
 
 	return metricsAppenderOptions{

--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -129,7 +129,8 @@ func defaultMetricsAppenderOptions(opts DownsamplerOptions, agg agg) metricsAppe
 	}
 	scope := opts.InstrumentOptions.MetricsScope().SubScope("metrics_appender")
 	metrics := metricsAppenderMetrics{
-		processedCount: scope.Counter("processed_count"),
+		processedCountNonRollup: scope.Tagged(map[string]string{"aggType": "non_rollup"}).Counter("processed_count"),
+		processedCountRollup:    scope.Tagged(map[string]string{"aggType": "rollup"}).Counter("processed_count"),
 	}
 
 	return metricsAppenderOptions{

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -77,7 +77,8 @@ func (p *metricsAppenderPool) Put(v *metricsAppender) {
 }
 
 type metricsAppenderMetrics struct {
-	processedCount tally.Counter
+	processedCountNonRollup tally.Counter
+	processedCountRollup    tally.Counter
 }
 
 type metricsAppender struct {
@@ -409,11 +410,12 @@ func (a *metricsAppender) SamplesAppender(opts SampleAppenderOptions) (SamplesAp
 		a.debugLogMatch("downsampler applying matched rollup rule",
 			debugLogMatchOptions{Meta: rollup.Metadatas, RollupID: rollup.ID})
 		a.multiSamplesAppender.addSamplesAppender(samplesAppender{
-			agg:              a.agg,
-			clientRemote:     a.clientRemote,
-			processedCounter: a.metrics.processedCount,
-			unownedID:        rollup.ID,
-			stagedMetadatas:  rollup.Metadatas,
+			agg:                     a.agg,
+			clientRemote:            a.clientRemote,
+			processedCountNonRollup: a.metrics.processedCountNonRollup,
+			processedCountRollup:    a.metrics.processedCountRollup,
+			unownedID:               rollup.ID,
+			stagedMetadatas:         rollup.Metadatas,
 		})
 		if a.untimedRollups {
 			dropTimestamp = true
@@ -566,11 +568,12 @@ func (a *metricsAppender) newSamplesAppender(
 		return samplesAppender{}, fmt.Errorf("unable to encode tags: names=%v, values=%v", tags.names, tags.values)
 	}
 	return samplesAppender{
-		agg:              a.agg,
-		clientRemote:     a.clientRemote,
-		processedCounter: a.metrics.processedCount,
-		unownedID:        data.Bytes(),
-		stagedMetadatas:  []metadata.StagedMetadata{sm},
+		agg:                     a.agg,
+		clientRemote:            a.clientRemote,
+		processedCountNonRollup: a.metrics.processedCountNonRollup,
+		processedCountRollup:    a.metrics.processedCountRollup,
+		unownedID:               data.Bytes(),
+		stagedMetadatas:         []metadata.StagedMetadata{sm},
 	}, nil
 }
 

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
@@ -107,7 +107,8 @@ func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
 			matcher:                matcher,
 			agg:                    agg,
 			metrics: metricsAppenderMetrics{
-				processedCount: tally.NoopScope.Counter("test-counter"),
+				processedCountNonRollup: tally.NoopScope.Counter("test-counter-non-rollup"),
+				processedCountRollup:    tally.NoopScope.Counter("test-counter-rollup"),
 			},
 		})
 		name := []byte(fmt.Sprint("foo", i))

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
@@ -109,6 +109,7 @@ func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
 			metrics: metricsAppenderMetrics{
 				processedCountNonRollup: tally.NoopScope.Counter("test-counter-non-rollup"),
 				processedCountRollup:    tally.NoopScope.Counter("test-counter-rollup"),
+				operationsCount:         tally.NoopScope.Counter("test-counter-operations"),
 			},
 		})
 		name := []byte(fmt.Sprint("foo", i))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds additional information to the processed count metric - indicating if it was processed due to rollup or not.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
