### PR TITLE
[dbnode] Avoid use of grow on demand worker pool for fetchTagged and aggregate

### DIFF
--- a/src/dbnode/client/client_mock.go
+++ b/src/dbnode/client/client_mock.go
@@ -4394,7 +4394,7 @@ func (m *MockAdminOptions) SetThriftContextFn(value ThriftContextFn) Options {
 // SetThriftContextFn indicates an expected call of SetThriftContextFn
 func (mr *MockAdminOptionsMockRecorder) SetThriftContextFn(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetThriftContextFn", reflect.TypeOf((*MockOptions)(nil).SetThriftContextFn), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetThriftContextFn", reflect.TypeOf((*MockAdminOptions)(nil).SetThriftContextFn), value)
 }
 
 // ThriftContextFn mocks base method
@@ -4408,7 +4408,7 @@ func (m *MockAdminOptions) ThriftContextFn() ThriftContextFn {
 // ThriftContextFn indicates an expected call of ThriftContextFn
 func (mr *MockAdminOptionsMockRecorder) ThriftContextFn() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ThriftContextFn", reflect.TypeOf((*MockOptions)(nil).ThriftContextFn))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ThriftContextFn", reflect.TypeOf((*MockAdminOptions)(nil).ThriftContextFn))
 }
 
 // SetOrigin mocks base method

--- a/src/dbnode/client/client_mock.go
+++ b/src/dbnode/client/client_mock.go
@@ -2736,6 +2736,34 @@ func (mr *MockOptionsMockRecorder) NamespaceInitializer() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceInitializer", reflect.TypeOf((*MockOptions)(nil).NamespaceInitializer))
 }
 
+// SetThriftContextFn mocks base method
+func (m *MockOptions) SetThriftContextFn(value ThriftContextFn) Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetThriftContextFn", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+// SetThriftContextFn indicates an expected call of SetThriftContextFn
+func (mr *MockOptionsMockRecorder) SetThriftContextFn(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetThriftContextFn", reflect.TypeOf((*MockOptions)(nil).SetThriftContextFn), value)
+}
+
+// ThriftContextFn mocks base method
+func (m *MockOptions) ThriftContextFn() ThriftContextFn {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ThriftContextFn")
+	ret0, _ := ret[0].(ThriftContextFn)
+	return ret0
+}
+
+// ThriftContextFn indicates an expected call of ThriftContextFn
+func (mr *MockOptionsMockRecorder) ThriftContextFn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ThriftContextFn", reflect.TypeOf((*MockOptions)(nil).ThriftContextFn))
+}
+
 // MockAdminOptions is a mock of AdminOptions interface
 type MockAdminOptions struct {
 	ctrl     *gomock.Controller
@@ -4353,6 +4381,34 @@ func (m *MockAdminOptions) NamespaceInitializer() namespace.Initializer {
 func (mr *MockAdminOptionsMockRecorder) NamespaceInitializer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceInitializer", reflect.TypeOf((*MockAdminOptions)(nil).NamespaceInitializer))
+}
+
+// SetThriftContextFn mocks base method
+func (m *MockAdminOptions) SetThriftContextFn(value ThriftContextFn) Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetThriftContextFn", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+// SetThriftContextFn indicates an expected call of SetThriftContextFn
+func (mr *MockAdminOptionsMockRecorder) SetThriftContextFn(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetThriftContextFn", reflect.TypeOf((*MockOptions)(nil).SetThriftContextFn), value)
+}
+
+// ThriftContextFn mocks base method
+func (m *MockAdminOptions) ThriftContextFn() ThriftContextFn {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ThriftContextFn")
+	ret0, _ := ret[0].(ThriftContextFn)
+	return ret0
+}
+
+// ThriftContextFn indicates an expected call of ThriftContextFn
+func (mr *MockAdminOptionsMockRecorder) ThriftContextFn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ThriftContextFn", reflect.TypeOf((*MockOptions)(nil).ThriftContextFn))
 }
 
 // SetOrigin mocks base method

--- a/src/dbnode/client/options.go
+++ b/src/dbnode/client/options.go
@@ -21,6 +21,7 @@
 package client
 
 import (
+	gocontext "context"
 	"errors"
 	"math"
 	"runtime"
@@ -223,6 +224,11 @@ var (
 		IdleCheckInterval: 5 * time.Minute,
 	}
 
+	// defaultThriftContextFn is the default thrift context function.
+	defaultThriftContextFn = func(ctx gocontext.Context) thrift.Context {
+		return thrift.Wrap(ctx)
+	}
+
 	errNoTopologyInitializerSet    = errors.New("no topology initializer set")
 	errNoReaderIteratorAllocateSet = errors.New("no reader iterator allocator set, encoding not set")
 )
@@ -292,6 +298,7 @@ type options struct {
 	iterationOptions                        index.IterationOptions
 	writeTimestampOffset                    time.Duration
 	namespaceInitializer                    namespace.Initializer
+	thriftContextFn                         ThriftContextFn
 }
 
 // NewOptions creates a new set of client options with defaults
@@ -433,6 +440,7 @@ func newOptions() *options {
 		asyncTopologyInitializers:               []topology.Initializer{},
 		asyncWriteMaxConcurrency:                defaultAsyncWriteMaxConcurrency,
 		useV2BatchAPIs:                          defaultUseV2BatchAPIs,
+		thriftContextFn:                         defaultThriftContextFn,
 	}
 	return opts.SetEncodingM3TSZ().(*options)
 }
@@ -1122,4 +1130,14 @@ func (o *options) SetNamespaceInitializer(value namespace.Initializer) Options {
 
 func (o *options) NamespaceInitializer() namespace.Initializer {
 	return o.namespaceInitializer
+}
+
+func (o *options) SetThriftContextFn(value ThriftContextFn) Options {
+	opts := *o
+	opts.thriftContextFn = value
+	return &opts
+}
+
+func (o *options) ThriftContextFn() ThriftContextFn {
+	return o.thriftContextFn
 }

--- a/src/dbnode/client/options.go
+++ b/src/dbnode/client/options.go
@@ -21,11 +21,13 @@
 package client
 
 import (
-	gocontext "context"
 	"errors"
 	"math"
 	"runtime"
 	"time"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/thrift"
 
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
@@ -47,9 +49,6 @@ import (
 	"github.com/m3db/m3/src/x/sampler"
 	"github.com/m3db/m3/src/x/serialize"
 	xsync "github.com/m3db/m3/src/x/sync"
-
-	"github.com/uber/tchannel-go"
-	"github.com/uber/tchannel-go/thrift"
 )
 
 const (
@@ -225,9 +224,7 @@ var (
 	}
 
 	// defaultThriftContextFn is the default thrift context function.
-	defaultThriftContextFn = func(ctx gocontext.Context) thrift.Context {
-		return thrift.Wrap(ctx)
-	}
+	defaultThriftContextFn = thrift.Wrap
 
 	errNoTopologyInitializerSet    = errors.New("no topology initializer set")
 	errNoReaderIteratorAllocateSet = errors.New("no reader iterator allocator set, encoding not set")

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -22,8 +22,10 @@ package client
 
 import (
 	gocontext "context"
-	"github.com/uber/tchannel-go/thrift"
 	"time"
+
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/thrift"
 
 	"github.com/m3db/m3/src/cluster/shard"
 	"github.com/m3db/m3/src/dbnode/encoding"
@@ -44,8 +46,6 @@ import (
 	"github.com/m3db/m3/src/x/serialize"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
-
-	"github.com/uber/tchannel-go"
 )
 
 // Client can create sessions to write and read to a cluster.

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -22,6 +22,7 @@ package client
 
 import (
 	gocontext "context"
+	"github.com/uber/tchannel-go/thrift"
 	"time"
 
 	"github.com/m3db/m3/src/cluster/shard"
@@ -704,7 +705,16 @@ type Options interface {
 
 	// NamespaceInitializer returns the NamespaceInitializer.
 	NamespaceInitializer() namespace.Initializer
+
+	// SetThriftContextFn sets the retrier for streaming blocks.
+	SetThriftContextFn(value ThriftContextFn) Options
+
+	// ThriftContextFn returns the retrier for streaming blocks.
+	ThriftContextFn() ThriftContextFn
 }
+
+// ThriftContextFn turns a context into a thrift context for a thrift call.
+type ThriftContextFn func(gocontext.Context) thrift.Context
 
 // AdminOptions is a set of administration client options.
 type AdminOptions interface {

--- a/src/dbnode/integration/query_cancellation_client_test.go
+++ b/src/dbnode/integration/query_cancellation_client_test.go
@@ -30,18 +30,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/thrift"
+	"go.uber.org/zap"
+
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/retention"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/m3ninx/idx"
 	"github.com/m3db/m3/src/x/ident"
-	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestQueryCancellationAndDeadlinesClient(t *testing.T) {
@@ -73,8 +72,16 @@ func TestQueryCancellationAndDeadlinesClient(t *testing.T) {
 	require.NoError(t, err)
 
 	var (
-		hostQueueWorkerPools     []*mockWorkerPool
-		hostQueueWorkerPoolsLock sync.Mutex
+		intercept       func()
+		interceptLock   sync.Mutex
+		thriftContextFn = client.ThriftContextFn(func(ctx context.Context) thrift.Context {
+			interceptLock.Lock()
+			if intercept != nil {
+				intercept()
+			}
+			interceptLock.Unlock()
+			return thrift.Wrap(ctx)
+		})
 	)
 
 	testOpts := NewTestOptions(t).
@@ -82,16 +89,7 @@ func TestQueryCancellationAndDeadlinesClient(t *testing.T) {
 		SetWriteNewSeriesAsync(true).
 		SetCustomClientAdminOptions([]client.CustomAdminOption{
 			client.CustomAdminOption(func(opts client.AdminOptions) client.AdminOptions {
-				return opts.SetHostQueueNewPooledWorkerFn(func(
-					opts xsync.NewPooledWorkerOptions,
-				) (xsync.PooledWorkerPool, error) {
-					mocked := newMockWorkerPool()
-					hostQueueWorkerPoolsLock.Lock()
-					hostQueueWorkerPools = append(hostQueueWorkerPools, mocked)
-					hostQueueWorkerPoolsLock.Unlock()
-
-					return mocked, nil
-				}).(client.AdminOptions)
+				return opts.SetThriftContextFn(thriftContextFn).(client.AdminOptions)
 			}),
 		})
 
@@ -147,21 +145,18 @@ func TestQueryCancellationAndDeadlinesClient(t *testing.T) {
 	ctx, cancel := context.WithCancel(ContextWithDefaultTimeout())
 
 	var (
-		once      sync.Once
-		intercept = func() {
+		once          sync.Once
+		interceptExec = func() {
 			defer wg.Done()
 			log.Info("host queue worker enqueued, cancelling context")
 			cancel()
 		}
 	)
-	hostQueueWorkerPoolsLock.Lock()
-	for _, workers := range hostQueueWorkerPools {
-		workers.hookSet(func(ctx context.Context) {
-			assert.NotNil(t, ctx, "host queue worker pool context not set")
-			once.Do(intercept)
-		})
+	interceptLock.Lock()
+	intercept = func() {
+		once.Do(interceptExec)
 	}
-	hostQueueWorkerPoolsLock.Unlock()
+	interceptLock.Unlock()
 
 	_, _, err = session.FetchTagged(ctx, md.ID(), query, queryOpts)
 	// Expect error since we cancelled the context.
@@ -170,54 +165,4 @@ func TestQueryCancellationAndDeadlinesClient(t *testing.T) {
 
 	require.True(t, strings.Contains(err.Error(), "ErrCodeCancelled"),
 		fmt.Sprintf("actual error: %s\n", err.Error()))
-}
-
-var _ xsync.PooledWorkerPool = (*mockWorkerPool)(nil)
-
-type mockWorkerPool struct {
-	sync.RWMutex
-	hook func(ctx context.Context)
-}
-
-
-func newMockWorkerPool() *mockWorkerPool {
-	return &mockWorkerPool{}
-}
-
-func (p *mockWorkerPool) Init() {}
-
-func (p *mockWorkerPool) hookSet(hook func(ctx context.Context)) {
-	p.Lock()
-	defer p.Unlock()
-	p.hook = hook
-}
-
-func (p *mockWorkerPool) hookRun(ctx context.Context) {
-	p.RLock()
-	defer p.RUnlock()
-	if p.hook == nil {
-		return
-	}
-	p.hook(ctx)
-}
-
-func (p *mockWorkerPool) Go(work xsync.Work) {
-	p.hookRun(nil)
-	go func() { work() }()
-}
-
-func (p *mockWorkerPool) GoWithTimeout(work xsync.Work, timeout time.Duration) bool {
-	p.hookRun(nil)
-	go func() { work() }()
-	return true
-}
-
-func (p *mockWorkerPool) GoWithContext(ctx context.Context, work xsync.Work) bool {
-	p.hookRun(ctx)
-	go func() { work() }()
-	return true
-}
-
-func (p *mockWorkerPool) FastContextCheck(batchSize int) xsync.PooledWorkerPool {
-	return p
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The write code path frequently stack splits but the query path does not and ends up artificially delayed by the host queue flush interval. This removes using the worker pool and also avoids going through the host queue drain/rotate cycle which is delayed by the host queue flush interval.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
