### PR TITLE
[coordinator] support for augmenting prom quantiles

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1235,7 +1235,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesPromQuantileTag(t *tes
 						"agg":      ".p50",
 						"quantile": "0.5",
 					},
-					values: []expectedValue{{value: 30}},
+					values: []expectedValue{{value: 10}},
 					attributes: &storagemetadata.Attributes{
 						MetricsType: storagemetadata.AggregatedMetricsType,
 						Resolution:  1 * time.Second,

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1187,6 +1187,131 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesGraphitePrefixTag(t *t
 	testDownsamplerAggregation(t, testDownsampler)
 }
 
+func TestDownsamplerAggregationWithRulesConfigMappingRulesPromQuantileTag(t *testing.T) {
+	t.Parallel()
+
+	timerMetric := testTimerMetric{
+		tags: map[string]string{
+			nameTag:    "http_requests",
+			"app":      "nginx_edge",
+			"endpoint": "health",
+		},
+		timedSamples: []testTimerMetricTimedSample{
+			{value: 15}, {value: 10}, {value: 30}, {value: 5}, {value: 0},
+		},
+	}
+	tags := []Tag{
+		{Name: "__m3_prom_summary__"},
+	}
+	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
+		rulesConfig: &RulesConfiguration{
+			MappingRules: []MappingRuleConfiguration{
+				{
+					Filter:       "__m3_type__:timer",
+					Aggregations: []aggregation.Type{aggregation.P50},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: 1 * time.Second,
+							Retention:  30 * 24 * time.Hour,
+						},
+					},
+					Tags: tags,
+				},
+			},
+		},
+		sampleAppenderOpts: &SampleAppenderOptions{
+			SeriesAttributes: ts.SeriesAttributes{M3Type: ts.M3MetricTypeTimer},
+		},
+		ingest: &testDownsamplerOptionsIngest{
+			timerMetrics: []testTimerMetric{timerMetric},
+		},
+		expect: &testDownsamplerOptionsExpect{
+			writes: []testExpectedWrite{
+				{
+					tags: map[string]string{
+						nameTag:    "http_requests",
+						"app":      "nginx_edge",
+						"endpoint": "health",
+						"agg":      ".p50",
+						"quantile": "0.5",
+					},
+					values: []expectedValue{{value: 30}},
+					attributes: &storagemetadata.Attributes{
+						MetricsType: storagemetadata.AggregatedMetricsType,
+						Resolution:  1 * time.Second,
+						Retention:   30 * 24 * time.Hour,
+					},
+				},
+			},
+		},
+	})
+
+	// Test expected output
+	testDownsamplerAggregation(t, testDownsampler)
+}
+
+func TestDownsamplerAggregationWithRulesConfigMappingRulesPromQuantileTagIgnored(t *testing.T) {
+	t.Parallel()
+
+	timerMetric := testTimerMetric{
+		tags: map[string]string{
+			nameTag:    "http_requests",
+			"app":      "nginx_edge",
+			"endpoint": "health",
+		},
+		timedSamples: []testTimerMetricTimedSample{
+			{value: 15}, {value: 10}, {value: 30}, {value: 5}, {value: 0},
+		},
+	}
+	tags := []Tag{
+		{Name: "__m3_prom_summary__"},
+	}
+	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
+		rulesConfig: &RulesConfiguration{
+			MappingRules: []MappingRuleConfiguration{
+				{
+					Filter:       "__m3_type__:timer",
+					Aggregations: []aggregation.Type{aggregation.Max},
+					StoragePolicies: []StoragePolicyConfiguration{
+						{
+							Resolution: 1 * time.Second,
+							Retention:  30 * 24 * time.Hour,
+						},
+					},
+					Tags: tags,
+				},
+			},
+		},
+		sampleAppenderOpts: &SampleAppenderOptions{
+			SeriesAttributes: ts.SeriesAttributes{M3Type: ts.M3MetricTypeTimer},
+		},
+		ingest: &testDownsamplerOptionsIngest{
+			timerMetrics: []testTimerMetric{timerMetric},
+		},
+		expect: &testDownsamplerOptionsExpect{
+			writes: []testExpectedWrite{
+				{
+					tags: map[string]string{
+						nameTag:    "http_requests",
+						"app":      "nginx_edge",
+						"endpoint": "health",
+						"agg":      ".upper",
+					},
+					values: []expectedValue{{value: 30}},
+					attributes: &storagemetadata.Attributes{
+						MetricsType: storagemetadata.AggregatedMetricsType,
+						Resolution:  1 * time.Second,
+						Retention:   30 * 24 * time.Hour,
+					},
+				},
+			},
+		},
+	})
+
+	// Test expected output
+	testDownsamplerAggregation(t, testDownsampler)
+}
+
 func TestDownsamplerAggregationWithRulesConfigMappingRulesAugmentTag(t *testing.T) {
 	t.Parallel()
 
@@ -2603,6 +2728,20 @@ type testGaugeMetricTimedSample struct {
 	value  float64
 }
 
+type testTimerMetric struct {
+	tags                    map[string]string
+	samples                 []float64
+	timedSamples            []testTimerMetricTimedSample
+	expectDropPolicyApplied bool
+	expectDropTimestamp     bool
+}
+
+type testTimerMetricTimedSample struct {
+	time   time.Time
+	offset time.Duration
+	value  float64
+}
+
 type testCounterMetricsOptions struct {
 	timedSamples bool
 }
@@ -2666,10 +2805,14 @@ func testDownsamplerAggregation(
 	expectedWrites := append(counterMetricsExpect, gaugeMetricsExpect...)
 
 	// Allow overrides
-	var allowFilter *testDownsamplerOptionsExpectAllowFilter
+	var (
+		allowFilter  *testDownsamplerOptionsExpectAllowFilter
+		timerMetrics []testTimerMetric
+	)
 	if ingest := testOpts.ingest; ingest != nil {
 		counterMetrics = ingest.counterMetrics
 		gaugeMetrics = ingest.gaugeMetrics
+		timerMetrics = ingest.timerMetrics
 	}
 	if expect := testOpts.expect; expect != nil {
 		expectedWrites = expect.writes
@@ -2678,7 +2821,7 @@ func testDownsamplerAggregation(
 
 	// Ingest points
 	testDownsamplerAggregationIngest(t, testDownsampler,
-		counterMetrics, gaugeMetrics)
+		counterMetrics, gaugeMetrics, timerMetrics)
 
 	// Wait for writes
 	logger.Info("wait for test metrics to appear")
@@ -2893,7 +3036,7 @@ func testDownsamplerRemoteAggregation(
 
 	// Ingest points
 	testDownsamplerAggregationIngest(t, testDownsampler,
-		testCounterMetrics, testGaugeMetrics)
+		testCounterMetrics, testGaugeMetrics, []testTimerMetric{})
 
 	// Ensure we checked counters and gauges
 	samplesCounters := 0
@@ -2913,6 +3056,7 @@ func testDownsamplerAggregationIngest(
 	testDownsampler testDownsampler,
 	testCounterMetrics []testCounterMetric,
 	testGaugeMetrics []testGaugeMetric,
+	testTimerMetrics []testTimerMetric,
 ) {
 	downsampler := testDownsampler.downsampler
 
@@ -3006,6 +3150,44 @@ func testDownsamplerAggregationIngest(
 			require.NoError(t, err)
 		}
 	}
+
+	for _, metric := range testTimerMetrics {
+		appender.NextMetric()
+
+		for name, value := range metric.tags {
+			appender.AddTag([]byte(name), []byte(value))
+		}
+
+		samplesAppenderResult, err := appender.SamplesAppender(opts)
+		require.NoError(t, err)
+		require.Equal(t, metric.expectDropPolicyApplied,
+			samplesAppenderResult.IsDropPolicyApplied)
+		require.Equal(t, metric.expectDropTimestamp,
+			samplesAppenderResult.ShouldDropTimestamp)
+
+		samplesAppender := samplesAppenderResult.SamplesAppender
+		for _, sample := range metric.samples {
+			err = samplesAppender.AppendUntimedTimerSample(sample, nil)
+			require.NoError(t, err)
+		}
+		for _, sample := range metric.timedSamples {
+			if sample.time.IsZero() {
+				sample.time = now // Allow empty time to mean "now"
+			}
+			if sample.offset > 0 {
+				sample.time = sample.time.Add(sample.offset)
+			}
+			if testOpts.waitForOffset {
+				time.Sleep(sample.offset)
+			}
+			if samplesAppenderResult.ShouldDropTimestamp {
+				err = samplesAppender.AppendUntimedTimerSample(sample.value, nil)
+			} else {
+				err = samplesAppender.AppendTimerSample(sample.time, sample.value, nil)
+			}
+			require.NoError(t, err)
+		}
+	}
 }
 
 func setAggregatedNamespaces(
@@ -3064,6 +3246,7 @@ type testDownsamplerOptions struct {
 type testDownsamplerOptionsIngest struct {
 	counterMetrics []testCounterMetric
 	gaugeMetrics   []testGaugeMetric
+	timerMetrics   []testTimerMetric
 }
 
 type testDownsamplerOptionsExpect struct {

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -1327,6 +1327,7 @@ func TestDownsamplerAggregationWithRulesConfigMappingRulesAugmentTag(t *testing.
 	tags := []Tag{
 		{Name: "datacenter", Value: "abc"},
 	}
+	//nolint:dupl
 	testDownsampler := newTestDownsampler(t, testDownsamplerOptions{
 		identTag: "app",
 		rulesConfig: &RulesConfiguration{
@@ -3151,6 +3152,7 @@ func testDownsamplerAggregationIngest(
 		}
 	}
 
+	//nolint:dupl
 	for _, metric := range testTimerMetrics {
 		appender.NextMetric()
 

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender.go
@@ -639,6 +639,17 @@ func (a *metricsAppender) processTags(
 			)
 			tags.append(name, value)
 		}
+		if bytes.Equal(tag.Name, metric.M3MetricsPromSummary) {
+			types, err := id.Types()
+			if err != nil || len(types) == 0 {
+				continue
+			}
+			value, ok := types[0].QuantileBytes()
+			if !ok {
+				continue
+			}
+			tags.append(metric.PromQuantileName, value)
+		}
 	}
 	return tags
 }

--- a/src/metrics/aggregation/type.go
+++ b/src/metrics/aggregation/type.go
@@ -127,7 +127,7 @@ var (
 		P9999:  []byte("p9999"),
 	}
 
-	typeStringQuantiles = map[Type][]byte{
+	typeQuantileBytes = map[Type][]byte{
 		P10:   []byte("0.1"),
 		P20:   []byte("0.2"),
 		P30:   []byte("0.3"),
@@ -233,7 +233,7 @@ func (a Type) Quantile() (float64, bool) {
 
 // QuantileBytes returns the quantile bytes represented by the Type.
 func (a Type) QuantileBytes() ([]byte, bool) {
-	val, ok := typeStringQuantiles[a]
+	val, ok := typeQuantileBytes[a]
 	return val, ok
 }
 

--- a/src/metrics/aggregation/type.go
+++ b/src/metrics/aggregation/type.go
@@ -126,6 +126,22 @@ var (
 		P999:   []byte("p999"),
 		P9999:  []byte("p9999"),
 	}
+
+	typeStringQuantiles = map[Type][]byte{
+		P10:   []byte("0.1"),
+		P20:   []byte("0.2"),
+		P30:   []byte("0.3"),
+		P40:   []byte("0.4"),
+		P50:   []byte("0.5"),
+		P60:   []byte("0.6"),
+		P70:   []byte("0.7"),
+		P80:   []byte("0.8"),
+		P90:   []byte("0.9"),
+		P95:   []byte("0.95"),
+		P99:   []byte("0.99"),
+		P999:  []byte("0.999"),
+		P9999: []byte("0.9999"),
+	}
 )
 
 // Type defines an aggregation function.
@@ -213,6 +229,12 @@ func (a Type) Quantile() (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+// QuantileBytes returns the quantile bytes represented by the Type.
+func (a Type) QuantileBytes() ([]byte, bool) {
+	val, ok := typeStringQuantiles[a]
+	return val, ok
 }
 
 // Proto returns the proto of the aggregation type.

--- a/src/metrics/metric/types.go
+++ b/src/metrics/metric/types.go
@@ -58,6 +58,7 @@ var (
 	PromSummaryValue        = []byte("summary")
 	PromInfoValue           = []byte("info")
 	PromStateSetValue       = []byte("state_set")
+	PromQuantileName        = []byte("quantile")
 
 	M3MetricsPrefix       = []byte("__m3")
 	M3MetricsPrefixString = string(M3MetricsPrefix)
@@ -67,6 +68,7 @@ var (
 	M3MetricsGraphitePrefix      = []byte(M3MetricsPrefixString + "_graphite_prefix__")
 	M3MetricsDropTimestamp       = []byte(M3MetricsPrefixString + "_drop_timestamp__")
 	M3PromTypeTag                = []byte(M3MetricsPrefixString + "_prom_type__")
+	M3MetricsPromSummary         = []byte(M3MetricsPrefixString + "_prom_summary__")
 )
 
 func (t Type) String() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds a new custom tag in the coordinator that will augment the prometheus quantile tag on metrics.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
