### PR TITLE
[dbnode] Adaptive WriteBatch allocations

### DIFF
--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -2546,7 +2546,7 @@ func TestServiceWriteBatchRaw(t *testing.T) {
 		{"bar", time.Now().Truncate(time.Second), 42.42},
 	}
 
-	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(0, ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Return(writeBatch, nil)
@@ -2600,7 +2600,7 @@ func TestServiceWriteBatchRawV2SingleNS(t *testing.T) {
 		{"bar", time.Now().Truncate(time.Second), 42.42},
 	}
 
-	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(0, ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Return(writeBatch, nil)
@@ -2657,8 +2657,8 @@ func TestServiceWriteBatchRawV2MultiNS(t *testing.T) {
 			{"bar", time.Now().Truncate(time.Second), 42.42},
 		}
 
-		writeBatch1 = writes.NewWriteBatch(ident.StringID(nsID1), nil)
-		writeBatch2 = writes.NewWriteBatch(ident.StringID(nsID2), nil)
+		writeBatch1 = writes.NewWriteBatch(0, ident.StringID(nsID1), nil)
+		writeBatch2 = writes.NewWriteBatch(0, ident.StringID(nsID2), nil)
 	)
 
 	mockDB.EXPECT().
@@ -2751,7 +2751,7 @@ func TestServiceWriteBatchRawOverMaxOutstandingRequests(t *testing.T) {
 		testIsComplete       = make(chan struct{}, 0)
 		requestIsOutstanding = make(chan struct{}, 0)
 	)
-	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(0, ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Do(func(nsID ident.ID, numValues int) {
@@ -2859,7 +2859,7 @@ func TestServiceWriteTaggedBatchRaw(t *testing.T) {
 		{"bar", "c|dd", time.Now().Truncate(time.Second), 42.42},
 	}
 
-	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(len(values), ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Return(writeBatch, nil)
@@ -2925,7 +2925,7 @@ func TestServiceWriteTaggedBatchRawV2(t *testing.T) {
 		{"bar", "c|dd", time.Now().Truncate(time.Second), 42.42},
 	}
 
-	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(len(values), ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Return(writeBatch, nil)
@@ -2992,8 +2992,8 @@ func TestServiceWriteTaggedBatchRawV2MultiNS(t *testing.T) {
 			{"foo", "a|b", time.Now().Truncate(time.Second), 12.34},
 			{"bar", "c|dd", time.Now().Truncate(time.Second), 42.42},
 		}
-		writeBatch1 = writes.NewWriteBatch(ident.StringID(nsID1), nil)
-		writeBatch2 = writes.NewWriteBatch(ident.StringID(nsID2), nil)
+		writeBatch1 = writes.NewWriteBatch(len(values), ident.StringID(nsID1), nil)
+		writeBatch2 = writes.NewWriteBatch(len(values), ident.StringID(nsID2), nil)
 	)
 
 	mockDB.EXPECT().

--- a/src/dbnode/network/server/tchannelthrift/node/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/node/service_test.go
@@ -2546,7 +2546,7 @@ func TestServiceWriteBatchRaw(t *testing.T) {
 		{"bar", time.Now().Truncate(time.Second), 42.42},
 	}
 
-	writeBatch := writes.NewWriteBatch(len(values), ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Return(writeBatch, nil)
@@ -2600,7 +2600,7 @@ func TestServiceWriteBatchRawV2SingleNS(t *testing.T) {
 		{"bar", time.Now().Truncate(time.Second), 42.42},
 	}
 
-	writeBatch := writes.NewWriteBatch(len(values), ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Return(writeBatch, nil)
@@ -2657,8 +2657,8 @@ func TestServiceWriteBatchRawV2MultiNS(t *testing.T) {
 			{"bar", time.Now().Truncate(time.Second), 42.42},
 		}
 
-		writeBatch1 = writes.NewWriteBatch(len(values), ident.StringID(nsID1), nil)
-		writeBatch2 = writes.NewWriteBatch(len(values), ident.StringID(nsID2), nil)
+		writeBatch1 = writes.NewWriteBatch(ident.StringID(nsID1), nil)
+		writeBatch2 = writes.NewWriteBatch(ident.StringID(nsID2), nil)
 	)
 
 	mockDB.EXPECT().
@@ -2751,7 +2751,7 @@ func TestServiceWriteBatchRawOverMaxOutstandingRequests(t *testing.T) {
 		testIsComplete       = make(chan struct{}, 0)
 		requestIsOutstanding = make(chan struct{}, 0)
 	)
-	writeBatch := writes.NewWriteBatch(len(values), ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Do(func(nsID ident.ID, numValues int) {
@@ -2859,7 +2859,7 @@ func TestServiceWriteTaggedBatchRaw(t *testing.T) {
 		{"bar", "c|dd", time.Now().Truncate(time.Second), 42.42},
 	}
 
-	writeBatch := writes.NewWriteBatch(len(values), ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Return(writeBatch, nil)
@@ -2925,7 +2925,7 @@ func TestServiceWriteTaggedBatchRawV2(t *testing.T) {
 		{"bar", "c|dd", time.Now().Truncate(time.Second), 42.42},
 	}
 
-	writeBatch := writes.NewWriteBatch(len(values), ident.StringID(nsID), nil)
+	writeBatch := writes.NewWriteBatch(ident.StringID(nsID), nil)
 	mockDB.EXPECT().
 		BatchWriter(ident.NewIDMatcher(nsID), len(values)).
 		Return(writeBatch, nil)
@@ -2992,8 +2992,8 @@ func TestServiceWriteTaggedBatchRawV2MultiNS(t *testing.T) {
 			{"foo", "a|b", time.Now().Truncate(time.Second), 12.34},
 			{"bar", "c|dd", time.Now().Truncate(time.Second), 42.42},
 		}
-		writeBatch1 = writes.NewWriteBatch(len(values), ident.StringID(nsID1), nil)
-		writeBatch2 = writes.NewWriteBatch(len(values), ident.StringID(nsID2), nil)
+		writeBatch1 = writes.NewWriteBatch(ident.StringID(nsID1), nil)
+		writeBatch2 = writes.NewWriteBatch(ident.StringID(nsID2), nil)
 	)
 
 	mockDB.EXPECT().

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -1064,7 +1064,7 @@ func TestCommitLogBatchWriteDoesNotAddErroredOrSkippedSeries(t *testing.T) {
 		finalized++
 	}
 
-	writes := writes.NewWriteBatch(ident.StringID("ns"), finalizeFn)
+	writes := writes.NewWriteBatch(0, ident.StringID("ns"), finalizeFn)
 
 	testSeriesWrites := []ts.Series{
 		testSeries(t, opts, 0, "foo.bar", testTags0, 42),

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -161,7 +161,7 @@ func testSeries(
 		UniqueIndex: uniqueIndex,
 		Namespace:   ident.StringID("testNS"),
 		ID:          ident.StringID(id),
-		EncodedTags: ts.EncodedTags(encodedTagsChecked.Bytes()),
+		EncodedTags: encodedTagsChecked.Bytes(),
 		Shard:       shard,
 	}
 }
@@ -1064,7 +1064,7 @@ func TestCommitLogBatchWriteDoesNotAddErroredOrSkippedSeries(t *testing.T) {
 		finalized++
 	}
 
-	writes := writes.NewWriteBatch(4, ident.StringID("ns"), finalizeFn)
+	writes := writes.NewWriteBatch(ident.StringID("ns"), finalizeFn)
 
 	testSeriesWrites := []ts.Series{
 		testSeries(t, opts, 0, "foo.bar", testTags0, 42),

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -193,7 +193,7 @@ func newOptions(poolOpts pool.ObjectPoolOptions) Options {
 	bytesPool.Init()
 	seriesOpts := series.NewOptions()
 
-	writeBatchPool := writes.NewWriteBatchPool(poolOpts, nil, nil)
+	writeBatchPool := writes.NewWriteBatchPool(poolOpts, nil)
 	writeBatchPool.Init()
 
 	segmentReaderPool := xio.NewSegmentReaderPool(poolOpts)

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -193,7 +193,7 @@ func newOptions(poolOpts pool.ObjectPoolOptions) Options {
 	bytesPool.Init()
 	seriesOpts := series.NewOptions()
 
-	writeBatchPool := writes.NewWriteBatchPool(poolOpts, nil)
+	writeBatchPool := writes.NewWriteBatchPool(poolOpts, 0, nil)
 	writeBatchPool.Init()
 
 	segmentReaderPool := xio.NewSegmentReaderPool(poolOpts)

--- a/src/dbnode/ts/writes/write_batch_pool.go
+++ b/src/dbnode/ts/writes/write_batch_pool.go
@@ -25,46 +25,36 @@ import (
 )
 
 const (
-	// defaultInitialiBatchSize determines the initial batch size that will be used when filling up the
-	// pool.
-	defaultInitialBatchSize = 1024
-	// defaultWritePoolMaxBatchSize is the default maximum size for a writeBatch that the pool
+	// defaultMaxBatchSize is the default maximum size for a writeBatch that the pool
 	// will allow to remain in the pool. Any batches larger than that will be discarded to prevent
 	// excessive memory use forever in the case of an exceptionally large batch write.
-	defaultMaxBatchSize = 100000
+	defaultMaxBatchSize = 10000
 )
 
 // WriteBatchPool is a pool of WriteBatch.
 type WriteBatchPool struct {
 	pool             pool.ObjectPool
-	initialBatchSize int
 	maxBatchSize     int
 }
 
 // NewWriteBatchPool constructs a new WriteBatchPool.
 func NewWriteBatchPool(
 	opts pool.ObjectPoolOptions,
-	initialBatchSizeOverride,
 	maxBatchSizeOverride *int,
 ) *WriteBatchPool {
-	initialBatchSize := defaultInitialBatchSize
-	if initialBatchSizeOverride != nil {
-		initialBatchSize = *initialBatchSizeOverride
-	}
-
 	maxBatchSize := defaultMaxBatchSize
 	if maxBatchSizeOverride != nil {
 		maxBatchSize = *maxBatchSizeOverride
 	}
 
 	p := pool.NewObjectPool(opts)
-	return &WriteBatchPool{pool: p, initialBatchSize: initialBatchSize, maxBatchSize: maxBatchSize}
+	return &WriteBatchPool{pool: p, maxBatchSize: maxBatchSize}
 }
 
 // Init initializes a WriteBatchPool.
 func (p *WriteBatchPool) Init() {
 	p.pool.Init(func() interface{} {
-		return NewWriteBatch(p.initialBatchSize, nil, p.Put)
+		return NewWriteBatch(nil, p.Put)
 	})
 }
 

--- a/src/dbnode/ts/writes/write_batch_test.go
+++ b/src/dbnode/ts/writes/write_batch_test.go
@@ -118,7 +118,7 @@ func (w testWrite) encodedTags(t *testing.T) checked.Bytes {
 }
 
 func TestBatchWriterAddAndIter(t *testing.T) {
-	writeBatch := NewWriteBatch(namespace, nil)
+	writeBatch := NewWriteBatch(batchSize, namespace, nil)
 
 	for i, write := range writes {
 		writeBatch.Add(
@@ -135,7 +135,7 @@ func TestBatchWriterAddAndIter(t *testing.T) {
 }
 
 func TestBatchWriterAddTaggedAndIter(t *testing.T) {
-	writeBatch := NewWriteBatch(namespace, nil)
+	writeBatch := NewWriteBatch(batchSize, namespace, nil)
 
 	for i, write := range writes {
 		writeBatch.AddTagged(
@@ -154,7 +154,7 @@ func TestBatchWriterAddTaggedAndIter(t *testing.T) {
 }
 
 func TestBatchWriterSetSeries(t *testing.T) {
-	writeBatch := NewWriteBatch(namespace, nil)
+	writeBatch := NewWriteBatch(batchSize, namespace, nil)
 
 	for i, write := range writes {
 		writeBatch.AddTagged(
@@ -221,7 +221,7 @@ func TestBatchWriterSetSeries(t *testing.T) {
 func TestWriteBatchReset(t *testing.T) {
 	var (
 		numResets  = 10
-		writeBatch = NewWriteBatch(namespace, nil)
+		writeBatch = NewWriteBatch(batchSize, namespace, nil)
 	)
 
 	for i := 0; i < numResets; i++ {
@@ -286,7 +286,7 @@ func TestBatchWriterFinalizer(t *testing.T) {
 		}
 	)
 
-	writeBatch := NewWriteBatch(namespace, finalizeFn)
+	writeBatch := NewWriteBatch(batchSize, namespace, finalizeFn)
 	writeBatch.SetFinalizeEncodedTagsFn(finalizeEncodedTagsFn)
 	writeBatch.SetFinalizeAnnotationFn(finalizeAnnotationFn)
 

--- a/src/dbnode/ts/writes/write_batch_test.go
+++ b/src/dbnode/ts/writes/write_batch_test.go
@@ -118,7 +118,7 @@ func (w testWrite) encodedTags(t *testing.T) checked.Bytes {
 }
 
 func TestBatchWriterAddAndIter(t *testing.T) {
-	writeBatch := NewWriteBatch(batchSize, namespace, nil)
+	writeBatch := NewWriteBatch(namespace, nil)
 
 	for i, write := range writes {
 		writeBatch.Add(
@@ -135,7 +135,7 @@ func TestBatchWriterAddAndIter(t *testing.T) {
 }
 
 func TestBatchWriterAddTaggedAndIter(t *testing.T) {
-	writeBatch := NewWriteBatch(batchSize, namespace, nil)
+	writeBatch := NewWriteBatch(namespace, nil)
 
 	for i, write := range writes {
 		writeBatch.AddTagged(
@@ -154,7 +154,7 @@ func TestBatchWriterAddTaggedAndIter(t *testing.T) {
 }
 
 func TestBatchWriterSetSeries(t *testing.T) {
-	writeBatch := NewWriteBatch(batchSize, namespace, nil)
+	writeBatch := NewWriteBatch(namespace, nil)
 
 	for i, write := range writes {
 		writeBatch.AddTagged(
@@ -221,7 +221,7 @@ func TestBatchWriterSetSeries(t *testing.T) {
 func TestWriteBatchReset(t *testing.T) {
 	var (
 		numResets  = 10
-		writeBatch = NewWriteBatch(batchSize, namespace, nil)
+		writeBatch = NewWriteBatch(namespace, nil)
 	)
 
 	for i := 0; i < numResets; i++ {
@@ -286,7 +286,7 @@ func TestBatchWriterFinalizer(t *testing.T) {
 		}
 	)
 
-	writeBatch := NewWriteBatch(batchSize, namespace, finalizeFn)
+	writeBatch := NewWriteBatch(namespace, finalizeFn)
 	writeBatch.SetFinalizeEncodedTagsFn(finalizeEncodedTagsFn)
 	writeBatch.SetFinalizeAnnotationFn(finalizeAnnotationFn)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases we have to handle write batches that are an order of magnitude smaller than the default expected size (128).
Thus, always preallocating the default size (which results in 49152 bytes allocated) is really wasteful.
This PR attempts to avoid preallocating write batches of the given size, and instead defers allocation to a later time, when the actual batch size is known. Then slices of the needed capacity (plus 20% more) are allocated. Allocating 20% more than needed for the current write batch should help avoid subsequent allocations when the same write batch is taken from the pool and is used for another write batch of slightly bigger size.

**Special notes for your reviewer**:
The original behaviour is preserved in case `InitialBatchSize` is defined in the config.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
