### PR TITLE
feat: add integration to test tag based deduplication in m3query

### DIFF
--- a/scripts/docker-integration-tests/query_fanout_tag_dedup/docker-compose.yml
+++ b/scripts/docker-integration-tests/query_fanout_tag_dedup/docker-compose.yml
@@ -1,0 +1,76 @@
+version: "3.5"
+services:
+  dbnode-cluster-a:
+    expose:
+      - "9000-9004"
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:9000-9004:9000-9004"
+      - "0.0.0.0:2379-2380:2379-2380"
+    networks:
+      - backend
+    image: "m3dbnode_integration:${REVISION}"
+  coordinator-cluster-a:
+    expose:
+      - "7201"
+      - "7203"
+      - "7204"
+    ports:
+      - "0.0.0.0:7201:7201"
+      - "0.0.0.0:7203:7203"
+      - "0.0.0.0:7204:7204"
+    networks:
+      - backend
+    image: "m3coordinator_integration:${REVISION}"
+    volumes:
+      - "./m3coordinator-cluster-a.yml:/etc/m3coordinator/m3coordinator.yml"
+  dbnode-cluster-b:
+    expose:
+      - "9000-9004"
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:19000-19004:9000-9004"
+      - "0.0.0.0:12379-12380:2379-2380"
+    networks:
+      - backend
+    image: "m3dbnode_integration:${REVISION}"
+  coordinator-cluster-b:
+    expose:
+      - "7201"
+      - "7203"
+      - "7204"
+    ports:
+      - "0.0.0.0:17201:7201"
+      - "0.0.0.0:17203:7203"
+      - "0.0.0.0:17204:7204"
+    networks:
+      - backend
+    image: "m3coordinator_integration:${REVISION}"
+    volumes:
+      - "./m3coordinator-cluster-b.yml:/etc/m3coordinator/m3coordinator.yml"
+  dbnode-cluster-c:
+    expose:
+      - "9000-9004"
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:29000-29004:9000-9004"
+      - "0.0.0.0:22379-22380:2379-2380"
+    networks:
+      - backend
+    image: "m3dbnode_integration:${REVISION}"
+  coordinator-cluster-c:
+    expose:
+      - "7201"
+      - "7203"
+      - "7204"
+    ports:
+      - "0.0.0.0:27201:7201"
+      - "0.0.0.0:27203:7203"
+      - "0.0.0.0:27204:7204"
+    networks:
+      - backend
+    image: "m3coordinator_integration:${REVISION}"
+    volumes:
+      - "./m3coordinator-cluster-c.yml:/etc/m3coordinator/m3coordinator.yml"
+networks:
+  backend:

--- a/scripts/docker-integration-tests/query_fanout_tag_dedup/m3coordinator-cluster-a.yml
+++ b/scripts/docker-integration-tests/query_fanout_tag_dedup/m3coordinator-cluster-a.yml
@@ -1,0 +1,36 @@
+# Fanout queries to remote clusters
+rpc:
+  enabled: true
+  listenAddress: "0.0.0.0:7202"
+  remotes:
+    - name: "cluster-b"
+      remoteListenAddresses: ["coordinator-cluster-b:7202"]
+    - name: "cluster-c"
+      remoteListenAddresses: ["coordinator-cluster-c:7202"]
+
+clusters:
+  - client:
+      config:
+        service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+            - zone: embedded
+              endpoints:
+                - dbnode-cluster-a:2379
+
+carbon:
+  ingester:
+    listenAddress: "0.0.0.0:7204"
+    rules:
+      - pattern: .*
+        policies:
+          - resolution: 5s
+            retention: 10h
+
+# Use tag consolidation here; other integration tests handle id consolidations.
+query:
+  consolidation:
+    matchType: tags

--- a/scripts/docker-integration-tests/query_fanout_tag_dedup/m3coordinator-cluster-b.yml
+++ b/scripts/docker-integration-tests/query_fanout_tag_dedup/m3coordinator-cluster-b.yml
@@ -1,0 +1,34 @@
+# Fanout queries to remote clusters
+rpc:
+  enabled: true
+  listenAddress: "0.0.0.0:7202"
+  remotes:
+    - name: "cluster-a"
+      remoteListenAddresses: ["coordinator-cluster-a:7202"]
+    - name: "cluster-c"
+      remoteListenAddresses: ["coordinator-cluster-c:7202"]
+
+clusters:
+  - client:
+      config:
+        service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+            - zone: embedded
+              endpoints:
+                - dbnode-cluster-b:2379
+
+carbon:
+  ingester:
+    listenAddress: "0.0.0.0:7204"
+    rules:
+      - pattern: .*
+        policies:
+          - resolution: 5s
+            retention: 10h
+query:
+  consolidation:
+    matchType: tags

--- a/scripts/docker-integration-tests/query_fanout_tag_dedup/m3coordinator-cluster-c.yml
+++ b/scripts/docker-integration-tests/query_fanout_tag_dedup/m3coordinator-cluster-c.yml
@@ -1,0 +1,35 @@
+# Fanout queries to remote clusters
+rpc:
+  enabled: true
+  listenAddress: "0.0.0.0:7202"
+  remotes:
+    - name: "cluster-a"
+      remoteListenAddresses: ["coordinator-cluster-a:7202"]
+    - name: "cluster-b"
+      remoteListenAddresses: ["coordinator-cluster-b:7202"]
+
+clusters:
+  - client:
+      config:
+        service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: /var/lib/m3kv
+          etcdClusters:
+            - zone: embedded
+              endpoints:
+                - dbnode-cluster-c:2379
+
+carbon:
+  ingester:
+    listenAddress: "0.0.0.0:7204"
+    rules:
+      - pattern: .*
+        policies:
+          - resolution: 5s
+            retention: 10h
+
+query:
+  consolidation:
+    matchType: tags

--- a/scripts/docker-integration-tests/query_fanout_tag_dedup/test.sh
+++ b/scripts/docker-integration-tests/query_fanout_tag_dedup/test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -xe
+
+TEST_PATH="$M3_PATH"/scripts/docker-integration-tests
+FANOUT_PATH=$TEST_PATH/query_fanout
+source $TEST_PATH/common.sh
+source $FANOUT_PATH/warning.sh
+source $FANOUT_PATH/restrict.sh
+
+REVISION=$(git rev-parse HEAD)
+COMPOSE_FILE="$M3_PATH"/scripts/docker-integration-tests/query_fanout/docker-compose.yml
+export REVISION
+
+echo "Run m3dbnode and m3coordinator containers"
+docker-compose -f ${COMPOSE_FILE} up -d dbnode-cluster-a
+docker-compose -f ${COMPOSE_FILE} up -d coordinator-cluster-a
+
+docker-compose -f ${COMPOSE_FILE} up -d dbnode-cluster-b
+docker-compose -f ${COMPOSE_FILE} up -d coordinator-cluster-b
+
+docker-compose -f ${COMPOSE_FILE} up -d dbnode-cluster-c
+docker-compose -f ${COMPOSE_FILE} up -d coordinator-cluster-c
+
+# think of this as a defer func() in golang
+function defer {
+  docker-compose -f ${COMPOSE_FILE} down || echo "unable to shutdown containers" # CI fails to stop all containers sometimes
+}
+trap defer EXIT
+
+AGG_RESOLUTION=5s DBNODE_HOST=dbnode-cluster-a DBDNODE_PORT=9000 DBNODE_HEALTH_PORT=9002 COORDINATOR_PORT=7201 \
+ setup_single_m3db_node
+
+AGG_RESOLUTION=5s DBNODE_HOST=dbnode-cluster-b DBDNODE_PORT=19000 DBNODE_HEALTH_PORT=19002 COORDINATOR_PORT=17201 \
+ setup_single_m3db_node
+
+AGG_RESOLUTION=5s DBNODE_HOST=dbnode-cluster-c DBDNODE_PORT=29000 DBNODE_HEALTH_PORT=29002 COORDINATOR_PORT=27201 \
+ setup_single_m3db_node
+
+echo "Write data to cluster a"
+curl -vvvsS -X POST 0.0.0.0:9003/writetagged -d '{
+  "namespace": "unagg",
+  "id": "{__name__=\"test_metric\",cluster=\"cluster-a\",endpoint=\"/request\"}",
+  "tags": [
+    {
+      "name": "__name__",
+      "value": "test_metric"
+    },
+    {
+      "name": "cluster",
+      "value": "cluster-a"
+    },
+    {
+      "name": "endpoint",
+      "value": "/request"
+    }
+  ],
+  "datapoint": {
+    "timestamp":'"$(date +"%s")"',
+    "value": 42.123456789
+  }
+}'
+
+echo "Write data to cluster b"
+curl -vvvsS -X POST 0.0.0.0:19003/writetagged -d '{
+  "namespace": "unagg",
+  "id": "{__name__=\"test_metric\",cluster=\"cluster-b\",endpoint=\"/request\"}",
+  "tags": [
+    {
+      "name": "__name__",
+      "value": "test_metric"
+    },
+    {
+      "name": "cluster",
+      "value": "cluster-a"
+    },
+    {
+      "name": "endpoint",
+      "value": "/request"
+    }
+  ],
+  "datapoint": {
+    "timestamp":'"$(date +"%s")"',
+    "value": 42.123456789
+  }
+}'
+
+echo "Write data to cluster c"
+curl -vvvsS -X POST 0.0.0.0:29003/writetagged -d '{
+  "namespace": "unagg",
+  "id": "{__name__=\"test_metric\",cluster=\"cluster-c\",endpoint=\"/request\"}",
+  "tags": [
+    {
+      "name": "__name__",
+      "value": "test_metric"
+    },
+    {
+      "name": "cluster",
+      "value": "cluster-a"
+    },
+    {
+      "name": "endpoint",
+      "value": "/request"
+    }
+  ],
+  "datapoint": {
+    "timestamp":'"$(date +"%s")"',
+    "value": 42.123456789
+  }
+}'
+
+# Because we have time series with same tags sent into database. We expected to see those time series will be deduplicated.
+
+function read {
+  RESPONSE=$(curl "http://0.0.0.0:7201/api/v1/query?query=test_metric")
+  ACTUAL=$(echo $RESPONSE | jq .data.result | jq length)
+#  test "$(echo $ACTUAL)" = '"cluster-a" "cluster-b" "cluster-c"'
+  test $ACTUAL = '"1"'
+}
+
+ATTEMPTS=5 TIMEOUT=1 retry_with_backoff read
+
+function read_count {
+  RESPONSE=$(curl "http://0.0.0.0:7201/api/v1/query?query=count(test_metric)")
+  ACTUAL=$(echo $RESPONSE | jq .data.result[].value[1])
+  test $ACTUAL = '"1"'
+}
+
+ATTEMPTS=5 TIMEOUT=1 retry_with_backoff read_count


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR provides an integration test to reproduce the bug mentioned in https://github.com/m3db/m3/issues/3034. Most of the test was adopted from `query_fanout` integration test. 

In the test, we ingest three time series with the same tags but different ids. We enabled tag-based consolidation in coord. We expect to see only one time series when query by the metric's name.

It may be best to merge it with `query_fanout` integration test before the merge. But to exclude other tests not related to the bug I create a new integration test here.

In this test, we ingest three data point with identical tags to each dbnode respectively. Then run query `test_metric` to retrieve them. Since they have the same tags. We expected to see them shows as one time series. But the result shows three different time series.

```json
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "test_metric",
          "cluster": "cluster-a",
          "endpoint": "/request"
        },
        "value": [
          1619479908.66,
          "42.123456789"
        ]
      },
      {
        "metric": {
          "__name__": "test_metric",
          "cluster": "cluster-a",
          "endpoint": "/request"
        },
        "value": [
          1619479908.66,
          "42.123456789"
        ]
      },
      {
        "metric": {
          "__name__": "test_metric",
          "cluster": "cluster-a",
          "endpoint": "/request"
        },
        "value": [
          1619479908.66,
          "42.123456789"
        ]
      }
    ]
  }
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
No
