### PR TITLE
Add missing RUnlock's to m3aggregator locking code

### DIFF
--- a/src/aggregator/aggregator/aggregator.go
+++ b/src/aggregator/aggregator/aggregator.go
@@ -201,6 +201,7 @@ func (agg *aggregator) placementTick() {
 		agg.RLock()
 		placement, err := agg.placementManager.Placement()
 		if err != nil {
+			agg.RUnlock()
 			m.updateFailures.Inc(1)
 			continue
 		}
@@ -396,6 +397,7 @@ func (agg *aggregator) shardFor(id id.RawID) (*aggregatorShard, error) {
 
 	agg.RLock()
 	if int(shardID) >= len(agg.shards) {
+		agg.RUnlock()
 		return nil, errShardNotOwned
 	}
 	shard := agg.shards[shardID]


### PR DESCRIPTION
These were missed in https://github.com/m3db/m3/pull/3315/files -- we suspect they're causing occasional hangs for us in prod.

More details later; diff just for early review.