### PR TITLE
Fix LRU cache locking up

### DIFF
--- a/src/x/cache/lru_cache.go
+++ b/src/x/cache/lru_cache.go
@@ -408,10 +408,20 @@ func (c *LRU) updateCacheEntryWithLock(
 	if expiresAt.IsZero() {
 		expiresAt = c.now().Add(c.ttl)
 	}
-
 	entry.expiresAt = expiresAt
-	entry.loadTimeElt = c.byLoadTime.PushFront(entry)
-	entry.accessTimeElt = c.byAccessTime.PushFront(entry)
+
+	if entry.loadTimeElt == nil {
+		entry.loadTimeElt = c.byLoadTime.PushFront(entry)
+	} else {
+		c.byLoadTime.MoveToFront(entry.loadTimeElt)
+	}
+
+	if entry.accessTimeElt == nil {
+		entry.accessTimeElt = c.byAccessTime.PushFront(entry)
+	} else {
+		c.byAccessTime.MoveToFront(entry.accessTimeElt)
+	}
+
 	c.metrics.entries.Update(float64(len(c.entries)))
 
 	// Tell any other callers that we're done loading

--- a/src/x/cache/lru_cache_test.go
+++ b/src/x/cache/lru_cache_test.go
@@ -584,6 +584,21 @@ func TestLRU_PutWithTTL_NoExistingEntry(t *testing.T) {
 	assert.Equal(t, "bar", value.(string))
 }
 
+func TestLRU_GetNonExisting_FromFullCache_AfterDoublePut(t *testing.T) {
+	lru := NewLRU(&LRUOptions{MaxEntries: 2})
+
+	// insert same key twice:
+	lru.Put("foo", "1")
+	lru.Put("foo", "1")
+
+	// insert another key to make cache full:
+	lru.Put("bar", "2")
+
+	// try to get entry that does not exist:
+	_, err := lru.Get(context.Background(), "new", nil)
+	require.Error(t, err, ErrEntryNotFound.Error())
+}
+
 var defaultKeys = []string{
 	"key-0", "key-1", "key-2", "key-3", "key-4", "key-5", "key-6", "key-7", "key-8", "key-9", "key10",
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Under the following (rarely observed in practice) conditions, `LRU.reserveCapacity` would go into an infinite loop under a lock, perpetually blocking any further uses of LRU cache:
- the cache full to `maxEntries` or above
- there are duplicate elements in `byAccessTime`/ `byLoadTime` lists for the same entry (which would happen as a result of double `Put`)
- an attempt to `Get` a non-existing key is made

This PR:
1. Adds a unit test `TestLRU_GetNonExisting_FromFullCache_AfterDoublePut` that reproduces the situation described above.
2. Fixes the issue by preventing duplicate elements in `byAccessTime`/ `byLoadTime` lists (if an element is already in the list, it is now moved to front, instead of repeatingly inserting it to the front).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE