### PR TITLE
[dbnode] - Add filesystem available space reporting

### DIFF
--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -387,6 +387,12 @@ func Run(runOpts RunOptions) {
 	}
 	defer buildReporter.Stop()
 
+	fileSystemReporter := instrument.NewFileSystemReporter(iOpts, cfg.Filesystem.FilePathPrefixOrDefault())
+	if err := fileSystemReporter.Start(); err != nil {
+		logger.Fatal("unable to start filesystem reporter", zap.Error(err))
+	}
+	defer fileSystemReporter.Stop()
+
 	mmapCfg := cfg.Filesystem.MmapConfigurationOrDefault()
 	shouldUseHugeTLB := mmapCfg.HugeTLB.Enabled
 	if shouldUseHugeTLB {

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -391,7 +391,10 @@ func Run(runOpts RunOptions) {
 	if err := fileSystemReporter.Start(); err != nil {
 		logger.Fatal("unable to start filesystem reporter", zap.Error(err))
 	}
-	defer fileSystemReporter.Stop()
+	defer func() {
+		err := fileSystemReporter.Stop()
+		logger.Warn("unable to stop filesystem reporter", zap.Error(err))
+	}()
 
 	mmapCfg := cfg.Filesystem.MmapConfigurationOrDefault()
 	shouldUseHugeTLB := mmapCfg.HugeTLB.Enabled

--- a/src/x/instrument/filesystem.go
+++ b/src/x/instrument/filesystem.go
@@ -1,3 +1,4 @@
+// Package instrument - filesystem metrics
 package instrument
 
 import (
@@ -5,8 +6,9 @@ import (
 	"path/filepath"
 	"time"
 
-	xos "github.com/m3db/m3/src/x/os"
 	"github.com/uber-go/tally"
+
+	xos "github.com/m3db/m3/src/x/os"
 )
 
 const (
@@ -75,6 +77,7 @@ func (r *fileSystemMetrics) report() {
 	}
 }
 
+// NewFileSystemReporter creates a new filesystem reporter
 func NewFileSystemReporter(
 	opts Options,
 	rootDir string,

--- a/src/x/instrument/filesystem.go
+++ b/src/x/instrument/filesystem.go
@@ -1,0 +1,58 @@
+package instrument
+
+import (
+	"time"
+
+	xos "github.com/m3db/m3/src/x/os"
+	"github.com/uber-go/tally"
+)
+
+const (
+	// report interval (default 1s) is extended for this reporter
+	// to keep the reporting overhead low
+	fileSystemReportMultiplier = 30
+)
+
+type fileSystemReporter struct {
+	baseReporter
+
+	metrics fileSystemMetrics
+}
+
+type fileSystemMetrics struct {
+	Total  tally.Gauge // total space in the filesystem in bytes
+	Avail  tally.Gauge // available space in the filesystem in bytes
+	Errors tally.Counter
+
+	rootDir string
+	opts    Options
+}
+
+func (r *fileSystemMetrics) report() {
+	info, err := xos.GetFileSystemStats(r.rootDir)
+	if err != nil {
+		r.Errors.Inc(1)
+	}
+	r.Total.Update(float64(info.Total))
+	r.Avail.Update(float64(info.Avail))
+}
+
+func NewFileSystemReporter(
+	opts Options,
+	rootDir string,
+) Reporter {
+	fileSystemScope := opts.MetricsScope().SubScope("filesystem")
+
+	r := &fileSystemReporter{
+		metrics: fileSystemMetrics{
+			Total:   fileSystemScope.Gauge("total_bytes"),
+			Avail:   fileSystemScope.Gauge("avail_bytes"),
+			Errors:  fileSystemScope.Counter("num_api_errors"),
+			rootDir: rootDir,
+			opts:    opts,
+		},
+	}
+	reportInterval := time.Duration(opts.ReportInterval() * fileSystemReportMultiplier)
+	r.init(reportInterval, r.metrics.report)
+	return r
+}

--- a/src/x/instrument/filesystem.go
+++ b/src/x/instrument/filesystem.go
@@ -59,19 +59,19 @@ func (r *fileSystemMetrics) report() {
 	if err != nil {
 		r.dirErrors.Inc(1)
 	} else {
-		r.commitlogsSize.Update(float64(snapshotsStats.Size))
+		r.snapshotsSize.Update(float64(snapshotsStats.Size))
 	}
 	dataStats, err := xos.GetDirectoryStats(filepath.Join(r.rootDir, dataDir))
 	if err != nil {
 		r.dirErrors.Inc(1)
 	} else {
-		r.commitlogsSize.Update(float64(dataStats.Size))
+		r.dataSize.Update(float64(dataStats.Size))
 	}
 	indexStats, err := xos.GetDirectoryStats(filepath.Join(r.rootDir, indexDir))
 	if err != nil {
 		r.dirErrors.Inc(1)
 	} else {
-		r.commitlogsSize.Update(float64(indexStats.Size))
+		r.indexSize.Update(float64(indexStats.Size))
 	}
 }
 

--- a/src/x/instrument/filesystem.go
+++ b/src/x/instrument/filesystem.go
@@ -32,6 +32,7 @@ func (r *fileSystemMetrics) report() {
 	info, err := xos.GetFileSystemStats(r.rootDir)
 	if err != nil {
 		r.Errors.Inc(1)
+		return
 	}
 	r.Total.Update(float64(info.Total))
 	r.Avail.Update(float64(info.Avail))

--- a/src/x/instrument/filesystem_test.go
+++ b/src/x/instrument/filesystem_test.go
@@ -19,12 +19,15 @@ func TestFileSystemMetricsReport(t *testing.T) {
 
 	tempDir, err := ioutil.TempDir("", "fssizetest")
 	assert.Nil(t, err)
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		err := os.RemoveAll(tempDir)
+		assert.Nil(t, err)
+	}()
 
-	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "commitlogs"), 0755))
-	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "snapshots"), 0755))
-	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "data"), 0755))
-	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "index"), 0755))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "commitlogs"), 0750))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "snapshots"), 0750))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "data"), 0750))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "index"), 0750))
 
 	fsReporter := NewFileSystemReporter(opts, tempDir)
 	assert.Nil(t, fsReporter.Start())
@@ -38,9 +41,9 @@ func TestFileSystemMetricsReport(t *testing.T) {
 	assert.True(t, ok)
 	assert.NotEqual(t, float64(0), availBytes.Value())
 
-	numFsApiErrors, ok := testScope.Snapshot().Counters()["filesystem.num_fs_api_errors+"]
+	numFsAPIErrors, ok := testScope.Snapshot().Counters()["filesystem.num_fs_api_errors+"]
 	assert.True(t, ok)
-	assert.Equal(t, int64(0), numFsApiErrors.Value())
+	assert.Equal(t, int64(0), numFsAPIErrors.Value())
 
 	commitLogsSize, ok := testScope.Snapshot().Gauges()["filesystem.commitlogs_bytes+"]
 	assert.True(t, ok)
@@ -58,9 +61,9 @@ func TestFileSystemMetricsReport(t *testing.T) {
 	assert.True(t, ok)
 	assert.NotEqual(t, float64(0), indexSize.Value())
 
-	numDirApiErrors, ok := testScope.Snapshot().Counters()["filesystem.num_dir_api_errors+"]
+	numDirAPIErrors, ok := testScope.Snapshot().Counters()["filesystem.num_dir_api_errors+"]
 	assert.True(t, ok)
-	assert.Equal(t, int64(0), numDirApiErrors.Value())
+	assert.Equal(t, int64(0), numDirAPIErrors.Value())
 
 	assert.Nil(t, fsReporter.Stop())
 }

--- a/src/x/instrument/filesystem_test.go
+++ b/src/x/instrument/filesystem_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestFileSystemMetricsReport(t *testing.T) {
 	testScope := tally.NewTestScope("", nil)
+
 	every := 10 * time.Millisecond
 	opts := NewOptions().SetMetricsScope(testScope).SetReportInterval(every)
 
@@ -23,8 +24,9 @@ func TestFileSystemMetricsReport(t *testing.T) {
 	availBytes, ok := testScope.Snapshot().Gauges()["filesystem.avail_bytes+"]
 	assert.True(t, ok)
 	assert.NotEqual(t, 0, availBytes.Value())
-	numErrors, ok := testScope.Snapshot().Counters()["filesystem.num_api_errors+"]
+	numErrors, ok := testScope.Snapshot().Counters()["filesystem.num_fs_api_errors+"]
 	assert.True(t, ok)
 	assert.Equal(t, int64(0), numErrors.Value())
+
 	assert.Nil(t, fsReporter.Stop())
 }

--- a/src/x/instrument/filesystem_test.go
+++ b/src/x/instrument/filesystem_test.go
@@ -1,0 +1,30 @@
+package instrument
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+)
+
+func TestFileSystemMetricsReport(t *testing.T) {
+	testScope := tally.NewTestScope("", nil)
+	every := 10 * time.Millisecond
+	opts := NewOptions().SetMetricsScope(testScope).SetReportInterval(every)
+
+	fsReporter := NewFileSystemReporter(opts, "/")
+	assert.Nil(t, fsReporter.Start())
+	time.Sleep(1 * every)
+
+	totalBytes, ok := testScope.Snapshot().Gauges()["filesystem.total_bytes+"]
+	assert.True(t, ok)
+	assert.NotEqual(t, 0, totalBytes.Value())
+	availBytes, ok := testScope.Snapshot().Gauges()["filesystem.avail_bytes+"]
+	assert.True(t, ok)
+	assert.NotEqual(t, 0, availBytes.Value())
+	numErrors, ok := testScope.Snapshot().Counters()["filesystem.num_api_errors+"]
+	assert.True(t, ok)
+	assert.Equal(t, int64(0), numErrors.Value())
+	assert.Nil(t, fsReporter.Stop())
+}

--- a/src/x/instrument/filesystem_test.go
+++ b/src/x/instrument/filesystem_test.go
@@ -1,6 +1,9 @@
 package instrument
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,19 +17,50 @@ func TestFileSystemMetricsReport(t *testing.T) {
 	every := 10 * time.Millisecond
 	opts := NewOptions().SetMetricsScope(testScope).SetReportInterval(every)
 
-	fsReporter := NewFileSystemReporter(opts, "/")
+	tempDir, err := ioutil.TempDir("", "fssizetest")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tempDir)
+
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "commitlogs"), 0755))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "snapshots"), 0755))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "data"), 0755))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "index"), 0755))
+
+	fsReporter := NewFileSystemReporter(opts, tempDir)
 	assert.Nil(t, fsReporter.Start())
 	time.Sleep(1 * every)
 
 	totalBytes, ok := testScope.Snapshot().Gauges()["filesystem.total_bytes+"]
 	assert.True(t, ok)
-	assert.NotEqual(t, 0, totalBytes.Value())
+	assert.NotEqual(t, float64(0), totalBytes.Value())
+
 	availBytes, ok := testScope.Snapshot().Gauges()["filesystem.avail_bytes+"]
 	assert.True(t, ok)
-	assert.NotEqual(t, 0, availBytes.Value())
-	numErrors, ok := testScope.Snapshot().Counters()["filesystem.num_fs_api_errors+"]
+	assert.NotEqual(t, float64(0), availBytes.Value())
+
+	numFsApiErrors, ok := testScope.Snapshot().Counters()["filesystem.num_fs_api_errors+"]
 	assert.True(t, ok)
-	assert.Equal(t, int64(0), numErrors.Value())
+	assert.Equal(t, int64(0), numFsApiErrors.Value())
+
+	commitLogsSize, ok := testScope.Snapshot().Gauges()["filesystem.commitlogs_bytes+"]
+	assert.True(t, ok)
+	assert.NotEqual(t, float64(0), commitLogsSize.Value())
+
+	snapshotsSize, ok := testScope.Snapshot().Gauges()["filesystem.snapshots_bytes+"]
+	assert.True(t, ok)
+	assert.NotEqual(t, float64(0), snapshotsSize.Value())
+
+	dataSize, ok := testScope.Snapshot().Gauges()["filesystem.data_bytes+"]
+	assert.True(t, ok)
+	assert.NotEqual(t, float64(0), dataSize.Value())
+
+	indexSize, ok := testScope.Snapshot().Gauges()["filesystem.index_bytes+"]
+	assert.True(t, ok)
+	assert.NotEqual(t, float64(0), indexSize.Value())
+
+	numDirApiErrors, ok := testScope.Snapshot().Counters()["filesystem.num_dir_api_errors+"]
+	assert.True(t, ok)
+	assert.Equal(t, int64(0), numDirApiErrors.Value())
 
 	assert.Nil(t, fsReporter.Stop())
 }

--- a/src/x/os/filesystem.go
+++ b/src/x/os/filesystem.go
@@ -1,0 +1,7 @@
+package xos
+
+// Stats on the filesystem.
+type FileSystemStats struct {
+	Total uint64 // Total space in the filesystem in bytes
+	Avail uint64 // Available space in the filesystem in bytes
+}

--- a/src/x/os/filesystem.go
+++ b/src/x/os/filesystem.go
@@ -5,3 +5,7 @@ type FileSystemStats struct {
 	Total uint64 // Total space in the filesystem in bytes
 	Avail uint64 // Available space in the filesystem in bytes
 }
+
+type DirectoryStats struct {
+	Size uint64 // Size of the directory
+}

--- a/src/x/os/filesystem.go
+++ b/src/x/os/filesystem.go
@@ -1,11 +1,13 @@
+// Package xos - filesystem metrics
 package xos
 
-// Stats on the filesystem.
+// FileSystemStats keeps available and total space
 type FileSystemStats struct {
 	Total uint64 // Total space in the filesystem in bytes
 	Avail uint64 // Available space in the filesystem in bytes
 }
 
+// DirectoryStats keeps size
 type DirectoryStats struct {
 	Size uint64 // Size of the directory
 }

--- a/src/x/os/filesystem_linux.go
+++ b/src/x/os/filesystem_linux.go
@@ -1,0 +1,16 @@
+package xos
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func GetFileSystemStats(path string) (*FileSystemStats, error) {
+	stats := &unix.Statfs_t{}
+	if err := unix.Statfs(path, stats); err != nil {
+		return nil, err
+	}
+	ret := &FileSystemStats{}
+	ret.Avail = stats.Bavail * uint64(stats.Bsize)
+	ret.Total = stats.Blocks * uint64(stats.Bsize)
+	return ret, nil
+}

--- a/src/x/os/filesystem_linux.go
+++ b/src/x/os/filesystem_linux.go
@@ -1,16 +1,36 @@
 package xos
 
 import (
+	"os"
+	"path/filepath"
+
 	"golang.org/x/sys/unix"
 )
 
-func GetFileSystemStats(path string) (*FileSystemStats, error) {
+// GetFileSystemStats returns stats for filesystem rooted
+// at rootDir. Stats includes available and total space.
+func GetFileSystemStats(rootDir string) (*FileSystemStats, error) {
 	stats := &unix.Statfs_t{}
-	if err := unix.Statfs(path, stats); err != nil {
+	if err := unix.Statfs(rootDir, stats); err != nil {
 		return nil, err
 	}
 	ret := &FileSystemStats{}
 	ret.Avail = stats.Bavail * uint64(stats.Bsize)
 	ret.Total = stats.Blocks * uint64(stats.Bsize)
 	return ret, nil
+}
+
+// GetDirectoryStats returns stats for directory.
+// Stats includes total size of all files (not subdirectories)
+// in the directory.
+func GetDirectoryStats(path string) (*DirectoryStats, error) {
+	ret := &DirectoryStats{}
+	err := filepath.Walk(path, func(n string, fInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		ret.Size += uint64(fInfo.Size())
+		return err
+	})
+	return ret, err
 }

--- a/src/x/os/filesystem_linux.go
+++ b/src/x/os/filesystem_linux.go
@@ -20,16 +20,19 @@ func GetFileSystemStats(rootDir string) (*FileSystemStats, error) {
 	return ret, nil
 }
 
-// GetDirectoryStats returns stats for directory.
-// Stats includes total size of all files (not subdirectories)
-// in the directory.
+// GetDirectoryStats returns the total size of all files
+// in the directory tree. Note that this will be different
+// from the output of the utility du as it only counts
+// apparent sizes of files, and not the disk usage of files.
 func GetDirectoryStats(path string) (*DirectoryStats, error) {
 	ret := &DirectoryStats{}
 	err := filepath.Walk(path, func(n string, fInfo os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		ret.Size += uint64(fInfo.Size())
+		if !fInfo.IsDir() {
+			ret.Size += uint64(fInfo.Size())
+		}
 		return err
 	})
 	return ret, err

--- a/src/x/os/filesystem_linux_test.go
+++ b/src/x/os/filesystem_linux_test.go
@@ -13,3 +13,9 @@ func TestGetFileSystemStats(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEqual(t, uint64(0), stats.Total)
 }
+
+func TestGetDirectoryStats(t *testing.T) {
+	stats, err := GetDirectoryStats("/etc")
+	assert.Nil(t, err)
+	assert.NotEqual(t, uint64(0), stats.Size)
+}

--- a/src/x/os/filesystem_linux_test.go
+++ b/src/x/os/filesystem_linux_test.go
@@ -27,7 +27,9 @@ func createTempFsForTests(t *testing.T) string {
 }
 func TestGetFileSystemStats(t *testing.T) {
 	tempDir := createTempFsForTests(t)
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		assert.Nil(t, os.RemoveAll(tempDir))
+	}()
 	stats, err := GetFileSystemStats(tempDir)
 	assert.Nil(t, err)
 	assert.NotEqual(t, uint64(0), stats.Total)

--- a/src/x/os/filesystem_linux_test.go
+++ b/src/x/os/filesystem_linux_test.go
@@ -3,19 +3,57 @@
 package xos
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	contents = []byte("0123456789")
+)
+
+func createTempFsForTests(t *testing.T) string {
+	tempDir, err := ioutil.TempDir("", "fssizetest")
+	assert.Nil(t, err)
+
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "commitlogs"), 0755))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "snapshots"), 0755))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "data"), 0755))
+	assert.Nil(t, os.Mkdir(filepath.Join(tempDir, "index"), 0755))
+	return tempDir
+}
 func TestGetFileSystemStats(t *testing.T) {
-	stats, err := GetFileSystemStats("/")
+	tempDir := createTempFsForTests(t)
+	defer os.RemoveAll(tempDir)
+	stats, err := GetFileSystemStats(tempDir)
 	assert.Nil(t, err)
 	assert.NotEqual(t, uint64(0), stats.Total)
 }
 
-func TestGetDirectoryStats(t *testing.T) {
-	stats, err := GetDirectoryStats("/etc")
+func createFilesForTests(t *testing.T, path string) {
+	commitlogsDir := filepath.Join(path, "commitlogs")
+	commitlogsFileName := filepath.Join(commitlogsDir, "commitlog-0-77.db")
+	err := ioutil.WriteFile(commitlogsFileName, contents, 0644)
 	assert.Nil(t, err)
-	assert.NotEqual(t, uint64(0), stats.Size)
+}
+
+func checkDirectorySizes(t *testing.T, path string) {
+	commitlogsDir := filepath.Join(path, "commitlogs")
+	stats, err := GetDirectoryStats(commitlogsDir)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(len(contents)), stats.Size)
+	snapshotsDir := filepath.Join(path, "snapshots")
+	stats, err = GetDirectoryStats(snapshotsDir)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0), stats.Size)
+}
+
+func TestGetDirectoryStats(t *testing.T) {
+	tempDir := createTempFsForTests(t)
+	createFilesForTests(t, tempDir)
+	defer os.RemoveAll(tempDir)
+	checkDirectorySizes(t, tempDir)
 }

--- a/src/x/os/filesystem_linux_test.go
+++ b/src/x/os/filesystem_linux_test.go
@@ -1,0 +1,15 @@
+// +build linux
+
+package xos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFileSystemStats(t *testing.T) {
+	stats, err := GetFileSystemStats("/")
+	assert.Nil(t, err)
+	assert.NotEqual(t, uint64(0), stats.Total)
+}

--- a/src/x/os/filesystem_other.go
+++ b/src/x/os/filesystem_other.go
@@ -8,8 +8,13 @@ import (
 
 var (
 	ErrFileSystemStats = fmt.Errorf("unable to get filesystem stats for non-linux os")
+	ErrDirectoryStats  = fmt.Errorf("unable to get directory stats for non-linux os")
 )
 
 func GetFileSystemStats(path string) (*FileSystemStats, error) {
 	return nil, ErrFileSystemStats
+}
+
+func GetDirectoryStats(path string) (*DirectoryStats, error) {
+	return nil, ErrDirectoryStats
 }

--- a/src/x/os/filesystem_other.go
+++ b/src/x/os/filesystem_other.go
@@ -7,14 +7,18 @@ import (
 )
 
 var (
+	// ErrFileSystemStats filesystem stats not supported
 	ErrFileSystemStats = fmt.Errorf("unable to get filesystem stats for non-linux os")
-	ErrDirectoryStats  = fmt.Errorf("unable to get directory stats for non-linux os")
+	// ErrDirectoryStats directory stats not supported
+	ErrDirectoryStats = fmt.Errorf("unable to get directory stats for non-linux os")
 )
 
+// GetFileSystemStats returns stats for filesystem
 func GetFileSystemStats(path string) (*FileSystemStats, error) {
 	return nil, ErrFileSystemStats
 }
 
+// GetDirectoryStats returns stats for directory
 func GetDirectoryStats(path string) (*DirectoryStats, error) {
 	return nil, ErrDirectoryStats
 }

--- a/src/x/os/filesystem_other.go
+++ b/src/x/os/filesystem_other.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package xos
+
+import (
+	"fmt"
+)
+
+var (
+	ErrFileSystemStats = fmt.Errorf("unable to get filesystem stats for non-linux os")
+)
+
+func GetFileSystemStats(path string) (*FileSystemStats, error) {
+	return nil, ErrFileSystemStats
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
Fixes #3400 
Please refer to the discussion in the issue. In summary, this PR adds metrics
for available space in the filesystem, and the sizes of files in different m3db 
directories. It can be used to alert on filesystem available space thresholds.
The added metrics look like this:
```
# TYPE filesystem_avail_bytes gauge
filesystem_avail_bytes 4.2259341312e+10
# HELP filesystem_commitlogs_bytes filesystem_commitlogs_bytes gauge
# TYPE filesystem_commitlogs_bytes gauge
filesystem_commitlogs_bytes 40
# HELP filesystem_data_bytes filesystem_data_bytes gauge
# TYPE filesystem_data_bytes gauge
filesystem_data_bytes 66304
# HELP filesystem_index_bytes filesystem_index_bytes gauge
# TYPE filesystem_index_bytes gauge
filesystem_index_bytes 4310
# HELP filesystem_num_dir_api_errors filesystem_num_dir_api_errors counter
# TYPE filesystem_num_dir_api_errors counter
filesystem_num_dir_api_errors 1.829242e+06
# HELP filesystem_num_fs_api_errors filesystem_num_fs_api_errors counter
# TYPE filesystem_num_fs_api_errors counter
filesystem_num_fs_api_errors 0
# HELP filesystem_snapshots_bytes filesystem_snapshots_bytes gauge
# TYPE filesystem_snapshots_bytes gauge
filesystem_snapshots_bytes 1.8173384e+07
# HELP filesystem_total_bytes filesystem_total_bytes gauge
# TYPE filesystem_total_bytes gauge
filesystem_total_bytes 6.2725623808e+10
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
