### PR TITLE
[query] Fix Graphite aliasByNode to compile and use the first path expr instead of string check for function

### DIFF
--- a/src/query/graphite/common/aliasing.go
+++ b/src/query/graphite/common/aliasing.go
@@ -58,38 +58,6 @@ func AliasByMetric(ctx *Context, series ts.SeriesList) (ts.SeriesList, error) {
 	return series, nil
 }
 
-// AliasByNode renames a time series result according to a subset of the nodes
-// in its hierarchy.
-func AliasByNode(_ *Context, seriesList ts.SeriesList, nodes ...int) (ts.SeriesList, error) {
-	renamed := make([]*ts.Series, 0, seriesList.Len())
-	for _, series := range seriesList.Values {
-		name := series.Name()
-		left := strings.LastIndex(name, "(") + 1
-		name = name[left:]
-		right := strings.IndexAny(name, ",)")
-		if right == -1 {
-			right = len(name)
-		}
-		nameParts := strings.Split(name[0:right], ".")
-		newNameParts := make([]string, 0, len(nodes))
-		for _, node := range nodes {
-			// NB(jayp): graphite supports negative indexing, so we need to also!
-			if node < 0 {
-				node += len(nameParts)
-			}
-			if node < 0 || node >= len(nameParts) {
-				continue
-			}
-			newNameParts = append(newNameParts, nameParts[node])
-		}
-		newName := strings.Join(newNameParts, ".")
-		newSeries := series.RenamedTo(newName)
-		renamed = append(renamed, newSeries)
-	}
-	seriesList.Values = renamed
-	return seriesList, nil
-}
-
 // AliasSub runs series names through a regex search/replace.
 func AliasSub(_ *Context, input ts.SeriesList, search, replace string) (ts.SeriesList, error) {
 	regex, err := regexp.Compile(search)

--- a/src/query/graphite/native/alias_functions_test.go
+++ b/src/query/graphite/native/alias_functions_test.go
@@ -220,7 +220,7 @@ func TestAliasByNodeWithComposition(t *testing.T) {
 
 func TestAliasByNodeWithManyPathExpressions(t *testing.T) {
 	ctx := common.NewTestContext()
-	defer ctx.Close()
+	defer func() { _ = ctx.Close() }()
 
 	now := time.Now()
 	values := ts.NewConstantValues(ctx, 10.0, 1000, 10)

--- a/src/query/graphite/native/expression.go
+++ b/src/query/graphite/native/expression.go
@@ -55,6 +55,10 @@ type CallASTNode interface {
 
 // ArgumentASTNode is an interface to help with printing the AST.
 type ArgumentASTNode interface {
+	// PathExpression returns the path expression and true if argument
+	// is a path.
+	PathExpression() (string, bool)
+	// String is the pretty printed format.
 	String() string
 }
 
@@ -66,6 +70,10 @@ type fetchExpression struct {
 
 type fetchExpressionPathArg struct {
 	path string
+}
+
+func (a fetchExpressionPathArg) PathExpression() (string, bool) {
+	return a.path, true
 }
 
 func (a fetchExpressionPathArg) String() string {
@@ -83,6 +91,10 @@ func (f *fetchExpression) Name() string {
 
 func (f *fetchExpression) Arguments() []ArgumentASTNode {
 	return []ArgumentASTNode{f.pathArg}
+}
+
+func (f *fetchExpression) PathExpression() (string, bool) {
+	return "", false
 }
 
 // Execute fetches results from storage

--- a/src/query/graphite/native/functions.go
+++ b/src/query/graphite/native/functions.go
@@ -514,7 +514,8 @@ func (c constFuncArg) Evaluate(ctx *common.Context) (reflect.Value, error) { ret
 func (c constFuncArg) CompatibleWith(reflectType reflect.Type) bool {
 	return c.value.Type() == reflectType || reflectType == interfaceType
 }
-func (c constFuncArg) String() string { return fmt.Sprintf("%v", c.value.Interface()) }
+func (c constFuncArg) String() string                 { return fmt.Sprintf("%v", c.value.Interface()) }
+func (c constFuncArg) PathExpression() (string, bool) { return "", false }
 
 // A functionCall is an actual call to a function, with resolution for arguments
 type functionCall struct {
@@ -532,6 +533,10 @@ func (call *functionCall) Arguments() []ArgumentASTNode {
 		args[i] = arg
 	}
 	return args
+}
+
+func (call *functionCall) PathExpression() (string, bool) {
+	return "", false
 }
 
 // Evaluate evaluates the function call and returns the result as a reflect.Value


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This fixes aliasByNode to match the original Graphite implementation which tokenizes and compiles the series name to detect the first path expression.

This can be seen here with aggKey which is called by aliasByNode:
https://github.com/graphite-project/graphite-web/blob/19f2155a8902f1dc075d4276d384409f1c006764/webapp/graphite/render/functions.py#L111-L115

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
