### PR TITLE
Do not create a loadingCh for expired entries, if loader is nil

### DIFF
--- a/src/x/cache/lru_cache.go
+++ b/src/x/cache/lru_cache.go
@@ -353,7 +353,7 @@ func (c *LRU) tryCached(
 	// Otherwise we need to load it
 	c.metrics.misses.Inc(1)
 
-	if getWithNoLoader && !exists {
+	if getWithNoLoader {
 		// If we're not using a loader then return entry not found
 		// rather than creating a loading channel since we are not trying
 		// to load an element we are just attempting to retrieve it if and

--- a/src/x/cache/lru_cache_test.go
+++ b/src/x/cache/lru_cache_test.go
@@ -622,7 +622,7 @@ func TestLRU_TryGetExpired(t *testing.T) {
 		return now
 	}})
 
-	// create an entry in the cache and expre it.
+	// create an entry in the cache and expire it.
 	lru.Put("foo", "1")
 	now = now.Add(time.Second * 2)
 

--- a/src/x/cache/lru_cache_test.go
+++ b/src/x/cache/lru_cache_test.go
@@ -614,6 +614,28 @@ func TestLRU_GetNonExisting_FromFullCache_AfterDoublePut(t *testing.T) {
 	require.Error(t, err, ErrEntryNotFound.Error())
 }
 
+// TestLRU_TryGetExpired is a regression test for a bug that would create a loadingCh for expired entries in the cache,
+// even if the loader was nil.
+func TestLRU_TryGetExpired(t *testing.T) {
+	now := time.Now()
+	lru := NewLRU(&LRUOptions{MaxEntries: 2, TTL: time.Second, Now: func() time.Time {
+		return now
+	}})
+
+	// create an entry in the cache and expre it.
+	lru.Put("foo", "1")
+	now = now.Add(time.Second * 2)
+
+	// first load is not found since it's expired.
+	_, ok := lru.TryGet("foo")
+	require.False(t, ok)
+
+	// second load is still not found since it's expired. previously the bug would attempt to wait on the loadingCh
+	// and fail with a panic because the ctx is nil.
+	_, ok = lru.TryGet("foo")
+	require.False(t, ok)
+}
+
 var defaultKeys = []string{
 	"key-0", "key-1", "key-2", "key-3", "key-4", "key-5", "key-6", "key-7", "key-8", "key-9", "key10",
 }


### PR DESCRIPTION
A previous commit stopped creating loading channels if the loader is
nil. However, it was not completely correct and would still create a
channel if the entry was expired.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
