### PR TITLE
[aggregator] Allow campaigning with no shards

### DIFF
--- a/src/aggregator/aggregator/aggregator_mock.go
+++ b/src/aggregator/aggregator/aggregator_mock.go
@@ -456,6 +456,21 @@ func (mr *MockPlacementManagerMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockPlacementManager)(nil).Close))
 }
 
+// ExclusiveShardSetOwner mocks base method
+func (m *MockPlacementManager) ExclusiveShardSetOwner() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExclusiveShardSetOwner")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExclusiveShardSetOwner indicates an expected call of ExclusiveShardSetOwner
+func (mr *MockPlacementManagerMockRecorder) ExclusiveShardSetOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExclusiveShardSetOwner", reflect.TypeOf((*MockPlacementManager)(nil).ExclusiveShardSetOwner))
+}
+
 // HasReplacementInstance mocks base method
 func (m *MockPlacementManager) HasReplacementInstance() (bool, error) {
 	m.ctrl.T.Helper()

--- a/src/aggregator/aggregator/election_mgr.go
+++ b/src/aggregator/aggregator/election_mgr.go
@@ -643,6 +643,19 @@ func (mgr *electionManager) campaignIsEnabled() (bool, error) {
 		return false, err
 	}
 
+	if shards.NumShards() == 0 {
+		// Allow the instance with no shards take the leadership if it is the only instance owning
+		// this shard set.
+		// This is needed for limited duration, during cluster expansion, when adding new instances.
+		exclusiveShardSetOwner, err := mgr.placementManager.ExclusiveShardSetOwner()
+		if err != nil {
+			return false, err
+		}
+		if exclusiveShardSetOwner {
+			return true, nil
+		}
+	}
+
 	// NB(xichen): We apply an offset when checking if a shard has been cutoff in order
 	// to detect if the campaign should be stopped before all the shards are cut off.
 	// This is to avoid the situation where the campaign is stopped after the shards
@@ -672,7 +685,7 @@ func (mgr *electionManager) campaignIsEnabled() (bool, error) {
 	}
 
 	// If no shards have been cut over, campaign is disabled to avoid writing
-	// incomplele data before shards are cut over.
+	// incomplete data before shards are cut over.
 	if noCutoverShards {
 		mgr.metrics.campaignCheckNoCutoverShards.Inc(1)
 		mgr.logger.Warn("campaign is not enabled, no cutover shards")

--- a/src/aggregator/aggregator/placement_mgr.go
+++ b/src/aggregator/aggregator/placement_mgr.go
@@ -60,6 +60,10 @@ type PlacementManager interface {
 	// the current instance, and false otherwise.
 	HasReplacementInstance() (bool, error)
 
+	// ExclusiveShardSetOwner returns true iff this instance is the only instance owning
+	// this shard set..
+	ExclusiveShardSetOwner() (bool, error)
+
 	// Shards returns the current shards owned by the instance.
 	Shards() (shard.Shards, error)
 
@@ -203,6 +207,28 @@ func (mgr *placementManager) HasReplacementInstance() (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func (mgr *placementManager) ExclusiveShardSetOwner() (bool, error) {
+	placement, err := mgr.Placement()
+	if err != nil {
+		return false, err
+	}
+
+	currInstance, err := mgr.instanceFrom(placement)
+	if err != nil {
+		return false, err
+	}
+	currShardSetID := currInstance.ShardSetID()
+	allInstances := placement.Instances()
+
+	for _, instance := range allInstances {
+		if instance.ShardSetID() == currShardSetID && instance.ID() != mgr.instanceID {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func (mgr *placementManager) Shards() (shard.Shards, error) {

--- a/src/aggregator/aggregator/placement_mgr_test.go
+++ b/src/aggregator/aggregator/placement_mgr_test.go
@@ -387,7 +387,7 @@ func TestPlacementExclusiveShardSetOwner(t *testing.T) {
 	require.NoError(t, mgr.Open())
 
 	for _, tt := range tests {
-		t.Run(tt.name, func (t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			proto := &placementpb.PlacementSnapshots{
 				Snapshots: []*placementpb.Placement{tt.placement},
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a special case to the aggregator election manager - allowing the instance with **no shards** to take the leadership if it is the only instance owning this shard set.
This is needed for limited duration, during cluster expansion, when adding new instances.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE