### PR TITLE
Replace db server.RunOptions with a single Transform function.

### DIFF
--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -276,7 +276,7 @@ func NewTestSetup(
 		indexMode = index.InsertAsync
 	}
 
-	plCache, stopReporting, err := index.NewPostingsListCache(10, index.PostingsListCacheOptions{
+	plCache, err := index.NewPostingsListCache(10, index.PostingsListCacheOptions{
 		InstrumentOptions: iOpts,
 	})
 	if err != nil {
@@ -284,7 +284,7 @@ func NewTestSetup(
 	}
 	// Ok to run immediately since it just closes the background reporting loop. Only ok because
 	// this is a test setup, in production we would want the metrics.
-	stopReporting()
+	plCache.Start()()
 
 	indexOpts := storageOpts.IndexOptions().
 		SetInsertMode(indexMode).

--- a/src/dbnode/persist/fs/migration/migration_test.go
+++ b/src/dbnode/persist/fs/migration/migration_test.go
@@ -77,8 +77,8 @@ func TestToVersion1_1Run(t *testing.T) {
 	plCache, err := index.NewPostingsListCache(1, index.PostingsListCacheOptions{
 		InstrumentOptions: instrument.NewOptions(),
 	})
-	defer plCache.Start()()
 	require.NoError(t, err)
+	defer plCache.Start()()
 
 	opts := NewTaskOptions().
 		SetNewMergerFn(fs.NewMerger).

--- a/src/dbnode/persist/fs/migration/migration_test.go
+++ b/src/dbnode/persist/fs/migration/migration_test.go
@@ -74,10 +74,11 @@ func TestToVersion1_1Run(t *testing.T) {
 	md, err := namespace.NewMetadata(nsID, namespace.NewOptions())
 	require.NoError(t, err)
 
-	plCache, closer, err := index.NewPostingsListCache(1, index.PostingsListCacheOptions{
+	plCache, err := index.NewPostingsListCache(1, index.PostingsListCacheOptions{
 		InstrumentOptions: instrument.NewOptions(),
 	})
-	defer closer()
+	defer plCache.Start()()
+	require.NoError(t, err)
 
 	opts := NewTaskOptions().
 		SetNewMergerFn(fs.NewMerger).

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_data_test.go
@@ -965,7 +965,7 @@ func newTestStorageOptions(
 	pm persist.Manager,
 	icm fs.IndexClaimsManager,
 ) (storage.Options, index.Closer) {
-	plCache, closer, err := index.NewPostingsListCache(1, index.PostingsListCacheOptions{
+	plCache, err := index.NewPostingsListCache(1, index.PostingsListCacheOptions{
 		InstrumentOptions: instrument.NewOptions(),
 	})
 	require.NoError(t, err)
@@ -980,5 +980,5 @@ func newTestStorageOptions(
 		SetRepairEnabled(false).
 		SetIndexOptions(index.NewOptions().
 			SetPostingsListCache(plCache)).
-		SetBlockLeaseManager(block.NewLeaseManager(nil)), closer
+		SetBlockLeaseManager(block.NewLeaseManager(nil)), plCache.Start()
 }

--- a/src/dbnode/storage/index/block_prop_test.go
+++ b/src/dbnode/storage/index/block_prop_test.go
@@ -86,11 +86,11 @@ func TestPostingsListCacheDoesNotAffectBlockQueryResults(t *testing.T) {
 		t, blockStart, testMD, testOpts.SetPostingsListCache(nil))
 	require.NoError(t, err)
 
-	plCache, stopReporting, err := NewPostingsListCache(1000, PostingsListCacheOptions{
+	plCache, err := NewPostingsListCache(1000, PostingsListCacheOptions{
 		InstrumentOptions: instrument.NewOptions(),
 	})
 	require.NoError(t, err)
-	defer stopReporting()
+	defer plCache.Start()()
 
 	cachedOptions := testOpts.
 		SetPostingsListCache(plCache).

--- a/src/dbnode/storage/index/postings_list_cache.go
+++ b/src/dbnode/storage/index/postings_list_cache.go
@@ -67,10 +67,10 @@ type PostingsListCache struct {
 }
 
 // NewPostingsListCache creates a new query cache.
-func NewPostingsListCache(size int, opts PostingsListCacheOptions) (*PostingsListCache, Closer, error) {
+func NewPostingsListCache(size int, opts PostingsListCacheOptions) (*PostingsListCache, error) {
 	lru, err := newPostingsListLRU(size)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	plc := &PostingsListCache{
@@ -80,8 +80,12 @@ func NewPostingsListCache(size int, opts PostingsListCacheOptions) (*PostingsLis
 		metrics: newPostingsListCacheMetrics(opts.InstrumentOptions.MetricsScope()),
 	}
 
-	closer := plc.startReportLoop()
-	return plc, closer, nil
+	return plc, nil
+}
+
+// Start the background report loop and return a Closer to cleanup.
+func (q *PostingsListCache) Start() Closer {
+	return q.startReportLoop()
 }
 
 // GetRegexp returns the cached results for the provided regexp query, if any.

--- a/src/dbnode/storage/index/postings_list_cache_test.go
+++ b/src/dbnode/storage/index/postings_list_cache_test.go
@@ -85,9 +85,9 @@ type testEntry struct {
 
 func TestSimpleLRUBehavior(t *testing.T) {
 	size := 3
-	plCache, stopReporting, err := NewPostingsListCache(size, testPostingListCacheOptions)
+	plCache, err := NewPostingsListCache(size, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer plCache.Start()()
 
 	var (
 		e0 = testPlEntries[0]
@@ -131,9 +131,9 @@ func TestSimpleLRUBehavior(t *testing.T) {
 
 func TestPurgeSegment(t *testing.T) {
 	size := len(testPlEntries)
-	plCache, stopReporting, err := NewPostingsListCache(size, testPostingListCacheOptions)
+	plCache, err := NewPostingsListCache(size, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer plCache.Start()()
 
 	// Write many entries with the same segment UUID.
 	for i := 0; i < 100; i++ {
@@ -189,9 +189,9 @@ func TestPurgeSegment(t *testing.T) {
 }
 
 func TestEverthingInsertedCanBeRetrieved(t *testing.T) {
-	plCache, stopReporting, err := NewPostingsListCache(len(testPlEntries), testPostingListCacheOptions)
+	plCache, err := NewPostingsListCache(len(testPlEntries), testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer plCache.Start()()
 
 	for i := range testPlEntries {
 		putEntry(t, plCache, i)
@@ -213,9 +213,9 @@ func TestConcurrencyVerifyResultsNoEviction(t *testing.T) {
 }
 
 func testConcurrency(t *testing.T, size int, purge bool, verify bool) {
-	plCache, stopReporting, err := NewPostingsListCache(size, testPostingListCacheOptions)
+	plCache, err := NewPostingsListCache(size, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer plCache.Start()()
 
 	wg := sync.WaitGroup{}
 	// Spin up writers.

--- a/src/dbnode/storage/index/read_through_segment_test.go
+++ b/src/dbnode/storage/index/read_through_segment_test.go
@@ -48,9 +48,9 @@ func TestReadThroughSegmentMatchRegexp(t *testing.T) {
 	reader := segment.NewMockReader(ctrl)
 	seg.EXPECT().Reader().Return(reader, nil)
 
-	cache, stopReporting, err := NewPostingsListCache(1, testPostingListCacheOptions)
+	cache, err := NewPostingsListCache(1, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer cache.Start()()
 
 	field := []byte("some-field")
 	parsedRegex, err := syntax.Parse(".*this-will-be-slow.*", syntax.Simple)
@@ -87,9 +87,9 @@ func TestReadThroughSegmentMatchRegexpCacheDisabled(t *testing.T) {
 	reader := segment.NewMockReader(ctrl)
 	seg.EXPECT().Reader().Return(reader, nil)
 
-	cache, stopReporting, err := NewPostingsListCache(1, testPostingListCacheOptions)
+	cache, err := NewPostingsListCache(1, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer cache.Start()()
 
 	field := []byte("some-field")
 	parsedRegex, err := syntax.Parse(".*this-will-be-slow.*", syntax.Simple)
@@ -161,9 +161,9 @@ func TestReadThroughSegmentMatchTerm(t *testing.T) {
 	reader := segment.NewMockReader(ctrl)
 	seg.EXPECT().Reader().Return(reader, nil)
 
-	cache, stopReporting, err := NewPostingsListCache(1, testPostingListCacheOptions)
+	cache, err := NewPostingsListCache(1, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer cache.Start()()
 
 	var (
 		field = []byte("some-field")
@@ -199,9 +199,9 @@ func TestReadThroughSegmentMatchTermCacheDisabled(t *testing.T) {
 	reader := segment.NewMockReader(ctrl)
 	seg.EXPECT().Reader().Return(reader, nil)
 
-	cache, stopReporting, err := NewPostingsListCache(1, testPostingListCacheOptions)
+	cache, err := NewPostingsListCache(1, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer cache.Start()()
 
 	var (
 		field = []byte("some-field")
@@ -267,9 +267,9 @@ func TestClose(t *testing.T) {
 	defer ctrl.Finish()
 
 	segment := fst.NewMockSegment(ctrl)
-	cache, stopReporting, err := NewPostingsListCache(1, testPostingListCacheOptions)
+	cache, err := NewPostingsListCache(1, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer cache.Start()()
 
 	readThroughSeg := NewReadThroughSegment(
 		segment, cache, defaultReadThroughSegmentOptions)
@@ -302,9 +302,9 @@ func TestReadThroughSegmentMatchField(t *testing.T) {
 	reader := segment.NewMockReader(ctrl)
 	seg.EXPECT().Reader().Return(reader, nil)
 
-	cache, stopReporting, err := NewPostingsListCache(1, testPostingListCacheOptions)
+	cache, err := NewPostingsListCache(1, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer cache.Start()()
 
 	var (
 		field = []byte("some-field")
@@ -339,9 +339,9 @@ func TestReadThroughSegmentMatchFieldCacheDisabled(t *testing.T) {
 	reader := segment.NewMockReader(ctrl)
 	seg.EXPECT().Reader().Return(reader, nil)
 
-	cache, stopReporting, err := NewPostingsListCache(1, testPostingListCacheOptions)
+	cache, err := NewPostingsListCache(1, testPostingListCacheOptions)
 	require.NoError(t, err)
-	defer stopReporting()
+	defer cache.Start()()
 
 	var (
 		field = []byte("some-field")

--- a/src/dbnode/storage/limits/query_limits.go
+++ b/src/dbnode/storage/limits/query_limits.go
@@ -82,6 +82,16 @@ func DefaultLookbackLimitOptions() LookbackLimitOptions {
 	}
 }
 
+// DefaultLimitsOptions is the set of default limits options.
+func DefaultLimitsOptions(iOpts instrument.Options) Options {
+	return NewOptions().
+		SetInstrumentOptions(iOpts).
+		SetBytesReadLimitOpts(DefaultLookbackLimitOptions()).
+		SetDocsLimitOpts(DefaultLookbackLimitOptions()).
+		SetAggregateDocsLimitOpts(DefaultLookbackLimitOptions()).
+		SetDiskSeriesReadLimitOpts(DefaultLookbackLimitOptions())
+}
+
 // NewQueryLimits returns a new query limits manager.
 func NewQueryLimits(options Options) (QueryLimits, error) {
 	if err := options.Validate(); err != nil {

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -99,6 +99,7 @@ var (
 	errIndexClaimsManagerNotSet   = errors.New("index claims manager is not set")
 	errBlockLeaserNotSet          = errors.New("block leaser is not set")
 	errOnColdFlushNotSet          = errors.New("on cold flush is not set, requires at least a no-op implementation")
+	errLimitsOptionsNotSet        = errors.New("limits options are not set")
 )
 
 // NewSeriesOptionsFromOptions creates a new set of database series options from provided options.
@@ -178,6 +179,7 @@ type options struct {
 	namespaceHooks                  NamespaceHooks
 	tileAggregator                  TileAggregator
 	permitsOptions                  permits.Options
+	limitsOptions                   limits.Options
 }
 
 // NewOptions creates a new set of storage options with defaults.
@@ -311,6 +313,10 @@ func (o *options) Validate() error {
 
 	if o.onColdFlush == nil {
 		return errOnColdFlushNotSet
+	}
+
+	if o.limitsOptions == nil {
+		return errLimitsOptionsNotSet
 	}
 
 	return nil
@@ -912,6 +918,16 @@ func (o *options) SetPermitsOptions(value permits.Options) Options {
 	opts := *o
 	opts.permitsOptions = value
 
+	return &opts
+}
+
+func (o *options) LimitsOptions() limits.Options {
+	return o.limitsOptions
+}
+
+func (o *options) SetLimitsOptions(value limits.Options) Options {
+	opts := *o
+	opts.limitsOptions = value
 	return &opts
 }
 

--- a/src/dbnode/storage/options.go
+++ b/src/dbnode/storage/options.go
@@ -207,9 +207,10 @@ func newOptions(poolOpts pool.ObjectPoolOptions) Options {
 	bytesWrapperPool := xpool.NewCheckedBytesWrapperPool(poolOpts)
 	bytesWrapperPool.Init()
 
+	iOpts := instrument.NewOptions()
 	o := &options{
 		clockOpts:                clock.NewOptions(),
-		instrumentOpts:           instrument.NewOptions(),
+		instrumentOpts:           iOpts,
 		blockOpts:                block.NewOptions(),
 		commitLogOpts:            commitlog.NewOptions(),
 		runtimeOptsMgr:           m3dbruntime.NewOptionsManager(),
@@ -253,6 +254,7 @@ func newOptions(poolOpts pool.ObjectPoolOptions) Options {
 		namespaceHooks:                  &noopNamespaceHooks{},
 		tileAggregator:                  &noopTileAggregator{},
 		permitsOptions:                  permits.NewOptions(),
+		limitsOptions:                   limits.DefaultLimitsOptions(iOpts),
 	}
 	return o.SetEncodingM3TSZPooled()
 }

--- a/src/dbnode/storage/storage_mock.go
+++ b/src/dbnode/storage/storage_mock.go
@@ -5352,6 +5352,34 @@ func (mr *MockOptionsMockRecorder) SetPermitsOptions(value interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPermitsOptions", reflect.TypeOf((*MockOptions)(nil).SetPermitsOptions), value)
 }
 
+// LimitsOptions mocks base method
+func (m *MockOptions) LimitsOptions() limits.Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LimitsOptions")
+	ret0, _ := ret[0].(limits.Options)
+	return ret0
+}
+
+// LimitsOptions indicates an expected call of LimitsOptions
+func (mr *MockOptionsMockRecorder) LimitsOptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LimitsOptions", reflect.TypeOf((*MockOptions)(nil).LimitsOptions))
+}
+
+// SetLimitsOptions mocks base method
+func (m *MockOptions) SetLimitsOptions(value limits.Options) Options {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLimitsOptions", value)
+	ret0, _ := ret[0].(Options)
+	return ret0
+}
+
+// SetLimitsOptions indicates an expected call of SetLimitsOptions
+func (mr *MockOptionsMockRecorder) SetLimitsOptions(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLimitsOptions", reflect.TypeOf((*MockOptions)(nil).SetLimitsOptions), value)
+}
+
 // MockMemoryTracker is a mock of MemoryTracker interface
 type MockMemoryTracker struct {
 	ctrl     *gomock.Controller

--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -1394,6 +1394,12 @@ type Options interface {
 
 	// SetPermitsOptions sets the permits options.
 	SetPermitsOptions(value permits.Options) Options
+
+	// LimitsOptions returns the limit options.
+	LimitsOptions() limits.Options
+
+	// SetLimitsOptions sets the limits options.
+	SetLimitsOptions(value limits.Options) Options
 }
 
 // MemoryTracker tracks memory.

--- a/src/dbnode/storage/util.go
+++ b/src/dbnode/storage/util.go
@@ -59,13 +59,14 @@ func DefaultTestOptions() Options {
 			panic(err)
 		}
 
-		plCache, stopReporting, err := index.NewPostingsListCache(10, index.PostingsListCacheOptions{
+		plCache, err := index.NewPostingsListCache(10, index.PostingsListCacheOptions{
 			InstrumentOptions: opts.InstrumentOptions(),
 		})
 		if err != nil {
 			panic(err)
 		}
-		defer stopReporting()
+		plStop := plCache.Start()
+		defer plStop()
 
 		indexOpts := opts.IndexOptions().
 			SetPostingsListCache(plCache)


### PR DESCRIPTION
Allowing multiple Transform functions is error prone when sub Options are
dependent on each other and you want to transform both. It's more
straight forward to Transform the top level Option in a single transform
function once.

Additionally, this delays Starting any Option until after the Tranform
is run, in case the originally Option value is transformed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
