### PR TITLE
Split handleroptions.AddResponseHeaders into two separate methods

### DIFF
--- a/src/query/api/v1/handler/graphite/find.go
+++ b/src/query/api/v1/handler/graphite/find.go
@@ -44,10 +44,8 @@ const (
 	FindURL = handler.RoutePrefixV1 + "/graphite/metrics/find"
 )
 
-var (
-	// FindHTTPMethods are the HTTP methods for this handler.
-	FindHTTPMethods = []string{http.MethodGet, http.MethodPost}
-)
+// FindHTTPMethods are the HTTP methods for this handler.
+var FindHTTPMethods = []string{http.MethodGet, http.MethodPost}
 
 type grahiteFindHandler struct {
 	storage             graphitestorage.Storage
@@ -168,7 +166,7 @@ func (h *grahiteFindHandler) ServeHTTP(
 		prefix += "."
 	}
 
-	err = handleroptions.AddResponseHeaders(w, meta, opts, nil, nil)
+	err = handleroptions.AddDBResultResponseHeaders(w, meta, opts)
 	if err != nil {
 		logger.Error("unable to render find header", zap.Error(err))
 		xhttp.WriteError(w, err)

--- a/src/query/api/v1/handler/graphite/render.go
+++ b/src/query/api/v1/handler/graphite/render.go
@@ -47,10 +47,8 @@ const (
 	ReadURL = handler.RoutePrefixV1 + "/graphite/render"
 )
 
-var (
-	// ReadHTTPMethods are the HTTP methods used with this resource.
-	ReadHTTPMethods = []string{http.MethodGet, http.MethodPost}
-)
+// ReadHTTPMethods are the HTTP methods used with this resource.
+var ReadHTTPMethods = []string{http.MethodGet, http.MethodPost}
 
 // A renderHandler implements the graphite /render endpoint, including full
 // support for executing functions. It only works against data in M3.
@@ -220,7 +218,7 @@ func (h *renderHandler) serveHTTP(
 		SortApplied: true,
 	}
 
-	if err := handleroptions.AddResponseHeaders(w, meta, fetchOpts, nil, nil); err != nil {
+	if err := handleroptions.AddDBResultResponseHeaders(w, meta, fetchOpts); err != nil {
 		return err
 	}
 

--- a/src/query/api/v1/handler/prom/read.go
+++ b/src/query/api/v1/handler/prom/read.go
@@ -170,6 +170,13 @@ func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			zap.Bool("instant", h.opts.instant))
 	}
 
+	err = handleroptions.AddDBResultResponseHeaders(w, resultMetadata, fetchOptions)
+	if err != nil {
+		h.logger.Error("error writing database limit headers", zap.Error(err))
+		xhttp.WriteError(w, err)
+		return
+	}
+
 	returnedDataLimited := h.limitReturnedData(query, res, fetchOptions)
 	h.returnedDataMetrics.FetchDatapoints.RecordValue(float64(returnedDataLimited.Datapoints))
 	h.returnedDataMetrics.FetchSeries.RecordValue(float64(returnedDataLimited.Series))
@@ -180,7 +187,7 @@ func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		TotalSeries: returnedDataLimited.TotalSeries,
 		Datapoints:  returnedDataLimited.Datapoints,
 	}
-	err = handleroptions.AddResponseHeaders(w, resultMetadata, fetchOptions, limited, nil)
+	err = handleroptions.AddReturnedLimitResponseHeaders(w, limited, nil)
 	if err != nil {
 		h.logger.Error("error writing response headers",
 			zap.Error(err), zap.String("query", query),

--- a/src/query/api/v1/handler/prometheus/native/complete_tags.go
+++ b/src/query/api/v1/handler/prometheus/native/complete_tags.go
@@ -128,6 +128,13 @@ func (h *CompleteTagsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	err := handleroptions.AddDBResultResponseHeaders(w, meta, opts)
+	if err != nil {
+		logger.Error("error writing database limit headers", zap.Error(err))
+		xhttp.WriteError(w, err)
+		return
+	}
+
 	// First write out results to zero output to check if will limit
 	// results and if so then write the header about truncation if occurred.
 	var (
@@ -149,8 +156,8 @@ func (h *CompleteTagsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		TotalResults: renderResult.TotalResults,
 		Limited:      renderResult.LimitedMaxReturnedData,
 	}
-	if err := handleroptions.AddResponseHeaders(w, meta, opts, nil, limited); err != nil {
-		logger.Error("unable to render complete tags headers", zap.Error(err))
+	if err := handleroptions.AddReturnedLimitResponseHeaders(w, nil, limited); err != nil {
+		logger.Error("unable to writing returned limit response headers", zap.Error(err))
 		xhttp.WriteError(w, err)
 		return
 	}

--- a/src/query/api/v1/handler/prometheus/remote/match.go
+++ b/src/query/api/v1/handler/prometheus/remote/match.go
@@ -44,10 +44,8 @@ const (
 	PromSeriesMatchURL = handler.RoutePrefixV1 + "/series"
 )
 
-var (
-	// PromSeriesMatchHTTPMethods are the HTTP methods for this handler.
-	PromSeriesMatchHTTPMethods = []string{http.MethodGet, http.MethodPost}
-)
+// PromSeriesMatchHTTPMethods are the HTTP methods for this handler.
+var PromSeriesMatchHTTPMethods = []string{http.MethodGet, http.MethodPost}
 
 // PromSeriesMatchHandler represents a handler for
 // the prometheus series matcher endpoint.
@@ -106,6 +104,13 @@ func (h *PromSeriesMatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		meta = meta.CombineMetadata(result.Metadata)
 	}
 
+	err = handleroptions.AddDBResultResponseHeaders(w, meta, opts)
+	if err != nil {
+		logger.Error("error writing database limit headers", zap.Error(err))
+		xhttp.WriteError(w, err)
+		return
+	}
+
 	// First write out results to zero output to check if will limit
 	// results and if so then write the header about truncation if occurred.
 	var (
@@ -126,8 +131,8 @@ func (h *PromSeriesMatchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		TotalResults: renderResult.TotalResults,
 		Limited:      renderResult.LimitedMaxReturnedData,
 	}
-	if err := handleroptions.AddResponseHeaders(w, meta, opts, nil, limited); err != nil {
-		logger.Error("unable to render list tags headers", zap.Error(err))
+	if err := handleroptions.AddReturnedLimitResponseHeaders(w, nil, limited); err != nil {
+		logger.Error("unable to returned data headers", zap.Error(err))
 		xhttp.WriteError(w, err)
 		return
 	}

--- a/src/query/api/v1/handler/prometheus/remote/read.go
+++ b/src/query/api/v1/handler/prometheus/remote/read.go
@@ -61,10 +61,8 @@ const (
 	PromReadURL = handler.RoutePrefixV1 + "/prom/remote/read"
 )
 
-var (
-	// PromReadHTTPMethods are the HTTP methods used with this resource.
-	PromReadHTTPMethods = []string{http.MethodPost, http.MethodGet}
-)
+// PromReadHTTPMethods are the HTTP methods used with this resource.
+var PromReadHTTPMethods = []string{http.MethodPost, http.MethodGet}
 
 // promReadHandler is a handler for the prometheus remote read endpoint.
 type promReadHandler struct {
@@ -137,7 +135,7 @@ func (h *promReadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Write headers before response.
-	err = handleroptions.AddResponseHeaders(w, readResult.Meta, fetchOpts, nil, nil)
+	err = handleroptions.AddDBResultResponseHeaders(w, readResult.Meta, fetchOpts)
 	if err != nil {
 		h.promReadMetrics.incError(err)
 		logger.Error("remote read query write response header error",
@@ -446,7 +444,8 @@ func Read(
 				LimitMaxReturnedSeries:         fetchOpts.ReturnedSeriesLimit,
 				LimitMaxReturnedDatapoints:     fetchOpts.ReturnedDatapointsLimit,
 				LimitMaxReturnedSeriesMetadata: fetchOpts.ReturnedSeriesMetadataLimit,
-			}}
+			},
+		}
 
 		engine = opts.Engine()
 

--- a/src/query/api/v1/handler/prometheus/remote/tag_values.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values.go
@@ -110,6 +110,13 @@ func (h *TagValuesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	err = handleroptions.AddDBResultResponseHeaders(w, result.Metadata, opts)
+	if err != nil {
+		logger.Error("error writing database limit headers", zap.Error(err))
+		xhttp.WriteError(w, err)
+		return
+	}
+
 	// First write out results to zero output to check if will limit
 	// results and if so then write the header about truncation if occurred.
 	var (
@@ -125,14 +132,13 @@ func (h *TagValuesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	meta := result.Metadata
 	limited := &handleroptions.ReturnedMetadataLimited{
 		Results:      renderResult.Results,
 		TotalResults: renderResult.TotalResults,
 		Limited:      renderResult.LimitedMaxReturnedData,
 	}
-	if err := handleroptions.AddResponseHeaders(w, meta, opts, nil, limited); err != nil {
-		logger.Error("unable to render tag values headers", zap.Error(err))
+	if err := handleroptions.AddReturnedLimitResponseHeaders(w, nil, limited); err != nil {
+		logger.Error("unable to add returned data headers", zap.Error(err))
 		xhttp.WriteError(w, err)
 		return
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR adds  `AddDBResultResponseHeaders` and `AddReturnedLimitResponseHeaders` to handle adding response headers to a read response. This refactoring is done so that we can encapsulate all the functionality related to limiting a response in a single place in a future change.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
