### PR TITLE
Add Middleware to populate source in request context

### DIFF
--- a/src/query/source/source.go
+++ b/src/query/source/source.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package source identifies the source of query requests.
+package source
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+
+	"github.com/m3db/m3/src/x/headers"
+	"github.com/m3db/m3/src/x/instrument"
+)
+
+type key int
+
+const (
+	typedKey key = iota
+	rawKey
+)
+
+// Deserializer deserializes the raw source bytes into a type for easier use.
+// The raw source can be nil and the Deserializer can return a typed empty value for the application.
+type Deserializer func([]byte) (interface{}, error)
+
+// NewContext returns a new context with the source bytes as a value if the source is non-nil.
+// If a non-nil deserializer is provided an additional typed value is added for easier use.
+func NewContext(ctx context.Context, source []byte, deserialize Deserializer) (context.Context, error) {
+	if source != nil {
+		ctx = context.WithValue(ctx, rawKey, source)
+	}
+	if deserialize != nil {
+		// N.B - it's ok to pass a nil source to the deserializer so it can populate an "empty" value for the
+		// application.
+		typed, err := deserialize(source)
+		if err != nil {
+			return nil, err
+		}
+		ctx = context.WithValue(ctx, typedKey, typed)
+	}
+	return ctx, nil
+}
+
+// FromContext extracts the typed source, or false if it doesn't exist.
+func FromContext(ctx context.Context) (interface{}, bool) {
+	typed := ctx.Value(typedKey)
+	if typed == nil {
+		return nil, false
+	}
+	return typed, true
+}
+
+// RawFromContext extracts the raw bytes of the source, or false if it doesn't exist.
+// This is used by middleware to propagate the source across API boundaries. Application code should use FromContext.
+func RawFromContext(ctx context.Context) ([]byte, bool) {
+	b, ok := ctx.Value(rawKey).([]byte)
+	return b, ok
+}
+
+// Middleware adds the headers.SourceHeader value to the request context.
+// Installing this middleware function allows application code to access the typed source value using FromContext.
+// Additionally a source log field is added to the request scope logger.
+func Middleware(d Deserializer, iOpts instrument.Options) mux.MiddlewareFunc {
+	return func(base http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hs := r.Header[headers.SourceHeader]
+			l := iOpts.LoggerFromContext(r.Context())
+			if len(hs) > 1 {
+				l.Error("multiple values for source header", zap.Strings("headers", hs))
+				base.ServeHTTP(w, r)
+				return
+			}
+			if len(hs) == 0 {
+				l.Error("no source header found")
+				base.ServeHTTP(w, r)
+				return
+			}
+			l = l.With(zap.String("source", hs[0]))
+			ctx := instrument.NewContextFromLogger(r.Context(), l)
+			ctx, err := NewContext(ctx, []byte(hs[0]), d)
+			if err != nil {
+				l.Error("failed to deserialize source", zap.Error(err))
+				base.ServeHTTP(w, r)
+				return
+			}
+			base.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/src/query/source/source.go
+++ b/src/query/source/source.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/query/source/source_test.go
+++ b/src/query/source/source_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package source
 
 import (

--- a/src/query/source/source_test.go
+++ b/src/query/source/source_test.go
@@ -1,0 +1,166 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/m3db/m3/src/x/headers"
+	"github.com/m3db/m3/src/x/instrument"
+)
+
+type testSource struct {
+	name string
+}
+
+var testDeserialize = func(bytes []byte) (interface{}, error) {
+	return testSource{string(bytes)}, nil
+}
+
+func TestSource(t *testing.T) {
+	ctx, err := NewContext(context.Background(), []byte("foobar"), testDeserialize)
+	require.NoError(t, err)
+
+	typed, ok := FromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, testSource{"foobar"}, typed.(testSource))
+
+	raw, ok := RawFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, []byte("foobar"), raw)
+}
+
+func TestNoTypedSource(t *testing.T) {
+	ctx, err := NewContext(context.Background(), []byte("foobar"), nil)
+	require.NoError(t, err)
+
+	typed, ok := FromContext(ctx)
+	require.False(t, ok)
+	require.Nil(t, typed)
+
+	raw, ok := RawFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, []byte("foobar"), raw)
+}
+
+func TestNoSource(t *testing.T) {
+	typed, ok := FromContext(context.Background())
+	require.False(t, ok)
+	require.Nil(t, typed)
+
+	raw, ok := RawFromContext(context.Background())
+	require.False(t, ok)
+	require.Nil(t, raw)
+}
+
+func TestNilSource(t *testing.T) {
+	ctx, err := NewContext(context.Background(), nil, func(bytes []byte) (interface{}, error) {
+		return testSource{"nil"}, nil
+	})
+	require.NoError(t, err)
+
+	typed, ok := FromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, testSource{"nil"}, typed.(testSource))
+
+	raw, ok := RawFromContext(ctx)
+	require.False(t, ok)
+	require.Nil(t, raw)
+}
+
+func TestFromContextErr(t *testing.T) {
+	ctx, err := NewContext(context.Background(), []byte("foobar"), func(bytes []byte) (interface{}, error) {
+		return nil, errors.New("boom")
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boom")
+	require.Nil(t, ctx)
+}
+
+func TestMiddleware(t *testing.T) {
+	cases := []struct {
+		name          string
+		sourceHeaders []string
+		expected      testSource
+		deserializer  Deserializer
+	}{
+		{
+			name:          "happy path",
+			sourceHeaders: []string{"foobar"},
+			expected:      testSource{"foobar"},
+		},
+		{
+			name:          "no source header",
+			sourceHeaders: []string{},
+			expected:      testSource{},
+		},
+		{
+			name:          "multiple source headers",
+			sourceHeaders: []string{"foo", "bar"},
+			expected:      testSource{},
+		},
+		{
+			name:          "deserialize error",
+			sourceHeaders: []string{"foobar"},
+			expected:      testSource{},
+			deserializer: func(bytes []byte) (interface{}, error) {
+				return nil, errors.New("boom")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		core, recorded := observer.New(zapcore.InfoLevel)
+		l := zap.New(core)
+		iOpts := instrument.NewOptions().SetLogger(l)
+		t.Run(tc.name, func(t *testing.T) {
+			r := mux.NewRouter()
+			r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				l = iOpts.LoggerFromContext(r.Context())
+				l.Info("test")
+				typed, ok := FromContext(r.Context())
+				if tc.expected.name == "" {
+					require.False(t, ok)
+					require.Nil(t, typed)
+				} else {
+					require.True(t, ok)
+					require.Equal(t, tc.expected, typed.(testSource))
+				}
+			})
+			if tc.deserializer == nil {
+				tc.deserializer = testDeserialize
+			}
+			r.Use(Middleware(tc.deserializer, iOpts))
+			s := httptest.NewServer(r)
+			defer s.Close()
+
+			req, err := http.NewRequestWithContext(context.Background(), "GET", s.URL, nil)
+			require.NoError(t, err)
+			for _, h := range tc.sourceHeaders {
+				req.Header.Add(headers.SourceHeader, h)
+			}
+			resp, err := s.Client().Do(req)
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+
+			testMsgs := recorded.FilterMessage("test").All()
+			require.Len(t, testMsgs, 1)
+			entry := testMsgs[0]
+			require.Equal(t, "test", entry.Message)
+			fields := entry.ContextMap()
+			if tc.expected.name != "" {
+				require.Len(t, fields, 1)
+				require.Equal(t, tc.expected.name, fields["source"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
This middleware func populates the request context with the value of the
M3-Source header. Additionally it allows providing an optional
Deserializer to convert the header value into a more user friendly type
for the application layer. Both the typed and raw values are accessible
from the context. Most likely only other middleware will use the raw
bytes to forward along the source across api boundaries.

Additionally the Middleware uses the new request scoped logger to add
the source logging field.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
