### PR TITLE
[matcher] [coordinator] Add RequireNamespaceWatchOnInit option

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -284,6 +284,9 @@ type MatcherConfiguration struct {
 	// NamespaceTag defines the namespace tag to use to select rules
 	// namespace to evaluate against. Default is "__m3_namespace__".
 	NamespaceTag string `yaml:"namespaceTag"`
+	// RequireNamespaceWatchOnInit returns the flag to ensure matcher is initialized with a loaded namespace watch.
+	// This only makes sense to use if the corresponding namespace / ruleset values are properly seeded.
+	RequireNamespaceWatchOnInit bool `yaml:"requireNamespaceWatchOnInit"`
 }
 
 // MatcherCacheConfiguration is the configuration for the rule matcher cache.
@@ -710,7 +713,8 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		SetInstrumentOptions(instrumentOpts).
 		SetRuleSetOptions(ruleSetOpts).
 		SetKVStore(o.RulesKVStore).
-		SetNamespaceTag([]byte(namespaceTag))
+		SetNamespaceTag([]byte(namespaceTag)).
+		SetRequireNamespaceWatchOnInit(cfg.Matcher.RequireNamespaceWatchOnInit)
 
 	// NB(r): If rules are being explicitly set in config then we are
 	// going to use an in memory KV store for rules and explicitly set them up.

--- a/src/metrics/matcher/config.go
+++ b/src/metrics/matcher/config.go
@@ -38,15 +38,16 @@ import (
 
 // Configuration is config used to create a Matcher.
 type Configuration struct {
-	InitWatchTimeout      time.Duration                `yaml:"initWatchTimeout"`
-	RulesKVConfig         kv.OverrideConfiguration     `yaml:"rulesKVConfig"`
-	NamespacesKey         string                       `yaml:"namespacesKey" validate:"nonzero"`
-	RuleSetKeyFmt         string                       `yaml:"ruleSetKeyFmt" validate:"nonzero"`
-	NamespaceTag          string                       `yaml:"namespaceTag" validate:"nonzero"`
-	DefaultNamespace      string                       `yaml:"defaultNamespace" validate:"nonzero"`
-	NameTagKey            string                       `yaml:"nameTagKey" validate:"nonzero"`
-	MatchRangePast        *time.Duration               `yaml:"matchRangePast"`
-	SortedTagIteratorPool pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
+	InitWatchTimeout            time.Duration                `yaml:"initWatchTimeout"`
+	RulesKVConfig               kv.OverrideConfiguration     `yaml:"rulesKVConfig"`
+	NamespacesKey               string                       `yaml:"namespacesKey" validate:"nonzero"`
+	RuleSetKeyFmt               string                       `yaml:"ruleSetKeyFmt" validate:"nonzero"`
+	NamespaceTag                string                       `yaml:"namespaceTag" validate:"nonzero"`
+	DefaultNamespace            string                       `yaml:"defaultNamespace" validate:"nonzero"`
+	NameTagKey                  string                       `yaml:"nameTagKey" validate:"nonzero"`
+	MatchRangePast              *time.Duration               `yaml:"matchRangePast"`
+	SortedTagIteratorPool       pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
+	RequireNamespaceWatchOnInit bool                         `yaml:"requireNamespaceWatchOnInit"`
 }
 
 // NewNamespaces creates a matcher.Namespaces.
@@ -136,7 +137,8 @@ func (cfg *Configuration) NewOptions(
 		SetNamespacesKey(cfg.NamespacesKey).
 		SetRuleSetKeyFn(ruleSetKeyFn).
 		SetNamespaceTag([]byte(cfg.NamespaceTag)).
-		SetDefaultNamespace([]byte(cfg.DefaultNamespace))
+		SetDefaultNamespace([]byte(cfg.DefaultNamespace)).
+		SetRequireNamespaceWatchOnInit(cfg.RequireNamespaceWatchOnInit)
 
 	if cfg.InitWatchTimeout != 0 {
 		opts = opts.SetInitWatchTimeout(cfg.InitWatchTimeout)

--- a/src/metrics/matcher/config.go
+++ b/src/metrics/matcher/config.go
@@ -38,16 +38,15 @@ import (
 
 // Configuration is config used to create a Matcher.
 type Configuration struct {
-	InitWatchTimeout            time.Duration                `yaml:"initWatchTimeout"`
-	RulesKVConfig               kv.OverrideConfiguration     `yaml:"rulesKVConfig"`
-	NamespacesKey               string                       `yaml:"namespacesKey" validate:"nonzero"`
-	RuleSetKeyFmt               string                       `yaml:"ruleSetKeyFmt" validate:"nonzero"`
-	NamespaceTag                string                       `yaml:"namespaceTag" validate:"nonzero"`
-	DefaultNamespace            string                       `yaml:"defaultNamespace" validate:"nonzero"`
-	NameTagKey                  string                       `yaml:"nameTagKey" validate:"nonzero"`
-	MatchRangePast              *time.Duration               `yaml:"matchRangePast"`
-	SortedTagIteratorPool       pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
-	RequireNamespaceWatchOnInit bool                         `yaml:"requireNamespaceWatchOnInit"`
+	InitWatchTimeout      time.Duration                `yaml:"initWatchTimeout"`
+	RulesKVConfig         kv.OverrideConfiguration     `yaml:"rulesKVConfig"`
+	NamespacesKey         string                       `yaml:"namespacesKey" validate:"nonzero"`
+	RuleSetKeyFmt         string                       `yaml:"ruleSetKeyFmt" validate:"nonzero"`
+	NamespaceTag          string                       `yaml:"namespaceTag" validate:"nonzero"`
+	DefaultNamespace      string                       `yaml:"defaultNamespace" validate:"nonzero"`
+	NameTagKey            string                       `yaml:"nameTagKey" validate:"nonzero"`
+	MatchRangePast        *time.Duration               `yaml:"matchRangePast"`
+	SortedTagIteratorPool pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
 }
 
 // NewNamespaces creates a matcher.Namespaces.
@@ -137,8 +136,7 @@ func (cfg *Configuration) NewOptions(
 		SetNamespacesKey(cfg.NamespacesKey).
 		SetRuleSetKeyFn(ruleSetKeyFn).
 		SetNamespaceTag([]byte(cfg.NamespaceTag)).
-		SetDefaultNamespace([]byte(cfg.DefaultNamespace)).
-		SetRequireNamespaceWatchOnInit(cfg.RequireNamespaceWatchOnInit)
+		SetDefaultNamespace([]byte(cfg.DefaultNamespace))
 
 	if cfg.InitWatchTimeout != 0 {
 		opts = opts.SetInitWatchTimeout(cfg.InitWatchTimeout)

--- a/src/metrics/matcher/options.go
+++ b/src/metrics/matcher/options.go
@@ -135,22 +135,29 @@ type Options interface {
 
 	// OnRuleSetUpdatedFn returns the function to be called when a ruleset is updated.
 	OnRuleSetUpdatedFn() OnRuleSetUpdatedFn
+
+	// SetRequireNamespaceWatchOnInit sets the flag to ensure matcher is initialized with a loaded namespace watch.
+	SetRequireNamespaceWatchOnInit(value bool) Options
+
+	// RequireNamespaceWatchOnInit returns the flag to ensure matcher is initialized with a loaded namespace watch.
+	RequireNamespaceWatchOnInit() bool
 }
 
 type options struct {
-	clockOpts            clock.Options
-	instrumentOpts       instrument.Options
-	ruleSetOpts          rules.Options
-	initWatchTimeout     time.Duration
-	kvStore              kv.Store
-	namespacesKey        string
-	ruleSetKeyFn         RuleSetKeyFn
-	namespaceTag         []byte
-	defaultNamespace     []byte
-	matchRangePast       time.Duration
-	onNamespaceAddedFn   OnNamespaceAddedFn
-	onNamespaceRemovedFn OnNamespaceRemovedFn
-	onRuleSetUpdatedFn   OnRuleSetUpdatedFn
+	clockOpts                   clock.Options
+	instrumentOpts              instrument.Options
+	ruleSetOpts                 rules.Options
+	initWatchTimeout            time.Duration
+	kvStore                     kv.Store
+	namespacesKey               string
+	ruleSetKeyFn                RuleSetKeyFn
+	namespaceTag                []byte
+	defaultNamespace            []byte
+	matchRangePast              time.Duration
+	onNamespaceAddedFn          OnNamespaceAddedFn
+	onNamespaceRemovedFn        OnNamespaceRemovedFn
+	onRuleSetUpdatedFn          OnRuleSetUpdatedFn
+	requireNamespaceWatchOnInit bool
 }
 
 // NewOptions creates a new set of options.
@@ -297,6 +304,18 @@ func (o *options) SetOnRuleSetUpdatedFn(value OnRuleSetUpdatedFn) Options {
 
 func (o *options) OnRuleSetUpdatedFn() OnRuleSetUpdatedFn {
 	return o.onRuleSetUpdatedFn
+}
+
+// SetRequireNamespaceWatchOnInit sets the flag to ensure matcher is initialized with a loaded namespace watch.
+func (o *options) SetRequireNamespaceWatchOnInit(value bool) Options {
+	opts := *o
+	opts.requireNamespaceWatchOnInit = value
+	return &opts
+}
+
+// RequireNamespaceWatchOnInit returns the flag to ensure matcher is initialized with a loaded namespace watch.
+func (o *options) RequireNamespaceWatchOnInit() bool {
+	return o.requireNamespaceWatchOnInit
 }
 
 func defaultRuleSetKeyFn(namespace []byte) string {


### PR DESCRIPTION
This option on the matcher will require that namespace
values and corresponding rulesets are loaded
in the matcher as part of startup.

This is useful in ensuring dynamic rules are loaded
before we start ingesting metrics.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
