### PR TITLE
[query] Fix bugs in aggregateWithWildcards and update it to support more aggr…

### DIFF
--- a/src/query/graphite/native/aggregation_functions.go
+++ b/src/query/graphite/native/aggregation_functions.go
@@ -338,21 +338,44 @@ func sumSeriesWithWildcards(
 // aggregateWithWildcards splits the given set of series into sub-groupings
 // based on wildcard matches in the hierarchy, then aggregate the values in
 // each grouping based on the given function.
+// Similar to combineSeriesWithWildcards function but more general, as it
+// supports any aggregate functions while combineSeriesWithWildcards only
+// support aggregation with existing ts.ConsolidationFunc.
 func aggregateWithWildcards(
 	ctx *common.Context,
 	series singlePathSpec,
 	fname string,
 	positions ...int,
 ) (ts.SeriesList, error) {
-	f, fexists := summarizeFuncs[fname]
-	if !fexists {
-		err := xerrors.NewInvalidParamsError(fmt.Errorf(
-			"invalid func %s", fname))
-		return ts.NewSeriesList(), err
+	if len(series.Values) == 0 {
+		return ts.SeriesList(series), nil
 	}
 
-	return combineSeriesWithWildcards(ctx, series, positions, f.specificationFunc, f.consolidationFunc)
-}
+	toAggregate, _ := splitSeriesIntoSubgroups(series, positions)
+
+	newSeries := make([]*ts.Series, 0, len(toAggregate))
+	for name, toAggregateSeries := range toAggregate {
+		seriesList := ts.SeriesList{
+			Values:   toAggregateSeries,
+			Metadata: series.Metadata,
+		}
+		aggregated, err := aggregate(ctx, singlePathSpec(seriesList), fname)
+		if err != nil {
+			return ts.NewSeriesList(), err
+		}
+		renamedSeries := aggregated.Values[0].RenamedTo(name)
+		newSeries = append(newSeries, renamedSeries)
+	}
+
+	r := ts.SeriesList(series)
+
+	r.Values = newSeries
+
+	// Ranging over hash map to create results destroys
+	// any sort order on the incoming series list
+	r.SortApplied = false
+
+	return r, nil}
 
 // combineSeriesWithWildcards splits the given set of series into sub-groupings
 // based on wildcard matches in the hierarchy, then combines the values in each
@@ -368,6 +391,34 @@ func combineSeriesWithWildcards(
 		return ts.SeriesList(series), nil
 	}
 
+	toCombine, _ := splitSeriesIntoSubgroups(series, positions)
+
+	newSeries := make([]*ts.Series, 0, len(toCombine))
+	for name, toCombineSeries := range toCombine {
+		seriesList := ts.SeriesList{
+			Values:   toCombineSeries,
+			Metadata: series.Metadata,
+		}
+		combined, err := combineSeries(ctx, multiplePathSpecs(seriesList), name, f)
+		if err != nil {
+			return ts.NewSeriesList(), err
+		}
+		combined.Values[0].Specification = sf(seriesList)
+		newSeries = append(newSeries, combined.Values...)
+	}
+
+	r := ts.SeriesList(series)
+
+	r.Values = newSeries
+
+	// Ranging over hash map to create results destroys
+	// any sort order on the incoming series list
+	r.SortApplied = false
+
+	return r, nil
+}
+
+func splitSeriesIntoSubgroups(series singlePathSpec, positions []int) (map[string][]*ts.Series, error) {
 	var (
 		toCombine = make(map[string][]*ts.Series)
 		wildcards = make(map[int]struct{})
@@ -392,29 +443,7 @@ func combineSeriesWithWildcards(
 		toCombine[newName] = append(toCombine[newName], series)
 	}
 
-	newSeries := make([]*ts.Series, 0, len(toCombine))
-	for name, combinedSeries := range toCombine {
-		seriesList := ts.SeriesList{
-			Values:   combinedSeries,
-			Metadata: series.Metadata,
-		}
-		combined, err := combineSeries(ctx, multiplePathSpecs(seriesList), name, f)
-		if err != nil {
-			return ts.NewSeriesList(), err
-		}
-		combined.Values[0].Specification = sf(seriesList)
-		newSeries = append(newSeries, combined.Values...)
-	}
-
-	r := ts.SeriesList(series)
-
-	r.Values = newSeries
-
-	// Ranging over hash map to create results destroys
-	// any sort order on the incoming series list
-	r.SortApplied = false
-
-	return r, nil
+	return toCombine, nil
 }
 
 // splits a slice into chunks

--- a/src/query/graphite/native/aggregation_functions.go
+++ b/src/query/graphite/native/aggregation_functions.go
@@ -351,7 +351,7 @@ func aggregateWithWildcards(
 		return ts.SeriesList(series), nil
 	}
 
-	toAggregate, _ := splitSeriesIntoSubgroups(series, positions)
+	toAggregate := splitSeriesIntoSubgroups(series, positions)
 
 	newSeries := make([]*ts.Series, 0, len(toAggregate))
 	for name, toAggregateSeries := range toAggregate {
@@ -375,7 +375,8 @@ func aggregateWithWildcards(
 	// any sort order on the incoming series list
 	r.SortApplied = false
 
-	return r, nil}
+	return r, nil
+}
 
 // combineSeriesWithWildcards splits the given set of series into sub-groupings
 // based on wildcard matches in the hierarchy, then combines the values in each
@@ -391,7 +392,7 @@ func combineSeriesWithWildcards(
 		return ts.SeriesList(series), nil
 	}
 
-	toCombine, _ := splitSeriesIntoSubgroups(series, positions)
+	toCombine := splitSeriesIntoSubgroups(series, positions)
 
 	newSeries := make([]*ts.Series, 0, len(toCombine))
 	for name, toCombineSeries := range toCombine {
@@ -418,7 +419,7 @@ func combineSeriesWithWildcards(
 	return r, nil
 }
 
-func splitSeriesIntoSubgroups(series singlePathSpec, positions []int) (map[string][]*ts.Series, error) {
+func splitSeriesIntoSubgroups(series singlePathSpec, positions []int) map[string][]*ts.Series {
 	var (
 		toCombine = make(map[string][]*ts.Series)
 		wildcards = make(map[int]struct{})
@@ -443,7 +444,7 @@ func splitSeriesIntoSubgroups(series singlePathSpec, positions []int) (map[strin
 		toCombine[newName] = append(toCombine[newName], series)
 	}
 
-	return toCombine, nil
+	return toCombine
 }
 
 // splits a slice into chunks

--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -651,7 +651,6 @@ func TestAggregateWithWildcards(t *testing.T) {
 	)
 	defer ctx.Close()
 
-
 	type result struct {
 		name      string
 		sumOfVals float64
@@ -663,7 +662,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 		expectedResults []result
 	}{
 		{"avg", []int{1, 2}, []result{
-			{"servers.status.400", ((20 + 30 + 40 ) / 3) * 12},
+			{"servers.status.400", ((20 + 30 + 40) / 3) * 12},
 			{"servers.status.500", ((2 + 4 + 6 + 8 + 10) / 5) * 12},
 		}},
 		{"max", []int{2, 4}, []result{
@@ -691,7 +690,7 @@ func TestAggregateWithWildcards(t *testing.T) {
 
 		for i, expected := range test.expectedResults {
 			series := outSeries.Values[i]
-			assert.Equal(t, expected.name, series.Name(),"wrong name for %v %s (%d)", test.nodes, test.fname, i)
+			assert.Equal(t, expected.name, series.Name(), "wrong name for %v %s (%d)", test.nodes, test.fname, i)
 
 			assert.Equal(t, expected.sumOfVals, series.SafeSum(),
 				"wrong result for %v %s (%d)", test.nodes, test.fname, i)

--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -651,26 +651,51 @@ func TestAggregateWithWildcards(t *testing.T) {
 	)
 	defer ctx.Close()
 
-	outSeries, err := aggregateWithWildcards(ctx, singlePathSpec{
-		Values: inputs,
-	}, "sum", 1, 2)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(outSeries.Values))
 
-	outSeries, _ = sortByName(ctx, singlePathSpec(outSeries), false, false)
-
-	expectedOutputs := []struct {
+	type result struct {
 		name      string
 		sumOfVals float64
-	}{
-		{"servers.status.400", 90 * 12},
-		{"servers.status.500", 30 * 12},
 	}
 
-	for i, expected := range expectedOutputs {
-		series := outSeries.Values[i]
-		assert.Equal(t, expected.name, series.Name())
-		assert.Equal(t, expected.sumOfVals, series.SafeSum())
+	tests := []struct {
+		fname           string
+		nodes           []int
+		expectedResults []result
+	}{
+		{"avg", []int{1, 2}, []result{
+			{"servers.status.400", ((20 + 30 + 40 ) / 3) * 12},
+			{"servers.status.500", ((2 + 4 + 6 + 8 + 10) / 5) * 12},
+		}},
+		{"max", []int{2, 4}, []result{
+			{"servers.status.400", 40 * 12},
+			{"servers.status.500", 10 * 12},
+		}},
+		{"min", []int{2, -1}, []result{
+			{"servers.status.400", 20 * 12},
+			{"servers.status.500", 2 * 12},
+		}},
+		{"median", []int{1, 2}, []result{
+			{"servers.status.400", 30 * 12},
+			{"servers.status.500", 6 * 12},
+		}},
+	}
+
+	for _, test := range tests {
+		outSeries, err := aggregateWithWildcards(ctx, singlePathSpec{
+			Values: inputs,
+		}, test.fname, 1, 2)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(outSeries.Values))
+
+		outSeries, _ = sortByName(ctx, singlePathSpec(outSeries), false, false)
+
+		for i, expected := range test.expectedResults {
+			series := outSeries.Values[i]
+			assert.Equal(t, expected.name, series.Name(),"wrong name for %v %s (%d)", test.nodes, test.fname, i)
+
+			assert.Equal(t, expected.sumOfVals, series.SafeSum(),
+				"wrong result for %v %s (%d)", test.nodes, test.fname, i)
+		}
 	}
 }
 


### PR DESCRIPTION
…egate functions

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
aggregateWithWildcards will crash if use with 'median' aggregate function. Also there are other function it doesn't support such as diff, multiple, range, etc. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
