### PR TITLE
[tools] Close the reader in read_data_files

### DIFF
--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -204,4 +204,8 @@ func main() {
 			fmt.Printf("\nTotal annotation size: %d bytes\n", annotationSizeTotal) // nolint: forbidigo
 		}
 	}
+
+	if err := reader.Close(); err != nil {
+		log.Fatalf("unable close reader: %v", err)
+	}
 }

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -206,6 +206,6 @@ func main() {
 	}
 
 	if err := reader.Close(); err != nil {
-		log.Fatalf("unable close reader: %v", err)
+		log.Fatalf("unable to close reader: %v", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a missing `reader.Close()` to `read_data_files` utility.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE