### PR TITLE
[tools] Use streaming reads in read_data_files

### DIFF
--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -136,7 +136,8 @@ func main() {
 			BlockStart:  time.Unix(0, *optBlockstart),
 			VolumeIndex: int(*volume),
 		},
-		FileSetType: fileSetType,
+		FileSetType:      fileSetType,
+		StreamingEnabled: true,
 	}
 
 	err = reader.Open(openOpts)
@@ -145,7 +146,7 @@ func main() {
 	}
 
 	for {
-		id, _, data, _, err := reader.Read()
+		entry, err := reader.StreamingRead()
 		if err == io.EOF {
 			break
 		}
@@ -153,14 +154,17 @@ func main() {
 			log.Fatalf("err reading metadata: %v", err)
 		}
 
+		var (
+			id   = entry.ID
+			data = entry.Data
+		)
+
 		if *idFilter != "" && !strings.Contains(id.String(), *idFilter) {
 			continue
 		}
 
 		if benchMode != benchmarkSeries {
-			data.IncRef()
-
-			iter := m3tsz.NewReaderIterator(xio.NewBytesReader64(data.Bytes()), true, encodingOpts)
+			iter := m3tsz.NewReaderIterator(xio.NewBytesReader64(data), true, encodingOpts)
 			for iter.Next() {
 				dp, _, annotation := iter.Current()
 				if benchMode == benchmarkNone {
@@ -179,11 +183,8 @@ func main() {
 				log.Fatalf("unable to iterate original data: %v", err)
 			}
 			iter.Close()
-
-			data.DecRef()
 		}
 
-		data.Finalize()
 		seriesCount++
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Modifies `read_data_files` to use `StreamingRead`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
