### PR TITLE
[query] Fix Graphite context time window expansions not being cumulative

### DIFF
--- a/src/query/graphite/common/context.go
+++ b/src/query/graphite/common/context.go
@@ -161,12 +161,8 @@ func (c *Context) NewChildContext(opts ChildContextOptions) *Context {
 		child.TimeRangeAdjustment.OriginalEnd = origEnd
 		child.TimeRangeAdjustment.ShiftStart += opts.adjustment.shiftStart
 		child.TimeRangeAdjustment.ShiftEnd += opts.adjustment.shiftEnd
-		if opts.adjustment.expandStart > child.TimeRangeAdjustment.ExpandStart {
-			child.TimeRangeAdjustment.ExpandStart = opts.adjustment.expandStart
-		}
-		if opts.adjustment.expandEnd > child.TimeRangeAdjustment.ExpandEnd {
-			child.TimeRangeAdjustment.ExpandEnd = opts.adjustment.expandEnd
-		}
+		child.TimeRangeAdjustment.ExpandStart += opts.adjustment.expandStart
+		child.TimeRangeAdjustment.ExpandEnd += opts.adjustment.expandEnd
 
 		child.StartTime = origStart.
 			Add(child.TimeRangeAdjustment.ShiftStart).

--- a/src/query/graphite/common/test_util.go
+++ b/src/query/graphite/common/test_util.go
@@ -92,16 +92,22 @@ func NewConsolidationTestSeries(start, end time.Time, duration time.Duration) (*
 }
 
 // CompareOutputsAndExpected compares the actual output with the expected output.
-func CompareOutputsAndExpected(t *testing.T, step int, start time.Time, expected []TestSeries,
-	actual []*ts.Series) {
-	require.Equal(t, len(expected), len(actual))
+func CompareOutputsAndExpected(
+	t *testing.T,
+	step int,
+	start time.Time,
+	expected []TestSeries,
+	actual []*ts.Series,
+) {
+	require.Equal(t, len(expected), len(actual), "mismatch series count")
 	for i := range expected {
 		i := i // To capture for wrapMsg.
 		e := expected[i].Data
 		a := actual[i]
 		wrapMsg := func(str string) string {
-			return fmt.Sprintf("%s\nseries=%d\nexpected=%v\nactual=%v",
-				str, i, e, a.SafeValues())
+			return fmt.Sprintf("%s\nseries=%d\nexpected=%v\nactual=%v\n"+
+				"expectedStart=%v\nactualStart=%v\n",
+				str, i, e, a.SafeValues(), start, a.StartTime())
 		}
 		require.Equal(t, expected[i].Name, a.Name())
 		assert.Equal(t, step, a.MillisPerStep(), wrapMsg(a.Name()+

--- a/src/query/graphite/native/builtin_functions_test.go
+++ b/src/query/graphite/native/builtin_functions_test.go
@@ -1080,7 +1080,6 @@ func TestMovingSumOfMovingSum(t *testing.T) {
 			}
 			length := int(opts.EndTime.Sub(opts.StartTime) / time.Minute)
 			values := data[len(data)-length:]
-			fmt.Printf("returning values: %v\n", values)
 			return &storage.FetchResult{
 				SeriesList: []*ts.Series{
 					ts.NewSeries(ctx, query, opts.StartTime,

--- a/src/query/graphite/native/builtin_functions_test.go
+++ b/src/query/graphite/native/builtin_functions_test.go
@@ -1066,7 +1066,7 @@ func TestMovingSumOfMovingSum(t *testing.T) {
 	)
 
 	defer ctrl.Finish()
-	defer ctx.Close()
+	defer func() { _ = ctx.Close() }()
 
 	store.EXPECT().
 		FetchByQuery(gomock.Any(), "foo.bar", gomock.Any()).

--- a/src/query/graphite/native/builtin_functions_test.go
+++ b/src/query/graphite/native/builtin_functions_test.go
@@ -1046,6 +1046,74 @@ func TestMovingSumSuccess(t *testing.T) {
 	testMovingFunction(t, "movingSum(foo.bar.baz, '30s')", "movingSum(foo.bar.baz,3)", nil, nil, nil)
 }
 
+// TestMovingSumOfMovingSum tests that expansion of the time window
+// fetched is stacked when child contexts are created, otherwise the child
+// functions do not have enough data to work with to satisfy the parent call.
+func TestMovingSumOfMovingSum(t *testing.T) {
+	var (
+		ctrl   = xgomock.NewController(t)
+		store  = storage.NewMockStorage(ctrl)
+		engine = NewEngine(store, CompileOptions{})
+		end    = time.Now().Truncate(time.Minute)
+		start  = end.Add(-5 * time.Minute)
+		ctx    = common.NewContext(common.ContextOptions{
+			Start:  start,
+			End:    end,
+			Engine: engine,
+		})
+		millisPerStep = 60000
+		data          = []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
+	)
+
+	defer ctrl.Finish()
+	defer ctx.Close()
+
+	store.EXPECT().
+		FetchByQuery(gomock.Any(), "foo.bar", gomock.Any()).
+		DoAndReturn(func(
+			_ *common.Context,
+			query string,
+			opts storage.FetchOptions,
+		) (*storage.FetchResult, error) {
+			if !opts.EndTime.Equal(end) {
+				return nil, fmt.Errorf("unexpected end")
+			}
+			length := int(opts.EndTime.Sub(opts.StartTime) / time.Minute)
+			values := data[len(data)-length:]
+			fmt.Printf("returning values: %v\n", values)
+			return &storage.FetchResult{
+				SeriesList: []*ts.Series{
+					ts.NewSeries(ctx, query, opts.StartTime,
+						common.NewTestSeriesValues(ctx, millisPerStep, values)),
+				},
+			}, nil
+		}).
+		AnyTimes()
+
+	target := `movingSum(movingSum(foo.bar,"2min"),"5min")`
+
+	phonyContext := common.NewContext(common.ContextOptions{
+		Start:  start,
+		End:    end,
+		Engine: engine,
+	})
+
+	expr, err := phonyContext.Engine.(*Engine).Compile(target)
+	require.NoError(t, err)
+	res, err := expr.Execute(phonyContext)
+	require.NoError(t, err)
+
+	expected := []common.TestSeries{
+		{
+			Name: target,
+			Data: []float64{65, 75, 85, 95, 105},
+		},
+	}
+
+	common.CompareOutputsAndExpected(t, millisPerStep, start,
+		expected, res.Values)
+}
+
 func TestMovingSumError(t *testing.T) {
 	testMovingFunctionError(t, "movingSum(foo.bar.baz, '-30s')")
 	testMovingFunctionError(t, "movingSum(foo.bar.baz, 0)")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Expansions of time windows need to be stacked not taken maximum of when creating context shifts so that the first few datapoints have enough of the inner shifted time window than the outer.

This affects calls such as the following missing the first few datapoints (as per test):
```
movingSum(movingSum(foo.bar,"2min"),"5min")
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
