### PR TITLE
[query] Fix Graphite nil arg not interpreted as explicit nil for asPercent

### DIFF
--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -1112,24 +1112,15 @@ func asPercent(ctx *common.Context, input singlePathSpec, total genericInterface
 				"require total to be missing, float, single series or same number of series: series=%d, total=%d",
 				len(input.Values), total.Len()))
 		}
-		if total.Len() == 0 {
-			// Same as nil take as sum of input.
-			sum, err := sumSeries(ctx, multiplePathSpecs(input))
-			if err != nil {
-				return ts.NewSeriesList(), err
-			}
-			totalSeriesList = sum
-		} else {
-			// Sort both by name so they get divided by same name if same length
-			// or closest match.
-			sort.Slice(input.Values, func(i, j int) bool {
-				return strings.Compare(input.Values[i].Name(), input.Values[j].Name()) < 0
-			})
-			sort.Slice(total.Values, func(i, j int) bool {
-				return strings.Compare(total.Values[i].Name(), total.Values[j].Name()) < 0
-			})
-			totalSeriesList = total
-		}
+		// Sort both by name so they get divided by same name if same length
+		// or closest match.
+		sort.Slice(input.Values, func(i, j int) bool {
+			return strings.Compare(input.Values[i].Name(), input.Values[j].Name()) < 0
+		})
+		sort.Slice(total.Values, func(i, j int) bool {
+			return strings.Compare(total.Values[i].Name(), total.Values[j].Name()) < 0
+		})
+		totalSeriesList = total
 	default:
 		err := xerrors.NewInvalidParamsError(errors.New(
 			"total must be either an nil, float, a series or same number of series"))
@@ -2568,7 +2559,7 @@ func init() {
 		4: "", // newName
 	})
 	MustRegisterFunction(asPercent).WithDefaultParams(map[uint8]interface{}{
-		2: []*ts.Series(nil), // total
+		2: nil, // total
 	})
 	MustRegisterFunction(averageAbove)
 	MustRegisterFunction(averageSeries)

--- a/src/query/graphite/native/compiler_test.go
+++ b/src/query/graphite/native/compiler_test.go
@@ -406,7 +406,12 @@ func assertExprTree(t *testing.T, expected interface{}, actual interface{}, msg 
 	case constFuncArg:
 		a, ok := actual.(constFuncArg)
 		require.True(t, ok, msg)
-		xtest.Equalish(t, e.value.Interface(), a.value.Interface(), msg)
+		if !a.value.IsValid() {
+			// Explicit nil.
+			require.True(t, e.value.IsZero())
+		} else {
+			xtest.Equalish(t, e.value.Interface(), a.value.Interface(), msg)
+		}
 	default:
 		assert.Equal(t, expected, actual, msg)
 	}

--- a/src/query/graphite/native/functions.go
+++ b/src/query/graphite/native/functions.go
@@ -444,6 +444,11 @@ func (f *Function) reflectCall(ctx *common.Context, args []reflect.Value) (refle
 
 	// Cast to the expected typealias type of ts.SeriesList before calling
 	for i, arg := range in {
+		if !arg.IsValid() {
+			// Zero value arg is a nil.
+			in[i] = reflect.New(genericInterfaceType).Elem()
+			continue
+		}
 		typeArg := arg.Type()
 		if typeArg != seriesListType {
 			continue
@@ -625,12 +630,12 @@ func (call *functionCall) String() string {
 // isTimeSeries checks whether the given value contains a timeseries or
 // timeseries list
 func isTimeSeries(v reflect.Value) bool {
-	return v.Type() == seriesListType
+	return v.IsValid() && v.Type() == seriesListType
 }
 
 // getStats gets trace stats for the given timeseries argument
 func getStats(v reflect.Value) common.TraceStats {
-	if v.Type() == timeSeriesType {
+	if v.IsValid() && v.Type() == timeSeriesType {
 		return common.TraceStats{NumSeries: 1}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
By default Graphite uses `nil` to mean take the sum of the numerator as the denominator. Using an empty list as the default value for the total arg causes it not to be interpreted as explicit `nil` and instead for it to treat it as an empty fetch expression that fetched no series which then causes an error (which is correct if you fetched no series, but in this case the correct behavior is to use the sum of the numerator as the denominator).

This also fixes Graphite function execution to allow passing explicit nil as arguments since before it would cause issues unwrapping the nil without checking during function call execution.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
