### PR TITLE
[dbnode] Refactor fs.ReadIndexInfoFiles parameters

### DIFF
--- a/src/cmd/tools/query_index_segments/main/main.go
+++ b/src/cmd/tools/query_index_segments/main/main.go
@@ -135,8 +135,11 @@ func run(opts runOptions) {
 
 	var (
 		nsID      = ident.StringID(opts.namespace)
-		infoFiles = fs.ReadIndexInfoFiles(fsOpts.FilePathPrefix(), nsID,
-			fsOpts.InfoReaderBufferSize())
+		infoFiles = fs.ReadIndexInfoFiles(fs.ReadIndexInfoFilesOptions{
+			FilePathPrefix:   fsOpts.FilePathPrefix(),
+			Namespace:        nsID,
+			ReaderBufferSize: fsOpts.InfoReaderBufferSize(),
+		})
 		results     = make(map[string]struct{})
 		resultsLock sync.Mutex
 		wg          sync.WaitGroup

--- a/src/cmd/tools/read_index_segments/main/main.go
+++ b/src/cmd/tools/read_index_segments/main/main.go
@@ -157,8 +157,11 @@ func readNamespaceSegments(
 	log *zap.Logger,
 ) {
 	var (
-		infoFiles = fs.ReadIndexInfoFiles(fsOpts.FilePathPrefix(), nsID,
-			fsOpts.InfoReaderBufferSize())
+		infoFiles = fs.ReadIndexInfoFiles(fs.ReadIndexInfoFilesOptions{
+			FilePathPrefix:   fsOpts.FilePathPrefix(),
+			Namespace:        nsID,
+			ReaderBufferSize: fsOpts.InfoReaderBufferSize(),
+		})
 		wg sync.WaitGroup
 	)
 

--- a/src/dbnode/integration/peers_bootstrap_index_test.go
+++ b/src/dbnode/integration/peers_bootstrap_index_test.go
@@ -215,11 +215,11 @@ func getNumDocsPerBlockStart(
 	fsOpts fs.Options,
 ) (map[xtime.UnixNano]int, error) {
 	numDocsPerBlockStart := make(map[xtime.UnixNano]int)
-	infoFiles := fs.ReadIndexInfoFiles(
-		fsOpts.FilePathPrefix(),
-		nsID,
-		fsOpts.InfoReaderBufferSize(),
-	)
+	infoFiles := fs.ReadIndexInfoFiles(fs.ReadIndexInfoFilesOptions{
+		FilePathPrefix:   fsOpts.FilePathPrefix(),
+		Namespace:        nsID,
+		ReaderBufferSize: fsOpts.InfoReaderBufferSize(),
+	})
 	// Grab the latest index info file for each blockstart.
 	latestIndexInfoPerBlockStart := make(map[xtime.UnixNano]indexInfo)
 	for _, f := range infoFiles {

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -82,9 +82,7 @@ const (
 	errUnexpectedFilenamePattern = "unexpected filename: %s"
 )
 
-var (
-	defaultBufioReaderSize = bufio.NewReader(nil).Size()
-)
+var defaultBufioReaderSize = bufio.NewReader(nil).Size()
 
 type fileOpener func(filePath string) (*os.File, error)
 
@@ -859,6 +857,13 @@ func ReadInfoFiles(
 	return infoFileResults
 }
 
+// ReadIndexInfoFilesOptions specifies options for reading index info files.
+type ReadIndexInfoFilesOptions struct {
+	FilePathPrefix   string
+	Namespace        ident.ID
+	ReaderBufferSize int
+}
+
 // ReadIndexInfoFileResult is the result of reading an info file
 type ReadIndexInfoFileResult struct {
 	ID                FileSetFileIdentifier
@@ -869,20 +874,16 @@ type ReadIndexInfoFileResult struct {
 
 // ReadIndexInfoFiles reads all the valid index info entries. Even if ReadIndexInfoFiles returns an error,
 // there may be some valid entries in the returned slice.
-func ReadIndexInfoFiles(
-	filePathPrefix string,
-	namespace ident.ID,
-	readerBufferSize int,
-) []ReadIndexInfoFileResult {
+func ReadIndexInfoFiles(opts ReadIndexInfoFilesOptions) []ReadIndexInfoFileResult {
 	var infoFileResults []ReadIndexInfoFileResult
 	forEachInfoFile(
 		forEachInfoFileSelector{
 			fileSetType:    persist.FileSetFlushType,
 			contentType:    persist.FileSetIndexContentType,
-			filePathPrefix: filePathPrefix,
-			namespace:      namespace,
+			filePathPrefix: opts.FilePathPrefix,
+			namespace:      opts.Namespace,
 		},
-		readerBufferSize,
+		opts.ReaderBufferSize,
 		func(file FileSetFile, data []byte) {
 			filepath, _ := file.InfoFilePath()
 			id := file.ID

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source.go
@@ -936,8 +936,11 @@ func (s *fileSystemSource) bootstrapFromIndexPersistedBlocks(
 	}
 
 	indexBlockSize := ns.Options().IndexOptions().BlockSize()
-	infoFiles := fs.ReadIndexInfoFiles(s.fsopts.FilePathPrefix(), ns.ID(),
-		s.fsopts.InfoReaderBufferSize())
+	infoFiles := fs.ReadIndexInfoFiles(fs.ReadIndexInfoFilesOptions{
+		FilePathPrefix:   s.fsopts.FilePathPrefix(),
+		Namespace:        ns.ID(),
+		ReaderBufferSize: s.fsopts.InfoReaderBufferSize(),
+	})
 
 	for _, infoFile := range infoFiles {
 		if err := infoFile.Err.Error(); err != nil {

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/source_index_test.go
@@ -339,8 +339,11 @@ func TestBootstrapIndex(t *testing.T) {
 	indexResults := tester.ResultForNamespace(nsMD.ID()).IndexResult.IndexResults()
 
 	// Check that single persisted segment got written out
-	infoFiles := fs.ReadIndexInfoFiles(src.fsopts.FilePathPrefix(), testNs1ID,
-		src.fsopts.InfoReaderBufferSize())
+	infoFiles := fs.ReadIndexInfoFiles(fs.ReadIndexInfoFilesOptions{
+		FilePathPrefix:   src.fsopts.FilePathPrefix(),
+		Namespace:        testNs1ID,
+		ReaderBufferSize: src.fsopts.InfoReaderBufferSize(),
+	})
 	require.Equal(t, 1, len(infoFiles))
 
 	for _, infoFile := range infoFiles {
@@ -419,8 +422,11 @@ func TestBootstrapIndexIgnoresPersistConfigIfSnapshotType(t *testing.T) {
 	indexResults := tester.ResultForNamespace(nsMD.ID()).IndexResult.IndexResults()
 
 	// Check that not segments were written out
-	infoFiles := fs.ReadIndexInfoFiles(src.fsopts.FilePathPrefix(), testNs1ID,
-		src.fsopts.InfoReaderBufferSize())
+	infoFiles := fs.ReadIndexInfoFiles(fs.ReadIndexInfoFilesOptions{
+		FilePathPrefix:   src.fsopts.FilePathPrefix(),
+		Namespace:        testNs1ID,
+		ReaderBufferSize: src.fsopts.InfoReaderBufferSize(),
+	})
 	require.Equal(t, 0, len(infoFiles))
 
 	// Check that both segments are mutable
@@ -641,8 +647,11 @@ func testBootstrapIndexWithPersistForIndexBlockAtRetentionEdge(t *testing.T, tes
 	indexResults := tester.ResultForNamespace(ns.ID()).IndexResult.IndexResults()
 
 	// Check that single persisted segment got written out
-	infoFiles := fs.ReadIndexInfoFiles(src.fsopts.FilePathPrefix(), testNs1ID,
-		src.fsopts.InfoReaderBufferSize())
+	infoFiles := fs.ReadIndexInfoFiles(fs.ReadIndexInfoFilesOptions{
+		FilePathPrefix:   src.fsopts.FilePathPrefix(),
+		Namespace:        testNs1ID,
+		ReaderBufferSize: src.fsopts.InfoReaderBufferSize(),
+	})
 	require.Equal(t, test.expectedInfoFiles, len(infoFiles), "index info files")
 
 	for _, infoFile := range infoFiles {

--- a/src/dbnode/storage/cleanup.go
+++ b/src/dbnode/storage/cleanup.go
@@ -146,27 +146,27 @@ func (m *cleanupManager) WarmFlushCleanup(t time.Time) error {
 	multiErr := xerrors.NewMultiError()
 	if err := m.cleanupExpiredIndexFiles(t, namespaces); err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
-			"encountered errors when cleaning up index files for %v: %v", t, err))
+			"encountered errors when cleaning up index files for %v: %w", t, err))
 	}
 
 	if err := m.cleanupDuplicateIndexFiles(namespaces); err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
-			"encountered errors when cleaning up index files for %v: %v", t, err))
+			"encountered errors when cleaning up index files for %v: %w", t, err))
 	}
 
 	if err := m.deleteInactiveDataSnapshotFiles(namespaces); err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
-			"encountered errors when deleting inactive snapshot files for %v: %v", t, err))
+			"encountered errors when deleting inactive snapshot files for %v: %w", t, err))
 	}
 
 	if err := m.deleteInactiveNamespaceFiles(namespaces); err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
-			"encountered errors when deleting inactive namespace files for %v: %v", t, err))
+			"encountered errors when deleting inactive namespace files for %v: %w", t, err))
 	}
 
 	if err := m.cleanupSnapshotsAndCommitlogs(namespaces); err != nil {
 		multiErr = multiErr.Add(fmt.Errorf(
-			"encountered errors when cleaning up snapshot and commitlog files: %v", err))
+			"encountered errors when cleaning up snapshot and commitlog files: %w", err))
 	}
 
 	return multiErr.FinalError()
@@ -201,6 +201,7 @@ func (m *cleanupManager) ColdFlushCleanup(t time.Time) error {
 
 	return multiErr.FinalError()
 }
+
 func (m *cleanupManager) Report() {
 	m.RLock()
 	coldFlushCleanupInProgress := m.coldFlushCleanupInProgress

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -190,10 +190,7 @@ type indexFilesetsBeforeFn func(dir string,
 	exclusiveTime time.Time,
 ) ([]string, error)
 
-type readIndexInfoFilesFn func(filePathPrefix string,
-	namespace ident.ID,
-	readerBufferSize int,
-) []fs.ReadIndexInfoFileResult
+type readIndexInfoFilesFn func(opts fs.ReadIndexInfoFilesOptions) []fs.ReadIndexInfoFileResult
 
 type newNamespaceIndexOpts struct {
 	md                      namespace.Metadata
@@ -1039,11 +1036,11 @@ func (i *nsIndex) flushableBlocks(
 	// NB(bodu): We read index info files once here to avoid re-reading all of them
 	// for each block.
 	fsOpts := i.opts.CommitLogOptions().FilesystemOptions()
-	infoFiles := i.readIndexInfoFilesFn(
-		fsOpts.FilePathPrefix(),
-		i.nsMetadata.ID(),
-		fsOpts.InfoReaderBufferSize(),
-	)
+	infoFiles := i.readIndexInfoFilesFn(fs.ReadIndexInfoFilesOptions{
+		FilePathPrefix:   fsOpts.FilePathPrefix(),
+		Namespace:        i.nsMetadata.ID(),
+		ReaderBufferSize: fsOpts.InfoReaderBufferSize(),
+	})
 	flushable := make([]index.Block, 0, len(i.state.blocksByTime))
 
 	now := i.nowFn()
@@ -2071,11 +2068,11 @@ func (i *nsIndex) CleanupExpiredFileSets(t time.Time) error {
 
 func (i *nsIndex) CleanupDuplicateFileSets(activeShards []uint32) error {
 	fsOpts := i.opts.CommitLogOptions().FilesystemOptions()
-	infoFiles := i.readIndexInfoFilesFn(
-		fsOpts.FilePathPrefix(),
-		i.nsMetadata.ID(),
-		fsOpts.InfoReaderBufferSize(),
-	)
+	infoFiles := i.readIndexInfoFilesFn(fs.ReadIndexInfoFilesOptions{
+		FilePathPrefix:   fsOpts.FilePathPrefix(),
+		Namespace:        i.nsMetadata.ID(),
+		ReaderBufferSize: fsOpts.InfoReaderBufferSize(),
+	})
 
 	segmentsOrderByVolumeIndexByVolumeTypeAndBlockStart := make(map[xtime.UnixNano]map[idxpersist.IndexVolumeType][]fs.Segments)
 	for _, file := range infoFiles {

--- a/src/dbnode/storage/index_test.go
+++ b/src/dbnode/storage/index_test.go
@@ -138,11 +138,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets(t *testing.T) {
 		},
 	}
 
-	idx.readIndexInfoFilesFn = func(
-		filePathPrefix string,
-		namespace ident.ID,
-		readerBufferSize int,
-	) []fs.ReadIndexInfoFileResult {
+	idx.readIndexInfoFilesFn = func(_ fs.ReadIndexInfoFilesOptions) []fs.ReadIndexInfoFileResult {
 		return infoFiles
 	}
 	idx.deleteFilesFn = func(s []string) error {
@@ -221,7 +217,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets_SortingByBlockStartAndVolumeType
 		testShardSet, DefaultTestOptions())
 	require.NoError(t, err)
 	idx := nsIdx.(*nsIndex)
-	idx.readIndexInfoFilesFn = func(_ string, _ ident.ID, _ int) []fs.ReadIndexInfoFileResult {
+	idx.readIndexInfoFilesFn = func(_ fs.ReadIndexInfoFilesOptions) []fs.ReadIndexInfoFileResult {
 		return infoFiles
 	}
 	idx.deleteFilesFn = func(s []string) error {
@@ -286,7 +282,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets_ChangingShardList(t *testing.T) 
 		testShardSet, DefaultTestOptions())
 	require.NoError(t, err)
 	idx := nsIdx.(*nsIndex)
-	idx.readIndexInfoFilesFn = func(_ string, _ ident.ID, _ int) []fs.ReadIndexInfoFileResult {
+	idx.readIndexInfoFilesFn = func(_ fs.ReadIndexInfoFilesOptions) []fs.ReadIndexInfoFileResult {
 		return infoFiles
 	}
 	idx.deleteFilesFn = func(s []string) error {
@@ -337,7 +333,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets_IgnoreNonActiveShards(t *testing
 		testShardSet, DefaultTestOptions())
 	require.NoError(t, err)
 	idx := nsIdx.(*nsIndex)
-	idx.readIndexInfoFilesFn = func(_ string, _ ident.ID, _ int) []fs.ReadIndexInfoFileResult {
+	idx.readIndexInfoFilesFn = func(_ fs.ReadIndexInfoFilesOptions) []fs.ReadIndexInfoFileResult {
 		return infoFiles
 	}
 	idx.deleteFilesFn = func(s []string) error {
@@ -388,7 +384,7 @@ func TestNamespaceIndexCleanupDuplicateFilesets_NoActiveShards(t *testing.T) {
 		testShardSet, DefaultTestOptions())
 	require.NoError(t, err)
 	idx := nsIdx.(*nsIndex)
-	idx.readIndexInfoFilesFn = func(_ string, _ ident.ID, _ int) []fs.ReadIndexInfoFileResult {
+	idx.readIndexInfoFilesFn = func(_ fs.ReadIndexInfoFilesOptions) []fs.ReadIndexInfoFileResult {
 		return infoFiles
 	}
 	idx.deleteFilesFn = func(s []string) error {
@@ -450,11 +446,7 @@ func TestNamespaceIndexCleanupDuplicateFilesetsNoop(t *testing.T) {
 		},
 	}
 
-	idx.readIndexInfoFilesFn = func(
-		filePathPrefix string,
-		namespace ident.ID,
-		readerBufferSize int,
-	) []fs.ReadIndexInfoFileResult {
+	idx.readIndexInfoFilesFn = func(_ fs.ReadIndexInfoFilesOptions) []fs.ReadIndexInfoFileResult {
 		return infoFiles
 	}
 	idx.deleteFilesFn = func(s []string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Refactor  `fs.ReadIndexInfoFiles` function arguments. This is extracted out of #3430 in order to make the latter smaller and a bit more focused.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
