### PR TITLE
Support M3-Timeout header for request timeouts

### DIFF
--- a/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
@@ -427,6 +427,11 @@ func ParseRequestTimeout(
 	if v := r.Header.Get(TimeoutParam); v != "" {
 		timeout = v
 	}
+	// Prefer the M3-Timeout header to the incorrect header using the param name. The param name should have never been
+	// allowed as a header, but we continue to support it for backwards compatibility.
+	if v := r.Header.Get(headers.TimeoutHeader); v != "" {
+		timeout = v
+	}
 
 	if timeout == "" {
 		return configFetchTimeout, nil

--- a/src/query/api/v1/handler/prometheus/handleroptions/fetch_options_test.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/fetch_options_test.go
@@ -431,7 +431,13 @@ func TestTimeoutParseWithHeader(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, timeout, time.Millisecond)
 
+	req.Header.Add(headers.TimeoutHeader, "1s")
+	timeout, err = ParseRequestTimeout(req, time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, timeout, time.Second)
+
 	req.Header.Del("timeout")
+	req.Header.Del(headers.TimeoutHeader)
 	timeout, err = ParseRequestTimeout(req, 2*time.Minute)
 	assert.NoError(t, err)
 	assert.Equal(t, timeout, 2*time.Minute)


### PR DESCRIPTION
Using the timeout form param name for the header was incorrect. For
backwards compatibility we can still support it, but should encourage
clients to set the M3-Timeout header instead.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
