### PR TITLE
Use the path template for the http handler metrics

### DIFF
--- a/src/query/api/v1/middleware/metrics_test.go
+++ b/src/query/api/v1/middleware/metrics_test.go
@@ -37,15 +37,16 @@ func TestResponseMetrics(t *testing.T) {
 	iOpts := instrument.NewOptions().SetMetricsScope(scope)
 
 	r := mux.NewRouter()
-	h := ResponseMetrics(iOpts).Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	route := r.NewRoute()
+	h := ResponseMetrics(iOpts, route).Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	}))
-	r.Handle("/test", h)
+	route.Path("/test").Handler(h)
 
 	server := httptest.NewServer(r)
 	defer server.Close()
 
-	resp, err := server.Client().Get(server.URL + "/test") //nolint: noctx
+	resp, err := server.Client().Get(server.URL + "/test?foo=bar") //nolint: noctx
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 

--- a/src/query/api/v1/middleware/middleware.go
+++ b/src/query/api/v1/middleware/middleware.go
@@ -30,65 +30,65 @@ import (
 	"github.com/prometheus/prometheus/util/httputil"
 
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/native"
+	"github.com/m3db/m3/src/query/api/v1/options"
 	"github.com/m3db/m3/src/query/source"
-	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/net/http/cors"
 )
 
 // Default is the default list of middleware functions applied if no middleware functions are set in the
 // HandlerOptions.
-func Default(iOpts instrument.Options) []mux.MiddlewareFunc {
+func Default(opts options.MiddlewareOptions) []mux.MiddlewareFunc {
 	// The order of middleware is important. Be very careful when reordering existing middleware.
 	return []mux.MiddlewareFunc{
 		Cors(),
 		// install tracing before logging so the trace_id is available for response logging.
-		Tracing(opentracing.GlobalTracer(), iOpts),
-		RequestID(iOpts),
-		ResponseLogging(time.Second, iOpts),
-		ResponseMetrics(iOpts),
+		Tracing(opentracing.GlobalTracer(), opts.InstrumentOpts),
+		RequestID(opts.InstrumentOpts),
+		ResponseLogging(time.Second, opts.InstrumentOpts),
+		ResponseMetrics(opts.InstrumentOpts, opts.Route),
 		// install panic handler after any middleware that adds extra useful information to the context logger.
-		Panic(iOpts),
+		Panic(opts.InstrumentOpts),
 		Compression(),
 	}
 }
 
 // Query is the list of middleware functions for query endpoints.
-func Query(iOpts instrument.Options) []mux.MiddlewareFunc {
-	return query(ResponseLogging(time.Second, iOpts), iOpts)
+func Query(opts options.MiddlewareOptions) []mux.MiddlewareFunc {
+	return query(ResponseLogging(time.Second, opts.InstrumentOpts), opts)
 }
 
 // PromQuery is the list of middleware functions for prometheus query endpoints.
-func PromQuery(iOpts instrument.Options) []mux.MiddlewareFunc {
-	return query(native.QueryResponse(time.Second, iOpts), iOpts)
+func PromQuery(opts options.MiddlewareOptions) []mux.MiddlewareFunc {
+	return query(native.QueryResponse(time.Second, opts.InstrumentOpts), opts)
 }
 
-func query(response mux.MiddlewareFunc, iOpts instrument.Options) []mux.MiddlewareFunc {
+func query(response mux.MiddlewareFunc, opts options.MiddlewareOptions) []mux.MiddlewareFunc {
 	// The order of middleware is important. Be very careful when reordering existing middleware.
 	return []mux.MiddlewareFunc{
 		Cors(),
 		// install tracing before logging so the trace_id is available for response logging.
-		Tracing(opentracing.GlobalTracer(), iOpts),
-		RequestID(iOpts),
+		Tracing(opentracing.GlobalTracer(), opts.InstrumentOpts),
+		RequestID(opts.InstrumentOpts),
 		// install source before logging so the source is available for response logging.
-		source.Middleware(nil, iOpts),
+		source.Middleware(nil, opts.InstrumentOpts),
 		response,
-		ResponseMetrics(iOpts),
+		ResponseMetrics(opts.InstrumentOpts, opts.Route),
 		// install panic handler after any middleware that adds extra useful information to the context logger.
-		Panic(iOpts),
+		Panic(opts.InstrumentOpts),
 		Compression(),
 	}
 }
 
 // NoResponseLogging removes response logging from the set of Default.
-func NoResponseLogging(iOpts instrument.Options) []mux.MiddlewareFunc {
+func NoResponseLogging(opts options.MiddlewareOptions) []mux.MiddlewareFunc {
 	// The order of middleware is important. Be very careful when reordering existing middleware.
 	return []mux.MiddlewareFunc{
 		Cors(),
-		Tracing(opentracing.GlobalTracer(), iOpts),
-		RequestID(iOpts),
-		ResponseMetrics(iOpts),
+		Tracing(opentracing.GlobalTracer(), opts.InstrumentOpts),
+		RequestID(opts.InstrumentOpts),
+		ResponseMetrics(opts.InstrumentOpts, opts.Route),
 		// install panic handler after any middleware that adds extra useful information to the context logger.
-		Panic(iOpts),
+		Panic(opts.InstrumentOpts),
 		Compression(),
 	}
 }

--- a/src/query/api/v1/middleware/middleware_test.go
+++ b/src/query/api/v1/middleware/middleware_test.go
@@ -36,6 +36,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/m3db/m3/src/query/api/v1/options"
 	"github.com/m3db/m3/src/query/util/logging"
 	"github.com/m3db/m3/src/x/instrument"
 )
@@ -105,11 +106,10 @@ func TestCors(t *testing.T) {
 
 // TestDefaults is a quick check to see if a new MiddlewareFunc was added to all the appropriate default sets.
 func TestDefaults(t *testing.T) {
-	iOpts := instrument.NewOptions()
-	noResponse := NoResponseLogging(iOpts)
-	defaultSet := Default(iOpts)
-	query := Query(iOpts)
-	promQuery := PromQuery(iOpts)
+	noResponse := NoResponseLogging(options.MiddlewareOptions{})
+	defaultSet := Default(options.MiddlewareOptions{})
+	query := Query(options.MiddlewareOptions{})
+	promQuery := PromQuery(options.MiddlewareOptions{})
 
 	// If these checks fail and you're adding a new MiddlewareFunc you need to either:
 	// 1. Add the new MiddlewareFunc to all the appropriate default sets

--- a/src/query/api/v1/options/handler.go
+++ b/src/query/api/v1/options/handler.go
@@ -69,7 +69,13 @@ type CustomHandlerOptions struct {
 }
 
 // RegisterMiddleware is a func to build the set of middleware functions.
-type RegisterMiddleware func(iOpts instrument.Options) []mux.MiddlewareFunc
+type RegisterMiddleware func(opts MiddlewareOptions) []mux.MiddlewareFunc
+
+// MiddlewareOptions is the set of parameters passed to the RegisterMiddleware function.
+type MiddlewareOptions struct {
+	InstrumentOpts instrument.Options
+	Route          *mux.Route
+}
 
 // CustomHandler allows for custom third party http handlers.
 type CustomHandler interface {

--- a/src/query/util/queryhttp/queryhttp.go
+++ b/src/query/util/queryhttp/queryhttp.go
@@ -88,6 +88,7 @@ func (r *EndpointRegistry) Register(opts RegisterOptions) error {
 	}
 
 	if p := opts.Path; p != "" && len(opts.Methods) > 0 {
+		route.Path(p).Handler(handler).Methods(opts.Methods...)
 		for _, method := range opts.Methods {
 			key := routeKey{
 				path:   p,
@@ -97,7 +98,7 @@ func (r *EndpointRegistry) Register(opts RegisterOptions) error {
 				return fmt.Errorf("route already exists: path=%s, method=%s",
 					p, method)
 			}
-			r.registered[key] = r.router.Handle(p, handler).Methods(method)
+			r.registered[key] = route
 		}
 	} else if p := opts.PathPrefix; p != "" {
 		key := routeKey{
@@ -107,7 +108,7 @@ func (r *EndpointRegistry) Register(opts RegisterOptions) error {
 			return fmt.Errorf("route already exists: pathPrefix=%s", p)
 		}
 
-		r.registered[key] = r.router.Handle(p, handler)
+		r.registered[key] = route.PathPrefix(p).Handler(handler)
 	} else {
 		return fmt.Errorf("no path and methods or path prefix set: +%v", opts)
 	}


### PR DESCRIPTION
This fixes a bug that was introduced with the middelware refactorings.
The RequestURI cannot be used because it may contain url encoded data.
Instead we want to use the Path registered with the mux.Route. This
required threading the mux.Route to the Middleware funcs.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
