### PR TITLE
[aggregator] connection retries must be bounded

### DIFF
--- a/src/aggregator/client/conn.go
+++ b/src/aggregator/client/conn.go
@@ -206,8 +206,7 @@ func (c *connection) checkReconnectWithLock() error {
 	enoughFailuresToRetry := c.numFailures >= c.threshold
 	exhaustedMaxFailures := c.numFailures >= c.maxThreshold
 	sufficientTimePassed := c.nowFn().UnixNano()-c.lastConnectAttemptNanos >= c.maxDuration.Nanoseconds()
-	if (!enoughFailuresToRetry && !sufficientTimePassed) ||
-		(exhaustedMaxFailures && !sufficientTimePassed) {
+	if !sufficientTimePassed && (exhaustedMaxFailures || !enoughFailuresToRetry) {
 		return errNoActiveConnection
 	}
 	err := c.connectWithLockFn()

--- a/src/aggregator/client/conn.go
+++ b/src/aggregator/client/conn.go
@@ -44,9 +44,11 @@ var (
 	uninitWriter          uninitializedWriter
 )
 
-type sleepFn func(time.Duration)
-type connectWithLockFn func() error
-type writeWithLockFn func([]byte) error
+type (
+	sleepFn           func(time.Duration)
+	connectWithLockFn func() error
+	writeWithLockFn   func([]byte) error
+)
 
 // connection is a persistent connection that retries establishing
 // connection with exponential backoff if the connection goes down.
@@ -199,9 +201,13 @@ func (c *connection) checkReconnectWithLock() error {
 	// If we haven't accumulated enough failures to warrant another reconnect
 	// and we haven't past the maximum duration since the last time we attempted
 	// to connect then we simply return false without reconnecting.
-	tooManyFailures := c.numFailures >= c.threshold
+	// If we exhausted maximum allowed failures then we will retry only based on
+	// maximum duration since the last attempt.
+	enoughFailuresToRetry := c.numFailures >= c.threshold
+	exhaustedMaxFailures := c.numFailures >= c.maxThreshold
 	sufficientTimePassed := c.nowFn().UnixNano()-c.lastConnectAttemptNanos >= c.maxDuration.Nanoseconds()
-	if !tooManyFailures && !sufficientTimePassed {
+	if (!enoughFailuresToRetry && !sufficientTimePassed) ||
+		(exhaustedMaxFailures && !sufficientTimePassed) {
 		return errNoActiveConnection
 	}
 	err := c.connectWithLockFn()
@@ -211,7 +217,7 @@ func (c *connection) checkReconnectWithLock() error {
 	}
 
 	// Only raise the threshold when it is crossed, not when the max duration is reached.
-	if tooManyFailures && c.threshold < c.maxThreshold {
+	if enoughFailuresToRetry && c.threshold < c.maxThreshold {
 		newThreshold := c.threshold * c.multiplier
 		if newThreshold > c.maxThreshold {
 			newThreshold = c.maxThreshold

--- a/src/aggregator/client/conn_test.go
+++ b/src/aggregator/client/conn_test.go
@@ -96,8 +96,8 @@ func TestConnectionNumFailuresThresholdReconnectProperty(t *testing.T) {
 				conn.numFailures = conn.threshold + 1
 				conn.maxThreshold = 2 * conn.numFailures
 
-				if err := conn.Write(nil); err != errTestConnect {
-					return false, fmt.Errorf("unexpected error: %v", err)
+				if err := conn.Write(nil); !errors.Is(err, errTestConnect) {
+					return false, fmt.Errorf("unexpected error: %w", err)
 				}
 				return true, nil
 			},
@@ -114,8 +114,8 @@ func TestConnectionNumFailuresThresholdReconnectProperty(t *testing.T) {
 				conn.maxThreshold = conn.threshold
 				conn.numFailures = conn.maxThreshold + 1
 
-				if err := conn.Write(nil); err != errNoActiveConnection {
-					return false, fmt.Errorf("unexpected error: %v", err)
+				if err := conn.Write(nil); !errors.Is(err, errNoActiveConnection) {
+					return false, fmt.Errorf("unexpected error: %w", err)
 				}
 				return true, nil
 			},
@@ -136,11 +136,11 @@ func TestConnectionNumFailuresThresholdReconnectProperty(t *testing.T) {
 
 				now := time.Now()
 				conn.nowFn = func() time.Time { return now }
-				conn.lastConnectAttemptNanos = now.UnixNano() - int64(delay)
+				conn.lastConnectAttemptNanos = now.UnixNano() - delay
 				conn.maxDuration = time.Duration(delay)
 
-				if err := conn.Write(nil); err != errTestConnect {
-					return false, fmt.Errorf("unexpected error: %v", err)
+				if err := conn.Write(nil); !errors.Is(err, errTestConnect) {
+					return false, fmt.Errorf("unexpected error: %w", err)
 				}
 				return true, nil
 			},
@@ -160,7 +160,7 @@ func TestConnectionMaxDurationReconnectProperty(t *testing.T) {
 				conn.connectWithLockFn = func() error { return errTestConnect }
 				now := time.Now()
 				conn.nowFn = func() time.Time { return now }
-				conn.lastConnectAttemptNanos = now.UnixNano() - int64(delay)
+				conn.lastConnectAttemptNanos = now.UnixNano() - delay
 				conn.maxDuration = time.Duration(delay)
 
 				if err := conn.Write(nil); err != errTestConnect {

--- a/src/aggregator/client/conn_test.go
+++ b/src/aggregator/client/conn_test.go
@@ -95,9 +95,12 @@ func TestConnectionNumFailuresThresholdReconnectProperty(t *testing.T) {
 				conn.threshold = int(threshold)
 				conn.multiplier = 2
 				conn.numFailures = conn.threshold + 1
-				conn.maxThreshold = 2 * conn.numFailures
+				conn.maxThreshold = testMaxReconnectThreshold
 
 				expectedNewThreshold := conn.threshold * conn.multiplier
+				if expectedNewThreshold > conn.maxThreshold {
+					expectedNewThreshold = conn.maxThreshold
+				}
 				if err := conn.Write(nil); !errors.Is(err, errTestConnect) {
 					return false, fmt.Errorf("unexpected error: %w", err)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

There is a bug in the aggregator client connection retry logic: after the number of failures crosses the maximum configured threshold, the retries are attempted again on every write call without any backoff. That slows down flushing of forwarded metrics from healthy nodes to other healthy nodes and the receiving nodes reject them because they becom past their due time. This condition is triggered when there are dead nodes in the placement due to host(s) going hard-down and becoming unreachable. The healthy nodes still attempt to write forwarded metrics to dead nodes but always fail with tcp timeout errors.

Fix retry logic so that after the maximum threshold is reached, retry again only after the maximum duration time since last attempt.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->


**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
