### PR TITLE
[query] Return series count header

### DIFF
--- a/src/query/api/v1/handler/prometheus/handleroptions/header_test.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/header_test.go
@@ -100,4 +100,11 @@ func TestAddResponseHeaders(t *testing.T) {
 	assert.Equal(t, 1, len(recorder.Header()))
 	assert.Equal(t, "{\"waitedIndex\":3,\"waitedSeriesRead\":42}",
 		recorder.Header().Get(headers.WaitedHeader))
+
+	recorder = httptest.NewRecorder()
+	meta = block.NewResultMetadata()
+	meta.SeriesCount = 42
+	require.NoError(t, AddResponseHeaders(recorder, meta, nil, nil, nil))
+	assert.Equal(t, 1, len(recorder.Header()))
+	assert.Equal(t, "42", recorder.Header().Get(headers.SeriesCount))
 }

--- a/src/query/api/v1/handler/prometheus/handleroptions/header_test.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/header_test.go
@@ -103,8 +103,8 @@ func TestAddResponseHeaders(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 	meta = block.NewResultMetadata()
-	meta.SeriesCount = 42
+	meta.FetchedSeriesCount = 42
 	require.NoError(t, AddResponseHeaders(recorder, meta, nil, nil, nil))
 	assert.Equal(t, 1, len(recorder.Header()))
-	assert.Equal(t, "42", recorder.Header().Get(headers.SeriesCount))
+	assert.Equal(t, "42", recorder.Header().Get(headers.FetchedSeriesCount))
 }

--- a/src/query/api/v1/handler/prometheus/handleroptions/headers.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/headers.go
@@ -22,6 +22,7 @@ package handleroptions
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -82,6 +83,7 @@ func AddResponseHeaders(
 	if fetchOpts != nil {
 		w.Header().Set(headers.TimeoutHeader, fetchOpts.Timeout.String())
 	}
+
 	if limited := returnedDataLimited; limited != nil {
 		s, err := json.Marshal(limited)
 		if err != nil {
@@ -89,6 +91,7 @@ func AddResponseHeaders(
 		}
 		w.Header().Add(headers.ReturnedDataLimitedHeader, string(s))
 	}
+
 	if limited := returnedMetadataLimited; limited != nil {
 		s, err := json.Marshal(limited)
 		if err != nil {
@@ -96,10 +99,17 @@ func AddResponseHeaders(
 		}
 		w.Header().Add(headers.ReturnedMetadataLimitedHeader, string(s))
 	}
+
 	waiting := Waiting{
 		WaitedIndex:      meta.WaitedIndex,
 		WaitedSeriesRead: meta.WaitedSeriesRead,
 	}
+
+	// NB: only add series count header if there are series present.
+	if meta.SeriesCount > 0 {
+		w.Header().Add(headers.SeriesCount, fmt.Sprint(meta.SeriesCount))
+	}
+
 	if waiting.WaitedAny() {
 		s, err := json.Marshal(waiting)
 		if err != nil {

--- a/src/query/api/v1/handler/prometheus/handleroptions/headers.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/headers.go
@@ -106,8 +106,8 @@ func AddResponseHeaders(
 	}
 
 	// NB: only add series count header if there are series present.
-	if meta.SeriesCount > 0 {
-		w.Header().Add(headers.SeriesCount, fmt.Sprint(meta.SeriesCount))
+	if meta.FetchedSeriesCount > 0 {
+		w.Header().Add(headers.FetchedSeriesCount, fmt.Sprint(meta.FetchedSeriesCount))
 	}
 
 	if waiting.WaitedAny() {

--- a/src/query/block/meta.go
+++ b/src/query/block/meta.go
@@ -74,6 +74,8 @@ type ResultMetadata struct {
 	WaitedIndex int
 	// WaitedSeriesRead counts how many times series being read had to wait for permits.
 	WaitedSeriesRead int
+	// SeriesCount is the total number of series within all fetches in this result.
+	SeriesCount int
 }
 
 // NewResultMetadata creates a new result metadata.
@@ -150,25 +152,25 @@ func (m ResultMetadata) Equals(n ResultMetadata) bool {
 	if m.WaitedIndex != n.WaitedIndex {
 		return false
 	}
+
 	if m.WaitedSeriesRead != n.WaitedSeriesRead {
 		return false
 	}
 
-	return true
+	return m.SeriesCount == n.SeriesCount
 }
 
 // CombineMetadata combines two result metadatas.
 func (m ResultMetadata) CombineMetadata(other ResultMetadata) ResultMetadata {
-	meta := ResultMetadata{
+	return ResultMetadata{
 		LocalOnly:        m.LocalOnly && other.LocalOnly,
 		Exhaustive:       m.Exhaustive && other.Exhaustive,
 		Warnings:         combineWarnings(m.Warnings, other.Warnings),
 		Resolutions:      combineResolutions(m.Resolutions, other.Resolutions),
 		WaitedIndex:      m.WaitedIndex + other.WaitedIndex,
 		WaitedSeriesRead: m.WaitedSeriesRead + other.WaitedSeriesRead,
+		SeriesCount:      m.SeriesCount + other.SeriesCount,
 	}
-
-	return meta
 }
 
 // IsDefault returns true if this result metadata matches the unchanged default.

--- a/src/query/block/meta.go
+++ b/src/query/block/meta.go
@@ -74,8 +74,9 @@ type ResultMetadata struct {
 	WaitedIndex int
 	// WaitedSeriesRead counts how many times series being read had to wait for permits.
 	WaitedSeriesRead int
-	// SeriesCount is the total number of series within all fetches in this result.
-	SeriesCount int
+	// FetchedSeriesCount is the total number of series that were fetched to compute
+	// this result.
+	FetchedSeriesCount int
 }
 
 // NewResultMetadata creates a new result metadata.
@@ -157,19 +158,19 @@ func (m ResultMetadata) Equals(n ResultMetadata) bool {
 		return false
 	}
 
-	return m.SeriesCount == n.SeriesCount
+	return m.FetchedSeriesCount == n.FetchedSeriesCount
 }
 
 // CombineMetadata combines two result metadatas.
 func (m ResultMetadata) CombineMetadata(other ResultMetadata) ResultMetadata {
 	return ResultMetadata{
-		LocalOnly:        m.LocalOnly && other.LocalOnly,
-		Exhaustive:       m.Exhaustive && other.Exhaustive,
-		Warnings:         combineWarnings(m.Warnings, other.Warnings),
-		Resolutions:      combineResolutions(m.Resolutions, other.Resolutions),
-		WaitedIndex:      m.WaitedIndex + other.WaitedIndex,
-		WaitedSeriesRead: m.WaitedSeriesRead + other.WaitedSeriesRead,
-		SeriesCount:      m.SeriesCount + other.SeriesCount,
+		LocalOnly:          m.LocalOnly && other.LocalOnly,
+		Exhaustive:         m.Exhaustive && other.Exhaustive,
+		Warnings:           combineWarnings(m.Warnings, other.Warnings),
+		Resolutions:        combineResolutions(m.Resolutions, other.Resolutions),
+		WaitedIndex:        m.WaitedIndex + other.WaitedIndex,
+		WaitedSeriesRead:   m.WaitedSeriesRead + other.WaitedSeriesRead,
+		FetchedSeriesCount: m.FetchedSeriesCount + other.FetchedSeriesCount,
 	}
 }
 

--- a/src/query/storage/m3/consolidators/complete_tags_result.go
+++ b/src/query/storage/m3/consolidators/complete_tags_result.go
@@ -78,7 +78,7 @@ func (r *multiSearchResult) FinalResult() (TagResult, error) {
 	}
 
 	// NB: explicitly set series count here to get the count post-duplication.
-	r.meta.SeriesCount = len(r.dedupeMap)
+	r.meta.FetchedSeriesCount = len(r.dedupeMap)
 	return TagResult{
 		Tags:     result,
 		Metadata: r.meta,

--- a/src/query/storage/m3/consolidators/complete_tags_result.go
+++ b/src/query/storage/m3/consolidators/complete_tags_result.go
@@ -77,6 +77,8 @@ func (r *multiSearchResult) FinalResult() (TagResult, error) {
 		result = append(result, it)
 	}
 
+	// NB: explicitly set series count here to get the count post-duplication.
+	r.meta.SeriesCount = len(r.dedupeMap)
 	return TagResult{
 		Tags:     result,
 		Metadata: r.meta,

--- a/src/query/storage/m3/consolidators/complete_tags_result_test.go
+++ b/src/query/storage/m3/consolidators/complete_tags_result_test.go
@@ -92,12 +92,13 @@ func TestMultiFetchTagsResult(t *testing.T) {
 	it := res.Tags[0].Iter
 
 	// NB: assert tags are still iteratable.
-	ex := []tag{tag{name: "foo", value: "bar"}}
+	ex := []tag{{name: "foo", value: "bar"}}
 	for i := 0; it.Next(); i++ {
 		tag := it.Current()
 		assert.Equal(t, ex[i].name, tag.Name.String())
 		assert.Equal(t, ex[i].value, tag.Value.String())
 	}
 
+	require.Equal(t, 1, res.Metadata.FetchedSeriesCount)
 	require.NoError(t, it.Err())
 }

--- a/src/query/storage/m3/consolidators/multi_fetch_result_tag_test.go
+++ b/src/query/storage/m3/consolidators/multi_fetch_result_tag_test.go
@@ -56,6 +56,7 @@ type expectedSeries struct {
 	dps  []dp
 }
 
+//nolint:dupl
 func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()

--- a/src/query/storage/m3/consolidators/multi_fetch_result_tag_test.go
+++ b/src/query/storage/m3/consolidators/multi_fetch_result_tag_test.go
@@ -76,7 +76,7 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 	combinedMeta := warn1Meta.CombineMetadata(warn2Meta)
 
 	tests := []dedupeTest{
-		dedupeTest{
+		{
 			name: "same tags, same ids",
 			entries: []insertEntry{
 				{
@@ -90,9 +90,9 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 				},
 			},
 			expected: []expectedSeries{
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar"},
-					dps:  []dp{dp{t: step(1), val: 1}, dp{t: step(5), val: 6}},
+					dps:  []dp{{t: step(1), val: 1}, {t: step(5), val: 6}},
 				},
 			},
 			exMeta:  warn1Meta,
@@ -100,7 +100,7 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 			exAttrs: []storagemetadata.Attributes{unaggHr},
 		},
 
-		dedupeTest{
+		{
 			name: "same tags, different ids",
 			entries: []insertEntry{
 				{
@@ -114,9 +114,9 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 				},
 			},
 			expected: []expectedSeries{
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar"},
-					dps:  []dp{dp{t: step(1), val: 1}, dp{t: step(5), val: 6}},
+					dps:  []dp{{t: step(1), val: 1}, {t: step(5), val: 6}},
 				},
 			},
 			exMeta:  warn1Meta,
@@ -124,7 +124,7 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 			exAttrs: []storagemetadata.Attributes{unaggHr},
 		},
 
-		dedupeTest{
+		{
 			name: "different tags, same ids",
 			entries: []insertEntry{
 				{
@@ -138,13 +138,13 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 				},
 			},
 			expected: []expectedSeries{
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar"},
-					dps:  []dp{dp{t: step(1), val: 1}},
+					dps:  []dp{{t: step(1), val: 1}},
 				},
-				expectedSeries{
+				{
 					tags: []string{"foo", "baz"},
-					dps:  []dp{dp{t: step(5), val: 6}},
+					dps:  []dp{{t: step(5), val: 6}},
 				},
 			},
 			exMeta:  warn1Meta,
@@ -152,7 +152,7 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 			exAttrs: []storagemetadata.Attributes{unaggHr, unaggHr},
 		},
 
-		dedupeTest{
+		{
 			name: "one iterator, mixed scenario",
 			entries: []insertEntry{
 				{
@@ -173,21 +173,21 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 				},
 			},
 			expected: []expectedSeries{
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar", "qux", "quail"},
-					dps:  []dp{dp{t: step(1), val: 1}, dp{t: step(2), val: 2}},
+					dps:  []dp{{t: step(1), val: 1}, {t: step(2), val: 2}},
 				},
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar", "qux", "quart"},
-					dps:  []dp{dp{t: step(1), val: 3}},
+					dps:  []dp{{t: step(1), val: 3}},
 				},
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar", "qux", "queen"},
-					dps:  []dp{dp{t: step(1), val: 5}, dp{t: step(2), val: 6}},
+					dps:  []dp{{t: step(1), val: 5}, {t: step(2), val: 6}},
 				},
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar", "qux", "quz"},
-					dps:  []dp{dp{t: step(2), val: 4}},
+					dps:  []dp{{t: step(2), val: 4}},
 				},
 			},
 			exMeta:  warn1Meta,
@@ -195,10 +195,10 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 			exAttrs: []storagemetadata.Attributes{unaggHr, unaggHr, unaggHr, unaggHr},
 		},
 
-		dedupeTest{
+		{
 			name: "multiple iterators, mixed scenario",
 			entries: []insertEntry{
-				insertEntry{
+				{
 					attr: unaggHr,
 					meta: warn1Meta,
 					err:  nil,
@@ -207,7 +207,7 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 						it(ctrl, dp{t: step(2), val: 2}, "id2", "foo", "bar", "qux", "quail"),
 					}, nil),
 				},
-				insertEntry{
+				{
 					attr: unaggHr,
 					meta: warn2Meta,
 					err:  nil,
@@ -216,7 +216,7 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 						it(ctrl, dp{t: step(2), val: 4}, "id3", "foo", "bar", "qux", "quz"),
 					}, nil),
 				},
-				insertEntry{
+				{
 					attr: unaggHr,
 					meta: warn1Meta,
 					err:  nil,
@@ -227,21 +227,21 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 				},
 			},
 			expected: []expectedSeries{
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar", "qux", "quail"},
-					dps:  []dp{dp{t: step(1), val: 1}, dp{t: step(2), val: 2}},
+					dps:  []dp{{t: step(1), val: 1}, {t: step(2), val: 2}},
 				},
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar", "qux", "quart"},
-					dps:  []dp{dp{t: step(1), val: 3}},
+					dps:  []dp{{t: step(1), val: 3}},
 				},
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar", "qux", "queen"},
-					dps:  []dp{dp{t: step(1), val: 5}, dp{t: step(2), val: 6}},
+					dps:  []dp{{t: step(1), val: 5}, {t: step(2), val: 6}},
 				},
-				expectedSeries{
+				{
 					tags: []string{"foo", "bar", "qux", "quz"},
-					dps:  []dp{dp{t: step(2), val: 4}},
+					dps:  []dp{{t: step(2), val: 4}},
 				},
 			},
 			exMeta:  combinedMeta,
@@ -281,6 +281,7 @@ func testMultiFetchResultTagDedupeMap(
 	result, attrs, err := r.FinalResultWithAttrs()
 	require.NoError(t, err)
 
+	test.exMeta.FetchedSeriesCount = len(test.expected)
 	assert.Equal(t, test.exMeta, result.Metadata)
 	require.Equal(t, len(test.exAttrs), len(attrs))
 	for i, ex := range test.exAttrs {
@@ -322,9 +323,11 @@ func TestFilteredInsert(t *testing.T) {
 
 	warn1Meta := block.NewResultMetadata()
 	warn1Meta.AddWarning("warn", "1")
+	warn1Meta.FetchedSeriesCount = 1
 
 	warn2Meta := block.NewResultMetadata()
 	warn2Meta.AddWarning("warn", "2")
+	warn2Meta.FetchedSeriesCount = 1
 
 	dedupe := dedupeTest{
 		name: "same tags, same ids",
@@ -340,9 +343,9 @@ func TestFilteredInsert(t *testing.T) {
 			},
 		},
 		expected: []expectedSeries{
-			expectedSeries{
+			{
 				tags: []string{"foo", "bar"},
-				dps:  []dp{dp{t: step(1), val: 1}, dp{t: step(5), val: 6}},
+				dps:  []dp{{t: step(1), val: 1}, {t: step(5), val: 6}},
 			},
 		},
 		exMeta:  warn1Meta,

--- a/src/query/storage/m3/consolidators/multi_fetch_result_test.go
+++ b/src/query/storage/m3/consolidators/multi_fetch_result_test.go
@@ -131,6 +131,7 @@ func testMultiResult(t *testing.T, fanoutType QueryFanoutType, expected string) 
 		defaultTestOpts, models.NewTagOptions())
 
 	meta := block.NewResultMetadata()
+	meta.FetchedSeriesCount = 4
 	for _, ns := range namespaces {
 		iters := generateSeriesIterators(ctrl, ns.ns)
 		r.Add(iters, meta, ns.attrs, nil)

--- a/src/query/storage/m3/consolidators/series_fetch_result.go
+++ b/src/query/storage/m3/consolidators/series_fetch_result.go
@@ -36,19 +36,15 @@ func NewSeriesFetchResult(
 	meta block.ResultMetadata,
 ) (SeriesFetchResult, error) {
 	if iters == nil || iters.Len() == 0 {
-		return SeriesFetchResult{
-			Metadata: meta,
-			seriesData: seriesData{
-				seriesIterators: nil,
-				tags:            []*models.Tags{},
-			},
-		}, nil
+		return NewEmptyFetchResult(meta), nil
 	}
 
 	if tags == nil {
 		tags = make([]*models.Tags, iters.Len())
 	}
 
+	// NB: explicitly set series count here to get the count post-duplication.
+	meta.SeriesCount = iters.Len()
 	return SeriesFetchResult{
 		Metadata: meta,
 		seriesData: seriesData{

--- a/src/query/storage/m3/consolidators/series_fetch_result.go
+++ b/src/query/storage/m3/consolidators/series_fetch_result.go
@@ -44,7 +44,7 @@ func NewSeriesFetchResult(
 	}
 
 	// NB: explicitly set series count here to get the count post-duplication.
-	meta.SeriesCount = iters.Len()
+	meta.FetchedSeriesCount = iters.Len()
 	return SeriesFetchResult{
 		Metadata: meta,
 		seriesData: seriesData{

--- a/src/x/headers/headers.go
+++ b/src/x/headers/headers.go
@@ -149,8 +149,9 @@ const (
 	// WaitedHeader is the header added when permits had to be waited for.
 	WaitedHeader = M3HeaderPrefix + "Waited"
 
-	// SeriesCount is the header added for total series count.
-	SeriesCount = M3HeaderPrefix + "Series-Count"
+	// FetchedSeriesCount is the header added that tracks the total number of
+	// series that were fetched by the query, before computation.
+	FetchedSeriesCount = M3HeaderPrefix + "Series-Count"
 
 	// RenderFormat is used to switch result format for query results rendering.
 	RenderFormat = M3HeaderPrefix + "Render-Format"

--- a/src/x/headers/headers.go
+++ b/src/x/headers/headers.go
@@ -149,6 +149,9 @@ const (
 	// WaitedHeader is the header added when permits had to be waited for.
 	WaitedHeader = M3HeaderPrefix + "Waited"
 
+	// SeriesCount is the header added for total series count.
+	SeriesCount = M3HeaderPrefix + "Series-Count"
+
 	// RenderFormat is used to switch result format for query results rendering.
 	RenderFormat = M3HeaderPrefix + "Render-Format"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a returned header tracking the number of unique series included in the query. 