### PR TITLE
[query] Improve readerIterator performance

### DIFF
--- a/src/dbnode/encoding/m3tsz/iterator.go
+++ b/src/dbnode/encoding/m3tsz/iterator.go
@@ -56,6 +56,7 @@ type readerIterator struct {
 	mult uint8 // current int multiplier
 	sig  uint8 // current number of significant bits for int diff
 
+	curr         ts.Datapoint
 	intOptimized bool // whether encoding scheme is optimized for ints
 	isFloat      bool // whether encoding is in int or float
 
@@ -92,6 +93,14 @@ func (it *readerIterator) Next() bool {
 		it.readNextValue()
 	} else {
 		it.readFirstValue()
+	}
+
+	it.curr.Timestamp = it.tsIterator.PrevTime.ToTime()
+	it.curr.TimestampNanos = it.tsIterator.PrevTime
+	if !it.intOptimized || it.isFloat {
+		it.curr.Value = math.Float64frombits(it.floatIter.PrevFloatBits)
+	} else {
+		it.curr.Value = convertFromIntFloat(it.intVal, it.mult)
 	}
 
 	return it.hasNext()
@@ -219,18 +228,7 @@ func (it *readerIterator) readBits(numBits uint8) (res uint64) {
 // Users should not hold on to the returned Annotation object as it may get invalidated when
 // the iterator calls Next().
 func (it *readerIterator) Current() (ts.Datapoint, xtime.Unit, ts.Annotation) {
-	dp := ts.Datapoint{
-		Timestamp:      it.tsIterator.PrevTime.ToTime(),
-		TimestampNanos: it.tsIterator.PrevTime,
-	}
-
-	if !it.intOptimized || it.isFloat {
-		dp.Value = math.Float64frombits(it.floatIter.PrevFloatBits)
-	} else {
-		dp.Value = convertFromIntFloat(it.intVal, it.mult)
-	}
-
-	return dp, it.tsIterator.TimeUnit, it.tsIterator.PrevAnt
+	return it.curr, it.tsIterator.TimeUnit, it.tsIterator.PrevAnt
 }
 
 // Err returns the error encountered


### PR DESCRIPTION
**What this PR does / why we need it**:
Takes logic from the Current() function used to calculate the values
into the Next() function so that it will only be executed once.

Below benchmarks from running the `./bin/read_data_files` tool:

Before:
```
Running time: 732.597858ms
35238 series read
(48100.06 series/second)
2535668 datapoints decoded
(3461200.40 datapoints/second)
```

After:
```
Running time: 649.265258ms
35238 series read
(54273.66 series/second)
2535668 datapoints decoded
(3905442.30 datapoints/second)
```