### PR TITLE
Add InstanceMultiple config to lower per instance series limit

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -373,7 +373,7 @@ type PerQueryLimitsConfiguration struct {
 	//
 	// A value > 1 allows a buffer in case data is not uniformly sharded across instances in a replica.
 	// If set to 0 the feature is disabled and the MaxFetchedSeries is used as the limit for database instance.
-	// For large clusters, enabling this feature this can dramatically decrease the amount of wasted series read from a
+	// For large clusters, enabling this feature can dramatically decrease the amount of wasted series read from a
 	// single database instance.
 	InstanceMultiple float32 `yaml:"instanceMultiple"`
 

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -366,6 +366,17 @@ type PerQueryLimitsConfiguration struct {
 	// service.
 	MaxFetchedSeries int `yaml:"maxFetchedSeries"`
 
+	// InstanceMultiple increases the per database instance series limit.
+	// The series limit per database instance is calculated as:
+	//
+	// InstanceSeriesLimit = MaxFetchesSeries / (instances per replica) * InstanceMultiple.
+	//
+	// A value > 1 allows a buffer in case data is not uniformly sharded across instances in a replica.
+	// If set to 0 the feature is disabled and the MaxFetchedSeries is used as the limit for database instance.
+	// For large clusters, enabling this feature this can dramatically decrease the amount of wasted series read from a
+	// single database instance.
+	InstanceMultiple float32 `yaml:"instanceMultiple"`
+
 	// MaxFetchedDocs limits the number of index documents matched for any given
 	// individual storage node per query, before returning result to query
 	// service.
@@ -395,6 +406,7 @@ func (l *PerQueryLimitsConfiguration) AsFetchOptionsBuilderLimitsOptions() handl
 
 	return handleroptions.FetchOptionsBuilderLimitsOptions{
 		SeriesLimit:       int(seriesLimit),
+		InstanceMultiple:  l.InstanceMultiple,
 		DocsLimit:         int(docsLimit),
 		RequireExhaustive: requireExhaustive,
 	}

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -1547,6 +1547,14 @@ func (s *session) fetchTaggedAttempt(
 	// once https://github.com/m3db/m3ninx/issues/42 lands. Including transferring ownership
 	// of the Clone()'d value to the `fetchState`.
 	const fetchData = true
+	if opts.InstanceMultiple > 0 {
+		topo := s.state.topoMap
+		iPerReplica := len(topo.Hosts()) / topo.Replicas()
+		iSeriesLimit := int(float32(opts.SeriesLimit)*opts.InstanceMultiple) / iPerReplica
+		if iSeriesLimit < opts.SeriesLimit {
+			opts.SeriesLimit = iSeriesLimit
+		}
+	}
 	req, err := convert.ToRPCFetchTaggedRequest(nsClone, q, opts, fetchData)
 	if err != nil {
 		s.state.RUnlock()

--- a/src/dbnode/storage/index/types.go
+++ b/src/dbnode/storage/index/types.go
@@ -84,6 +84,8 @@ type QueryOptions struct {
 	EndExclusive time.Time
 	// SeriesLimit is an optional limit for number of series matched.
 	SeriesLimit int
+	// InstanceMultiple is how much to increase the per database instance series limit.
+	InstanceMultiple float32
 	// DocsLimit is an optional limit for number of documents matched.
 	DocsLimit int
 	// RequireExhaustive requires queries to be under given limit sizes.

--- a/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
@@ -84,6 +84,7 @@ func (o FetchOptionsBuilderOptions) Validate() error {
 // creating a fetch options builder.
 type FetchOptionsBuilderLimitsOptions struct {
 	SeriesLimit                 int
+	InstanceMultiple            float32
 	DocsLimit                   int
 	ReturnedSeriesLimit         int
 	ReturnedDatapointsLimit     int
@@ -212,6 +213,7 @@ func (b fetchOptionsBuilder) newFetchOptions(
 	}
 
 	fetchOpts.SeriesLimit = seriesLimit
+	fetchOpts.InstanceMultiple = b.opts.Limits.InstanceMultiple
 
 	docsLimit, err := ParseLimit(req, headers.LimitMaxDocsHeader,
 		"docsLimit", b.opts.Limits.DocsLimit)

--- a/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
@@ -77,6 +77,9 @@ type FetchOptionsBuilderOptions struct {
 
 // Validate validates the fetch options builder options.
 func (o FetchOptionsBuilderOptions) Validate() error {
+	if o.Limits.InstanceMultiple < 0 || (o.Limits.InstanceMultiple > 0 && o.Limits.InstanceMultiple < 1) {
+		return fmt.Errorf("InstanceMultiple must be 0 or >= 1: %v", o.Limits.InstanceMultiple)
+	}
 	return validateTimeout(o.Timeout)
 }
 

--- a/src/query/errors/storage.go
+++ b/src/query/errors/storage.go
@@ -22,6 +22,8 @@ package errors
 
 import (
 	"errors"
+
+	terrors "github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/errors"
 )
 
 var (
@@ -88,4 +90,8 @@ var (
 	// request returns an inconsistenent type.
 	ErrInconsistentCompleteTagsType = errors.New("inconsistent complete tags" +
 		" response type")
+
+	// ErrSeriesLimit is an error returned when the series limit is exceeded and the caller required exhaustive results.
+	// This is wrapped in a ResourceExhaustedError so it behaves the same as an error returned from the db.
+	ErrSeriesLimit = terrors.NewResourceExhaustedError(errors.New("series limit exceeded"))
 )

--- a/src/query/storage/index.go
+++ b/src/query/storage/index.go
@@ -71,6 +71,7 @@ func TagsToIdentTagIterator(tags models.Tags) ident.TagIterator {
 func FetchOptionsToM3Options(fetchOptions *FetchOptions, fetchQuery *FetchQuery) index.QueryOptions {
 	return index.QueryOptions{
 		SeriesLimit:       fetchOptions.SeriesLimit,
+		InstanceMultiple:  fetchOptions.InstanceMultiple,
 		DocsLimit:         fetchOptions.DocsLimit,
 		RequireExhaustive: fetchOptions.RequireExhaustive,
 		RequireNoWait:     fetchOptions.RequireNoWait,

--- a/src/query/storage/m3/consolidators/multi_fetch_result.go
+++ b/src/query/storage/m3/consolidators/multi_fetch_result.go
@@ -254,7 +254,7 @@ func (r *multiResult) Add(
 	}
 
 	// the series limit was reached by adding the results of this namespace to the existing results.
-	if !added {
+	if !added && r.err.Empty() {
 		r.metadata.Exhaustive = false
 		if r.limitOpts.RequireExhaustive {
 			r.err = r.err.Add(errors.ErrSeriesLimit)

--- a/src/query/storage/m3/consolidators/multi_fetch_result_tag_test.go
+++ b/src/query/storage/m3/consolidators/multi_fetch_result_tag_test.go
@@ -48,6 +48,7 @@ type dedupeTest struct {
 	expected []expectedSeries
 	exMeta   block.ResultMetadata
 	exErr    error
+	limit    int
 	exAttrs  []storagemetadata.Attributes
 }
 
@@ -76,6 +77,9 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 
 	combinedMeta := warn1Meta.CombineMetadata(warn2Meta)
 
+	nonExhaustiveMeta := block.NewResultMetadata()
+	nonExhaustiveMeta.Exhaustive = false
+
 	tests := []dedupeTest{
 		{
 			name: "same tags, same ids",
@@ -100,7 +104,6 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 			exErr:   nil,
 			exAttrs: []storagemetadata.Attributes{unaggHr},
 		},
-
 		{
 			name: "same tags, different ids",
 			entries: []insertEntry{
@@ -151,6 +154,57 @@ func TestMultiFetchResultTagDedupeMap(t *testing.T) {
 			exMeta:  warn1Meta,
 			exErr:   nil,
 			exAttrs: []storagemetadata.Attributes{unaggHr, unaggHr},
+		},
+
+		{
+			name: "limit",
+			entries: []insertEntry{
+				{
+					attr: unaggHr,
+					meta: block.NewResultMetadata(),
+					err:  nil,
+					iter: encoding.NewSeriesIterators([]encoding.SeriesIterator{
+						it(ctrl, dp{t: step(1), val: 1}, "id1", "foo", "bar"),
+						notReadIt(ctrl, dp{t: step(2), val: 2}, "id1", "foo", "baz"),
+					}, nil),
+				},
+			},
+			limit: 1,
+			expected: []expectedSeries{
+				{
+					tags: []string{"foo", "bar"},
+					dps:  []dp{{t: step(1), val: 1}},
+				},
+			},
+			exMeta:  nonExhaustiveMeta,
+			exErr:   nil,
+			exAttrs: []storagemetadata.Attributes{unaggHr},
+		},
+
+		{
+			name: "limit can still update",
+			entries: []insertEntry{
+				{
+					attr: unaggHr,
+					meta: block.NewResultMetadata(),
+					err:  nil,
+					iter: encoding.NewSeriesIterators([]encoding.SeriesIterator{
+						it(ctrl, dp{t: step(1), val: 1}, "id1", "foo", "bar"),
+						it(ctrl, dp{t: step(1), val: 2}, "id1", "foo", "bar"),
+						notReadIt(ctrl, dp{t: step(2), val: 2}, "id1", "foo", "baz"),
+					}, nil),
+				},
+			},
+			limit: 1,
+			expected: []expectedSeries{
+				{
+					tags: []string{"foo", "bar"},
+					dps:  []dp{{t: step(1), val: 2}},
+				},
+			},
+			exMeta:  nonExhaustiveMeta,
+			exErr:   nil,
+			exAttrs: []storagemetadata.Attributes{unaggHr},
 		},
 
 		{
@@ -272,8 +326,11 @@ func testMultiFetchResultTagDedupeMap(
 		MatchType: MatchTags,
 	}
 
-	r := NewMultiFetchResult(NamespaceCoversAllQueryRange, pools,
-		opts, tagOptions)
+	limitOpts := LimitOptions{Limit: 1000}
+	if test.limit > 0 {
+		limitOpts.Limit = test.limit
+	}
+	r := NewMultiFetchResult(NamespaceCoversAllQueryRange, pools, opts, tagOptions, limitOpts)
 
 	for _, entry := range test.entries {
 		r.Add(entry.iter, entry.meta, entry.attr, entry.err)

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -310,7 +310,14 @@ func (s *m3storage) fetchCompressed(
 
 	matchOpts := s.opts.SeriesConsolidationMatchOptions()
 	tagOpts := s.opts.TagOptions()
-	result := consolidators.NewMultiFetchResult(fanout, pools, matchOpts, tagOpts)
+	limitOpts := consolidators.LimitOptions{
+		Limit: options.SeriesLimit,
+		// Piggy back on the new InstanceMultiple option to enable checking require exhaustive. This preserves the
+		// existing buggy behavior of the coordinators not requiring exhaustive. Once InstanceMultiple is enabled by
+		// default, this can be removed.
+		RequireExhaustive: queryOptions.InstanceMultiple > 0 && options.RequireExhaustive,
+	}
+	result := consolidators.NewMultiFetchResult(fanout, pools, matchOpts, tagOpts, limitOpts)
 	for _, namespace := range namespaces {
 		namespace := namespace // Capture var
 		wg.Add(1)

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -114,7 +114,7 @@ type FetchOptions struct {
 	Remote bool
 	// SeriesLimit is the maximum number of series to return.
 	SeriesLimit int
-	// InstanceMultiple is how much to increase the per database instance series limit.src/dbnode/client/session.go
+	// InstanceMultiple is how much to increase the per database instance series limit.
 	InstanceMultiple float32
 	// DocsLimit is the maximum number of docs to return.
 	DocsLimit int

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -114,6 +114,8 @@ type FetchOptions struct {
 	Remote bool
 	// SeriesLimit is the maximum number of series to return.
 	SeriesLimit int
+	// InstanceMultiple is how much to increase the per database instance series limit.src/dbnode/client/session.go
+	InstanceMultiple float32
 	// DocsLimit is the maximum number of docs to return.
 	DocsLimit int
 	// ReturnedSeriesLimit is the maximum number of series to return.


### PR DESCRIPTION
Previously the per query series limit was passed directly to every
database instance as the series limit.
For large clusters this can result in a lot of wasted series read from the
database. For example a cluster with 30 instances per replica could read 30x
the time series, just to truncate the results in the coordinators.

Theoretically if the data is perfectly sharded, the per instance limit
is equal to the query series limit / # instance per replica. To allow
for unbalanced data, the InstanceMultiple config increases this
theoretical calculation by a factor to add a buffer.

By default, this option is off, but the hope is to add a sane default
for the next major release.

Additionally if this config is set, a bug is fixed that never returned
an error if RequiredExhaustive=true and the query series limit was
exceeded by summing the individual instance results in the coordinator.
This bug, coupled with the larger per instance series limit, would
actually result in the coordinator processing far more results than
necessary and then silently truncating the results.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
