### PR TITLE
Do not use the req.SeriesLimit when consolidating fetch results

### DIFF
--- a/src/dbnode/client/fetch_state.go
+++ b/src/dbnode/client/fetch_state.go
@@ -187,6 +187,7 @@ func (f *fetchState) markDoneWithLock(err error) {
 
 func (f *fetchState) asTaggedIDsIterator(
 	pools fetchTaggedPools,
+	limit int,
 ) (TaggedIDsIterator, FetchResponseMetadata, error) {
 	f.Lock()
 	defer f.Unlock()
@@ -205,7 +206,9 @@ func (f *fetchState) asTaggedIDsIterator(
 		return nil, FetchResponseMetadata{}, err
 	}
 
-	limit := f.fetchTaggedOp.requestSeriesLimit(maxInt)
+	if limit == 0 {
+		limit = maxInt
+	}
 	return f.tagResultAccumulator.AsTaggedIDsIterator(limit, pools)
 }
 
@@ -213,6 +216,7 @@ func (f *fetchState) asEncodingSeriesIterators(
 	pools fetchTaggedPools,
 	descr namespace.SchemaDescr,
 	opts index.IterationOptions,
+	limit int,
 ) (encoding.SeriesIterators, FetchResponseMetadata, error) {
 	f.Lock()
 	defer f.Unlock()
@@ -231,7 +235,9 @@ func (f *fetchState) asEncodingSeriesIterators(
 		return nil, FetchResponseMetadata{}, err
 	}
 
-	limit := f.fetchTaggedOp.requestSeriesLimit(maxInt)
+	if limit == 0 {
+		limit = maxInt
+	}
 	return f.tagResultAccumulator.AsEncodingSeriesIterators(limit, pools, descr, opts)
 }
 

--- a/src/dbnode/client/fetch_tagged_op.go
+++ b/src/dbnode/client/fetch_tagged_op.go
@@ -53,13 +53,6 @@ func (f *fetchTaggedOp) update(
 	f.completionFn = fn
 }
 
-func (f *fetchTaggedOp) requestSeriesLimit(defaultValue int) int {
-	if f.request.SeriesLimit == nil {
-		return defaultValue
-	}
-	return int(*f.request.SeriesLimit)
-}
-
 func (f *fetchTaggedOp) close() {
 	f.completionFn = nil
 	f.request = fetchTaggedOpRequestZeroed

--- a/src/dbnode/client/session_test.go
+++ b/src/dbnode/client/session_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -33,8 +34,10 @@ import (
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
 	"github.com/m3db/m3/src/dbnode/sharding"
+	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/dbnode/x/xpool"
+	"github.com/m3db/m3/src/m3ninx/idx"
 	xerror "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
@@ -277,6 +280,67 @@ func TestIteratorPools(t *testing.T) {
 	assert.Equal(t, idPool, itPool.ID())
 }
 
+func TestSeriesLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := newSessionTestOptions()
+	shardSet := sessionTestShardSet()
+	var hostShardSets []topology.HostShardSet
+	// setup 9 hosts so there are 3 instances per replica. Each instance has a single shard.
+	for i := 0; i < sessionTestReplicas; i++ {
+		for j := 0; j < sessionTestShards; j++ {
+			id := fmt.Sprintf("testhost-%d-%d", i, j)
+			host := topology.NewHost(id, fmt.Sprintf("%s:9000", id))
+			hostShard, _ := sharding.NewShardSet([]shard.Shard{shardSet.All()[j]}, shardSet.HashFn())
+			hostShardSet := topology.NewHostShardSet(host, hostShard)
+			hostShardSets = append(hostShardSets, hostShardSet)
+		}
+	}
+
+	opts = opts.SetTopologyInitializer(topology.NewStaticInitializer(
+		topology.NewStaticOptions().
+			SetReplicas(sessionTestReplicas).
+			SetShardSet(shardSet).
+			SetHostShardSets(hostShardSets)))
+	s, err := newSession(opts)
+	assert.NoError(t, err)
+	sess := s.(*session)
+	// mock the host queue to return a result with a single series, this results in 3 series total, one per shard.
+	sess.newHostQueueFn = mockHostQueuesWithFn(ctrl, func(op op, host topology.Host) {
+		fOp := op.(*fetchTaggedOp)
+		assert.Equal(t, int64(2), *fOp.request.SeriesLimit)
+		shardID := strings.Split(host.ID(), "-")[2]
+		op.CompletionFn()(fetchTaggedResultAccumulatorOpts{
+			host: host,
+			response: &rpc.FetchTaggedResult_{
+				Exhaustive: true,
+				Elements: []*rpc.FetchTaggedIDResult_{
+					{
+						// use shard id for the metric id so it's stable across replicas.
+						ID: []byte(shardID),
+					},
+				},
+			},
+		}, nil)
+	})
+
+	require.NoError(t, sess.Open())
+	iters, meta, err := sess.fetchTaggedAttempt(context.TODO(), ident.StringID("ns"),
+		index.Query{Query: idx.NewAllQuery()},
+		index.QueryOptions{
+			// set to 6 so we can test the instance series limit is 2 (6 /3 instances per replica * InstanceMultiple)
+			SeriesLimit:      6,
+			InstanceMultiple: 1,
+		})
+	require.NoError(t, err)
+	require.NotNil(t, iters)
+	// expect a series per shard.
+	require.Equal(t, 3, iters.Len())
+	require.True(t, meta.Exhaustive)
+	require.NoError(t, sess.Close())
+}
+
 func TestSessionClusterConnectConsistencyLevelAny(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -375,6 +439,26 @@ func testSessionClusterConnectConsistencyLevel(
 	case outcomeFail:
 		assert.Error(t, err)
 		assert.Equal(t, ErrClusterConnectTimeout, err)
+	}
+}
+
+// mockHostQueuesWithFn mocks every host queue and calls the provided fn when an operation is enqueued. the provided
+// fn is dispatched in a separate goroutine to simulate the queue processing. this also allows the function to access
+// the state locks.
+func mockHostQueuesWithFn(ctrl *gomock.Controller, fn func(op op, host topology.Host)) newHostQueueFn {
+	return func(host topology.Host, hostQueueOpts hostQueueOpts) (hostQueue, error) {
+		q := NewMockhostQueue(ctrl)
+		q.EXPECT().Open()
+		q.EXPECT().ConnectionCount().Return(hostQueueOpts.opts.MinConnectionCount()).AnyTimes()
+		q.EXPECT().Host().Return(host).AnyTimes()
+		q.EXPECT().Enqueue(gomock.Any()).Do(func(op op) error {
+			go func() {
+				fn(op, host)
+			}()
+			return nil
+		}).Return(nil)
+		q.EXPECT().Close()
+		return q, nil
 	}
 }
 


### PR DESCRIPTION
A previous attempt to lower the req.SeriesLimit to each database
instance, accidentally used that same lower limit when consolidating the
results from all database instances. The consolidation logic should use
the total SeriesLimit for the query.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
