### PR TITLE
[query] Deduplicate resolved physical namespaces after logical namespaces resolved

### DIFF
--- a/src/query/storage/m3/cluster_resolver.go
+++ b/src/query/storage/m3/cluster_resolver.go
@@ -75,6 +75,7 @@ func resolveUnaggregatedNamespaceForQuery(
 
 // resolveClusterNamespacesForQuery returns the namespaces that need to be
 // fanned out to depending on the query time and the namespaces configured.
+// nolint: unparam
 func resolveClusterNamespacesForQuery(
 	now, start, end time.Time,
 	clusters Clusters,
@@ -91,7 +92,7 @@ func resolveClusterNamespacesForQuery(
 	// 2. Create physical plan.
 	// Now de-duplicate any namespaces that might be fetched twice due to
 	// the fact some of the same namespaces are reused once for unaggregated
-	// and another for aggregated rollups (which don't collid with timeseries).
+	// and another for aggregated rollups (which don't collide with timeseries).
 	filtered := namespaces[:0]
 	for _, ns := range namespaces {
 		keep := true

--- a/src/query/storage/m3/cluster_resolver.go
+++ b/src/query/storage/m3/cluster_resolver.go
@@ -75,7 +75,6 @@ func resolveUnaggregatedNamespaceForQuery(
 
 // resolveClusterNamespacesForQuery returns the namespaces that need to be
 // fanned out to depending on the query time and the namespaces configured.
-// nolint: unparam
 func resolveClusterNamespacesForQuery(
 	now, start, end time.Time,
 	clusters Clusters,
@@ -115,6 +114,7 @@ func resolveClusterNamespacesForQuery(
 
 // resolveClusterNamespacesForQueryLogicalPlan resolves the logical plan
 // for namespaces to query.
+// nolint: unparam
 func resolveClusterNamespacesForQueryLogicalPlan(
 	now, start, end time.Time,
 	clusters Clusters,

--- a/src/query/storage/m3/cluster_resolver_test.go
+++ b/src/query/storage/m3/cluster_resolver_test.go
@@ -414,11 +414,9 @@ func TestResolveClusterNamespacesForQueryWithOptions(t *testing.T) {
 			}
 
 			// NB: order does not matter.
-			sort.Sort(sort.StringSlice(actualNames))
-			sort.Sort(sort.StringSlice(tt.expectedClusterNames))
-
+			sort.Strings(actualNames)
+			sort.Strings(tt.expectedClusterNames)
 			assert.Equal(t, tt.expectedClusterNames, actualNames)
-
 			assert.Equal(t, tt.expectedType, fanoutType)
 		})
 	}
@@ -482,8 +480,8 @@ func TestLongUnaggregatedRetention(t *testing.T) {
 
 	expected := []string{"UNAGG", "AGG_NO_FILTER"}
 	// NB: order does not matter.
-	sort.Sort(sort.StringSlice(actualNames))
-	sort.Sort(sort.StringSlice(expected))
+	sort.Strings(actualNames)
+	sort.Strings(expected)
 	assert.Equal(t, expected, actualNames)
 	assert.Equal(t, consolidators.NamespaceCoversPartialQueryRange, fanoutType)
 }
@@ -529,7 +527,7 @@ func TestExampleCase(t *testing.T) {
 		}
 
 		// NB: order does not matter.
-		sort.Sort(sort.StringSlice(actualNames))
+		sort.Strings(actualNames)
 		assert.Equal(t, []string{"metrics_10s_24h",
 			"metrics_180s_360h", "metrics_600s_17520h"}, actualNames)
 		assert.Equal(t, consolidators.NamespaceCoversPartialQueryRange, fanoutType)
@@ -574,7 +572,7 @@ func TestDeduplicatePartialAggregateNamespaces(t *testing.T) {
 	}
 
 	// NB: order does not matter.
-	sort.Sort(sort.StringSlice(actualNames))
+	sort.Strings(actualNames)
 	assert.Equal(t, []string{"aggregated_block_6h"}, actualNames)
 	assert.Equal(t, consolidators.NamespaceCoversAllQueryRange, fanoutType)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This addresses an edge case where a namespace is overloaded for multiple resolutions, some of which store partial sets of the data set, we would fetch multiple times from the same physical namespace. This avoids that edge case.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
