### PR TITLE
[aggregator] Log shardId on message errors

### DIFF
--- a/src/aggregator/server/m3msg/server.go
+++ b/src/aggregator/server/m3msg/server.go
@@ -21,6 +21,7 @@
 package m3msg
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -66,7 +67,7 @@ func (s *server) Consume(c consumer.Consumer) {
 	for {
 		msg, err := c.Message()
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				s.logger.Error("could not read message", zap.Error(err))
 			}
 			break

--- a/src/aggregator/server/m3msg/server.go
+++ b/src/aggregator/server/m3msg/server.go
@@ -60,26 +60,26 @@ func NewServer(
 
 func (s *server) Consume(c consumer.Consumer) {
 	var (
-		pb     = &metricpb.MetricWithMetadatas{}
-		union  = &encoding.UnaggregatedMessageUnion{}
-		msgErr error
-		msg    consumer.Message
+		pb    = &metricpb.MetricWithMetadatas{}
+		union = &encoding.UnaggregatedMessageUnion{}
 	)
 	for {
-		msg, msgErr = c.Message()
-		if msgErr != nil {
+		msg, err := c.Message()
+		if err != nil {
+			if err != io.EOF {
+				s.logger.Error("could not read message", zap.Error(err))
+			}
 			break
 		}
 
 		// Reset and reuse the protobuf message for unpacking.
 		protobuf.ReuseMetricWithMetadatasProto(pb)
-		err := s.handleMessage(pb, union, msg)
-		if err != nil {
-			s.logger.Error("could not process message", zap.Error(err), zap.String("proto", pb.String()))
+		if err = s.handleMessage(pb, union, msg); err != nil {
+			s.logger.Error("could not process message",
+				zap.Error(err),
+				zap.Uint64("shard", msg.ShardID()),
+				zap.String("proto", pb.String()))
 		}
-	}
-	if msgErr != nil && msgErr != io.EOF {
-		s.logger.Error("could not read message", zap.Error(msgErr))
 	}
 	c.Close()
 }

--- a/src/msg/consumer/consumer.go
+++ b/src/msg/consumer/consumer.go
@@ -259,6 +259,10 @@ func (m *message) reset(c *consumer) {
 	resetProto(&m.Message)
 }
 
+func (m *message) ShardID() uint64 {
+	return m.Metadata.Shard
+}
+
 func resetProto(m *msgpb.Message) {
 	m.Metadata.Id = 0
 	m.Metadata.Shard = 0

--- a/src/msg/consumer/consumer_mock.go
+++ b/src/msg/consumer/consumer_mock.go
@@ -79,6 +79,20 @@ func (mr *MockMessageMockRecorder) Bytes() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bytes", reflect.TypeOf((*MockMessage)(nil).Bytes))
 }
 
+// ShardID mocks base method.
+func (m *MockMessage) ShardID() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShardID")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// ShardID indicates an expected call of ShardID.
+func (mr *MockMessageMockRecorder) ShardID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShardID", reflect.TypeOf((*MockMessage)(nil).ShardID))
+}
+
 // MockMessageProcessor is a mock of MessageProcessor interface.
 type MockMessageProcessor struct {
 	ctrl     *gomock.Controller

--- a/src/msg/consumer/types.go
+++ b/src/msg/consumer/types.go
@@ -35,6 +35,9 @@ type Message interface {
 
 	// Ack acks the message.
 	Ack()
+
+	// ShardID returns shard ID of the Message.
+	ShardID() uint64
 }
 
 // Consumer receives messages from a connection.

--- a/src/msg/producer/writer/message.go
+++ b/src/msg/producer/writer/message.go
@@ -101,6 +101,10 @@ func (m *message) Ack() {
 	m.RefCountedMessage.DecRef()
 }
 
+func (m *message) ShardID() uint64 {
+	return m.meta.shard
+}
+
 // Metadata returns the metadata.
 func (m *message) Metadata() metadata {
 	return m.meta


### PR DESCRIPTION
**What this PR does / why we need it**:
Logs `shardID` of the message on message processing errors.

**Special notes for your reviewer**:
Mostly intended to troubleshoot "shard not owned" errors.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
