### PR TITLE
Use lower per db instance limits for aggregate and fetchTaggedIDs

### DIFF
--- a/src/dbnode/client/fetch_state.go
+++ b/src/dbnode/client/fetch_state.go
@@ -241,7 +241,8 @@ func (f *fetchState) asEncodingSeriesIterators(
 	return f.tagResultAccumulator.AsEncodingSeriesIterators(limit, pools, descr, opts)
 }
 
-func (f *fetchState) asAggregatedTagsIterator(pools fetchTaggedPools) (AggregatedTagsIterator, FetchResponseMetadata, error) {
+func (f *fetchState) asAggregatedTagsIterator(pools fetchTaggedPools, limit int) (
+	AggregatedTagsIterator, FetchResponseMetadata, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -259,7 +260,9 @@ func (f *fetchState) asAggregatedTagsIterator(pools fetchTaggedPools) (Aggregate
 		return nil, FetchResponseMetadata{}, err
 	}
 
-	limit := f.aggregateOp.requestSeriesLimit(maxInt)
+	if limit == 0 {
+		limit = maxInt
+	}
 	return f.tagResultAccumulator.AsAggregatedTagsIterator(limit, pools)
 }
 

--- a/src/dbnode/client/session_test.go
+++ b/src/dbnode/client/session_test.go
@@ -280,6 +280,7 @@ func TestIteratorPools(t *testing.T) {
 	assert.Equal(t, idPool, itPool.ID())
 }
 
+//nolint:dupl
 func TestSeriesLimit_FetchTagged(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -318,6 +319,7 @@ func TestSeriesLimit_FetchTagged(t *testing.T) {
 	require.NoError(t, sess.Close())
 }
 
+//nolint:dupl
 func TestSeriesLimit_FetchTaggedIDs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -356,6 +358,7 @@ func TestSeriesLimit_FetchTaggedIDs(t *testing.T) {
 	require.NoError(t, sess.Close())
 }
 
+//nolint:dupl
 func TestSeriesLimit_Aggregate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
This has worked well for the FetchTagged endpoint, so rolling out to the
Aggregate and FetchTaggedIDs endpoints as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
