### PR TITLE
[coordinator] Middleware metric adds tags vs subscope

### DIFF
--- a/src/x/headers/headers.go
+++ b/src/x/headers/headers.go
@@ -166,7 +166,7 @@ const (
 	// using the fields it knows about.
 	JSONDisableDisallowUnknownFields = M3HeaderPrefix + "JSON-Disable-Disallow-Unknown-Fields"
 
-	// CustomResponseMetricsScope is a header that, if set, will add the name specified by the header
-	// as a custom subscope on the request's response metrics.
-	CustomResponseMetricsScope = M3HeaderPrefix + "Custom-Response-Metrics-Scope"
+	// CustomResponseMetricsType is a header that, if set, will override the `type` tag
+	// on the request's response metrics.
+	CustomResponseMetricsType = M3HeaderPrefix + "Custom-Response-Metrics-Type"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously the middleware would use a subscope when passed an override
header, but this makes inspecting and discovering correct metrics more
difficult. This PR changes this to be a metrics type tag; this in turn
necessitates a default value, since Prometheus does not deal with jagged
metrics well. 