### PR TITLE
Ignore off-by-one differences when optimizing sharded placement

### DIFF
--- a/src/cluster/placement/algo/sharded_helper.go
+++ b/src/cluster/placement/algo/sharded_helper.go
@@ -493,6 +493,7 @@ func (ph *helper) mostUnderLoadedInstance() (placement.Instance, bool) {
 	var (
 		res        placement.Instance
 		maxLoadGap int
+		totalLoadSurplus int
 	)
 
 	for id, instance := range ph.instances {
@@ -501,11 +502,13 @@ func (ph *helper) mostUnderLoadedInstance() (placement.Instance, bool) {
 			maxLoadGap = loadGap
 			res = instance
 		}
+		if loadGap < 0 {
+			totalLoadSurplus -= loadGap
+		}
 	}
-	if maxLoadGap > 0 {
+	if maxLoadGap > 0 && totalLoadSurplus != 0 {
 		return res, true
 	}
-
 	return nil, false
 }
 

--- a/src/cluster/placement/algo/sharded_helper_test.go
+++ b/src/cluster/placement/algo/sharded_helper_test.go
@@ -653,19 +653,19 @@ func TestMarkAllAsAvailable(t *testing.T) {
 func TestOptimize(t *testing.T) {
 	rf := 1
 	tests := []struct {
-		name string
-		shards []uint32
+		name            string
+		shards          []uint32
 		instancesBefore []placement.Instance
-		instancesAfter []placement.Instance
+		instancesAfter  []placement.Instance
 	}{
 		{
-			name: "empty",
+			name:            "empty",
 			instancesBefore: []placement.Instance{},
-			instancesAfter: []placement.Instance{},
+			instancesAfter:  []placement.Instance{},
 		},
 		{
-			name: "no optimization when instance is off by one",
-			shards:[]uint32{1, 2, 3, 4, 5},
+			name:   "no optimization when instance is off by one",
+			shards: []uint32{1, 2, 3, 4, 5},
 			instancesBefore: []placement.Instance{
 				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
 					shard.NewShards([]shard.Shard{
@@ -700,8 +700,8 @@ func TestOptimize(t *testing.T) {
 			},
 		},
 		{
-			name: "optimizing one imbalanced instance",
-			shards:[]uint32{1, 2, 3, 4, 5, 6},
+			name:   "optimizing one imbalanced instance",
+			shards: []uint32{1, 2, 3, 4, 5, 6},
 			instancesBefore: []placement.Instance{
 				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
 					shard.NewShards([]shard.Shard{
@@ -739,8 +739,8 @@ func TestOptimize(t *testing.T) {
 			},
 		},
 		{
-			name: "optimizing multiple imbalanced instances",
-			shards:[]uint32{1, 2, 3, 4, 5, 6, 7, 8},
+			name:   "optimizing multiple imbalanced instances",
+			shards: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
 			instancesBefore: []placement.Instance{
 				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
 					shard.NewShards([]shard.Shard{
@@ -782,8 +782,8 @@ func TestOptimize(t *testing.T) {
 			},
 		},
 		{
-			name: "no optimization for balanced instances with different weights",
-			shards:[]uint32{1, 2, 3, 4, 5, 6, 7, 8},
+			name:   "no optimization for balanced instances with different weights",
+			shards: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
 			instancesBefore: []placement.Instance{
 				placement.NewInstance().SetID("i1").SetWeight(2).SetShards(
 					shard.NewShards([]shard.Shard{
@@ -824,8 +824,8 @@ func TestOptimize(t *testing.T) {
 			},
 		},
 		{
-			name: "optimization for imbalanced instances with different weights",
-			shards:[]uint32{1, 2, 3, 4, 5, 6, 7, 8},
+			name:   "optimization for imbalanced instances with different weights",
+			shards: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
 			instancesBefore: []placement.Instance{
 				placement.NewInstance().SetID("i1").SetWeight(2).SetShards(
 					shard.NewShards([]shard.Shard{

--- a/src/cluster/placement/algo/sharded_helper_test.go
+++ b/src/cluster/placement/algo/sharded_helper_test.go
@@ -22,6 +22,7 @@ package algo
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -646,6 +647,241 @@ func TestMarkAllAsAvailable(t *testing.T) {
 		SetReplicaFactor(2)
 	_, _, err = markAllShardsAvailable(p, opts)
 	assert.Contains(t, err.Error(), "does not exist in placement")
+}
+
+func TestOptimize(t *testing.T) {
+	rf := 1
+	tests := []struct {
+		name string
+		shards []uint32
+		instancesBefore []placement.Instance
+		instancesAfter []placement.Instance
+	}{
+		{
+			name: "empty",
+			instancesBefore: []placement.Instance{},
+			instancesAfter: []placement.Instance{},
+		},
+		{
+			name: "no optimization when instance is off by one",
+			shards:[]uint32{1, 2, 3, 4, 5},
+			instancesBefore: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Available),
+						shard.NewShard(2).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(3).SetState(shard.Available),
+						shard.NewShard(4).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(5).SetState(shard.Available),
+					})),
+			},
+			instancesAfter: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Available),
+						shard.NewShard(2).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(3).SetState(shard.Available),
+						shard.NewShard(4).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(5).SetState(shard.Available),
+					})),
+			},
+		},
+		{
+			name: "optimizing one imbalanced instance",
+			shards:[]uint32{1, 2, 3, 4, 5, 6},
+			instancesBefore: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Available),
+						shard.NewShard(2).SetState(shard.Available),
+						shard.NewShard(3).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(4).SetState(shard.Available),
+						shard.NewShard(5).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(6).SetState(shard.Available),
+					})),
+			},
+			instancesAfter: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Leaving),
+						shard.NewShard(2).SetState(shard.Available),
+						shard.NewShard(3).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(4).SetState(shard.Available),
+						shard.NewShard(5).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Unknown).SetSourceID("i1"),
+						shard.NewShard(6).SetState(shard.Available),
+					})),
+			},
+		},
+		{
+			name: "optimizing multiple imbalanced instances",
+			shards:[]uint32{1, 2, 3, 4, 5, 6, 7, 8},
+			instancesBefore: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Available),
+						shard.NewShard(2).SetState(shard.Available),
+						shard.NewShard(3).SetState(shard.Available),
+						shard.NewShard(4).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(5).SetState(shard.Available),
+						shard.NewShard(6).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(7).SetState(shard.Available),
+						shard.NewShard(8).SetState(shard.Available),
+					})),
+			},
+			instancesAfter: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Leaving),
+						shard.NewShard(2).SetState(shard.Available),
+						shard.NewShard(3).SetState(shard.Available),
+						shard.NewShard(4).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Unknown).SetSourceID("i1"),
+						shard.NewShard(5).SetState(shard.Available),
+						shard.NewShard(6).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(7).SetState(shard.Available),
+						shard.NewShard(8).SetState(shard.Available),
+					})),
+			},
+		},
+		{
+			name: "no optimization for balanced instances with different weights",
+			shards:[]uint32{1, 2, 3, 4, 5, 6, 7, 8},
+			instancesBefore: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(2).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Available),
+						shard.NewShard(2).SetState(shard.Available),
+						shard.NewShard(3).SetState(shard.Available),
+						shard.NewShard(4).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(5).SetState(shard.Available),
+						shard.NewShard(6).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(7).SetState(shard.Available),
+						shard.NewShard(8).SetState(shard.Available),
+					})),
+			},
+			instancesAfter: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(2).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Available),
+						shard.NewShard(2).SetState(shard.Available),
+						shard.NewShard(3).SetState(shard.Available),
+						shard.NewShard(4).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(5).SetState(shard.Available),
+						shard.NewShard(6).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(7).SetState(shard.Available),
+						shard.NewShard(8).SetState(shard.Available),
+					})),
+			},
+		},
+		{
+			name: "optimization for imbalanced instances with different weights",
+			shards:[]uint32{1, 2, 3, 4, 5, 6, 7, 8},
+			instancesBefore: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(2).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Available),
+						shard.NewShard(2).SetState(shard.Available),
+						shard.NewShard(3).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(4).SetState(shard.Available),
+						shard.NewShard(5).SetState(shard.Available),
+						shard.NewShard(6).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(7).SetState(shard.Available),
+						shard.NewShard(8).SetState(shard.Available),
+					})),
+			},
+			instancesAfter: []placement.Instance{
+				placement.NewInstance().SetID("i1").SetWeight(2).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(1).SetState(shard.Available),
+						shard.NewShard(2).SetState(shard.Available),
+						shard.NewShard(3).SetState(shard.Available),
+						shard.NewShard(4).SetState(shard.Unknown).SetSourceID("i2"),
+					})),
+				placement.NewInstance().SetID("i2").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(4).SetState(shard.Leaving),
+						shard.NewShard(5).SetState(shard.Available),
+						shard.NewShard(6).SetState(shard.Available),
+					})),
+				placement.NewInstance().SetID("i3").SetWeight(1).SetShards(
+					shard.NewShards([]shard.Shard{
+						shard.NewShard(7).SetState(shard.Available),
+						shard.NewShard(8).SetState(shard.Available),
+					})),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := placement.NewPlacement().SetShards(tt.shards).SetReplicaFactor(rf).SetInstances(tt.instancesBefore)
+			ph := newHelper(p, rf, placement.NewOptions())
+
+			err := ph.optimize(unsafe)
+			assert.NoError(t, err)
+
+			instancesAfter := ph.Instances()
+			sort.Slice(instancesAfter, func(i, j int) bool {
+				return instancesAfter[i].ID() < instancesAfter[j].ID()
+			})
+			assert.Equal(t, tt.instancesAfter, instancesAfter)
+		})
+	}
 }
 
 func genShardCutoverFn(now time.Time) placement.ShardValidateFn {

--- a/src/cluster/placement/algo/sharded_helper_test.go
+++ b/src/cluster/placement/algo/sharded_helper_test.go
@@ -649,6 +649,7 @@ func TestMarkAllAsAvailable(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not exist in placement")
 }
 
+// nolint: dupl
 func TestOptimize(t *testing.T) {
 	rf := 1
 	tests := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Previously, sharded placement optimization (`optimize()`) which is performed during instance removal, replica addition and instance replacement (if `AllowPartialReplace` config is enabled), would cause unnecessary shard movement.
For example, if there were 3 instances A, B, C with 2, 2, 1 shards respectively, then replacement of node A with a new instance D would also trigger a movement of 1 shard from B to C.

To fix this, the way underloaded instance is determined was changed. In addition to checking if any instance has less than its target load of shards, a check for any instance having more than its target load of shards was added. The second check will fail and no optimization will be performed in scenarios like the one described above. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
