### PR TITLE
[cluster] Fix a bug in shards.Clone()

### DIFF
--- a/src/cluster/shard/shard.go
+++ b/src/cluster/shard/shard.go
@@ -404,8 +404,9 @@ func (ss *shards) Clone() Shards {
 	shardMap := make(map[uint32]Shard, len(ss.shards))
 
 	for _, shrd := range ss.shards {
-		shrds = append(shrds, shrd.Clone())
-		shardMap[shrd.ID()] = shrd
+		cloned := shrd.Clone()
+		shrds = append(shrds, cloned)
+		shardMap[shrd.ID()] = cloned
 	}
 
 	return &shards{

--- a/src/cluster/shard/shard_test.go
+++ b/src/cluster/shard/shard_test.go
@@ -233,6 +233,20 @@ func TestClone(t *testing.T) {
 	require.False(t, ss1.Equals(ss2))
 }
 
+func TestCloneCopiesToShardMap(t *testing.T) {
+	s := NewShard(1).SetState(Available)
+
+	ss := NewShards([]Shard{s})
+	clonedSS := ss.Clone()
+	require.True(t, ss.Equals(clonedSS))
+
+	s.SetState(Leaving)
+
+	clonedS, ok := clonedSS.Shard(1)
+	require.True(t, ok)
+	assert.Equal(t, Available, clonedS.State())
+}
+
 func TestShardAdd(t *testing.T) {
 	for i := 1; i < 500; i++ {
 		rndShards := makeTestShards(i)


### PR DESCRIPTION
**What this PR does / why we need it**:
`shards.Clone()` was adding the original shards to the cloned `shardMap` without making a copy of them.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
