### PR TITLE
Fix TestBlockRotation flakiness

### DIFF
--- a/src/dbnode/integration/index_block_rotation_test.go
+++ b/src/dbnode/integration/index_block_rotation_test.go
@@ -128,13 +128,15 @@ func TestIndexBlockRotation(t *testing.T) {
 	// move time to 4p
 	testSetup.SetNowFn(t2)
 
-	// give tick some time to evict the block
-	testSetup.SleepFor10xTickMinimumInterval()
-
 	// ensure all data is absent
 	log.Info("querying period0 results after expiry")
-	period0Results, _, err = session.FetchTagged(ContextWithDefaultTimeout(),
-		md.ID(), query, index.QueryOptions{StartInclusive: t0, EndExclusive: t1})
-	require.NoError(t, err)
+
+	// await for results to be empty.
+	startCheck := time.Now()
+	for time.Since(startCheck) < time.Second * 5 && period0Results.Len() > 0 {
+		period0Results, _, err = session.FetchTagged(ContextWithDefaultTimeout(),
+			md.ID(), query, index.QueryOptions{StartInclusive: t0, EndExclusive: t1})
+		require.NoError(t, err)
+	}
 	require.Equal(t, 0, period0Results.Len())
 }

--- a/src/dbnode/integration/index_block_rotation_test.go
+++ b/src/dbnode/integration/index_block_rotation_test.go
@@ -133,7 +133,7 @@ func TestIndexBlockRotation(t *testing.T) {
 
 	// await for results to be empty.
 	startCheck := time.Now()
-	for time.Since(startCheck) < time.Second * 5 && period0Results.Len() > 0 {
+	for time.Since(startCheck) < time.Second*5 && period0Results.Len() > 0 {
 		period0Results, _, err = session.FetchTagged(ContextWithDefaultTimeout(),
 			md.ID(), query, index.QueryOptions{StartInclusive: t0, EndExclusive: t1})
 		require.NoError(t, err)


### PR DESCRIPTION
Sleeping for 10x the tick is flaky. Instead await 5s for the expected
results.

❯ go test -tags integration ./src/dbnode/integration -run TestIndexBlockRotation -count=20
ok  	github.com/m3db/m3/src/dbnode/integration	232.725s

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
