### PR TITLE
WIP [aggregator] Respect cutover warmup/cutoff linger times in m3msg writes

### DIFF
--- a/src/aggregator/client/tcp_client.go
+++ b/src/aggregator/client/tcp_client.go
@@ -327,13 +327,14 @@ func (c *TCPClient) writeTimeRangeFor(shard shard.Shard) (int64, int64) {
 		latestNanos   = int64(math.MaxInt64)
 	)
 
-	if cutoverNanos >= int64(c.shardCutoverWarmupDuration) {
-		earliestNanos = cutoverNanos - int64(c.shardCutoverWarmupDuration)
+	if cutoverNanos >= c.shardCutoverWarmupDuration.Nanoseconds() {
+		earliestNanos = cutoverNanos - c.shardCutoverWarmupDuration.Nanoseconds()
 	}
 
-	if cutoffNanos <= math.MaxInt64-int64(c.shardCutoffLingerDuration) {
-		latestNanos = cutoffNanos + int64(c.shardCutoffLingerDuration)
+	if cutoffNanos <= math.MaxInt64-c.shardCutoffLingerDuration.Nanoseconds() {
+		latestNanos = cutoffNanos + c.shardCutoffLingerDuration.Nanoseconds()
 	}
+
 	return earliestNanos, latestNanos
 }
 

--- a/src/msg/producer/writer/message_writer.go
+++ b/src/msg/producer/writer/message_writer.go
@@ -289,7 +289,7 @@ func (w *messageWriterImpl) isValidWriteWithLock(nowNanos int64) bool {
 	if w.cutOffNanos > 0 {
 		var (
 			latestNanos       = int64(math.MaxInt64)
-			cutoffLingerNanos = w.opts.ClientOptions().ShardCutoffLingerDuration().Nanoseconds()
+			cutoffLingerNanos = w.opts.CutoffLingerDuration().Nanoseconds()
 		)
 		if w.cutOffNanos <= math.MaxInt64-cutoffLingerNanos {
 			latestNanos = w.cutOffNanos + cutoffLingerNanos
@@ -303,7 +303,7 @@ func (w *messageWriterImpl) isValidWriteWithLock(nowNanos int64) bool {
 	if w.cutOverNanos > 0 {
 		var (
 			earliestNanos      = int64(0)
-			cutoverWarmupNanos = w.opts.ClientOptions().ShardCutoverWarmupDuration().Nanoseconds()
+			cutoverWarmupNanos = w.opts.CutoverWarmupDuration().Nanoseconds()
 		)
 		if w.cutOverNanos >= cutoverWarmupNanos {
 			earliestNanos = w.cutOverNanos - cutoverWarmupNanos

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -23,6 +23,7 @@ package writer
 import (
 	"time"
 
+	"github.com/m3db/m3/src/aggregator/client"
 	"github.com/m3db/m3/src/cluster/placement"
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/msg/protocol/proto"
@@ -291,7 +292,7 @@ type Options interface {
 	// MessageRetryOptions returns the retry options for message retry.
 	MessageRetryOptions() retry.Options
 
-	// MessageRetryOptions returns the retry options for message retry.
+	// SetMessageRetryOptions sets the retry options for message retry.
 	SetMessageRetryOptions(value retry.Options) Options
 
 	// MessageQueueNewWritesScanInterval returns the interval between scanning
@@ -340,10 +341,10 @@ type Options interface {
 	// SetEncoderOptions sets the encoder's options.
 	SetEncoderOptions(value proto.Options) Options
 
-	// EncoderOptions returns the decoder's options.
+	// DecoderOptions returns the decoder's options.
 	DecoderOptions() proto.Options
 
-	// SetEncoderOptions sets the decoder's options.
+	// SetDecoderOptions sets the decoder's options.
 	SetDecoderOptions(value proto.Options) Options
 
 	// ConnectionOptions returns the options for connections.
@@ -357,6 +358,12 @@ type Options interface {
 
 	// SetInstrumentOptions sets the instrument options.
 	SetInstrumentOptions(value instrument.Options) Options
+
+	// ClientOptions returns the client options.
+	ClientOptions() client.Options
+
+	// SetClientOptions sets the client options.
+	SetClientOptions(value client.Options) Options
 }
 
 type writerOptions struct {
@@ -378,6 +385,7 @@ type writerOptions struct {
 	decOpts                           proto.Options
 	cOpts                             ConnectionOptions
 	iOpts                             instrument.Options
+	clientOpts                        client.Options
 }
 
 // NewOptions creates Options.
@@ -397,6 +405,7 @@ func NewOptions() Options {
 		decOpts:                           proto.NewOptions(),
 		cOpts:                             NewConnectionOptions(),
 		iOpts:                             instrument.NewOptions(),
+		clientOpts:                        client.NewOptions(),
 	}
 }
 
@@ -577,5 +586,15 @@ func (opts *writerOptions) InstrumentOptions() instrument.Options {
 func (opts *writerOptions) SetInstrumentOptions(value instrument.Options) Options {
 	o := *opts
 	o.iOpts = value
+	return &o
+}
+
+func (opts *writerOptions) ClientOptions() client.Options {
+	return opts.clientOpts
+}
+
+func (opts *writerOptions) SetClientOptions(value client.Options) Options {
+	o := *opts
+	o.clientOpts = value
 	return &o
 }

--- a/src/msg/producer/writer/shard_writer.go
+++ b/src/msg/producer/writer/shard_writer.go
@@ -78,7 +78,7 @@ func (w *sharedShardWriter) Write(rm *producer.RefCountedMessage) {
 	w.mw.Write(rm)
 }
 
-// This is not thread safe, must be called in one thread.
+// UpdateInstances is not thread safe, must be called in one thread.
 func (w *sharedShardWriter) UpdateInstances(
 	instances []placement.Instance,
 	cws map[string]consumerWriter,
@@ -166,7 +166,7 @@ func (w *replicatedShardWriter) Write(rm *producer.RefCountedMessage) {
 	w.RUnlock()
 }
 
-// This is not thread safe, must be called in one thread.
+// UpdateInstances is not thread safe, must be called in one thread.
 func (w *replicatedShardWriter) UpdateInstances(
 	instances []placement.Instance,
 	cws map[string]consumerWriter,


### PR DESCRIPTION
**What this PR does / why we need it**:
Respect cutover warmup/cutoff linger times in m3msg writes (based on the logics in tcp_client.go).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
