### PR TITLE
Explicitly create static or dynamic pooled worker pools

### DIFF
--- a/src/aggregator/client/writer_mgr.go
+++ b/src/aggregator/client/writer_mgr.go
@@ -105,7 +105,7 @@ type writerManager struct {
 	closed  bool
 	metrics writerManagerMetrics
 	_       cpu.CacheLinePad
-	pool    xsync.PooledWorkerPool
+	pool    xsync.StaticPooledWorkerPool
 }
 
 func newInstanceWriterManager(opts Options) (instanceWriterManager, error) {
@@ -116,9 +116,9 @@ func newInstanceWriterManager(opts Options) (instanceWriterManager, error) {
 		doneCh:  make(chan struct{}),
 	}
 
-	pool, err := xsync.NewPooledWorkerPool(
-		opts.FlushWorkerCount(),
-		xsync.NewPooledWorkerPoolOptions().SetKillWorkerProbability(0.05),
+	pool, err := xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions().
+		SetKillWorkerProbability(0.05).
+		SetNumShards(opts.FlushWorkerCount()),
 	)
 	if err != nil {
 		return nil, err

--- a/src/cmd/services/m3coordinator/ingest/carbon/ingest.go
+++ b/src/cmd/services/m3coordinator/ingest/carbon/ingest.go
@@ -325,7 +325,7 @@ func (i *ingester) Handle(conn net.Conn) {
 		if i.opts.StaticWorkerPool != nil {
 			i.opts.StaticWorkerPool.Go(work)
 		} else {
-			i.opts.DynamicWorkerPool.AlwaysGo(work)
+			i.opts.DynamicWorkerPool.GoAlways(work)
 		}
 
 		i.metrics.malformed.Inc(int64(s.MalformedCount))

--- a/src/cmd/services/m3coordinator/ingest/carbon/ingest_test.go
+++ b/src/cmd/services/m3coordinator/ingest/carbon/ingest_test.go
@@ -69,7 +69,7 @@ var (
 
 	testOptions = Options{
 		InstrumentOptions: instrument.NewOptions(),
-		WorkerPool:        nil, // Set by init().
+		StaticWorkerPool:  nil, // Set by init().
 	}
 
 	testTagOpts = models.NewTagOptions().
@@ -721,11 +721,11 @@ func assertTestMetricsAreEqual(t *testing.T, a, b []testMetric) {
 
 func init() {
 	var err error
-	testOptions.WorkerPool, err = xsync.NewPooledWorkerPool(16, xsync.NewPooledWorkerPoolOptions())
+	testOptions.StaticWorkerPool, err = xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 	if err != nil {
 		panic(err)
 	}
-	testOptions.WorkerPool.Init()
+	testOptions.StaticWorkerPool.Init()
 
 	for i := 0; i < numLinesInTestPacket; i++ {
 		var metric []byte

--- a/src/cmd/services/m3coordinator/ingest/m3msg/config.go
+++ b/src/cmd/services/m3coordinator/ingest/m3msg/config.go
@@ -62,10 +62,10 @@ func (cfg Configuration) newOptions(
 	scope := instrumentOptions.MetricsScope().Tagged(
 		map[string]string{"component": "ingester"},
 	)
-	workers, err := xsync.NewPooledWorkerPool(
-		cfg.WorkerPoolSize,
+	workers, err := xsync.NewStaticPooledWorkerPool(
 		xsync.NewPooledWorkerPoolOptions().
-			SetInstrumentOptions(instrumentOptions),
+			SetInstrumentOptions(instrumentOptions).
+			SetNumShards(cfg.WorkerPoolSize),
 	)
 	if err != nil {
 		return Options{}, err

--- a/src/cmd/services/m3coordinator/ingest/m3msg/ingest.go
+++ b/src/cmd/services/m3coordinator/ingest/m3msg/ingest.go
@@ -49,7 +49,7 @@ import (
 // Options configures the ingester.
 type Options struct {
 	Appender          storage.Appender
-	Workers           xsync.PooledWorkerPool
+	Workers           xsync.StaticPooledWorkerPool
 	PoolOptions       pool.ObjectPoolOptions
 	TagDecoderPool    serialize.TagDecoderPool
 	RetryOptions      retry.Options
@@ -78,7 +78,7 @@ func newIngestMetrics(scope tally.Scope) ingestMetrics {
 
 // Ingester ingests metrics with a worker pool.
 type Ingester struct {
-	workers xsync.PooledWorkerPool
+	workers xsync.StaticPooledWorkerPool
 	p       pool.ObjectPool
 }
 

--- a/src/cmd/services/m3coordinator/ingest/write.go
+++ b/src/cmd/services/m3coordinator/ingest/write.go
@@ -329,7 +329,7 @@ func (d *downsamplerAndWriter) writeToStorage(
 		p := p // Capture for goroutine.
 
 		wg.Add(1)
-		d.workerPool.AlwaysGo(func() {
+		d.workerPool.GoAlways(func() {
 			// NB(r): Allocate the write query at the top
 			// of the pooled worker instead of need to pass
 			// the options down the stack which can cause
@@ -409,7 +409,7 @@ func (d *downsamplerAndWriter) WriteBatch(
 			for _, p := range storagePolicies {
 				p := p // Capture for lambda.
 				wg.Add(1)
-				d.workerPool.AlwaysGo(func() {
+				d.workerPool.GoAlways(func() {
 					// NB(r): Allocate the write query at the top
 					// of the pooled worker instead of need to pass
 					// the options down the stack which can cause

--- a/src/cmd/services/m3coordinator/ingest/write.go
+++ b/src/cmd/services/m3coordinator/ingest/write.go
@@ -112,7 +112,7 @@ type downsamplerAndWriterMetrics struct {
 type downsamplerAndWriter struct {
 	store       storage.Storage
 	downsampler downsample.Downsampler
-	workerPool  xsync.PooledWorkerPool
+	workerPool  xsync.DynamicPooledWorkerPool
 
 	metrics downsamplerAndWriterMetrics
 }
@@ -121,7 +121,7 @@ type downsamplerAndWriter struct {
 func NewDownsamplerAndWriter(
 	store storage.Storage,
 	downsampler downsample.Downsampler,
-	workerPool xsync.PooledWorkerPool,
+	workerPool xsync.DynamicPooledWorkerPool,
 	instrumentOpts instrument.Options,
 ) DownsamplerAndWriter {
 	scope := instrumentOpts.MetricsScope().SubScope("downsampler")
@@ -329,7 +329,7 @@ func (d *downsamplerAndWriter) writeToStorage(
 		p := p // Capture for goroutine.
 
 		wg.Add(1)
-		d.workerPool.Go(func() {
+		d.workerPool.AlwaysGo(func() {
 			// NB(r): Allocate the write query at the top
 			// of the pooled worker instead of need to pass
 			// the options down the stack which can cause
@@ -409,7 +409,7 @@ func (d *downsamplerAndWriter) WriteBatch(
 			for _, p := range storagePolicies {
 				p := p // Capture for lambda.
 				wg.Add(1)
-				d.workerPool.Go(func() {
+				d.workerPool.AlwaysGo(func() {
 					// NB(r): Allocate the write query at the top
 					// of the pooled worker instead of need to pass
 					// the options down the stack which can cause

--- a/src/cmd/services/m3coordinator/ingest/write_test.go
+++ b/src/cmd/services/m3coordinator/ingest/write_test.go
@@ -47,7 +47,7 @@ import (
 
 var (
 	// Created by init().
-	testWorkerPool xsync.PooledWorkerPool
+	testWorkerPool xsync.DynamicPooledWorkerPool
 
 	testTags1 = models.NewTags(3, nil).AddTags(
 		[]models.Tag{
@@ -910,11 +910,7 @@ func newTestDownsamplerAndWriterWithAggregatedNamespace(
 
 func init() {
 	var err error
-	testWorkerPool, err = xsync.NewPooledWorkerPool(
-		16,
-		xsync.NewPooledWorkerPoolOptions().
-			SetGrowOnDemand(true),
-	)
+	testWorkerPool, err = xsync.NewDynamicPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 
 	if err != nil {
 		panic(fmt.Sprintf("unable to create pooled worker pool: %v", err))

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -101,10 +101,8 @@ var (
 	// users do not experience see unexpected results.
 	defaultRequireExhaustive = true
 
-	defaultWriteWorkerPool = xconfig.WorkerPoolPolicy{
-		GrowOnDemand:          true,
-		Size:                  4096,
-		KillWorkerProbability: 0.001,
+	defaultWorkerPoolPolicy = xconfig.WorkerPoolPolicy{
+		NumShards: 4096,
 	}
 )
 
@@ -147,7 +145,7 @@ type Configuration struct {
 	TagOptions TagOptionsConfiguration `yaml:"tagOptions"`
 
 	// ReadWorkerPool is the worker pool policy for read requests.
-	ReadWorkerPool xconfig.WorkerPoolPolicy `yaml:"readWorkerPoolPolicy"`
+	ReadWorkerPool *xconfig.WorkerPoolPolicy `yaml:"readWorkerPoolPolicy"`
 
 	// WriteWorkerPool is the worker pool policy for write requests.
 	WriteWorkerPool *xconfig.WorkerPoolPolicy `yaml:"writeWorkerPoolPolicy"`
@@ -225,7 +223,16 @@ func (c *Configuration) WriteWorkerPoolOrDefault() xconfig.WorkerPoolPolicy {
 		return *c.WriteWorkerPool
 	}
 
-	return defaultWriteWorkerPool
+	return defaultWorkerPoolPolicy
+}
+
+// ReadWorkerPoolOrDefault returns the read worker pool config or default.
+func (c *Configuration) ReadWorkerPoolOrDefault() xconfig.WorkerPoolPolicy {
+	if c.ReadWorkerPool != nil {
+		return *c.ReadWorkerPool
+	}
+
+	return defaultWorkerPoolPolicy
 }
 
 // WriteForwardingConfiguration is the write forwarding configuration.

--- a/src/dbnode/client/client_mock.go
+++ b/src/dbnode/client/client_mock.go
@@ -1169,10 +1169,10 @@ func (mr *MockOptionsMockRecorder) AsyncWriteMaxConcurrency() *gomock.Call {
 }
 
 // AsyncWriteWorkerPool mocks base method.
-func (m *MockOptions) AsyncWriteWorkerPool() sync.PooledWorkerPool {
+func (m *MockOptions) AsyncWriteWorkerPool() sync.DynamicPooledWorkerPool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AsyncWriteWorkerPool")
-	ret0, _ := ret[0].(sync.PooledWorkerPool)
+	ret0, _ := ret[0].(sync.DynamicPooledWorkerPool)
 	return ret0
 }
 
@@ -1435,10 +1435,10 @@ func (mr *MockOptionsMockRecorder) HostQueueEmitsHealthStatus() *gomock.Call {
 }
 
 // HostQueueNewPooledWorkerFn mocks base method.
-func (m *MockOptions) HostQueueNewPooledWorkerFn() sync.NewPooledWorkerFn {
+func (m *MockOptions) HostQueueNewPooledWorkerFn() sync.NewDynamicPooledWorkerFn {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostQueueNewPooledWorkerFn")
-	ret0, _ := ret[0].(sync.NewPooledWorkerFn)
+	ret0, _ := ret[0].(sync.NewDynamicPooledWorkerFn)
 	return ret0
 }
 
@@ -1729,7 +1729,7 @@ func (mr *MockOptionsMockRecorder) SetAsyncWriteMaxConcurrency(value interface{}
 }
 
 // SetAsyncWriteWorkerPool mocks base method.
-func (m *MockOptions) SetAsyncWriteWorkerPool(value sync.PooledWorkerPool) Options {
+func (m *MockOptions) SetAsyncWriteWorkerPool(value sync.DynamicPooledWorkerPool) Options {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAsyncWriteWorkerPool", value)
 	ret0, _ := ret[0].(Options)
@@ -2023,7 +2023,7 @@ func (mr *MockOptionsMockRecorder) SetHostQueueEmitsHealthStatus(value interface
 }
 
 // SetHostQueueNewPooledWorkerFn mocks base method.
-func (m *MockOptions) SetHostQueueNewPooledWorkerFn(value sync.NewPooledWorkerFn) Options {
+func (m *MockOptions) SetHostQueueNewPooledWorkerFn(value sync.NewDynamicPooledWorkerFn) Options {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHostQueueNewPooledWorkerFn", value)
 	ret0, _ := ret[0].(Options)
@@ -2816,10 +2816,10 @@ func (mr *MockAdminOptionsMockRecorder) AsyncWriteMaxConcurrency() *gomock.Call 
 }
 
 // AsyncWriteWorkerPool mocks base method.
-func (m *MockAdminOptions) AsyncWriteWorkerPool() sync.PooledWorkerPool {
+func (m *MockAdminOptions) AsyncWriteWorkerPool() sync.DynamicPooledWorkerPool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AsyncWriteWorkerPool")
-	ret0, _ := ret[0].(sync.PooledWorkerPool)
+	ret0, _ := ret[0].(sync.DynamicPooledWorkerPool)
 	return ret0
 }
 
@@ -3166,10 +3166,10 @@ func (mr *MockAdminOptionsMockRecorder) HostQueueEmitsHealthStatus() *gomock.Cal
 }
 
 // HostQueueNewPooledWorkerFn mocks base method.
-func (m *MockAdminOptions) HostQueueNewPooledWorkerFn() sync.NewPooledWorkerFn {
+func (m *MockAdminOptions) HostQueueNewPooledWorkerFn() sync.NewDynamicPooledWorkerFn {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostQueueNewPooledWorkerFn")
-	ret0, _ := ret[0].(sync.NewPooledWorkerFn)
+	ret0, _ := ret[0].(sync.NewDynamicPooledWorkerFn)
 	return ret0
 }
 
@@ -3474,7 +3474,7 @@ func (mr *MockAdminOptionsMockRecorder) SetAsyncWriteMaxConcurrency(value interf
 }
 
 // SetAsyncWriteWorkerPool mocks base method.
-func (m *MockAdminOptions) SetAsyncWriteWorkerPool(value sync.PooledWorkerPool) Options {
+func (m *MockAdminOptions) SetAsyncWriteWorkerPool(value sync.DynamicPooledWorkerPool) Options {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetAsyncWriteWorkerPool", value)
 	ret0, _ := ret[0].(Options)
@@ -3852,7 +3852,7 @@ func (mr *MockAdminOptionsMockRecorder) SetHostQueueEmitsHealthStatus(value inte
 }
 
 // SetHostQueueNewPooledWorkerFn mocks base method.
-func (m *MockAdminOptions) SetHostQueueNewPooledWorkerFn(value sync.NewPooledWorkerFn) Options {
+func (m *MockAdminOptions) SetHostQueueNewPooledWorkerFn(value sync.NewDynamicPooledWorkerFn) Options {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetHostQueueNewPooledWorkerFn", value)
 	ret0, _ := ret[0].(Options)

--- a/src/dbnode/client/config.go
+++ b/src/dbnode/client/config.go
@@ -347,9 +347,9 @@ func (c Configuration) NewAdminClient(
 
 		workerPoolInstrumentOpts := iopts.SetMetricsScope(writeRequestScope.SubScope("workerpool"))
 		workerPoolOpts := xsync.NewPooledWorkerPoolOptions().
-			SetGrowOnDemand(true).
-			SetInstrumentOptions(workerPoolInstrumentOpts)
-		workerPool, err := xsync.NewPooledWorkerPool(size, workerPoolOpts)
+			SetInstrumentOptions(workerPoolInstrumentOpts).
+			SetNumShards(size)
+		workerPool, err := xsync.NewDynamicPooledWorkerPool(workerPoolOpts)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create async worker pool: %v", err)
 		}

--- a/src/dbnode/client/host_queue.go
+++ b/src/dbnode/client/host_queue.go
@@ -514,7 +514,7 @@ func (q *queue) asyncTaggedWrite(
 	q.writeOpBatchSize.RecordValue(float64(len(elems)))
 	q.Add(1)
 
-	q.workerPool.AlwaysGo(func() {
+	q.workerPool.GoAlways(func() {
 		req := q.writeTaggedBatchRawRequestPool.Get()
 		req.NameSpace = namespace.Bytes()
 		req.Elements = elems
@@ -579,7 +579,7 @@ func (q *queue) asyncTaggedWriteV2(
 	q.writeOpBatchSize.RecordValue(float64(len(req.Elements)))
 	q.Add(1)
 
-	q.workerPool.AlwaysGo(func() {
+	q.workerPool.GoAlways(func() {
 		// NB(r): Defer is slow in the hot path unfortunately
 		cleanup := func() {
 			q.writeTaggedBatchRawV2RequestElementArrayPool.Put(req.Elements)
@@ -639,7 +639,7 @@ func (q *queue) asyncWrite(
 ) {
 	q.writeOpBatchSize.RecordValue(float64(len(elems)))
 	q.Add(1)
-	q.workerPool.AlwaysGo(func() {
+	q.workerPool.GoAlways(func() {
 		req := q.writeBatchRawRequestPool.Get()
 		req.NameSpace = namespace.Bytes()
 		req.Elements = elems
@@ -703,7 +703,7 @@ func (q *queue) asyncWriteV2(
 ) {
 	q.writeOpBatchSize.RecordValue(float64(len(req.Elements)))
 	q.Add(1)
-	q.workerPool.AlwaysGo(func() {
+	q.workerPool.GoAlways(func() {
 		// NB(r): Defer is slow in the hot path unfortunately
 		cleanup := func() {
 			q.writeBatchRawV2RequestElementArrayPool.Put(req.Elements)
@@ -759,7 +759,7 @@ func (q *queue) asyncWriteV2(
 func (q *queue) asyncFetch(op *fetchBatchOp) {
 	q.fetchOpBatchSize.RecordValue(float64(len(op.request.Ids)))
 	q.Add(1)
-	q.workerPool.AlwaysGo(func() {
+	q.workerPool.GoAlways(func() {
 		// NB(r): Defer is slow in the hot path unfortunately
 		cleanup := func() {
 			op.DecRef()
@@ -807,7 +807,7 @@ func (q *queue) asyncFetchV2(
 ) {
 	q.fetchOpBatchSize.RecordValue(float64(len(currV2FetchBatchRawReq.Elements)))
 	q.Add(1)
-	q.workerPool.AlwaysGo(func() {
+	q.workerPool.GoAlways(func() {
 		// NB(r): Defer is slow in the hot path unfortunately
 		cleanup := func() {
 			q.fetchBatchRawV2RequestElementArrayPool.Put(currV2FetchBatchRawReq.Elements)
@@ -951,7 +951,7 @@ func (q *queue) asyncAggregate(op *aggregateOp) {
 func (q *queue) asyncTruncate(op *truncateOp) {
 	q.Add(1)
 
-	q.workerPool.AlwaysGo(func() {
+	q.workerPool.GoAlways(func() {
 		cleanup := q.Done
 
 		client, _, err := q.connPool.NextClient()

--- a/src/dbnode/client/host_queue.go
+++ b/src/dbnode/client/host_queue.go
@@ -65,7 +65,7 @@ type queue struct {
 	writeTaggedBatchRawV2RequestElementArrayPool writeTaggedBatchRawV2RequestElementArrayPool
 	fetchBatchRawV2RequestPool                   fetchBatchRawV2RequestPool
 	fetchBatchRawV2RequestElementArrayPool       fetchBatchRawV2RequestElementArrayPool
-	workerPool                                   xsync.PooledWorkerPool
+	workerPool                                   xsync.DynamicPooledWorkerPool
 	size                                         int
 	ops                                          []op
 	opsSumSize                                   int
@@ -514,7 +514,7 @@ func (q *queue) asyncTaggedWrite(
 	q.writeOpBatchSize.RecordValue(float64(len(elems)))
 	q.Add(1)
 
-	q.workerPool.Go(func() {
+	q.workerPool.AlwaysGo(func() {
 		req := q.writeTaggedBatchRawRequestPool.Get()
 		req.NameSpace = namespace.Bytes()
 		req.Elements = elems
@@ -579,7 +579,7 @@ func (q *queue) asyncTaggedWriteV2(
 	q.writeOpBatchSize.RecordValue(float64(len(req.Elements)))
 	q.Add(1)
 
-	q.workerPool.Go(func() {
+	q.workerPool.AlwaysGo(func() {
 		// NB(r): Defer is slow in the hot path unfortunately
 		cleanup := func() {
 			q.writeTaggedBatchRawV2RequestElementArrayPool.Put(req.Elements)
@@ -639,7 +639,7 @@ func (q *queue) asyncWrite(
 ) {
 	q.writeOpBatchSize.RecordValue(float64(len(elems)))
 	q.Add(1)
-	q.workerPool.Go(func() {
+	q.workerPool.AlwaysGo(func() {
 		req := q.writeBatchRawRequestPool.Get()
 		req.NameSpace = namespace.Bytes()
 		req.Elements = elems
@@ -703,7 +703,7 @@ func (q *queue) asyncWriteV2(
 ) {
 	q.writeOpBatchSize.RecordValue(float64(len(req.Elements)))
 	q.Add(1)
-	q.workerPool.Go(func() {
+	q.workerPool.AlwaysGo(func() {
 		// NB(r): Defer is slow in the hot path unfortunately
 		cleanup := func() {
 			q.writeBatchRawV2RequestElementArrayPool.Put(req.Elements)
@@ -759,7 +759,7 @@ func (q *queue) asyncWriteV2(
 func (q *queue) asyncFetch(op *fetchBatchOp) {
 	q.fetchOpBatchSize.RecordValue(float64(len(op.request.Ids)))
 	q.Add(1)
-	q.workerPool.Go(func() {
+	q.workerPool.AlwaysGo(func() {
 		// NB(r): Defer is slow in the hot path unfortunately
 		cleanup := func() {
 			op.DecRef()
@@ -807,7 +807,7 @@ func (q *queue) asyncFetchV2(
 ) {
 	q.fetchOpBatchSize.RecordValue(float64(len(currV2FetchBatchRawReq.Elements)))
 	q.Add(1)
-	q.workerPool.Go(func() {
+	q.workerPool.AlwaysGo(func() {
 		// NB(r): Defer is slow in the hot path unfortunately
 		cleanup := func() {
 			q.fetchBatchRawV2RequestElementArrayPool.Put(currV2FetchBatchRawReq.Elements)
@@ -951,7 +951,7 @@ func (q *queue) asyncAggregate(op *aggregateOp) {
 func (q *queue) asyncTruncate(op *truncateOp) {
 	q.Add(1)
 
-	q.workerPool.Go(func() {
+	q.workerPool.AlwaysGo(func() {
 		cleanup := q.Done
 
 		client, _, err := q.connPool.NextClient()

--- a/src/dbnode/client/replicated_session.go
+++ b/src/dbnode/client/replicated_session.go
@@ -48,7 +48,7 @@ type replicatedSession struct {
 	session              clientSession
 	asyncSessions        []clientSession
 	newSessionFn         newSessionFn
-	workerPool           m3sync.PooledWorkerPool
+	workerPool           m3sync.DynamicPooledWorkerPool
 	replicationSemaphore chan struct{}
 	scope                tally.Scope
 	log                  *zap.Logger
@@ -163,7 +163,7 @@ func (s replicatedSession) replicate(params replicatedParams) error {
 		asyncSession := asyncSession // capture var
 		select {
 		case s.replicationSemaphore <- struct{}{}:
-			s.workerPool.Go(func() {
+			s.workerPool.AlwaysGo(func() {
 				var err error
 				if params.useTags {
 					err = asyncSession.WriteTagged(

--- a/src/dbnode/client/replicated_session.go
+++ b/src/dbnode/client/replicated_session.go
@@ -163,7 +163,7 @@ func (s replicatedSession) replicate(params replicatedParams) error {
 		asyncSession := asyncSession // capture var
 		select {
 		case s.replicationSemaphore <- struct{}{}:
-			s.workerPool.AlwaysGo(func() {
+			s.workerPool.GoAlways(func() {
 				var err error
 				if params.useTags {
 					err = asyncSession.WriteTagged(

--- a/src/dbnode/client/replicated_session_test.go
+++ b/src/dbnode/client/replicated_session_test.go
@@ -60,8 +60,7 @@ func optionsWithAsyncSessions(hasSync bool, asyncCount int) Options {
 	options := NewAdminOptions().
 		SetAsyncTopologyInitializers(topoInits)
 	if asyncCount > 0 {
-		workerPool, err := xsync.NewPooledWorkerPool(10,
-			xsync.NewPooledWorkerPoolOptions())
+		workerPool, err := xsync.NewDynamicPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 		if err != nil {
 			panic(err)
 		}

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -626,10 +626,10 @@ type Options interface {
 	HostQueueOpsArrayPoolSize() int
 
 	// SetHostQueueNewPooledWorkerFn sets the host queue new pooled worker function.
-	SetHostQueueNewPooledWorkerFn(value xsync.NewPooledWorkerFn) Options
+	SetHostQueueNewPooledWorkerFn(value xsync.NewDynamicPooledWorkerFn) Options
 
 	// HostQueueNewPooledWorkerFn sets the host queue new pooled worker function.
-	HostQueueNewPooledWorkerFn() xsync.NewPooledWorkerFn
+	HostQueueNewPooledWorkerFn() xsync.NewDynamicPooledWorkerFn
 
 	// SetHostQueueEmitsHealthStatus sets the hostQueueEmitHealthStatus.
 	SetHostQueueEmitsHealthStatus(value bool) Options
@@ -668,10 +668,10 @@ type Options interface {
 	AsyncTopologyInitializers() []topology.Initializer
 
 	// SetAsyncWriteWorkerPool sets the worker pool for async writes.
-	SetAsyncWriteWorkerPool(value xsync.PooledWorkerPool) Options
+	SetAsyncWriteWorkerPool(value xsync.DynamicPooledWorkerPool) Options
 
 	// AsyncWriteWorkerPool returns the worker pool for async writes.
-	AsyncWriteWorkerPool() xsync.PooledWorkerPool
+	AsyncWriteWorkerPool() xsync.DynamicPooledWorkerPool
 
 	// SetAsyncWriteMaxConcurrency sets the async writes maximum concurrency.
 	SetAsyncWriteMaxConcurrency(value int) Options

--- a/src/dbnode/persist/fs/writer_benchmark_test.go
+++ b/src/dbnode/persist/fs/writer_benchmark_test.go
@@ -119,8 +119,7 @@ func benchmarkCreateEmptyFilesets(b *testing.B, parallelism, numShards int) {
 		start     = xtime.Now().Truncate(blockSize)
 	)
 
-	workerPool, err := xsync.NewPooledWorkerPool(
-		parallelism, xsync.NewPooledWorkerPoolOptions())
+	workerPool, err := xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions().SetNumShards(parallelism))
 	if err != nil {
 		panic(err)
 	}

--- a/src/query/api/v1/httpd/handler_test.go
+++ b/src/query/api/v1/httpd/handler_test.go
@@ -53,7 +53,7 @@ import (
 
 var (
 	// Created by init().
-	testWorkerPool            xsync.PooledWorkerPool
+	testWorkerPool            xsync.DynamicPooledWorkerPool
 	testM3DBOpts              = m3db.NewOptions()
 	defaultLookbackDuration   = time.Minute
 	defaultCPUProfileduration = 5 * time.Second
@@ -291,11 +291,7 @@ func TestHealthGet(t *testing.T) {
 
 func init() {
 	var err error
-	testWorkerPool, err = xsync.NewPooledWorkerPool(
-		16,
-		xsync.NewPooledWorkerPoolOptions().
-			SetGrowOnDemand(true),
-	)
+	testWorkerPool, err = xsync.NewDynamicPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 
 	if err != nil {
 		panic(fmt.Sprintf("unable to create pooled worker pool: %v", err))

--- a/src/query/pools/query_pools.go
+++ b/src/query/pools/query_pools.go
@@ -69,20 +69,20 @@ func BuildWorkerPools(
 	instrumentOptions instrument.Options,
 	readPoolPolicy, writePoolPolicy xconfig.WorkerPoolPolicy,
 	scope tally.Scope,
-) (xsync.PooledWorkerPool, xsync.PooledWorkerPool, error) {
-	opts, readPoolSize := readPoolPolicy.Options()
+) (xsync.StaticPooledWorkerPool, xsync.DynamicPooledWorkerPool, error) {
+	opts := readPoolPolicy.Options()
 	opts = opts.SetInstrumentOptions(instrumentOptions.
 		SetMetricsScope(scope.SubScope("read-worker-pool")))
-	readWorkerPool, err := xsync.NewPooledWorkerPool(readPoolSize, opts)
+	readWorkerPool, err := xsync.NewStaticPooledWorkerPool(opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	readWorkerPool.Init()
-	opts, writePoolSize := writePoolPolicy.Options()
+	opts = writePoolPolicy.Options()
 	opts = opts.SetInstrumentOptions(instrumentOptions.
 		SetMetricsScope(scope.SubScope("write-worker-pool")))
-	writeWorkerPool, err := xsync.NewPooledWorkerPool(writePoolSize, opts)
+	writeWorkerPool, err := xsync.NewDynamicPooledWorkerPool(opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/src/query/remote/server_test.go
+++ b/src/query/remote/server_test.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -168,8 +167,7 @@ func checkErrorFetch(ctx context.Context, t *testing.T, client Client,
 }
 
 func buildClient(t *testing.T, hosts []string) Client {
-	readWorkerPool, err := xsync.NewPooledWorkerPool(runtime.NumCPU(),
-		xsync.NewPooledWorkerPoolOptions())
+	readWorkerPool, err := xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 	readWorkerPool.Init()
 	require.NoError(t, err)
 

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -335,7 +335,7 @@ func Run(runOpts RunOptions) {
 
 	readWorkerPool, writeWorkerPool, err := pools.BuildWorkerPools(
 		instrumentOptions,
-		cfg.ReadWorkerPool,
+		cfg.ReadWorkerPoolOrDefault(),
 		cfg.WriteWorkerPoolOrDefault(),
 		scope)
 	if err != nil {
@@ -1143,26 +1143,28 @@ func startCarbonIngestion(
 	var (
 		carbonIOpts = iOpts.SetMetricsScope(
 			iOpts.MetricsScope().SubScope("ingest-carbon"))
-		carbonWorkerPoolOpts xsync.PooledWorkerPoolOptions
-		carbonWorkerPoolSize int
+		staticWorkerPool  xsync.StaticPooledWorkerPool
+		dynamicWorkerPool xsync.DynamicPooledWorkerPool
+		err               error
 	)
 	if ingesterCfg.MaxConcurrency > 0 {
 		// Use a bounded worker pool if they requested a specific maximum concurrency.
-		carbonWorkerPoolOpts = xsync.NewPooledWorkerPoolOptions().
-			SetGrowOnDemand(false).
-			SetInstrumentOptions(carbonIOpts)
-		carbonWorkerPoolSize = ingesterCfg.MaxConcurrency
+		staticWorkerPool, err = xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions().
+			SetInstrumentOptions(carbonIOpts).
+			SetNumShards(ingesterCfg.MaxConcurrency))
+		if err != nil {
+			logger.Fatal("unable to create worker pool for carbon ingester", zap.Error(err))
+		}
+		staticWorkerPool.Init()
 	} else {
-		carbonWorkerPoolOpts = xsync.NewPooledWorkerPoolOptions().
-			SetGrowOnDemand(true).
-			SetKillWorkerProbability(0.001)
-		carbonWorkerPoolSize = defaultCarbonIngesterWorkerPoolSize
+		dynamicWorkerPool, err = xsync.NewDynamicPooledWorkerPool(xsync.NewPooledWorkerPoolOptions().
+			SetKillWorkerProbability(0.001).
+			SetNumShards(defaultCarbonIngesterWorkerPoolSize))
+		if err != nil {
+			logger.Fatal("unable to create worker pool for carbon ingester", zap.Error(err))
+		}
+		dynamicWorkerPool.Init()
 	}
-	workerPool, err := xsync.NewPooledWorkerPool(carbonWorkerPoolSize, carbonWorkerPoolOpts)
-	if err != nil {
-		logger.Fatal("unable to create worker pool for carbon ingester", zap.Error(err))
-	}
-	workerPool.Init()
 
 	if m3dbClusters == nil {
 		logger.Fatal("carbon ingestion is only supported when connecting to M3DB clusters directly")
@@ -1172,7 +1174,8 @@ func startCarbonIngestion(
 	ingester, err := ingestcarbon.NewIngester(
 		downsamplerAndWriter, clusterNamespacesWatcher, ingestcarbon.Options{
 			InstrumentOptions: carbonIOpts,
-			WorkerPool:        workerPool,
+			StaticWorkerPool:  staticWorkerPool,
+			DynamicWorkerPool: dynamicWorkerPool,
 			IngesterConfig:    ingesterCfg,
 		})
 	if err != nil {
@@ -1209,12 +1212,12 @@ func newDownsamplerAndWriter(
 	workerPoolPolicy xconfig.WorkerPoolPolicy,
 	iOpts instrument.Options,
 ) (ingest.DownsamplerAndWriter, error) {
-	// Make sure the downsampler and writer gets its own PooledWorkerPool and that its not shared with any other
+	// Make sure the downsampler and writer gets its own pool and that its not shared with any other
 	// codepaths because PooledWorkerPools can deadlock if used recursively.
-	downAndWriterWorkerPoolOpts, writePoolSize := workerPoolPolicy.Options()
+	downAndWriterWorkerPoolOpts := workerPoolPolicy.Options()
 	downAndWriterWorkerPoolOpts = downAndWriterWorkerPoolOpts.SetInstrumentOptions(iOpts.
 		SetMetricsScope(iOpts.MetricsScope().SubScope("ingest-writer-worker-pool")))
-	downAndWriteWorkerPool, err := xsync.NewPooledWorkerPool(writePoolSize, downAndWriterWorkerPoolOpts)
+	downAndWriteWorkerPool, err := xsync.NewDynamicPooledWorkerPool(downAndWriterWorkerPoolOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -711,7 +711,7 @@ func (s *m3storage) Write(
 		// capture var
 		datapoint := datapoint
 		wg.Add(1)
-		s.opts.WriteWorkerPool().AlwaysGo(func() {
+		s.opts.WriteWorkerPool().GoAlways(func() {
 			if err := s.writeSingle(ctx, query, datapoint, id, tagIter); err != nil {
 				multiErr.add(err)
 			}

--- a/src/query/storage/m3/storage_test.go
+++ b/src/query/storage/m3/storage_test.go
@@ -127,8 +127,7 @@ func setup(
 }
 
 func newTestStorage(t *testing.T, clusters Clusters) storage.Storage {
-	writePool, err := sync.NewPooledWorkerPool(10,
-		sync.NewPooledWorkerPoolOptions())
+	writePool, err := sync.NewDynamicPooledWorkerPool(sync.NewPooledWorkerPoolOptions())
 	require.NoError(t, err)
 	writePool.Init()
 	tagOpts := models.NewTagOptions().SetMetricName([]byte("name"))

--- a/src/query/storage/prom_converter.go
+++ b/src/query/storage/prom_converter.go
@@ -91,7 +91,7 @@ func toPromSequentially(
 func toPromConcurrently(
 	ctx context.Context,
 	fetchResult consolidators.SeriesFetchResult,
-	readWorkerPool xsync.PooledWorkerPool,
+	readWorkerPool xsync.StaticPooledWorkerPool,
 	tagOptions models.TagOptions,
 ) (PromResult, error) {
 	count := fetchResult.Count()
@@ -155,7 +155,7 @@ func toPromConcurrently(
 func seriesIteratorsToPromResult(
 	ctx context.Context,
 	fetchResult consolidators.SeriesFetchResult,
-	readWorkerPool xsync.PooledWorkerPool,
+	readWorkerPool xsync.StaticPooledWorkerPool,
 	tagOptions models.TagOptions,
 ) (PromResult, error) {
 	if readWorkerPool == nil {
@@ -170,7 +170,7 @@ func seriesIteratorsToPromResult(
 func SeriesIteratorsToPromResult(
 	ctx context.Context,
 	fetchResult consolidators.SeriesFetchResult,
-	readWorkerPool xsync.PooledWorkerPool,
+	readWorkerPool xsync.StaticPooledWorkerPool,
 	tagOptions models.TagOptions,
 ) (PromResult, error) {
 	defer fetchResult.Close()

--- a/src/query/storage/prom_converter_test.go
+++ b/src/query/storage/prom_converter_test.go
@@ -71,7 +71,7 @@ func verifyExpandPromSeries(
 	ctrl *gomock.Controller,
 	num int,
 	ex bool,
-	pools xsync.PooledWorkerPool,
+	pools xsync.StaticPooledWorkerPool,
 ) {
 	iters := seriesiter.NewMockSeriesIters(ctrl, ident.Tag{}, num, 2)
 	fetchResult := fr(t, iters, makeTag("foo", "bar", num)...)
@@ -105,7 +105,7 @@ func verifyExpandPromSeries(
 	}
 }
 
-func testExpandPromSeries(t *testing.T, ex bool, pools xsync.PooledWorkerPool) {
+func testExpandPromSeries(t *testing.T, ex bool, pools xsync.StaticPooledWorkerPool) {
 	ctrl := gomock.NewController(t)
 
 	for i := 0; i < 10; i++ {
@@ -120,7 +120,7 @@ func TestContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	pool, err := xsync.NewPooledWorkerPool(100, xsync.NewPooledWorkerPoolOptions())
+	pool, err := xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 	require.NoError(t, err)
 	pool.Init()
 
@@ -137,7 +137,7 @@ func TestExpandPromSeriesNilPools(t *testing.T) {
 }
 
 func TestExpandPromSeriesValidPools(t *testing.T) {
-	pool, err := xsync.NewPooledWorkerPool(100, xsync.NewPooledWorkerPoolOptions())
+	pool, err := xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 	require.NoError(t, err)
 	pool.Init()
 	testExpandPromSeries(t, false, pool)
@@ -145,7 +145,7 @@ func TestExpandPromSeriesValidPools(t *testing.T) {
 }
 
 func TestExpandPromSeriesSmallValidPools(t *testing.T) {
-	pool, err := xsync.NewPooledWorkerPool(2, xsync.NewPooledWorkerPoolOptions())
+	pool, err := xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 	require.NoError(t, err)
 	pool.Init()
 	testExpandPromSeries(t, false, pool)
@@ -325,7 +325,7 @@ func TestDecodeIteratorsWithEmptySeries(t *testing.T) {
 	require.NoError(t, err)
 	verifyResult(t, res)
 
-	pool, err := xsync.NewPooledWorkerPool(10, xsync.NewPooledWorkerPoolOptions())
+	pool, err := xsync.NewStaticPooledWorkerPool(xsync.NewPooledWorkerPoolOptions())
 	require.NoError(t, err)
 	pool.Init()
 

--- a/src/query/test/m3/test_storage.go
+++ b/src/query/test/m3/test_storage.go
@@ -62,8 +62,7 @@ func NewStorageAndSession(
 		Retention:   TestRetention,
 	})
 	require.NoError(t, err)
-	writePool, err := sync.NewPooledWorkerPool(10,
-		sync.NewPooledWorkerPoolOptions())
+	writePool, err := sync.NewDynamicPooledWorkerPool(sync.NewPooledWorkerPoolOptions())
 	require.NoError(t, err)
 	writePool.Init()
 	tagOptions := models.NewTagOptions().SetMetricName([]byte("name"))
@@ -96,8 +95,7 @@ func NewStorageAndSessionWithAggregatedNamespaces(
 	}, aggregatedNamespaces...)
 	require.NoError(t, err)
 
-	writePool, err := sync.NewPooledWorkerPool(10,
-		sync.NewPooledWorkerPoolOptions())
+	writePool, err := sync.NewDynamicPooledWorkerPool(sync.NewPooledWorkerPoolOptions())
 	require.NoError(t, err)
 	writePool.Init()
 	tagOptions := models.NewTagOptions().SetMetricName([]byte("name"))

--- a/src/query/ts/m3db/encoded_step_iterator_generic.go
+++ b/src/query/ts/m3db/encoded_step_iterator_generic.go
@@ -51,7 +51,7 @@ type encodedStepIterWithCollector struct {
 
 	updateFn updateFn
 
-	workerPool xsync.PooledWorkerPool
+	workerPool xsync.StaticPooledWorkerPool
 	wg         sync.WaitGroup
 }
 

--- a/src/query/ts/m3db/encoded_step_iterator_test.go
+++ b/src/query/ts/m3db/encoded_step_iterator_test.go
@@ -52,11 +52,9 @@ import (
 func withPool(t testing.TB, options Options) Options {
 	opts := xsync.
 		NewPooledWorkerPoolOptions().
-		SetGrowOnDemand(false).
-		SetKillWorkerProbability(0).
-		SetNumShards(1)
+		SetKillWorkerProbability(0)
 
-	readWorkerPools, err := xsync.NewPooledWorkerPool(64, opts)
+	readWorkerPools, err := xsync.NewStaticPooledWorkerPool(opts)
 	require.NoError(t, err)
 	readWorkerPools.Init()
 
@@ -524,7 +522,7 @@ func setupBlock(b *testing.B, iterations int, t iterType) (block.Block, reset, s
 	opts := newTestOptions()
 	if usePools {
 		poolOpts := xsync.NewPooledWorkerPoolOptions()
-		readWorkerPools, err := xsync.NewPooledWorkerPool(1024, poolOpts)
+		readWorkerPools, err := xsync.NewStaticPooledWorkerPool(poolOpts)
 		require.NoError(b, err)
 		readWorkerPools.Init()
 		opts = opts.SetReadWorkerPool(readWorkerPools)

--- a/src/query/ts/m3db/options.go
+++ b/src/query/ts/m3db/options.go
@@ -55,8 +55,8 @@ type encodedBlockOptions struct {
 	iterAlloc                     encoding.ReaderIteratorAllocate
 	pools                         encoding.IteratorPools
 	checkedPools                  pool.CheckedBytesPool
-	readWorkerPools               xsync.PooledWorkerPool
-	writeWorkerPools              xsync.PooledWorkerPool
+	readWorkerPools               xsync.StaticPooledWorkerPool
+	writeWorkerPools              xsync.DynamicPooledWorkerPool
 	queryConsolidatorMatchOptions queryconsolidator.MatchOptions
 	seriesIteratorProcessor       SeriesIteratorProcessor
 	batchingFn                    IteratorBatchingFn
@@ -170,23 +170,23 @@ func (o *encodedBlockOptions) CheckedBytesPool() pool.CheckedBytesPool {
 	return o.checkedPools
 }
 
-func (o *encodedBlockOptions) SetReadWorkerPool(p xsync.PooledWorkerPool) Options {
+func (o *encodedBlockOptions) SetReadWorkerPool(p xsync.StaticPooledWorkerPool) Options {
 	opts := *o
 	opts.readWorkerPools = p
 	return &opts
 }
 
-func (o *encodedBlockOptions) ReadWorkerPool() xsync.PooledWorkerPool {
+func (o *encodedBlockOptions) ReadWorkerPool() xsync.StaticPooledWorkerPool {
 	return o.readWorkerPools
 }
 
-func (o *encodedBlockOptions) SetWriteWorkerPool(p xsync.PooledWorkerPool) Options {
+func (o *encodedBlockOptions) SetWriteWorkerPool(p xsync.DynamicPooledWorkerPool) Options {
 	opts := *o
 	opts.writeWorkerPools = p
 	return &opts
 }
 
-func (o *encodedBlockOptions) WriteWorkerPool() xsync.PooledWorkerPool {
+func (o *encodedBlockOptions) WriteWorkerPool() xsync.DynamicPooledWorkerPool {
 	return o.writeWorkerPools
 }
 

--- a/src/query/ts/m3db/types.go
+++ b/src/query/ts/m3db/types.go
@@ -71,13 +71,13 @@ type Options interface {
 	// CheckedBytesPool returns the checked bytes pools for the converter.
 	CheckedBytesPool() pool.CheckedBytesPool
 	// SetReadWorkerPool sets the read worker pool for the converter.
-	SetReadWorkerPool(xsync.PooledWorkerPool) Options
+	SetReadWorkerPool(xsync.StaticPooledWorkerPool) Options
 	// ReadWorkerPool returns the read worker pool for the converter.
-	ReadWorkerPool() xsync.PooledWorkerPool
-	// SetReadWorkerPool sets the write worker pool for the converter.
-	SetWriteWorkerPool(xsync.PooledWorkerPool) Options
-	// ReadWorkerPool returns the write worker pool for the converter.
-	WriteWorkerPool() xsync.PooledWorkerPool
+	ReadWorkerPool() xsync.StaticPooledWorkerPool
+	// SetWriteWorkerPool sets the write worker pool for the converter.
+	SetWriteWorkerPool(xsync.DynamicPooledWorkerPool) Options
+	// WriteWorkerPool returns the write worker pool for the converter.
+	WriteWorkerPool() xsync.DynamicPooledWorkerPool
 	// SetSeriesConsolidationMatchOptions sets series consolidation options.
 	SetSeriesConsolidationMatchOptions(value queryconsolidator.MatchOptions) Options
 	// SetSeriesConsolidationMatchOptions sets series consolidation options.

--- a/src/x/config/pooling.go
+++ b/src/x/config/pooling.go
@@ -22,51 +22,31 @@ package config
 
 import "github.com/m3db/m3/src/x/sync"
 
-const (
-	defaultWorkerPoolStaticSize = 4096
-	defaultGrowKillProbability  = 0.001
-)
-
 // WorkerPoolPolicy specifies the policy for the worker pool.
 type WorkerPoolPolicy struct {
 	// Determines if the worker pool automatically grows to capacity.
+	// Deprecated: not used. Pools are explicitly defined as static or dynamic.
 	GrowOnDemand bool `yaml:"grow"`
 
 	// Size for static pools, initial size for dynamically growing pools.
+	// Deprecated: not used. NumShards controls the size of the pool.
 	Size int `yaml:"size"`
 
-	// The number of shards for the pool.
-	NumShards int64 `yaml:"shards"`
+	// NumShards is the number of worker channels in the pool.
+	NumShards int `yaml:"shards"`
 
-	// The probablility that a worker is killed after completing the task.
+	// The probability that a worker is killed after completing the task.
 	KillWorkerProbability float64 `yaml:"killProbability" validate:"min=0.0,max=1.0"`
 }
 
-// Options converts the worker pool policy to options, providing
-// the options, as well as the default size for the worker pool.
-func (w WorkerPoolPolicy) Options() (sync.PooledWorkerPoolOptions, int) {
+// Options converts policy to options
+func (w WorkerPoolPolicy) Options() sync.PooledWorkerPoolOptions {
 	opts := sync.NewPooledWorkerPoolOptions()
-	grow := w.GrowOnDemand
-	opts = opts.SetGrowOnDemand(grow)
 	if w.KillWorkerProbability != 0 {
 		opts = opts.SetKillWorkerProbability(w.KillWorkerProbability)
-	} else if grow {
-		// NB: if using a growing pool, default kill probability is too low, causing
-		// the pool to quickly grow out of control. Use a higher default kill probability
-		opts = opts.SetKillWorkerProbability(defaultGrowKillProbability)
 	}
-
 	if w.NumShards != 0 {
 		opts = opts.SetNumShards(w.NumShards)
 	}
-
-	if w.Size == 0 {
-		if grow {
-			w.Size = int(opts.NumShards())
-		} else {
-			w.Size = defaultWorkerPoolStaticSize
-		}
-	}
-
-	return opts, w.Size
+	return opts
 }

--- a/src/x/config/pooling_test.go
+++ b/src/x/config/pooling_test.go
@@ -29,37 +29,19 @@ import (
 
 func TestWorkerPoolPolicyConvertsToOptionsDefault(t *testing.T) {
 	wpp := WorkerPoolPolicy{}
-	opts, size := wpp.Options()
+	opts := wpp.Options()
 	defaultOpts := sync.NewPooledWorkerPoolOptions()
 
-	assert.False(t, opts.GrowOnDemand())
 	assert.Equal(t, defaultOpts.NumShards(), opts.NumShards())
 	assert.Equal(t, defaultOpts.KillWorkerProbability(), opts.KillWorkerProbability())
-	assert.Equal(t, defaultWorkerPoolStaticSize, size)
-}
-
-func TestWorkerPoolPolicyConvertsToOptionsDefaultGrow(t *testing.T) {
-	wpp := WorkerPoolPolicy{GrowOnDemand: true}
-	opts, size := wpp.Options()
-	defaultOpts := sync.NewPooledWorkerPoolOptions()
-
-	assert.True(t, opts.GrowOnDemand())
-	assert.Equal(t, defaultOpts.NumShards(), opts.NumShards())
-	assert.Equal(t, defaultGrowKillProbability, opts.KillWorkerProbability())
-	assert.Equal(t, opts.NumShards(), int64(size))
 }
 
 func TestWorkerPoolPolicyConvertsToOptions(t *testing.T) {
 	wpp := WorkerPoolPolicy{
-		GrowOnDemand:          true,
-		Size:                  100,
 		NumShards:             200,
 		KillWorkerProbability: 0.5,
 	}
-	opts, size := wpp.Options()
-	assert.True(t, opts.GrowOnDemand())
-	assert.Equal(t, int64(200), opts.NumShards())
+	opts := wpp.Options()
+	assert.Equal(t, 200, opts.NumShards())
 	assert.Equal(t, 0.5, opts.KillWorkerProbability())
-	assert.Equal(t, 100, size)
-
 }

--- a/src/x/sync/fast_pooled_worker_pool.go
+++ b/src/x/sync/fast_pooled_worker_pool.go
@@ -26,12 +26,12 @@ import (
 )
 
 type fastPooledWorkerPool struct {
-	workerPool PooledWorkerPool
+	workerPool StaticPooledWorkerPool
 	batchSize  int
 	count      int
 }
 
-var _ PooledWorkerPool = &fastPooledWorkerPool{}
+var _ StaticPooledWorkerPool = &fastPooledWorkerPool{}
 
 func (f *fastPooledWorkerPool) Init() {
 	f.workerPool.Init()
@@ -57,6 +57,6 @@ func (f *fastPooledWorkerPool) GoWithContext(ctx context.Context, work Work) boo
 	return true
 }
 
-func (f *fastPooledWorkerPool) FastContextCheck(batchSize int) PooledWorkerPool {
+func (f *fastPooledWorkerPool) FastContextCheck(batchSize int) StaticPooledWorkerPool {
 	return &fastPooledWorkerPool{workerPool: f.workerPool, batchSize: batchSize}
 }

--- a/src/x/sync/options.go
+++ b/src/x/sync/options.go
@@ -29,11 +29,10 @@ import (
 
 const (
 	defaultKillWorkerProbability = 0.001
-	defaultGrowOnDemand          = false
 )
 
 var (
-	defaultNumShards = int64(runtime.NumCPU())
+	defaultNumShards = runtime.NumCPU()
 	defaultNowFn     = time.Now
 )
 
@@ -43,39 +42,27 @@ type NowFn func() time.Time
 // NewPooledWorkerPoolOptions returns a new PooledWorkerPoolOptions with default options
 func NewPooledWorkerPoolOptions() PooledWorkerPoolOptions {
 	return &pooledWorkerPoolOptions{
-		growOnDemand:          defaultGrowOnDemand,
 		numShards:             defaultNumShards,
 		killWorkerProbability: defaultKillWorkerProbability,
-		nowFn: defaultNowFn,
-		iOpts: instrument.NewOptions(),
+		nowFn:                 defaultNowFn,
+		iOpts:                 instrument.NewOptions(),
 	}
 }
 
 type pooledWorkerPoolOptions struct {
-	growOnDemand          bool
-	numShards             int64
+	numShards             int
 	killWorkerProbability float64
 	nowFn                 NowFn
 	iOpts                 instrument.Options
 }
 
-func (o *pooledWorkerPoolOptions) SetGrowOnDemand(value bool) PooledWorkerPoolOptions {
-	opts := *o
-	opts.growOnDemand = value
-	return &opts
-}
-
-func (o *pooledWorkerPoolOptions) GrowOnDemand() bool {
-	return o.growOnDemand
-}
-
-func (o *pooledWorkerPoolOptions) SetNumShards(value int64) PooledWorkerPoolOptions {
+func (o *pooledWorkerPoolOptions) SetNumShards(value int) PooledWorkerPoolOptions {
 	opts := *o
 	opts.numShards = value
 	return &opts
 }
 
-func (o *pooledWorkerPoolOptions) NumShards() int64 {
+func (o *pooledWorkerPoolOptions) NumShards() int {
 	return o.numShards
 }
 

--- a/src/x/sync/pooled_worker_pool.go
+++ b/src/x/sync/pooled_worker_pool.go
@@ -89,7 +89,7 @@ func (p *pooledWorkerPool) Go(work Work) {
 	p.work(maybeContext{}, work, 0)
 }
 
-func (p *pooledWorkerPool) AlwaysGo(work Work) {
+func (p *pooledWorkerPool) GoAlways(work Work) {
 	p.work(maybeContext{}, work, 0)
 }
 

--- a/src/x/sync/pooled_worker_pool.go
+++ b/src/x/sync/pooled_worker_pool.go
@@ -44,41 +44,35 @@ type pooledWorkerPool struct {
 	numWorkingRoutinesGauge  tally.Gauge
 	growOnDemand             bool
 	workChs                  []chan Work
-	numShards                int64
 	killWorkerProbability    float64
 	nowFn                    NowFn
 }
 
-// NewPooledWorkerPool creates a new worker pool.
-func NewPooledWorkerPool(size int, opts PooledWorkerPoolOptions) (PooledWorkerPool, error) {
-	if size <= 0 {
-		return nil, fmt.Errorf("pooled worker pool size too small: %d", size)
-	}
+// NewDynamicPooledWorkerPool creates a new dynamic worker pool.
+func NewDynamicPooledWorkerPool(opts PooledWorkerPoolOptions) (DynamicPooledWorkerPool, error) {
+	return newPooledWorkerPool(opts, true)
+}
 
-	numShards := opts.NumShards()
-	if int64(size) < numShards {
-		numShards = int64(size)
-	}
+// NewStaticPooledWorkerPool creates a new worker pool.
+func NewStaticPooledWorkerPool(opts PooledWorkerPoolOptions) (StaticPooledWorkerPool, error) {
+	return newPooledWorkerPool(opts, false)
+}
 
-	workChs := make([]chan Work, numShards)
-	bufSize := int64(size) / numShards
-	if opts.GrowOnDemand() {
-		// Do not use buffered channels if the pool can grow on demand. This ensures a new worker is spawned if all
-		// workers are currently busy.
-		bufSize = 0
+func newPooledWorkerPool(opts PooledWorkerPoolOptions, growOnDemand bool) (*pooledWorkerPool, error) {
+	if opts.NumShards() <= 0 {
+		return nil, fmt.Errorf("pooled worker pool size too small: %d", opts.NumShards())
 	}
+	workChs := make([]chan Work, opts.NumShards())
 	for i := range workChs {
-		workChs[i] = make(chan Work, bufSize)
+		workChs[i] = make(chan Work)
 	}
-
 	return &pooledWorkerPool{
 		numRoutinesAtomic:        0,
 		numWorkingRoutinesAtomic: 0,
 		numRoutinesGauge:         opts.InstrumentOptions().MetricsScope().Gauge("num-routines"),
 		numWorkingRoutinesGauge:  opts.InstrumentOptions().MetricsScope().Gauge("num-working-routines"),
-		growOnDemand:             opts.GrowOnDemand(),
+		growOnDemand:             growOnDemand,
 		workChs:                  workChs,
-		numShards:                numShards,
 		killWorkerProbability:    opts.KillWorkerProbability(),
 		nowFn:                    opts.NowFn(),
 	}, nil
@@ -87,13 +81,15 @@ func NewPooledWorkerPool(size int, opts PooledWorkerPoolOptions) (PooledWorkerPo
 func (p *pooledWorkerPool) Init() {
 	rng := pcg.NewPCG64() // Just use default seed here
 	for _, workCh := range p.workChs {
-		for i := 0; i < cap(workCh); i++ {
-			p.spawnWorker(rng.Random(), nil, workCh, true)
-		}
+		p.spawnWorker(rng.Random(), nil, workCh, true)
 	}
 }
 
 func (p *pooledWorkerPool) Go(work Work) {
+	p.work(maybeContext{}, work, 0)
+}
+
+func (p *pooledWorkerPool) AlwaysGo(work Work) {
 	p.work(maybeContext{}, work, 0)
 }
 
@@ -105,7 +101,7 @@ func (p *pooledWorkerPool) GoWithContext(ctx context.Context, work Work) bool {
 	return p.work(maybeContext{ctx: ctx}, work, 0)
 }
 
-func (p *pooledWorkerPool) FastContextCheck(batchSize int) PooledWorkerPool {
+func (p *pooledWorkerPool) FastContextCheck(batchSize int) StaticPooledWorkerPool {
 	return &fastPooledWorkerPool{workerPool: p, batchSize: batchSize}
 }
 
@@ -124,7 +120,7 @@ func (p *pooledWorkerPool) work(
 	var (
 		// Use time.Now() to avoid excessive synchronization
 		currTime  = p.nowFn().UnixNano()
-		workChIdx = currTime % p.numShards
+		workChIdx = currTime % int64(len(p.workChs))
 		workCh    = p.workChs[workChIdx]
 	)
 

--- a/src/x/sync/pooled_worker_pool_test.go
+++ b/src/x/sync/pooled_worker_pool_test.go
@@ -146,7 +146,7 @@ func TestPooledWorkerPoolGrowOnDemand(t *testing.T) {
 		// this test would never complete this loop as the
 		// anonymous Work function below would not complete
 		// and would block further iterations.
-		p.AlwaysGo(func() {
+		p.GoAlways(func() {
 			atomic.AddUint32(&count, 1)
 			wg.Done()
 			<-doneCh
@@ -180,7 +180,7 @@ func TestPooledWorkerPoolGoOrGrowKillWorker(t *testing.T) {
 		// this test would never complete this loop as the
 		// anonymous Work function below would not complete
 		// and would block further iterations.
-		p.AlwaysGo(func() {
+		p.GoAlways(func() {
 			atomic.AddUint32(&count, 1)
 			wg.Done()
 			<-doneCh

--- a/src/x/sync/pooled_worker_pool_test.go
+++ b/src/x/sync/pooled_worker_pool_test.go
@@ -34,7 +34,7 @@ import (
 func TestPooledWorkerPoolGo(t *testing.T) {
 	var count uint32
 
-	p, err := NewPooledWorkerPool(testWorkerPoolSize, NewPooledWorkerPoolOptions())
+	p, err := NewStaticPooledWorkerPool(NewPooledWorkerPoolOptions().SetNumShards(testWorkerPoolSize))
 	require.NoError(t, err)
 	p.Init()
 
@@ -55,8 +55,7 @@ func TestPooledWorkerPoolGoWithContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	wp, err := NewPooledWorkerPool(testWorkerPoolSize,
-		NewPooledWorkerPoolOptions().SetGrowOnDemand(false))
+	wp, err := NewStaticPooledWorkerPool(NewPooledWorkerPoolOptions().SetNumShards(testWorkerPoolSize))
 	require.NoError(t, err)
 	wp.Init()
 
@@ -84,9 +83,9 @@ func TestPooledWorkerPoolGoWithContext(t *testing.T) {
 func TestPooledWorkerPoolGoWithTimeout(t *testing.T) {
 	var (
 		workers = 2
-		opts    = NewPooledWorkerPoolOptions().SetNumShards(int64(workers))
+		opts    = NewPooledWorkerPoolOptions().SetNumShards(workers)
 	)
-	p, err := NewPooledWorkerPool(workers, opts)
+	p, err := NewStaticPooledWorkerPool(opts)
 	require.NoError(t, err)
 	p.Init()
 
@@ -97,15 +96,11 @@ func TestPooledWorkerPoolGoWithTimeout(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	// Enqueue workers * 2 since buffered channel will allow workers / shards
-	// (which is 1, since 2 / 2 = 1) which means we need to enqueue two times
-	// the workers.
-	totalEnqueue := workers * 2
 	now := time.Now()
-	for i := 0; i < totalEnqueue; i++ {
+	for i := 0; i < workers; i++ {
 		// Set now in such a way that independent shards are selected.
 		shardNowSelect := now.
-			Truncate(time.Duration(totalEnqueue) * time.Nanosecond).
+			Truncate(time.Duration(workers) * time.Nanosecond).
 			Add(time.Duration(i) * time.Nanosecond)
 		pooledWorkerPool.nowFn = func() time.Time {
 			return shardNowSelect
@@ -135,10 +130,7 @@ func TestPooledWorkerPoolGoWithTimeout(t *testing.T) {
 func TestPooledWorkerPoolGrowOnDemand(t *testing.T) {
 	var count uint32
 
-	p, err := NewPooledWorkerPool(
-		1,
-		NewPooledWorkerPoolOptions().
-			SetGrowOnDemand(true))
+	p, err := NewDynamicPooledWorkerPool(NewPooledWorkerPoolOptions().SetNumShards(1))
 	require.NoError(t, err)
 	p.Init()
 
@@ -154,7 +146,7 @@ func TestPooledWorkerPoolGrowOnDemand(t *testing.T) {
 		// this test would never complete this loop as the
 		// anonymous Work function below would not complete
 		// and would block further iterations.
-		p.Go(func() {
+		p.AlwaysGo(func() {
 			atomic.AddUint32(&count, 1)
 			wg.Done()
 			<-doneCh
@@ -169,10 +161,9 @@ func TestPooledWorkerPoolGrowOnDemand(t *testing.T) {
 func TestPooledWorkerPoolGoOrGrowKillWorker(t *testing.T) {
 	var count uint32
 
-	p, err := NewPooledWorkerPool(
-		1,
+	p, err := NewDynamicPooledWorkerPool(
 		NewPooledWorkerPoolOptions().
-			SetGrowOnDemand(true).
+			SetNumShards(1).
 			SetKillWorkerProbability(1.0))
 	require.NoError(t, err)
 	p.Init()
@@ -189,7 +180,7 @@ func TestPooledWorkerPoolGoOrGrowKillWorker(t *testing.T) {
 		// this test would never complete this loop as the
 		// anonymous Work function below would not complete
 		// and would block further iterations.
-		p.Go(func() {
+		p.AlwaysGo(func() {
 			atomic.AddUint32(&count, 1)
 			wg.Done()
 			<-doneCh
@@ -204,9 +195,9 @@ func TestPooledWorkerPoolGoOrGrowKillWorker(t *testing.T) {
 func TestPooledWorkerPoolGoKillWorker(t *testing.T) {
 	var count uint32
 
-	p, err := NewPooledWorkerPool(
-		testWorkerPoolSize,
+	p, err := NewStaticPooledWorkerPool(
 		NewPooledWorkerPoolOptions().
+			SetNumShards(testWorkerPoolSize).
 			SetKillWorkerProbability(1.0))
 	require.NoError(t, err)
 	p.Init()
@@ -225,12 +216,12 @@ func TestPooledWorkerPoolGoKillWorker(t *testing.T) {
 }
 
 func TestPooledWorkerPoolSizeTooSmall(t *testing.T) {
-	_, err := NewPooledWorkerPool(0, NewPooledWorkerPoolOptions())
+	_, err := NewStaticPooledWorkerPool(NewPooledWorkerPoolOptions().SetNumShards(0))
 	require.Error(t, err)
 }
 
 func TestPooledWorkerFast(t *testing.T) {
-	wp, err := NewPooledWorkerPool(1, NewPooledWorkerPoolOptions())
+	wp, err := NewStaticPooledWorkerPool(NewPooledWorkerPoolOptions().SetNumShards(1))
 	require.NoError(t, err)
 	wp.Init()
 

--- a/src/x/sync/types.go
+++ b/src/x/sync/types.go
@@ -31,7 +31,7 @@ import (
 // Work is a unit of item to be worked on.
 type Work func()
 
-// PooledWorkerPool provides a pool for goroutines, but unlike WorkerPool,
+// StaticPooledWorkerPool provides a pool for goroutines, but unlike WorkerPool,
 // the actual goroutines themselves are re-used. This can be useful from a
 // performance perspective in scenarios where the allocation and growth of
 // the new goroutine and its stack is a bottleneck. Specifically, if the
@@ -40,26 +40,16 @@ type Work func()
 // allows the stack to be grown once, and then re-used for many invocations.
 //
 // In order to prevent abnormally large goroutine stacks from persisting over
-// the life-cycle of an application, the PooledWorkerPool will randomly kill
+// the life-cycle of an application, the StaticPooledWorkerPool will randomly kill
 // existing goroutines and spawn a new one.
 //
-// The PooledWorkerPool also implements sharding of its underlying worker channels
+// The StaticPooledWorkerPool also implements sharding of its underlying worker channels
 // to prevent excessive lock contention.
-type PooledWorkerPool interface {
+type StaticPooledWorkerPool interface {
 	// Init initializes the pool.
 	Init()
 
-	// Go assign the Work to be executed by a Goroutine. Whether or not
-	// it waits for an existing Goroutine to become available or not
-	// is determined by the GrowOnDemand() option. If GrowOnDemand is not
-	// set then the call to Go() will block until a goroutine is available.
-	// If GrowOnDemand() is set then it will expand the pool of goroutines to
-	// accommodate the work. The newly allocated goroutine will temporarily
-	// participate in the pool in an effort to amortize its allocation cost, but
-	// will eventually be killed. This allows the pool to dynamically respond to
-	// workloads without causing excessive memory pressure. The pool will grow in
-	// size when the workload exceeds its capacity and shrink back down to its
-	// original size if/when the burst subsides.
+	// Go assign the Work to be executed by a Goroutine, blocking until a goroutine is available.
 	Go(work Work)
 
 	// GoWithTimeout waits up to the given timeout for a worker to become
@@ -76,7 +66,23 @@ type PooledWorkerPool interface {
 	// iterations.
 	// This should only be used for code that can guarantee the wait time for a worker is low since if the ctx is not
 	// checked the calling goroutine blocks waiting for a worker.
-	FastContextCheck(batchSize int) PooledWorkerPool
+	FastContextCheck(batchSize int) StaticPooledWorkerPool
+}
+
+// DynamicPooledWorkerPool is like a StaticPooledWorkerPool, but can dynamically grow to ensure a client is never
+// blocked enqueuing work.
+type DynamicPooledWorkerPool interface {
+	// Init initializes the pool.
+	Init()
+
+	// AlwaysGo assigns the Work to be executed by a Goroutine, expanding the pool of goroutines to
+	// accommodate the work. The newly allocated goroutine will temporarily
+	// participate in the pool in an effort to amortize its allocation cost, but
+	// will eventually be killed. This allows the pool to dynamically respond to
+	// workloads without causing excessive memory pressure. The pool will grow in
+	// size when the workload exceeds its capacity and shrink back down to its
+	// original size if/when the burst subsides.
+	AlwaysGo(work Work)
 }
 
 // NewPooledWorkerOptions is a set of new instrument worker pool options.
@@ -84,8 +90,8 @@ type NewPooledWorkerOptions struct {
 	InstrumentOptions instrument.Options
 }
 
-// NewPooledWorkerFn returns a pooled worker pool that Init must be called on.
-type NewPooledWorkerFn func(opts NewPooledWorkerOptions) (PooledWorkerPool, error)
+// NewDynamicPooledWorkerFn returns a pooled worker pool that Init must be called on.
+type NewDynamicPooledWorkerFn func(opts NewPooledWorkerOptions) (DynamicPooledWorkerPool, error)
 
 // WorkerPool provides a pool for goroutines.
 type WorkerPool interface {
@@ -130,19 +136,13 @@ type ScheduleResult struct {
 	WaitTime time.Duration
 }
 
-// PooledWorkerPoolOptions is the options for a PooledWorkerPool.
+// PooledWorkerPoolOptions is the options for a StaticPooledWorkerPool.
 type PooledWorkerPoolOptions interface {
-	// SetGrowOnDemand sets whether the GrowOnDemand feature is enabled.
-	SetGrowOnDemand(value bool) PooledWorkerPoolOptions
-
-	// GrowOnDemand returns whether the GrowOnDemand feature is enabled.
-	GrowOnDemand() bool
-
 	// SetNumShards sets the number of worker channel shards.
-	SetNumShards(value int64) PooledWorkerPoolOptions
+	SetNumShards(value int) PooledWorkerPoolOptions
 
 	// NumShards returns the number of worker channel shards.
-	NumShards() int64
+	NumShards() int
 
 	// SetKillWorkerProbability sets the probability to kill a worker.
 	SetKillWorkerProbability(value float64) PooledWorkerPoolOptions

--- a/src/x/sync/types.go
+++ b/src/x/sync/types.go
@@ -75,14 +75,14 @@ type DynamicPooledWorkerPool interface {
 	// Init initializes the pool.
 	Init()
 
-	// AlwaysGo assigns the Work to be executed by a Goroutine, expanding the pool of goroutines to
+	// GoAlways assigns the Work to be executed by a Goroutine, expanding the pool of goroutines to
 	// accommodate the work. The newly allocated goroutine will temporarily
 	// participate in the pool in an effort to amortize its allocation cost, but
 	// will eventually be killed. This allows the pool to dynamically respond to
 	// workloads without causing excessive memory pressure. The pool will grow in
 	// size when the workload exceeds its capacity and shrink back down to its
 	// original size if/when the burst subsides.
-	AlwaysGo(work Work)
+	GoAlways(work Work)
 }
 
 // NewPooledWorkerOptions is a set of new instrument worker pool options.


### PR DESCRIPTION
This refactor requires code that uses a worker pool to explicitly choose
static or dynamic. It has been proven to be quite buggy/error prone to
allow a configurable worker pool type, because they are quite different.

1. a dynamic worker pool should never block, so it should not have
   methods like GoWitTimeout since it can never timeout.
2. test code was using a static worker pool, when prod code would be
   using a dynamic worker pool.
3. it can be quite dangerous to allow switching an unbounded pool to a
   bounded pool in prod.

Additionally, buffer channels were removed from the static worker pool.
Allowing a buffer can potentially lead to incorrect code when there is a
slot available, but the worker does not process it until after the
timeout. The client would have expected the enqueue request to timeout
instead. Buffered channels were removed from the dynamic queue earlier
this year for similar buggy reasons.

Removing the buffer made reasoning about the size much easier. Now there
is a single option, NumShards, to configure the number of worker
channels. This is the same for both static and dynamic. The only
difference with the dynamic is additionally goroutines are spun up
temporarily to handle bursts of traffic.