### PR TITLE
[coordinator] Add metric for writes that have empty annotation

### DIFF
--- a/src/cmd/services/m3coordinator/ingest/write.go
+++ b/src/cmd/services/m3coordinator/ingest/write.go
@@ -129,12 +129,12 @@ func NewDownsamplerAndWriter(
 	var (
 		scope = instrumentOpts.MetricsScope().SubScope("downsampler")
 
-		emptyAnnotationMetricName = "datapoints_with_empty_annotation"
-		typeTag                   = func(t string) map[string]string {
-			return map[string]string{"type": t}
+		emptyAnnotationMetricName = "writes_without_annotation"
+		storagePolicyTag          = func(t string) map[string]string {
+			return map[string]string{"storage_policy": t}
 		}
-		unaggregated = scope.Tagged(typeTag("unaggregated")).Counter(emptyAnnotationMetricName)
-		aggregated   = scope.Tagged(typeTag("aggregated")).Counter(emptyAnnotationMetricName)
+		unaggregated = scope.Tagged(storagePolicyTag("unaggregated")).Counter(emptyAnnotationMetricName)
+		aggregated   = scope.Tagged(storagePolicyTag("aggregated")).Counter(emptyAnnotationMetricName)
 	)
 
 	return &downsamplerAndWriter{

--- a/src/cmd/services/m3coordinator/ingest/write.go
+++ b/src/cmd/services/m3coordinator/ingest/write.go
@@ -331,7 +331,7 @@ func (d *downsamplerAndWriter) writeToStorage(
 		if err != nil {
 			return err
 		}
-		d.maybeRecordDatapointsWithEmptyAnnotation(writeQuery)
+		d.maybeRecordWritesWithoutAnnotation(writeQuery)
 		return d.store.Write(ctx, writeQuery)
 	}
 
@@ -358,7 +358,7 @@ func (d *downsamplerAndWriter) writeToStorage(
 				Attributes: storageAttributesFromPolicy(p),
 			})
 			if err == nil {
-				d.maybeRecordDatapointsWithEmptyAnnotation(writeQuery)
+				d.maybeRecordWritesWithoutAnnotation(writeQuery)
 				err = d.store.Write(ctx, writeQuery)
 			}
 			if err != nil {
@@ -375,7 +375,7 @@ func (d *downsamplerAndWriter) writeToStorage(
 	return multiErr.FinalError()
 }
 
-func (d *downsamplerAndWriter) maybeRecordDatapointsWithEmptyAnnotation(q *storage.WriteQuery) {
+func (d *downsamplerAndWriter) maybeRecordWritesWithoutAnnotation(q *storage.WriteQuery) {
 	if len(q.Annotation()) == 0 {
 		n := int64(len(q.Datapoints()))
 		switch q.Attributes().MetricsType {

--- a/src/cmd/services/m3coordinator/ingest/write.go
+++ b/src/cmd/services/m3coordinator/ingest/write.go
@@ -453,6 +453,7 @@ func (d *downsamplerAndWriter) WriteBatch(
 						Attributes: storageAttributesFromPolicy(p),
 					})
 					if err == nil {
+						d.maybeRecordWritesWithoutAnnotation(writeQuery)
 						err = d.store.Write(ctx, writeQuery)
 					}
 					if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds coordinator metric for the count of written datapoints that have empty annotation. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
