### PR TITLE
[query][coordinator] Fix missing multiprocess label

### DIFF
--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -200,6 +200,7 @@ func Run(runOpts RunOptions) {
 
 	xconfig.WarnOnDeprecation(cfg, logger)
 
+	var commonLabels map[string]string
 	if cfg.MultiProcess.Enabled {
 		runResult, err := multiProcessRun(cfg, logger, listenerOpts)
 		if err != nil {
@@ -215,6 +216,7 @@ func Run(runOpts RunOptions) {
 		cfg = runResult.cfg
 		logger = runResult.logger
 		listenerOpts = runResult.listenerOpts
+		commonLabels = runResult.commonLabels
 	}
 
 	prometheusEngineRegistry := extprom.NewRegistry()
@@ -231,6 +233,7 @@ func Run(runOpts RunOptions) {
 				// cause a panic.
 				logger.Error("register metric error", zap.Error(err))
 			},
+			CommonLabels: commonLabels,
 		})
 	if err != nil {
 		logger.Fatal("could not connect to metrics", zap.Error(err))

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -47,6 +47,7 @@ import (
 	xclock "github.com/m3db/m3/src/x/clock"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/serialize"
 	xtest "github.com/m3db/m3/src/x/test"
 
@@ -117,6 +118,103 @@ writeWorkerPoolPolicy:
   shards: 100
   killProbability: 0.3
 `
+
+func TestMultiProcessSetsProcessLabel(t *testing.T) {
+	ctrl := gomock.NewController(xtest.Reporter{T: t})
+	defer ctrl.Finish()
+
+
+	configFile, c := newTestFile(t, "config.yaml", configYAML)
+	defer c()
+
+	var cfg config.Configuration
+	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
+	require.NoError(t, err)
+
+	metricsPort := 8765
+	cfg.Metrics.PrometheusReporter.ListenAddress = fmt.Sprintf("127.0.0.1:%d", metricsPort)
+	cfg.MultiProcess = config.MultiProcessConfiguration{
+		Enabled: true,
+		Count: 2,
+	}
+	detailedMetrics := instrument.DetailedExtendedMetrics
+	cfg.Metrics.ExtendedMetrics = &detailedMetrics
+
+	// Override the client creation
+	require.Equal(t, 1, len(cfg.Clusters))
+
+	session := client.NewMockSession(ctrl)
+	session.EXPECT().Close().AnyTimes()
+
+	dbClient := client.NewMockClient(ctrl)
+	dbClient.EXPECT().DefaultSession().Return(session, nil).AnyTimes()
+
+	cfg.Clusters[0].NewClientFromConfig = m3.NewClientFromConfig(
+		func(
+			cfg client.Configuration,
+			params client.ConfigurationParameters,
+			custom ...client.CustomAdminOption,
+		) (client.Client, error) {
+			return dbClient, nil
+		})
+
+	interruptCh := make(chan error, 1)
+	doneCh := make(chan struct{}, 1)
+	listenerCh := make(chan net.Listener, 1)
+
+	rulesNamespacesValue := kv.NewMockValue(ctrl)
+	rulesNamespacesValue.EXPECT().Version().Return(0).AnyTimes()
+	rulesNamespacesValue.EXPECT().Unmarshal(gomock.Any()).DoAndReturn(func(v proto.Message) error {
+		msg := v.(*rulepb.Namespaces)
+		*msg = rulepb.Namespaces{}
+		return nil
+	})
+	rulesNamespacesWatchable := kv.NewValueWatchable()
+	_ = rulesNamespacesWatchable.Update(rulesNamespacesValue)
+	_, rulesNamespacesWatch, err := rulesNamespacesWatchable.Watch()
+	require.NoError(t, err)
+	kvClient := kv.NewMockStore(ctrl)
+	kvClient.EXPECT().Watch(gomock.Any()).Return(rulesNamespacesWatch, nil).AnyTimes()
+	clusterClient := clusterclient.NewMockClient(ctrl)
+	clusterClient.EXPECT().KV().Return(kvClient, nil).AnyTimes()
+	clusterClientCh := make(chan clusterclient.Client, 1)
+	clusterClientCh <- clusterClient
+
+	downsamplerReadyCh := make(chan struct{}, 1)
+
+	go func() {
+		Run(RunOptions{
+			Config:             cfg,
+			InterruptCh:        interruptCh,
+			ListenerCh:         listenerCh,
+			ClusterClient:      clusterClientCh,
+			DownsamplerReadyCh: downsamplerReadyCh,
+		})
+		doneCh <- struct{}{}
+	}()
+
+	// Wait for downsampler to be ready.
+	<-downsamplerReadyCh
+
+	// Wait for listener
+	listener := <-listenerCh
+	addr := listener.Addr().String()
+
+	// Wait for server to come up
+	waitForServerHealthy(t, addr)
+
+	r, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/metrics", metricsPort)) //nolint
+	require.NoError(t, err)
+	defer r.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	require.NoError(t, err)
+	metricsResponse := string(bodyBytes)
+	assert.Contains(t, metricsResponse, "coordinator_runtime_memory_allocated{multiprocess_id=\"1\"}")
+	assert.Contains(t, metricsResponse, "coordinator_ingest_success{multiprocess_id=\"1\"}")
+	// Ensure close server performs as expected
+	interruptCh <- fmt.Errorf("interrupt")
+	<-doneCh
+}
 
 func TestWriteH1(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -123,7 +123,6 @@ func TestMultiProcessSetsProcessLabel(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
-
 	configFile, c := newTestFile(t, "config.yaml", configYAML)
 	defer c()
 
@@ -135,7 +134,7 @@ func TestMultiProcessSetsProcessLabel(t *testing.T) {
 	cfg.Metrics.PrometheusReporter.ListenAddress = fmt.Sprintf("127.0.0.1:%d", metricsPort)
 	cfg.MultiProcess = config.MultiProcessConfiguration{
 		Enabled: true,
-		Count: 2,
+		Count:   2,
 	}
 	detailedMetrics := instrument.DetailedExtendedMetrics
 	cfg.Metrics.ExtendedMetrics = &detailedMetrics

--- a/src/x/instrument/config.go
+++ b/src/x/instrument/config.go
@@ -103,6 +103,8 @@ type NewRootScopeAndReportersOptions struct {
 	PrometheusHandlerListener    net.Listener
 	PrometheusExternalRegistries []PrometheusExternalRegistry
 	PrometheusOnError            func(e error)
+	// CommonLabels will be appended to every metric gathered.
+	CommonLabels map[string]string
 }
 
 // NewRootScopeAndReporters creates a new tally.Scope based on a tally.CachedStatsReporter
@@ -161,6 +163,7 @@ func (mc *MetricsConfiguration) NewRootScopeAndReporters(
 			ExternalRegistries: opts.PrometheusExternalRegistries,
 			HandlerListener:    opts.PrometheusHandlerListener,
 			OnError:            onError,
+			CommonLabels:       opts.CommonLabels,
 		}
 
 		// Use default instrument package default histogram buckets if not set.

--- a/src/x/instrument/config_prometheus.go
+++ b/src/x/instrument/config_prometheus.go
@@ -111,7 +111,7 @@ func (c PrometheusConfiguration) NewReporter(
 	configOpts PrometheusConfigurationOptions,
 ) (prometheus.Reporter, error) {
 	registry := configOpts.Registry
-	if configOpts.Registry == nil {
+	if registry == nil {
 		registry = prom.NewRegistry()
 	}
 	opts := prometheus.Options{

--- a/src/x/instrument/config_test.go
+++ b/src/x/instrument/config_test.go
@@ -27,8 +27,9 @@ import (
 	"net/http"
 	"testing"
 
-	xjson "github.com/m3db/m3/src/x/json"
 	"github.com/sergi/go-diff/diffmatchpatch"
+
+	xjson "github.com/m3db/m3/src/x/json"
 
 	"github.com/gogo/protobuf/jsonpb"
 	extprom "github.com/prometheus/client_golang/prometheus"
@@ -37,18 +38,8 @@ import (
 )
 
 func TestPrometheusDefaults(t *testing.T) {
-	sanitization := PrometheusMetricSanitization
-	extended := DetailedExtendedMetrics
-	cfg := MetricsConfiguration{
-		Sanitization: &sanitization,
-		SamplingRate: 1,
-		PrometheusReporter: &PrometheusConfiguration{
-			HandlerPath:   "/metrics",
-			ListenAddress: "0.0.0.0:0",
-			TimerType:     "histogram",
-		},
-		ExtendedMetrics: &extended,
-	}
+	cfg := newConfiguration()
+
 	_, closer, reporters, err := cfg.NewRootScopeAndReporters(
 		NewRootScopeAndReportersOptions{})
 	require.NoError(t, err)
@@ -61,7 +52,7 @@ func TestPrometheusDefaults(t *testing.T) {
 	require.True(t, numDefaultBuckets > 0)
 	require.Equal(t, numDefaultBuckets, len(cfg.PrometheusReporter.DefaultHistogramBuckets))
 
-	// Make sure populated default summmary objectives buckets.
+	// Make sure populated default summary objectives buckets.
 	numQuantiles := len(DefaultSummaryQuantileObjectives())
 	require.True(t, numQuantiles > 0)
 	require.Equal(t, numQuantiles, len(cfg.PrometheusReporter.DefaultSummaryObjectives))
@@ -77,21 +68,7 @@ func TestPrometheusExternalRegistries(t *testing.T) {
 		SubScope: "ext2",
 	}
 
-	sanitization := PrometheusMetricSanitization
-	extended := DetailedExtendedMetrics
-	cfg := MetricsConfiguration{
-		Sanitization: &sanitization,
-		SamplingRate: 1,
-		PrometheusReporter: &PrometheusConfiguration{
-			HandlerPath:   "/metrics",
-			ListenAddress: "0.0.0.0:0",
-			TimerType:     "histogram",
-		},
-		ExtendedMetrics: &extended,
-	}
-
-	listener, err := net.Listen("tcp", ":0")
-	require.NoError(t, err)
+	cfg, listener := startMetricsEndpoint(t)
 
 	scope, closer, reporters, err := cfg.NewRootScopeAndReporters(
 		NewRootScopeAndReportersOptions{
@@ -135,19 +112,8 @@ func TestPrometheusExternalRegistries(t *testing.T) {
 	// Wait for report.
 	require.NoError(t, closer.Close())
 
-	url := fmt.Sprintf("http://%s/metrics", listener.Addr().String())
-	resp, err := http.Get(url)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	defer resp.Body.Close()
-
-	var parser expfmt.TextParser
-	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
-	require.NoError(t, err)
-
 	expected := map[string]xjson.Map{
-		"foo": xjson.Map{
+		"foo": {
 			"name": "foo",
 			"help": "foo counter",
 			"type": "COUNTER",
@@ -163,7 +129,7 @@ func TestPrometheusExternalRegistries(t *testing.T) {
 				},
 			},
 		},
-		"ext1_bar": xjson.Map{
+		"ext1_bar": {
 			"name": "ext1_bar",
 			"help": "bar help",
 			"type": "COUNTER",
@@ -179,7 +145,7 @@ func TestPrometheusExternalRegistries(t *testing.T) {
 				},
 			},
 		},
-		"ext2_baz": xjson.Map{
+		"ext2_baz": {
 			"name": "ext2_baz",
 			"help": "baz help",
 			"type": "COUNTER",
@@ -196,6 +162,109 @@ func TestPrometheusExternalRegistries(t *testing.T) {
 			},
 		},
 	}
+
+	assertMetrics(t, listener, expected)
+}
+
+func TestCommonLabelsAdded(t *testing.T) {
+	extReg1 := PrometheusExternalRegistry{
+		Registry: extprom.NewRegistry(),
+		SubScope: "ext1",
+	}
+
+	cfg, listener := startMetricsEndpoint(t)
+
+	scope, closer, reporters, err := cfg.NewRootScopeAndReporters(
+		NewRootScopeAndReportersOptions{
+			PrometheusHandlerListener:    listener,
+			PrometheusExternalRegistries: []PrometheusExternalRegistry{extReg1},
+			CommonLabels:                 map[string]string{"commonLabel": "commonLabelValue"},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, reporters.PrometheusReporter)
+
+	foo := scope.Counter("foo")
+	foo.Inc(3)
+
+	bar := extprom.NewCounter(extprom.CounterOpts{Name: "bar", Help: "bar help"})
+	extReg1.Registry.MustRegister(bar)
+	bar.Inc()
+
+	// Wait for report.
+	require.NoError(t, closer.Close())
+
+	expected := map[string]xjson.Map{
+		"foo": {
+			"name": "foo",
+			"help": "foo counter",
+			"type": "COUNTER",
+			"metric": xjson.Array{
+				xjson.Map{
+					"counter": xjson.Map{"value": 3},
+					"label": xjson.Array{
+						xjson.Map{
+							"name":  "commonLabel",
+							"value": "commonLabelValue",
+						},
+					},
+				},
+			},
+		},
+		"ext1_bar": {
+			"name": "ext1_bar",
+			"help": "bar help",
+			"type": "COUNTER",
+			"metric": xjson.Array{
+				xjson.Map{
+					"counter": xjson.Map{"value": 1},
+					"label": xjson.Array{
+						xjson.Map{
+							"name":  "commonLabel",
+							"value": "commonLabelValue",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assertMetrics(t, listener, expected)
+}
+
+func startMetricsEndpoint(t *testing.T) (MetricsConfiguration, net.Listener) {
+	cfg := newConfiguration()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	return cfg, listener
+}
+
+func newConfiguration() MetricsConfiguration {
+	sanitization := PrometheusMetricSanitization
+	extended := DetailedExtendedMetrics
+	cfg := MetricsConfiguration{
+		Sanitization: &sanitization,
+		SamplingRate: 1,
+		PrometheusReporter: &PrometheusConfiguration{
+			HandlerPath:   "/metrics",
+			ListenAddress: "0.0.0.0:0",
+			TimerType:     "histogram",
+		},
+		ExtendedMetrics: &extended,
+	}
+	return cfg
+}
+
+func assertMetrics(t *testing.T, listener net.Listener, expected map[string]xjson.Map) {
+	url := fmt.Sprintf("http://%s/metrics", listener.Addr().String()) //nolint
+	resp, err := http.Get(url) //nolint
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	defer resp.Body.Close()
+
+	var parser expfmt.TextParser
+	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
+	require.NoError(t, err)
 
 	expectMatch := len(expected)
 	actualMatch := 0

--- a/src/x/instrument/config_test.go
+++ b/src/x/instrument/config_test.go
@@ -163,7 +163,7 @@ func TestPrometheusExternalRegistries(t *testing.T) {
 		},
 	}
 
-	assertMetrics(t, listener, expected)
+	assertMetricsEqual(t, listener, expected)
 }
 
 func TestCommonLabelsAdded(t *testing.T) {
@@ -228,7 +228,7 @@ func TestCommonLabelsAdded(t *testing.T) {
 		},
 	}
 
-	assertMetrics(t, listener, expected)
+	assertMetricsEqual(t, listener, expected)
 }
 
 func startMetricsEndpoint(t *testing.T) (MetricsConfiguration, net.Listener) {
@@ -254,7 +254,7 @@ func newConfiguration() MetricsConfiguration {
 	return cfg
 }
 
-func assertMetrics(t *testing.T, listener net.Listener, expected map[string]xjson.Map) {
+func assertMetricsEqual(t *testing.T, listener net.Listener, expected map[string]xjson.Map) {
 	url := fmt.Sprintf("http://%s/metrics", listener.Addr().String()) //nolint
 	resp, err := http.Get(url) //nolint
 	require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes missing multiprocess label when running coordinator in multiprocess mode.

**Special notes for your reviewer**:

Initial implementation was using `metrics.RootScope.CommonTags` to add `multiprocess_id` label to all metrics exposed in coordinator when running in multiprocess mode. However this only affected metrics exposed using `tally`. Prometheus client library has a concept of [collectors](https://prometheus.io/docs/instrumenting/writing_clientlibs/#standard-and-runtime-collectors). These collectors were still emitting metrics without added label. 

This PR removes use of `CommonTags` and appends this label at lower level - in `multiGatherer` implementation. This only affects coordinator metrics when multiprocess is enabled.
 
**Does this PR introduce a user-facing and/or backwards incompatible change?**: No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**: No
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
