### PR TITLE
[coordinator] Add support for HTTP/2 Cleartext (H2C)

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -138,6 +138,9 @@ type Configuration struct {
 	// RPC is the RPC configuration.
 	RPC *RPCConfiguration `yaml:"rpc"`
 
+	// HTTP is the HTTP configuration.
+	HTTP HTTPConfiguration `yaml:"http"`
+
 	// Backend is the backend store for query service. We currently support grpc and m3db (default).
 	Backend BackendStorageType `yaml:"backend"`
 
@@ -716,6 +719,14 @@ type RPCConfiguration struct {
 	// ReflectionEnabled will enable reflection on the GRPC server, useful
 	// for testing connectivity with grpcurl, etc.
 	ReflectionEnabled bool `yaml:"reflectionEnabled"`
+}
+
+// HTTPConfiguration is the HTTP configuration for configuring
+// the HTTP server used by the coordinator to serve incoming requests.
+type HTTPConfiguration struct {
+	// EnableH2C enables support for the HTTP/2 cleartext protocol. H2C
+	// enables the use of HTTP/2 without requiring TLS.
+	EnableH2C bool `yaml:"enableH2C"`
 }
 
 // TagOptionsConfiguration is the configuration for shared tag options

--- a/src/cmd/services/m3query/config/config_test.go
+++ b/src/cmd/services/m3query/config/config_test.go
@@ -99,6 +99,9 @@ func TestConfigLoading(t *testing.T) {
 			RequireExhaustive: &requireExhaustive,
 		},
 	}, &cfg.Limits)
+
+	assert.Equal(t, HTTPConfiguration{EnableH2C: true}, cfg.HTTP)
+
 	// TODO: assert on more fields here.
 }
 
@@ -132,7 +135,8 @@ func TestConfigValidation(t *testing.T) {
 			cfg.Limits = LimitsConfiguration{
 				PerQuery: PerQueryLimitsConfiguration{
 					MaxFetchedSeries: tc.limit,
-				}}
+				},
+			}
 
 			assert.NoError(t, validator.Validate(cfg))
 		})
@@ -153,7 +157,7 @@ func TestGraphiteIDGenerationSchemeIsInvalid(t *testing.T) {
 }
 
 func TestTagOptionsConfigWithTagGenerationScheme(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		schemeStr string
 		scheme    models.IDSchemeType
 	}{

--- a/src/cmd/services/m3query/config/testdata/config.yml
+++ b/src/cmd/services/m3query/config/testdata/config.yml
@@ -13,6 +13,9 @@ metrics:
   samplingRate: 1.0
   extended: none
 
+http:
+  enableH2C: true
+
 clusters:
   - namespaces:
       - namespace: default

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -136,8 +136,8 @@ func TestWriteH2C(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
-	configFile, close := newTestFile(t, "config.yaml", configYAML)
-	defer close()
+	configFile, closer := newTestFile(t, "config.yaml", configYAML)
+	defer closer()
 
 	var cfg config.Configuration
 	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
@@ -148,16 +148,12 @@ func TestWriteH2C(t *testing.T) {
 	testWrite(t, cfg, ctrl)
 }
 
-// TestIngest will test an M3Msg being ingested by the coordinator, it also
-// makes sure that the tag options is correctly propagated from the config
-// all the way to the M3Msg ingester and when written to the DB will include
-// the correctly formed ID.
 func TestIngestH1(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
-	configFile, close := newTestFile(t, "config.yaml", configYAML)
-	defer close()
+	configFile, closer := newTestFile(t, "config.yaml", configYAML)
+	defer closer()
 
 	var cfg config.Configuration
 	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
@@ -170,8 +166,8 @@ func TestIngestH2C(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
-	configFile, close := newTestFile(t, "config.yaml", configYAML)
-	defer close()
+	configFile, closer := newTestFile(t, "config.yaml", configYAML)
+	defer closer()
 
 	var cfg config.Configuration
 	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
@@ -279,6 +275,10 @@ func testWrite(t *testing.T, cfg config.Configuration, ctrl *gomock.Controller) 
 	<-doneCh
 }
 
+// testIngest will test an M3Msg being ingested by the coordinator, it also
+// makes sure that the tag options is correctly propagated from the config
+// all the way to the M3Msg ingester and when written to the DB will include
+// the correctly formed ID.
 func testIngest(t *testing.T, cfg config.Configuration, ctrl *gomock.Controller) {
 	// Override the client creation
 	require.Equal(t, 1, len(cfg.Clusters))

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -118,7 +118,7 @@ writeWorkerPoolPolicy:
   killProbability: 0.3
 `
 
-func TestWrite(t *testing.T) {
+func TestWriteH1(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
@@ -129,6 +129,60 @@ func TestWrite(t *testing.T) {
 	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
 	require.NoError(t, err)
 
+	testWrite(t, cfg, ctrl)
+}
+
+func TestWriteH2C(t *testing.T) {
+	ctrl := gomock.NewController(xtest.Reporter{T: t})
+	defer ctrl.Finish()
+
+	configFile, close := newTestFile(t, "config.yaml", configYAML)
+	defer close()
+
+	var cfg config.Configuration
+	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
+	require.NoError(t, err)
+
+	cfg.HTTP.EnableH2C = true
+
+	testWrite(t, cfg, ctrl)
+}
+
+// TestIngest will test an M3Msg being ingested by the coordinator, it also
+// makes sure that the tag options is correctly propagated from the config
+// all the way to the M3Msg ingester and when written to the DB will include
+// the correctly formed ID.
+func TestIngestH1(t *testing.T) {
+	ctrl := gomock.NewController(xtest.Reporter{T: t})
+	defer ctrl.Finish()
+
+	configFile, close := newTestFile(t, "config.yaml", configYAML)
+	defer close()
+
+	var cfg config.Configuration
+	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
+	require.NoError(t, err)
+
+	testIngest(t, cfg, ctrl)
+}
+
+func TestIngestH2C(t *testing.T) {
+	ctrl := gomock.NewController(xtest.Reporter{T: t})
+	defer ctrl.Finish()
+
+	configFile, close := newTestFile(t, "config.yaml", configYAML)
+	defer close()
+
+	var cfg config.Configuration
+	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
+	require.NoError(t, err)
+
+	cfg.HTTP.EnableH2C = true
+
+	testIngest(t, cfg, ctrl)
+}
+
+func testWrite(t *testing.T, cfg config.Configuration, ctrl *gomock.Controller) {
 	// Override the client creation
 	require.Equal(t, 1, len(cfg.Clusters))
 
@@ -225,21 +279,7 @@ func TestWrite(t *testing.T) {
 	<-doneCh
 }
 
-// TestIngest will test an M3Msg being ingested by the coordinator, it also
-// makes sure that the tag options is correctly propagated from the config
-// all the way to the M3Msg ingester and when written to the DB will include
-// the correctly formed ID.
-func TestIngest(t *testing.T) {
-	ctrl := gomock.NewController(xtest.Reporter{T: t})
-	defer ctrl.Finish()
-
-	configFile, close := newTestFile(t, "config.yaml", configYAML)
-	defer close()
-
-	var cfg config.Configuration
-	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
-	require.NoError(t, err)
-
+func testIngest(t *testing.T, cfg config.Configuration, ctrl *gomock.Controller) {
 	// Override the client creation
 	require.Equal(t, 1, len(cfg.Clusters))
 
@@ -404,7 +444,7 @@ func TestGRPCBackend(t *testing.T) {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	grpcAddr := lis.Addr().String()
-	var grpcConfigYAML = fmt.Sprintf(`
+	grpcConfigYAML := fmt.Sprintf(`
 listenAddress: 127.0.0.1:0
 
 logging:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR gives users the ability to configure whether the
coordinator supports requests made via H2C, which are HTTP/2
requests that do not require TLS.

Enabling this flag allows clients to realize the benefits of
HTTP/2 without requiring every request be done via TLS.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
