### PR TITLE
[query] Fix Graphite aliasByNode & aliasByMetric to use robust path expr extraction and add neg indexing to substr

### DIFF
--- a/src/query/graphite/common/aliasing.go
+++ b/src/query/graphite/common/aliasing.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/m3db/m3/src/query/graphite/ts"
 	"github.com/m3db/m3/src/x/errors"
@@ -40,19 +39,6 @@ func Alias(_ *Context, series ts.SeriesList, a string) (ts.SeriesList, error) {
 	renamed := make([]*ts.Series, series.Len())
 	for i := range series.Values {
 		renamed[i] = series.Values[i].RenamedTo(a)
-	}
-	series.Values = renamed
-	return series, nil
-}
-
-// AliasByMetric takes a seriesList and applies an alias derived from the base
-// metric name.
-func AliasByMetric(ctx *Context, series ts.SeriesList) (ts.SeriesList, error) {
-	renamed := make([]*ts.Series, series.Len())
-	for i, s := range series.Values {
-		firstPart := strings.Split(s.Name(), ",")[0]
-		terms := strings.Split(firstPart, ".")
-		renamed[i] = s.RenamedTo(terms[len(terms)-1])
 	}
 	series.Values = renamed
 	return series, nil

--- a/src/query/graphite/native/alias_functions_test.go
+++ b/src/query/graphite/native/alias_functions_test.go
@@ -199,7 +199,7 @@ func TestAliasByNodeWithComposition(t *testing.T) {
 	series := []*ts.Series{
 		ts.NewSeries(ctx, "derivative(servers.bob02-foo.cpu.load_5)", now, values),
 		ts.NewSeries(ctx, "derivative(derivative(servers.bob02-foo.cpu.load_5))", now, values),
-		ts.NewSeries(ctx, "~~~", now, values),
+		ts.NewSeries(ctx, "fooble", now, values),
 		ts.NewSeries(ctx, "", now, values),
 	}
 	results, err := aliasByNode(ctx, singlePathSpec{
@@ -209,7 +209,7 @@ func TestAliasByNodeWithComposition(t *testing.T) {
 	require.Equal(t, len(series), results.Len())
 	assert.Equal(t, "servers.bob02-foo", results.Values[0].Name())
 	assert.Equal(t, "servers.bob02-foo", results.Values[1].Name())
-	assert.Equal(t, "~~~", results.Values[2].Name())
+	assert.Equal(t, "fooble", results.Values[2].Name())
 	assert.Equal(t, "", results.Values[3].Name())
 }
 

--- a/src/query/graphite/native/alias_functions_test.go
+++ b/src/query/graphite/native/alias_functions_test.go
@@ -47,8 +47,7 @@ func TestAlias(t *testing.T) {
 	results, err := alias(nil, singlePathSpec{
 		Values: series,
 	}, a)
-	require.Nil(t, err)
-	require.NotNil(t, results)
+	require.NoError(t, err)
 	require.Equal(t, len(series), results.Len())
 	for _, s := range results.Values {
 		assert.Equal(t, a, s.Name())
@@ -145,14 +144,13 @@ func TestAliasByMetric(t *testing.T) {
 		ts.NewSeries(ctx, "foo.bar.baz.foo01-foo.writes.success", now, values),
 		ts.NewSeries(ctx, "foo.bar.baz.foo02-foo.writes.success.P99", now, values),
 		ts.NewSeries(ctx, "foo.bar.baz.foo03-foo.writes.success.P75", now, values),
-		ts.NewSeries(ctx, "scale(stats.foobar.gauges.quazqux.latency_minutes.foo, 60.123))", now, values),
+		ts.NewSeries(ctx, "scale(stats.foobar.gauges.quazqux.latency_minutes.foo, 60.123)", now, values),
 	}
 
 	results, err := aliasByMetric(ctx, singlePathSpec{
 		Values: series,
 	})
-	require.Nil(t, err)
-	require.NotNil(t, results)
+	require.NoError(t, err)
 	require.Equal(t, len(series), len(results.Values))
 	assert.Equal(t, "success", results.Values[0].Name())
 	assert.Equal(t, "P99", results.Values[1].Name())
@@ -176,8 +174,7 @@ func TestAliasByNode(t *testing.T) {
 	results, err := aliasByNode(ctx, singlePathSpec{
 		Values: series,
 	}, 3, 5, 6)
-	require.Nil(t, err)
-	require.NotNil(t, results)
+	require.NoError(t, err)
 	require.Equal(t, len(series), results.Len())
 	assert.Equal(t, "foo01-foo.success", results.Values[0].Name())
 	assert.Equal(t, "foo02-foo.success.P99", results.Values[1].Name())
@@ -186,8 +183,7 @@ func TestAliasByNode(t *testing.T) {
 	results, err = aliasByNode(nil, singlePathSpec{
 		Values: series,
 	}, -1)
-	require.Nil(t, err)
-	require.NotNil(t, results)
+	require.NoError(t, err)
 	require.Equal(t, len(series), results.Len())
 	assert.Equal(t, "success", results.Values[0].Name())
 	assert.Equal(t, "P99", results.Values[1].Name())
@@ -209,8 +205,7 @@ func TestAliasByNodeWithComposition(t *testing.T) {
 	results, err := aliasByNode(ctx, singlePathSpec{
 		Values: series,
 	}, 0, 1)
-	require.Nil(t, err)
-	require.NotNil(t, results)
+	require.NoError(t, err)
 	require.Equal(t, len(series), results.Len())
 	assert.Equal(t, "servers.bob02-foo", results.Values[0].Name())
 	assert.Equal(t, "servers.bob02-foo", results.Values[1].Name())
@@ -231,9 +226,27 @@ func TestAliasByNodeWithManyPathExpressions(t *testing.T) {
 	results, err := aliasByNode(ctx, singlePathSpec{
 		Values: series,
 	}, 0, 1)
-	require.Nil(t, err)
-	require.NotNil(t, results)
+	require.NoError(t, err)
 	require.Equal(t, len(series), results.Len())
 	assert.Equal(t, "servers.bob02-foo", results.Values[0].Name())
 	assert.Equal(t, "servers.bob04-foo", results.Values[1].Name())
+}
+
+func TestAliasByNodeWitCallSubExpressions(t *testing.T) {
+	ctx := common.NewTestContext()
+	defer func() { _ = ctx.Close() }()
+
+	now := time.Now()
+	values := ts.NewConstantValues(ctx, 10.0, 1000, 10)
+	series := []*ts.Series{
+		ts.NewSeries(ctx, "asPercent(foo01,sumSeries(bar,baz))", now, values),
+		ts.NewSeries(ctx, "asPercent(foo02,sumSeries(bar,baz))", now, values),
+	}
+	results, err := aliasByNode(ctx, singlePathSpec{
+		Values: series,
+	}, 0)
+	require.NoError(t, err)
+	require.Equal(t, len(series), results.Len())
+	assert.Equal(t, "foo01", results.Values[0].Name())
+	assert.Equal(t, "foo02", results.Values[1].Name())
 }

--- a/src/query/graphite/native/builtin_functions_test.go
+++ b/src/query/graphite/native/builtin_functions_test.go
@@ -3244,7 +3244,7 @@ func TestSubstr(t *testing.T) {
 		Values: []*ts.Series{series},
 	}, 1, 0)
 	expected := common.TestSeries{Name: "bar", Data: input.values}
-	require.Nil(t, err)
+	require.NoError(t, err)
 	common.CompareOutputsAndExpected(t, input.stepInMilli, input.startTime,
 		[]common.TestSeries{expected}, results.Values)
 
@@ -3252,7 +3252,7 @@ func TestSubstr(t *testing.T) {
 		Values: []*ts.Series{series},
 	}, 0, 2)
 	expected = common.TestSeries{Name: "foo.bar", Data: input.values}
-	require.Nil(t, err)
+	require.NoError(t, err)
 	common.CompareOutputsAndExpected(t, input.stepInMilli, input.startTime,
 		[]common.TestSeries{expected}, results.Values)
 
@@ -3260,24 +3260,28 @@ func TestSubstr(t *testing.T) {
 		Values: []*ts.Series{series},
 	}, 0, 0)
 	expected = common.TestSeries{Name: "foo.bar", Data: input.values}
-	require.Nil(t, err)
+	require.NoError(t, err)
+	common.CompareOutputsAndExpected(t, input.stepInMilli, input.startTime,
+		[]common.TestSeries{expected}, results.Values)
+
+	// Negative support -1, 0.
+	results, err = substr(ctx, singlePathSpec{
+		Values: []*ts.Series{series},
+	}, -1, 0)
+	expected = common.TestSeries{Name: "bar", Data: input.values}
+	require.NoError(t, err)
 	common.CompareOutputsAndExpected(t, input.stepInMilli, input.startTime,
 		[]common.TestSeries{expected}, results.Values)
 
 	results, err = substr(ctx, singlePathSpec{
 		Values: []*ts.Series{series},
 	}, 2, 1)
-	require.NotNil(t, err)
-
-	results, err = substr(ctx, singlePathSpec{
-		Values: []*ts.Series{series},
-	}, -1, 1)
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	results, err = substr(ctx, singlePathSpec{
 		Values: []*ts.Series{series},
 	}, 3, 4)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 type mockStorage struct{}

--- a/src/query/graphite/native/compiler.go
+++ b/src/query/graphite/native/compiler.go
@@ -362,7 +362,7 @@ func (c *compiler) expectToken(expectedType lexer.TokenType) (*lexer.Token, erro
 
 	return token, nil
 }
-P
+
 // errorf returns a formatted error vfrom the compiler
 func (c *compiler) errorf(msg string, args ...interface{}) error {
 	return errors.NewInvalidParamsError(fmt.Errorf("invalid expression '%s': %s", c.input, fmt.Sprintf(msg, args...)))

--- a/src/query/graphite/native/compiler.go
+++ b/src/query/graphite/native/compiler.go
@@ -37,24 +37,43 @@ type CompileOptions struct {
 
 // Compile converts an input stream into the corresponding Expression.
 func Compile(input string, opts CompileOptions) (Expression, error) {
+	compiler, closer := newCompiler(input, opts)
+	defer closer()
+	return compiler.compileExpression()
+}
+
+// ParseGrammar parses the grammar into a set of AST nodes and allows
+// for functions to not exist, etc.
+func ParseGrammar(input string, opts CompileOptions) (ASTNode, error) {
+	compiler, closer := newCompiler(input, opts)
+	defer closer()
+	return compiler.parseGrammar()
+}
+
+type closer func()
+
+func newCompiler(input string, opts CompileOptions) (*compiler, closer) {
 	booleanLiterals := map[string]lexer.TokenType{
 		"true":  lexer.True,
 		"false": lexer.False,
 	}
+
 	lex, tokens := lexer.NewLexer(input, booleanLiterals, lexer.Options{
 		EscapeAllNotOnlyQuotes: opts.EscapeAllNotOnlyQuotes,
 	})
+
 	go lex.Run()
 
-	lookforward := newTokenLookforward(tokens)
-	c := compiler{input: input, tokens: lookforward}
-	expr, err := c.compileExpression()
+	closer := closer(func() {
+		// Exhaust all tokens until closed or else lexer won't close.
+		for range tokens {
+		}
+	})
 
-	// Exhaust all tokens until closed or else lexer won't close
-	for range tokens {
-	}
-
-	return expr, err
+	return &compiler{
+		input:  input,
+		tokens: newTokenLookforward(tokens),
+	}, closer
 }
 
 type tokenLookforward struct {
@@ -115,7 +134,7 @@ func (c *compiler) compileExpression() (Expression, error) {
 		expr = newFetchExpression(token.Value())
 
 	case lexer.Identifier:
-		fc, err := c.compileFunctionCall(token.Value(), nil)
+		fc, err := c.compileFunctionCall(token.Value())
 		fetchCandidate := false
 		if err != nil {
 			_, fnNotFound := err.(errFuncNotFound)
@@ -145,6 +164,14 @@ func (c *compiler) compileExpression() (Expression, error) {
 	return expr, nil
 }
 
+func (c *compiler) parseGrammar() (ASTNode, error) {
+	expr, err := c.compileExpression()
+	if err != nil {
+		return nil, err
+	}
+	return rootASTNode{expr: expr}, nil
+}
+
 // canCompileAsFetch attempts to see if the given term is a non-delimited
 // carbon metric; no dots, without any trailing parentheses.
 func (c *compiler) canCompileAsFetch(fname string) bool {
@@ -160,20 +187,14 @@ type errFuncNotFound struct{ err error }
 func (e errFuncNotFound) Error() string { return e.err.Error() }
 
 // compileFunctionCall compiles a function call
-func (c *compiler) compileFunctionCall(fname string, nextToken *lexer.Token) (*functionCall, error) {
+func (c *compiler) compileFunctionCall(fname string) (*functionCall, error) {
 	fn := findFunction(fname)
 	if fn == nil {
 		return nil, errFuncNotFound{c.errorf("could not find function named %s", fname)}
 	}
 
-	if nextToken != nil {
-		if nextToken.TokenType() != lexer.LParenthesis {
-			return nil, c.errorf("expected %v but encountered %s", lexer.LParenthesis, nextToken.Value())
-		}
-	} else {
-		if _, err := c.expectToken(lexer.LParenthesis); err != nil {
-			return nil, err
-		}
+	if _, err := c.expectToken(lexer.LParenthesis); err != nil {
+		return nil, err
 	}
 
 	argTypes := fn.in
@@ -231,8 +252,11 @@ func (c *compiler) compileFunctionCall(fname string, nextToken *lexer.Token) (*f
 }
 
 // compileArg parses and compiles a single argument
-func (c *compiler) compileArg(fname string, index int,
-	reflectType reflect.Type) (arg funcArg, foundRParen bool, err error) {
+func (c *compiler) compileArg(
+	fname string,
+	index int,
+	reflectType reflect.Type,
+) (arg funcArg, foundRParen bool, err error) {
 	token := c.tokens.get()
 	if token == nil {
 		return nil, false, c.errorf("unexpected eof while parsing %s", fname)
@@ -294,12 +318,14 @@ func (c *compiler) convertTokenToArg(token *lexer.Token, reflectType reflect.Typ
 		currentToken := token.Value()
 
 		// handle named arguments
-		nextToken := c.tokens.get()
-		if nextToken == nil {
+		nextToken, hasNextToken := c.tokens.peek()
+		if !hasNextToken {
 			return nil, c.errorf("unexpected eof, %s should be followed by = or (", currentToken)
 		}
+
 		if nextToken.TokenType() == lexer.Equal {
 			// TODO: check if currentToken matches the expected parameter name
+			_ = c.tokens.get() // Consume the peeked equal token.
 			tokenAfterNext := c.tokens.get()
 			if tokenAfterNext == nil {
 				return nil, c.errorf("unexpected eof, named argument %s should be followed by its value", currentToken)
@@ -307,7 +333,16 @@ func (c *compiler) convertTokenToArg(token *lexer.Token, reflectType reflect.Typ
 			return c.convertTokenToArg(tokenAfterNext, reflectType)
 		}
 
-		return c.compileFunctionCall(currentToken, nextToken)
+		fc, err := c.compileFunctionCall(currentToken)
+		if err != nil {
+			_, fnNotFound := err.(errFuncNotFound)
+			if fnNotFound && c.canCompileAsFetch(currentToken) {
+				return newFetchExpression(currentToken), nil
+			}
+			return nil, err
+		}
+
+		return fc, nil
 	default:
 		return nil, c.errorf("%s not valid", token.Value())
 	}

--- a/src/query/graphite/native/compiler.go
+++ b/src/query/graphite/native/compiler.go
@@ -65,7 +65,7 @@ func newCompiler(input string, opts CompileOptions) (*compiler, closer) {
 
 	go lex.Run()
 
-	close := closer(func() {
+	cleanup := closer(func() {
 		// Exhaust all tokens until closed or else lexer won't close.
 		for range tokens {
 		}
@@ -74,7 +74,7 @@ func newCompiler(input string, opts CompileOptions) (*compiler, closer) {
 	return &compiler{
 		input:  input,
 		tokens: newTokenLookforward(tokens),
-	}, close
+	}, cleanup
 }
 
 type tokenLookforward struct {

--- a/src/query/graphite/native/compiler_test.go
+++ b/src/query/graphite/native/compiler_test.go
@@ -452,8 +452,7 @@ func TestCompileErrors(t *testing.T) {
 			"scale(servers.foobar*-qaz.quail.qux-qaz-qab.cpu.*, e)",
 			"invalid expression 'scale(servers.foobar*-qaz.quail.qux-qaz-qab.cpu.*, e)': " +
 				"invalid function call scale, " +
-				"arg 1: invalid expression 'scale(servers.foobar*-qaz.quail.qux-qaz-qab.cpu.*, e)': " +
-				"could not find function named e",
+				"arg 1: expected a float64, received 'fetch(e)'",
 		},
 		{
 			"scale(servers.foobar*-qaz.quail.qux-qaz-qab.cpu.*, 1.2ee)",

--- a/src/query/graphite/native/expression.go
+++ b/src/query/graphite/native/expression.go
@@ -49,15 +49,18 @@ type CallASTNode interface {
 	// Name returns the name of the call.
 	Name() string
 	// Arguments describe each argument that the call has, some
-	// arguments can be casted to an Call themselves.
-	Arguments() []ArgumentASTNode
+	// arguments that can either be a call or path expression.
+	Arguments() []ASTNode
 }
 
-// ArgumentASTNode is an interface to help with printing the AST.
-type ArgumentASTNode interface {
+// ASTNode is an interface to help with printing the AST.
+type ASTNode interface {
 	// PathExpression returns the path expression and true if argument
 	// is a path.
 	PathExpression() (string, bool)
+	// CallExpression returns the call expression and true if argument
+	// is a call.
+	CallExpression() (CallASTNode, bool)
 	// String is the pretty printed format.
 	String() string
 }
@@ -76,6 +79,10 @@ func (a fetchExpressionPathArg) PathExpression() (string, bool) {
 	return a.path, true
 }
 
+func (a fetchExpressionPathArg) CallExpression() (CallASTNode, bool) {
+	return nil, false
+}
+
 func (a fetchExpressionPathArg) String() string {
 	return a.path
 }
@@ -89,12 +96,16 @@ func (f *fetchExpression) Name() string {
 	return "fetch"
 }
 
-func (f *fetchExpression) Arguments() []ArgumentASTNode {
-	return []ArgumentASTNode{f.pathArg}
+func (f *fetchExpression) Arguments() []ASTNode {
+	return []ASTNode{f.pathArg}
 }
 
 func (f *fetchExpression) PathExpression() (string, bool) {
 	return "", false
+}
+
+func (f *fetchExpression) CallExpression() (CallASTNode, bool) {
+	return f, true
 }
 
 // Execute fetches results from storage
@@ -172,7 +183,7 @@ func (f *funcExpression) Name() string {
 	return f.call.Name()
 }
 
-func (f *funcExpression) Arguments() []ArgumentASTNode {
+func (f *funcExpression) Arguments() []ASTNode {
 	return f.call.Arguments()
 }
 
@@ -188,6 +199,8 @@ func (f *funcExpression) Execute(ctx *common.Context) (ts.SeriesList, error) {
 
 func (f *funcExpression) String() string { return f.call.String() }
 
+var _ ASTNode = noopExpression{}
+
 // A noopExpression is an empty expression that returns nothing
 type noopExpression struct{}
 
@@ -200,10 +213,46 @@ func (noop noopExpression) Name() string {
 	return "noop"
 }
 
-func (noop noopExpression) Arguments() []ArgumentASTNode {
+func (noop noopExpression) Arguments() []ASTNode {
 	return nil
 }
 
 func (noop noopExpression) String() string {
 	return noop.Name()
+}
+
+func (noop noopExpression) PathExpression() (string, bool) {
+	return "", false
+}
+
+func (noop noopExpression) CallExpression() (CallASTNode, bool) {
+	return noop, true
+}
+
+var _ ASTNode = rootASTNode{}
+
+// A rootASTNode is the root AST node which returns child nodes
+// when parsing the grammar.
+type rootASTNode struct {
+	expr Expression
+}
+
+func (r rootASTNode) Name() string {
+	return r.expr.Name()
+}
+
+func (r rootASTNode) Arguments() []ASTNode {
+	return r.expr.Arguments()
+}
+
+func (r rootASTNode) String() string {
+	return r.expr.(ASTNode).String()
+}
+
+func (r rootASTNode) PathExpression() (string, bool) {
+	return "", false
+}
+
+func (r rootASTNode) CallExpression() (CallASTNode, bool) {
+	return r.expr, true
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes `aliasByNode` and `aliasByMetric` to use robust path expr, there was a case when there was a single non-dot path separated path as a function argument that path extraction wasn't properly working (since patterns that didn't include special chars `{[*-.` were being treated as functions by the parse grammar step).

Also adds missing negative indexing support to `substr` which was missing and is supported by Graphite.
**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
