### PR TITLE
[aggregator] Refactor campaignIsEnabled logics to make it easier to read

### DIFF
--- a/src/aggregator/aggregator/election_mgr.go
+++ b/src/aggregator/aggregator/election_mgr.go
@@ -661,9 +661,9 @@ func (mgr *electionManager) campaignIsEnabled() (bool, error) {
 			mgr.metrics.campaignCheckHasActiveShards.Inc(1)
 			switch mgr.ElectionState() {
 			case LeaderState:
-					mgr.metrics.leadersWithActiveShards.Update(float64(1))
+				mgr.metrics.leadersWithActiveShards.Update(float64(1))
 			case FollowerState:
-					mgr.metrics.followersWithActiveShards.Update(float64(1))
+				mgr.metrics.followersWithActiveShards.Update(float64(1))
 			default:
 			}
 			return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor refactoring of `electionManager.campaignIsEnabled` logics to make it easier to read (every time I had to look at it, I got annoyed by those double negations etc.).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE