### PR TITLE
[query] Support rewriting range duration in queries 

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -283,12 +283,6 @@ type QueryConfiguration struct {
 	// RequireSeriesEndpointStartEndTime requires requests to /series endpoint
 	// to specify a start and end time to prevent unbounded queries.
 	RequireSeriesEndpointStartEndTime bool `yaml:"requireSeriesEndpointStartEndTime"`
-	// RewriteRangesLessThanResolutionMultiplier will rewrite the range in a query if it's
-	// determined that the namespaces used to service the request have resolution(s)
-	// that are greater than the range. The range will be updated to the largest resolution
-	// of the namespaces to service the request * the multiplier specified here. If this multiplier
-	// is 0, then this feature is disabled.
-	RewriteRangesLessThanResolutionMultiplier int `yaml:"rewriteRangesLessThanResolutionMultiplier"`
 }
 
 // TimeoutOrDefault returns the configured timeout or default value.
@@ -349,6 +343,12 @@ type ConsolidationConfiguration struct {
 type PrometheusQueryConfiguration struct {
 	// MaxSamplesPerQuery is the limit on fetched samples per query.
 	MaxSamplesPerQuery *int `yaml:"maxSamplesPerQuery"`
+	// RewriteRangesLessThanResolutionMultiplier will rewrite the range in a query if it's
+	// determined that the namespaces used to service the request have resolution(s)
+	// that are greater than the range. The range will be updated to the largest resolution
+	// of the namespaces to service the request * the multiplier specified here. If this multiplier
+	// is 0, then this feature is disabled.
+	RewriteRangesLessThanResolutionMultiplier int `yaml:"rewriteRangesLessThanResolutionMultiplier"`
 }
 
 // MaxSamplesPerQueryOrDefault returns the max samples per query or default.

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -283,6 +283,12 @@ type QueryConfiguration struct {
 	// RequireSeriesEndpointStartEndTime requires requests to /series endpoint
 	// to specify a start and end time to prevent unbounded queries.
 	RequireSeriesEndpointStartEndTime bool `yaml:"requireSeriesEndpointStartEndTime"`
+	// RewriteRangesLessThanResolutionMultiplier will rewrite the range in a query if it's
+	// determined that the namespaces used to service the request have resolution(s)
+	// that are greater than the range. The range will be updated to the largest resolution
+	// of the namespaces to service the request * the multiplier specified here. If this multiplier
+	// is 0, then this feature is disabled.
+	RewriteRangesLessThanResolutionMultiplier int `yaml:"rewriteRangesLessThanResolutionMultiplier"`
 }
 
 // TimeoutOrDefault returns the configured timeout or default value.

--- a/src/query/api/v1/handler/prom/read.go
+++ b/src/query/api/v1/handler/prom/read.go
@@ -109,26 +109,24 @@ func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.opts.instant {
-		updated, params, err := native.RewriteRangeDuration(ctx, request, h.hOpts)
-		if err != nil {
-			h.logger.Error("could not rewrite range duration", zap.Error(err))
-			xhttp.WriteError(w, err)
-			return
-		}
-
-		if updated {
-			originalQuery := request.Params.Query
-			request.Params = params
-			r.Form.Set(native.QueryParam, params.Query)
-
-			h.logger.Debug("rewrote range duration value within query",
-				zap.String("originalQuery", originalQuery),
-				zap.String("updatedQuery", params.Query))
-		}
+	updated, params, err := native.RewriteRangeDuration(ctx, request, h.hOpts)
+	if err != nil {
+		h.logger.Error("could not rewrite range duration", zap.Error(err))
+		xhttp.WriteError(w, err)
+		return
 	}
 
-	params := request.Params
+	if updated {
+		originalQuery := request.Params.Query
+		request.Params = params
+		r.Form.Set(native.QueryParam, params.Query)
+
+		h.logger.Debug("rewrote range duration value within query",
+			zap.String("originalQuery", originalQuery),
+			zap.String("updatedQuery", params.Query))
+	}
+
+	params = request.Params
 	fetchOptions := request.FetchOpts
 
 	// NB (@shreyas): We put the FetchOptions in context so it can be

--- a/src/query/api/v1/handler/prom/read.go
+++ b/src/query/api/v1/handler/prom/read.go
@@ -109,6 +109,25 @@ func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !h.opts.instant {
+		updated, params, err := native.RewriteRangeDuration(ctx, request, h.hOpts)
+		if err != nil {
+			h.logger.Error("could not rewrite range duration", zap.Error(err))
+			xhttp.WriteError(w, err)
+			return
+		}
+
+		if updated {
+			originalQuery := request.Params.Query
+			request.Params = params
+			r.Form.Set(native.QueryParam, params.Query)
+
+			h.logger.Debug("rewrote range duration value within query",
+				zap.String("originalQuery", originalQuery),
+				zap.String("updatedQuery", params.Query))
+		}
+	}
+
 	params := request.Params
 	fetchOptions := request.FetchOpts
 

--- a/src/query/api/v1/handler/prom/read_test.go
+++ b/src/query/api/v1/handler/prom/read_test.go
@@ -35,9 +35,13 @@ import (
 	"github.com/m3db/m3/src/query/api/v1/options"
 	"github.com/m3db/m3/src/query/executor"
 	"github.com/m3db/m3/src/query/storage"
+	"github.com/m3db/m3/src/query/storage/m3"
 	"github.com/m3db/m3/src/query/storage/prometheus"
+	m3test "github.com/m3db/m3/src/query/test/m3"
 	xerrors "github.com/m3db/m3/src/x/errors"
+	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
+	xtest "github.com/m3db/m3/src/x/test"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -63,6 +67,10 @@ type testHandlers struct {
 }
 
 func setupTest(t *testing.T) testHandlers {
+	return setupTestWithStoreAndMultiplier(t, nil, 0)
+}
+
+func setupTestWithStoreAndMultiplier(t *testing.T, store storage.Storage, mult int) testHandlers {
 	fetchOptsBuilderCfg := handleroptions.FetchOptionsBuilderOptions{
 		Timeout: 15 * time.Second,
 	}
@@ -75,7 +83,13 @@ func setupTest(t *testing.T) testHandlers {
 	engine := executor.NewEngine(engineOpts)
 	hOpts := options.EmptyHandlerOptions().
 		SetFetchOptionsBuilder(fetchOptsBuilder).
-		SetEngine(engine)
+		SetEngine(engine).
+		SetStorage(store)
+
+	cfg := hOpts.Config()
+	cfg.Query.RewriteRangesLessThanResolutionMultiplier = mult
+	hOpts = hOpts.SetConfig(cfg)
+
 	queryable := &mockQueryable{}
 	readHandler, err := newReadHandler(hOpts, opts{
 		promQLEngine: testPromQLEngine,
@@ -129,6 +143,40 @@ func TestPromReadHandler(t *testing.T) {
 	var resp response
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
 	require.Equal(t, statusSuccess, resp.Status)
+}
+
+func TestPromReadHandlerWithRewrite(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	aggregatedNamespaces := []m3.AggregatedClusterNamespaceDefinition{
+		{
+			NamespaceID: ident.StringID("1m:30d"),
+			Resolution:  time.Minute,
+			Retention:   30 * 24 * time.Hour,
+		},
+		{
+			NamespaceID: ident.StringID("5m:90d"),
+			Resolution:  5 * time.Minute,
+			Retention:   90 * 24 * time.Hour,
+		},
+	}
+	store, _ := m3test.NewStorageAndSessionWithAggregatedNamespaces(t, ctrl, aggregatedNamespaces)
+	setup := setupTestWithStoreAndMultiplier(t, store, 2)
+
+	req, _ := http.NewRequest("GET", native.PromReadURL, nil)
+	params := defaultParams()
+	params.Set(startParam, time.Now().Add(-60*24*time.Hour).Format(time.RFC3339))
+	params.Set(queryParam, `rate(http_requests_total{group="canary",job="prometheus"}[1m])`)
+	req.URL.RawQuery = params.Encode()
+
+	recorder := httptest.NewRecorder()
+	setup.readHandler.ServeHTTP(recorder, req)
+
+	var resp response
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
+	require.Equal(t, statusSuccess, resp.Status)
+	require.Equal(t, `rate(http_requests_total{group="canary",job="prometheus"}[10m])`, req.FormValue(queryParam))
 }
 
 func TestPromReadHandlerInvalidQuery(t *testing.T) {

--- a/src/query/api/v1/handler/prom/read_test.go
+++ b/src/query/api/v1/handler/prom/read_test.go
@@ -87,7 +87,7 @@ func setupTestWithStoreAndMultiplier(t *testing.T, store storage.Storage, mult i
 		SetStorage(store)
 
 	cfg := hOpts.Config()
-	cfg.Query.RewriteRangesLessThanResolutionMultiplier = mult
+	cfg.Query.Prometheus.RewriteRangesLessThanResolutionMultiplier = mult
 	hOpts = hOpts.SetConfig(cfg)
 
 	queryable := &mockQueryable{}

--- a/src/query/api/v1/handler/prometheus/native/common.go
+++ b/src/query/api/v1/handler/prometheus/native/common.go
@@ -42,10 +42,12 @@ import (
 )
 
 const (
+	// QueryParam is the name of the query form/url parameter
+	QueryParam = "query"
+
 	endParam          = "end"
 	startParam        = "start"
 	timeParam         = "time"
-	queryParam        = "query"
 	debugParam        = "debug"
 	endExclusiveParam = "end-exclusive"
 	blockTypeParam    = "block-type"
@@ -125,7 +127,7 @@ func parseParams(
 	query, err := ParseQuery(r)
 	if err != nil {
 		return params, xerrors.NewInvalidParamsError(
-			fmt.Errorf(formatErrStr, queryParam, err))
+			fmt.Errorf(formatErrStr, QueryParam, err))
 	}
 	params.Query = query
 
@@ -211,7 +213,7 @@ func ParseQuery(r *http.Request) (string, error) {
 	// parameters taking precedence over URL parameters (see r.ParseForm() docs
 	// for more details). We depend on the generic behavior for properly parsing
 	// POST and GET queries.
-	queries, ok := r.Form[queryParam]
+	queries, ok := r.Form[QueryParam]
 	if !ok || len(queries) == 0 || queries[0] == "" {
 		return "", errors.ErrNoQueryFound
 	}

--- a/src/query/api/v1/handler/prometheus/native/common_test.go
+++ b/src/query/api/v1/handler/prometheus/native/common_test.go
@@ -55,7 +55,7 @@ const (
 func defaultParams() url.Values {
 	vals := url.Values{}
 	now := time.Now()
-	vals.Add(queryParam, promQuery)
+	vals.Add(QueryParam, promQuery)
 	vals.Add(startParam, now.Format(time.RFC3339))
 	vals.Add(endParam, string(now.Add(time.Hour).Format(time.RFC3339)))
 	vals.Add(handleroptions.StepParam, (time.Duration(10) * time.Second).String())
@@ -102,7 +102,7 @@ func TestInstantaneousParamParsing(t *testing.T) {
 	req := httptest.NewRequest("GET", PromReadURL, nil)
 	params := url.Values{}
 	now := time.Now()
-	params.Add(queryParam, promQuery)
+	params.Add(QueryParam, promQuery)
 	params.Add(timeParam, now.Format(time.RFC3339))
 	req.URL.RawQuery = params.Encode()
 	fetchOptsBuilder, err := handleroptions.NewFetchOptionsBuilder(
@@ -132,7 +132,7 @@ func TestInvalidStart(t *testing.T) {
 func TestInvalidTarget(t *testing.T) {
 	req := httptest.NewRequest("GET", PromReadURL, nil)
 	vals := defaultParams()
-	vals.Del(queryParam)
+	vals.Del(QueryParam)
 	req.URL.RawQuery = vals.Encode()
 
 	p, err := testParseParams(req)

--- a/src/query/api/v1/handler/prometheus/native/middleware.go
+++ b/src/query/api/v1/handler/prometheus/native/middleware.go
@@ -51,7 +51,7 @@ var WithQueryParams middleware.OverrideOptions = func(opts middleware.Options) m
 
 var middlewareParseParams middleware.ParseQueryParams = func(r *http.Request, requestStart time.Time) (
 	middleware.QueryParams, error) {
-	query := r.FormValue(queryParam)
+	query := r.FormValue(QueryParam)
 	if query == "" {
 		return middleware.QueryParams{}, nil
 	}

--- a/src/query/api/v1/handler/prometheus/native/read.go
+++ b/src/query/api/v1/handler/prometheus/native/read.go
@@ -132,23 +132,21 @@ func (h *promReadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		zap.Duration("fetchTimeout", parsedOptions.FetchOpts.Timeout),
 	)
 
-	if !h.instant {
-		updated, params, err := RewriteRangeDuration(ctx, parsedOptions, h.opts)
-		if err != nil {
-			logger.Error("could not rewrite range duration", zap.Error(err))
-			xhttp.WriteError(w, err)
-			return
-		}
+	updated, params, err := RewriteRangeDuration(ctx, parsedOptions, h.opts)
+	if err != nil {
+		logger.Error("could not rewrite range duration", zap.Error(err))
+		xhttp.WriteError(w, err)
+		return
+	}
 
-		if updated {
-			originalQuery := parsedOptions.Params.Query
-			parsedOptions.Params = params
-			r.Form.Set(QueryParam, params.Query)
+	if updated {
+		originalQuery := parsedOptions.Params.Query
+		parsedOptions.Params = params
+		r.Form.Set(QueryParam, params.Query)
 
-			logger.Debug("rewrote range duration value within query",
-				zap.String("originalQuery", originalQuery),
-				zap.String("updatedQuery", params.Query))
-		}
+		logger.Debug("rewrote range duration value within query",
+			zap.String("originalQuery", originalQuery),
+			zap.String("updatedQuery", params.Query))
 	}
 
 	result, err := read(ctx, parsedOptions, h.opts)

--- a/src/query/api/v1/handler/prometheus/native/read.go
+++ b/src/query/api/v1/handler/prometheus/native/read.go
@@ -132,6 +132,25 @@ func (h *promReadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		zap.Duration("fetchTimeout", parsedOptions.FetchOpts.Timeout),
 	)
 
+	if !h.instant {
+		updated, params, err := RewriteRangeDuration(ctx, parsedOptions, h.opts)
+		if err != nil {
+			logger.Error("could not rewrite range duration", zap.Error(err))
+			xhttp.WriteError(w, err)
+			return
+		}
+
+		if updated {
+			originalQuery := parsedOptions.Params.Query
+			parsedOptions.Params = params
+			r.Form.Set(QueryParam, params.Query)
+
+			logger.Debug("rewrote range duration value within query",
+				zap.String("originalQuery", originalQuery),
+				zap.String("updatedQuery", params.Query))
+		}
+	}
+
 	result, err := read(ctx, parsedOptions, h.opts)
 	if err != nil {
 		sp := xopentracing.SpanFromContextOrNoop(ctx)

--- a/src/query/api/v1/handler/prometheus/native/read_common.go
+++ b/src/query/api/v1/handler/prometheus/native/read_common.go
@@ -297,7 +297,7 @@ func RewriteRangeDuration(
 	parsedOpts ParsedOptions,
 	handlerOpts options.HandlerOptions,
 ) (bool, models.RequestParams, error) {
-	rewriteMultiplier := handlerOpts.Config().Query.RewriteRangesLessThanResolutionMultiplier
+	rewriteMultiplier := handlerOpts.Config().Query.Prometheus.RewriteRangesLessThanResolutionMultiplier
 	if rewriteMultiplier == 0 {
 		return false, parsedOpts.Params, nil
 	}
@@ -344,6 +344,7 @@ func RewriteRangeDuration(
 func rewriteRangeInQuery(expr parser.Node, res time.Duration, multiplier int) bool {
 	updated := false
 	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+		// nolint:gocritic
 		switch n := node.(type) {
 		case *parser.MatrixSelector:
 			if n.Range <= res {

--- a/src/query/api/v1/handler/prometheus/native/read_common.go
+++ b/src/query/api/v1/handler/prometheus/native/read_common.go
@@ -22,9 +22,9 @@ package native
 
 import (
 	"context"
-	"encoding/json"
 	"math"
 	"net/http"
+	"time"
 
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus"
 	"github.com/m3db/m3/src/query/api/v1/options"
@@ -35,11 +35,11 @@ import (
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/ts"
 	xerrors "github.com/m3db/m3/src/x/errors"
-	"github.com/m3db/m3/src/x/headers"
 	xhttp "github.com/m3db/m3/src/x/net/http"
 	xopentracing "github.com/m3db/m3/src/x/opentracing"
 
 	opentracinglog "github.com/opentracing/opentracing-go/log"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/uber-go/tally"
 )
 
@@ -287,13 +287,72 @@ type ReturnedDataLimited struct {
 	Limited bool
 }
 
-// WriteReturnedDataLimitedHeader writes a header to indicate the returned data
-// was limited based on returned series or datapoint limits.
-func WriteReturnedDataLimitedHeader(w http.ResponseWriter, r ReturnedDataLimited) error {
-	s, err := json.Marshal(r)
-	if err != nil {
-		return err
+// RewriteRangeDuration checks the query for a range and validates that the range
+// is acceptable for the namespaces that will be used to return data for the query.
+// If the range is too low, the range will be adjusted to resolution * multiplier where resolution
+// is the highest resolution of the namespaces required to service the request.
+// Returns true if the query params were modified.
+func RewriteRangeDuration(
+	ctx context.Context,
+	parsedOpts ParsedOptions,
+	handlerOpts options.HandlerOptions,
+) (bool, models.RequestParams, error) {
+	rewriteMultiplier := handlerOpts.Config().Query.RewriteRangesLessThanResolutionMultiplier
+	if rewriteMultiplier == 0 {
+		return false, parsedOpts.Params, nil
 	}
-	w.Header().Add(headers.ReturnedDataLimitedHeader, string(s))
-	return nil
+
+	// Query for namespace metadata of namespaces used to service the request
+	var (
+		store  = handlerOpts.Storage()
+		params = parsedOpts.Params
+	)
+	attrs, err := store.QueryStorageMetadataAttributes(
+		ctx, params.Start.ToTime(), params.End.ToTime(), parsedOpts.FetchOpts,
+	)
+	if err != nil {
+		return false, params, err
+	}
+
+	// Find the largest resolution
+	var res time.Duration
+	for _, attr := range attrs {
+		if attr.Resolution > res {
+			res = attr.Resolution
+		}
+	}
+
+	// Largest resolution is 0 which means we're routing to the unaggregated namespace.
+	// Unaggregated namespace can service all requests, so return.
+	if res == 0 {
+		return false, params, nil
+	}
+
+	// Rewrite ranges within the query, if necessary
+	expr, err := parser.ParseExpr(params.Query)
+	if err != nil {
+		return false, params, err
+	}
+	updated := rewriteRangeInQuery(expr, res, rewriteMultiplier)
+	if updated {
+		params.Query = expr.String()
+	}
+
+	return updated, params, nil
+}
+
+func rewriteRangeInQuery(expr parser.Node, res time.Duration, multiplier int) bool {
+	updated := false
+	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+		switch n := node.(type) {
+		case *parser.MatrixSelector:
+			if n.Range <= res {
+				n.Range = res * time.Duration(multiplier)
+				updated = true
+			}
+		}
+		return nil
+	})
+
+	return updated
 }

--- a/src/query/api/v1/handler/prometheus/native/read_common_test.go
+++ b/src/query/api/v1/handler/prometheus/native/read_common_test.go
@@ -159,7 +159,7 @@ func TestRewriteRangeDuration(t *testing.T) {
 				SetStorage(store)
 
 			cfg := hOpts.Config()
-			cfg.Query.RewriteRangesLessThanResolutionMultiplier = tt.mult
+			cfg.Query.Prometheus.RewriteRangesLessThanResolutionMultiplier = tt.mult
 			hOpts = hOpts.SetConfig(cfg)
 
 			store.EXPECT().QueryStorageMetadataAttributes(

--- a/src/query/api/v1/handler/prometheus/native/read_common_test.go
+++ b/src/query/api/v1/handler/prometheus/native/read_common_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package native
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/m3db/m3/src/query/api/v1/options"
+	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/storage"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
+	xtest "github.com/m3db/m3/src/x/test"
+	xtime "github.com/m3db/m3/src/x/time"
+)
+
+func TestRewriteRangeDuration(t *testing.T) {
+	ctrl := xtest.NewController(t)
+
+	queryTests := []struct {
+		name     string
+		params   models.RequestParams
+		attrs    []storagemetadata.Attributes
+		mult     int
+		newQuery string
+	}{
+		{
+			name: "query with range to unagg",
+			params: models.RequestParams{
+				Query: "rate(foo[1m])",
+				Start: xtime.ToUnixNano(time.Now().Add(-10 * time.Minute)),
+				End:   xtime.Now(),
+			},
+			attrs: []storagemetadata.Attributes{
+				{
+					MetricsType: storagemetadata.UnaggregatedMetricsType,
+					Retention:   7 * 24 * time.Hour,
+				},
+			},
+			mult: 2,
+		},
+		{
+			name: "query with no range",
+			params: models.RequestParams{
+				Query: "foo",
+				Start: xtime.Now(),
+				End:   xtime.Now(),
+			},
+			attrs: []storagemetadata.Attributes{
+				{
+					MetricsType: storagemetadata.UnaggregatedMetricsType,
+					Retention:   7 * 24 * time.Hour,
+				},
+			},
+			mult: 2,
+		},
+		{
+			name: "query with range to agg; no rewrite",
+			params: models.RequestParams{
+				Query: "rate(foo[5m])",
+				Start: xtime.ToUnixNano(time.Now().Add(14 * 24 * time.Hour)),
+				End:   xtime.Now(),
+			},
+			attrs: []storagemetadata.Attributes{
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   30 * 24 * time.Hour,
+					Resolution:  1 * time.Minute,
+				},
+			},
+			mult: 2,
+		},
+		{
+			name: "query with rewriteable range; rewrite disabled",
+			params: models.RequestParams{
+				Query: "rate(foo[1m])",
+				Start: xtime.ToUnixNano(time.Now().Add(14 * 24 * time.Hour)),
+				End:   xtime.Now(),
+			},
+			attrs: []storagemetadata.Attributes{
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   30 * 24 * time.Hour,
+					Resolution:  5 * time.Minute,
+				},
+			},
+			mult: 0,
+		},
+		{
+			name: "query with range to agg; rewrite",
+			params: models.RequestParams{
+				Query: "rate(foo[1m])",
+				Start: xtime.ToUnixNano(time.Now().Add(14 * 24 * time.Hour)),
+				End:   xtime.Now(),
+			},
+			attrs: []storagemetadata.Attributes{
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   30 * 24 * time.Hour,
+					Resolution:  5 * time.Minute,
+				},
+			},
+			newQuery: "rate(foo[10m])",
+			mult:     2,
+		},
+		{
+			name: "query with range to multiple aggs; rewrite to largest",
+			params: models.RequestParams{
+				Query: "rate(foo[1m])",
+				Start: xtime.ToUnixNano(time.Now().Add(14 * 24 * time.Hour)),
+				End:   xtime.Now(),
+			},
+			attrs: []storagemetadata.Attributes{
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   30 * 24 * time.Hour,
+					Resolution:  2 * time.Minute,
+				},
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   60 * 24 * time.Hour,
+					Resolution:  4 * time.Minute,
+				},
+			},
+			newQuery: "rate(foo[12m])",
+			mult:     3,
+		},
+	}
+
+	for _, tt := range queryTests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := storage.NewMockStorage(ctrl)
+			opts := ParsedOptions{
+				Params:    tt.params,
+				FetchOpts: storage.NewFetchOptions(),
+			}
+			hOpts := options.EmptyHandlerOptions().
+				SetStorage(store)
+
+			cfg := hOpts.Config()
+			cfg.Query.RewriteRangesLessThanResolutionMultiplier = tt.mult
+			hOpts = hOpts.SetConfig(cfg)
+
+			store.EXPECT().QueryStorageMetadataAttributes(
+				context.Background(), opts.Params.Start.ToTime(), opts.Params.End.ToTime(), opts.FetchOpts,
+			).Return(tt.attrs, nil)
+
+			updated, params, err := RewriteRangeDuration(context.Background(), opts, hOpts)
+			require.NoError(t, err)
+
+			if tt.newQuery == "" {
+				require.False(t, updated)
+			} else {
+				require.True(t, updated)
+				opts.Params.Query = tt.newQuery
+			}
+			require.Equal(t, opts.Params, params)
+		})
+	}
+}

--- a/src/query/api/v1/handler/prometheus/native/read_instantaneous_test.go
+++ b/src/query/api/v1/handler/prometheus/native/read_instantaneous_test.go
@@ -112,7 +112,7 @@ func testPromReadInstantHandler(
 	req := httptest.NewRequest(PromReadInstantHTTPMethods[0], PromReadInstantURL, nil)
 
 	params := url.Values{}
-	params.Set(queryParam, "dummy0{}")
+	params.Set(QueryParam, "dummy0{}")
 
 	req.URL.RawQuery = params.Encode()
 
@@ -181,7 +181,7 @@ func TestPromReadInstantHandlerStorageError(t *testing.T) {
 	req := httptest.NewRequest(PromReadInstantHTTPMethods[0], PromReadInstantURL, nil)
 
 	params := url.Values{}
-	params.Set(queryParam, "dummy0{}")
+	params.Set(QueryParam, "dummy0{}")
 
 	req.URL.RawQuery = params.Encode()
 

--- a/src/query/api/v1/handler/prometheus/native/read_test.go
+++ b/src/query/api/v1/handler/prometheus/native/read_test.go
@@ -169,10 +169,10 @@ func TestPromReadHandlerWithRewrite(t *testing.T) {
 
 	// Set rewrite config
 	cfg := promRead.opts.Config()
-	cfg.Query.RewriteRangesLessThanResolutionMultiplier = 2
+	cfg.Query.Prometheus.RewriteRangesLessThanResolutionMultiplier = 2
 	promRead.opts = promRead.opts.SetConfig(cfg)
 
-	req, _ := http.NewRequest("GET", PromReadURL, nil)
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", PromReadURL, nil)
 	params := defaultParams()
 	params.Set(startParam, time.Now().Add(-60*24*time.Hour).Format(time.RFC3339))
 	params.Set(QueryParam, `rate(http_requests_total{group="canary",job="prometheus"}[1m])`)

--- a/src/query/remote/client.go
+++ b/src/query/remote/client.go
@@ -60,7 +60,9 @@ const (
 var (
 	errAlreadyClosed = goerrors.New("already closed")
 
-	errQueryStorageMetadataAttributesNotImplemented = goerrors.New("remote storage does not implement QueryStorageMetadataAttributes")
+	errQueryStorageMetadataAttributesNotImplemented = goerrors.New(
+		"remote storage does not implement QueryStorageMetadataAttributes",
+	)
 
 	// NB(r): These options tries to ensure we don't let connections go stale
 	// and cause failed RPCs as a result.

--- a/src/query/remote/client.go
+++ b/src/query/remote/client.go
@@ -28,6 +28,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/errors"
@@ -37,15 +42,11 @@ import (
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/storage/m3"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 	"github.com/m3db/m3/src/query/ts/m3db"
 	"github.com/m3db/m3/src/query/util/logging"
 	xgrpc "github.com/m3db/m3/src/x/grpc"
 	"github.com/m3db/m3/src/x/instrument"
-
-	"github.com/uber-go/tally"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/keepalive"
 )
 
 const (
@@ -58,6 +59,8 @@ const (
 
 var (
 	errAlreadyClosed = goerrors.New("already closed")
+
+	errQueryStorageMetadataAttributesNotImplemented = goerrors.New("remote storage does not implement QueryStorageMetadataAttributes")
 
 	// NB(r): These options tries to ensure we don't let connections go stale
 	// and cause failed RPCs as a result.
@@ -173,6 +176,14 @@ func NewGRPCClient(
 	}
 	go c.healthCheckUntilClosed()
 	return c, nil
+}
+
+func (s *grpcClient) QueryStorageMetadataAttributes(
+	ctx context.Context,
+	queryStart, queryEnd time.Time,
+	opts *storage.FetchOptions,
+) ([]storagemetadata.Attributes, error) {
+	return nil, errQueryStorageMetadataAttributesNotImplemented
 }
 
 func (c *grpcClient) healthCheckUntilClosed() {

--- a/src/query/storage/m3/m3_mock.go
+++ b/src/query/storage/m3/m3_mock.go
@@ -27,11 +27,13 @@ package m3
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 	"github.com/m3db/m3/src/x/ident"
 
 	"github.com/golang/mock/gomock"
@@ -176,6 +178,21 @@ func (m *MockStorage) Name() string {
 func (mr *MockStorageMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockStorage)(nil).Name))
+}
+
+// QueryStorageMetadataAttributes mocks base method.
+func (m *MockStorage) QueryStorageMetadataAttributes(arg0 context.Context, arg1, arg2 time.Time, arg3 *storage.FetchOptions) ([]storagemetadata.Attributes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryStorageMetadataAttributes", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]storagemetadata.Attributes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryStorageMetadataAttributes indicates an expected call of QueryStorageMetadataAttributes.
+func (mr *MockStorageMockRecorder) QueryStorageMetadataAttributes(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryStorageMetadataAttributes", reflect.TypeOf((*MockStorage)(nil).QueryStorageMetadataAttributes), arg0, arg1, arg2, arg3)
 }
 
 // SearchCompressed mocks base method.

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -86,7 +86,7 @@ func NewStorage(
 }
 
 func (s *m3storage) QueryStorageMetadataAttributes(
-	ctx context.Context,
+	_ context.Context,
 	queryStart, queryEnd time.Time,
 	opts *storage.FetchOptions,
 ) ([]storagemetadata.Attributes, error) {
@@ -149,7 +149,6 @@ func (s *m3storage) FetchProm(
 		s.opts.ReadWorkerPool(),
 		s.opts.TagOptions(),
 	)
-
 	if err != nil {
 		return storage.PromResult{}, err
 	}
@@ -183,7 +182,6 @@ func FetchResultToBlockResult(
 		bounds,
 		opts,
 	)
-
 	if err != nil {
 		return block.Result{
 			Metadata: block.NewResultMetadata(),

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -85,6 +85,29 @@ func NewStorage(
 	}, nil
 }
 
+func (s *m3storage) QueryStorageMetadataAttributes(
+	ctx context.Context,
+	queryStart, queryEnd time.Time,
+	opts *storage.FetchOptions,
+) ([]storagemetadata.Attributes, error) {
+	now := xtime.ToUnixNano(s.nowFn())
+	_, namespaces, err := resolveClusterNamespacesForQuery(now,
+		xtime.ToUnixNano(queryStart),
+		xtime.ToUnixNano(queryEnd),
+		s.clusters,
+		opts.FanoutOptions,
+		opts.RestrictQueryOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]storagemetadata.Attributes, 0, len(namespaces))
+	for _, ns := range namespaces {
+		results = append(results, ns.Options().Attributes())
+	}
+	return results, nil
+}
+
 func (s *m3storage) ErrorBehavior() storage.ErrorBehavior {
 	return storage.BehaviorFail
 }

--- a/src/query/storage/mock/storage.go
+++ b/src/query/storage/mock/storage.go
@@ -26,11 +26,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
-
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 )
 
 // Storage implements storage.Storage and provides methods to help

--- a/src/query/storage/noop_storage.go
+++ b/src/query/storage/noop_storage.go
@@ -23,9 +23,11 @@ package storage
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 )
 
 var errNoopClient = errors.New("operation not valid for noop client")
@@ -37,6 +39,14 @@ func NewNoopStorage() Storage {
 }
 
 type noopStorage struct{}
+
+func (noopStorage) QueryStorageMetadataAttributes(
+	ctx context.Context,
+	queryStart, queryEnd time.Time,
+	opts *FetchOptions,
+) ([]storagemetadata.Attributes, error) {
+	return nil, errNoopClient
+}
 
 func (noopStorage) Fetch(ctx context.Context, query *FetchQuery, options *FetchOptions) (*FetchResult, error) {
 	return nil, errNoopClient

--- a/src/query/storage/remote/storage.go
+++ b/src/query/storage/remote/storage.go
@@ -23,12 +23,14 @@ package remote
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/errors"
 	"github.com/m3db/m3/src/query/remote"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 )
 
 // Options contains options for remote clients.
@@ -47,6 +49,14 @@ type remoteStorage struct {
 // NewStorage creates a new remote Storage instance.
 func NewStorage(c remote.Client, opts Options) storage.Storage {
 	return &remoteStorage{client: c, opts: opts}
+}
+
+func (s *remoteStorage) QueryStorageMetadataAttributes(
+	ctx context.Context,
+	queryStart, queryEnd time.Time,
+	opts *storage.FetchOptions,
+) ([]storagemetadata.Attributes, error) {
+	return s.client.QueryStorageMetadataAttributes(ctx, queryStart, queryEnd, opts)
 }
 
 func (s *remoteStorage) FetchProm(

--- a/src/query/storage/storage_mock.go
+++ b/src/query/storage/storage_mock.go
@@ -27,9 +27,11 @@ package storage
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 
 	"github.com/golang/mock/gomock"
 )
@@ -142,6 +144,21 @@ func (m *MockStorage) Name() string {
 func (mr *MockStorageMockRecorder) Name() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockStorage)(nil).Name))
+}
+
+// QueryStorageMetadataAttributes mocks base method.
+func (m *MockStorage) QueryStorageMetadataAttributes(arg0 context.Context, arg1, arg2 time.Time, arg3 *FetchOptions) ([]storagemetadata.Attributes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryStorageMetadataAttributes", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]storagemetadata.Attributes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryStorageMetadataAttributes indicates an expected call of QueryStorageMetadataAttributes.
+func (mr *MockStorageMockRecorder) QueryStorageMetadataAttributes(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryStorageMetadataAttributes", reflect.TypeOf((*MockStorage)(nil).QueryStorageMetadataAttributes), arg0, arg1, arg2, arg3)
 }
 
 // SearchSeries mocks base method.

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -239,6 +239,14 @@ type Querier interface {
 		query *CompleteTagsQuery,
 		options *FetchOptions,
 	) (*consolidators.CompleteTagsResult, error)
+
+	// QueryStorageMetadataAttributes returns the storage metadata
+	// attributes for a query.
+	QueryStorageMetadataAttributes(
+		ctx context.Context,
+		queryStart, queryEnd time.Time,
+		opts *FetchOptions,
+	) ([]storagemetadata.Attributes, error)
 }
 
 // WriteQuery represents the input timeseries that is written to the database.

--- a/src/query/test/storage.go
+++ b/src/query/test/storage.go
@@ -22,11 +22,13 @@ package test
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 )
 
 // slowStorage slows down a request by delay
@@ -85,6 +87,14 @@ func (s *slowStorage) Write(
 ) error {
 	time.Sleep(s.delay)
 	return s.storage.Write(ctx, query)
+}
+
+func (s *slowStorage) QueryStorageMetadataAttributes(
+	ctx context.Context,
+	queryStart, queryEnd time.Time,
+	opts *storage.FetchOptions,
+) ([]storagemetadata.Attributes, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (s *slowStorage) Type() storage.Type {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR gives users the ability to configure whether they'd like to rewrite range durations in queries that would be routed to namespaces that have resolutions greater than the range. When disabled, behavior stays the same as it currently is today. Namely, if the range duration is less than the resolution on the namespace, the query will return no data. When enabled and this condition is detected, the range within the query will automatically be updated to a multiple of the largest namespace resolution for the query. That multiple is configurable. It defaults to 0, which turns the rewriting behavior off.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
