### PR TITLE
Add functions to tag instrument options

### DIFF
--- a/src/x/instrument/option.go
+++ b/src/x/instrument/option.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package instrument
 
 import (

--- a/src/x/instrument/option.go
+++ b/src/x/instrument/option.go
@@ -13,7 +13,7 @@ func WithOptions(iOpts Options, opts ...Option) Options {
 	return *ptr
 }
 
-// Option configures the instrument options.
+// Option applys optional settings to the instrument options.
 type Option func(*Options)
 
 // WithScopeAndLoggerTagged tags both the metric scope and logger in the

--- a/src/x/instrument/option.go
+++ b/src/x/instrument/option.go
@@ -1,0 +1,44 @@
+package instrument
+
+import (
+	"go.uber.org/zap"
+)
+
+// WithOptions creates a new instrument options with options.
+func WithOptions(iOpts Options, opts ...Option) Options {
+	ptr := &iOpts
+	for _, opt := range opts {
+		opt(ptr)
+	}
+	return *ptr
+}
+
+// Option configures the instrument options.
+type Option func(*Options)
+
+// WithScopeAndLoggerTagged tags both the metric scope and logger in the
+// instrument options.
+func WithScopeAndLoggerTagged(k, v string) Option {
+	return func(ptr *Options) {
+		WithScopeTagged(k, v)(ptr)
+		WithLoggerTagged(k, v)(ptr)
+	}
+}
+
+// WithScopeTagged tags the metric scope in the instrument options.
+func WithScopeTagged(k, v string) Option {
+	return func(ptr *Options) {
+		iOpts := *ptr
+		iOpts = iOpts.SetMetricsScope(iOpts.MetricsScope().Tagged(map[string]string{k: v}))
+		*ptr = iOpts
+	}
+}
+
+// WithLoggerTagged tags the logger in the instrument options.
+func WithLoggerTagged(k, v string) Option {
+	return func(ptr *Options) {
+		iOpts := *ptr
+		iOpts = iOpts.SetLogger(iOpts.Logger().With(zap.String(k, v)))
+		*ptr = iOpts
+	}
+}

--- a/src/x/instrument/option_test.go
+++ b/src/x/instrument/option_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package instrument
 
 import (

--- a/src/x/instrument/option_test.go
+++ b/src/x/instrument/option_test.go
@@ -1,0 +1,35 @@
+package instrument
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestScopeAndLoggerTagged(t *testing.T) {
+	core, recorded := observer.New(zapcore.InfoLevel)
+	iOpts := NewOptions().
+		SetMetricsScope(tally.NewTestScope("", map[string]string{})).
+		SetLogger(zap.New(core))
+	iOpts = WithOptions(iOpts, WithScopeAndLoggerTagged("k", "v"))
+
+	// Make sure the metric has tag k:v.
+	iOpts.MetricsScope().Counter("a").Inc(1)
+
+	ss := iOpts.MetricsScope().(tally.TestScope).Snapshot()
+	counters, ok := ss.Counters()["a+k=v"]
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"k": "v"}, counters.Tags())
+
+	// Make sure the log has tag k:v.
+	iOpts.Logger().Info("b")
+
+	require.Len(t, recorded.All(), 1)
+	require.Len(t, recorded.FilterField(
+		zap.String("k", "v"),
+	).All(), 1)
+}

--- a/src/x/instrument/options.go
+++ b/src/x/instrument/options.go
@@ -63,6 +63,14 @@ func NewOptions() Options {
 	}
 }
 
+// NewTaggedOptions returns a new Options with the metric and logging client
+// tagged with the provided key value.
+func NewTaggedOptions(iOpts Options, k, v string) Options {
+	scope := iOpts.MetricsScope().Tagged(map[string]string{k: v})
+	logger := iOpts.Logger().With(zap.String(k, v))
+	return iOpts.SetMetricsScope(scope).SetLogger(logger)
+}
+
 func (o *options) SetLogger(value *zap.Logger) Options {
 	opts := *o
 	opts.zap = value

--- a/src/x/instrument/options.go
+++ b/src/x/instrument/options.go
@@ -63,14 +63,6 @@ func NewOptions() Options {
 	}
 }
 
-// NewTaggedOptions returns a new Options with the metric and logging client
-// tagged with the provided key value.
-func NewTaggedOptions(iOpts Options, k, v string) Options {
-	scope := iOpts.MetricsScope().Tagged(map[string]string{k: v})
-	logger := iOpts.Logger().With(zap.String(k, v))
-	return iOpts.SetMetricsScope(scope).SetLogger(logger)
-}
-
 func (o *options) SetLogger(value *zap.Logger) Options {
 	opts := *o
 	opts.zap = value


### PR DESCRIPTION
When passing iOpts to a new library, I often find my self tagging both the scope and logger with something like "component":"server", this diff makes a utility function for that.
