### PR TITLE
[query] Fix Graphite groupByNodes panic on missing agg function when using median

### DIFF
--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -818,7 +818,7 @@ func TestGroupByNodes(t *testing.T) {
 			{"pod2.500", 10 * 12},
 		}},
 		{"median", []int{2, 4}, []result{ // test with different function
-			{"pod1.400",  ((20 + 30) / 2) * 12},
+			{"pod1.400", ((20 + 30) / 2) * 12},
 			{"pod1.500", 4 * 12},
 			{"pod2.400", 40 * 12},
 			{"pod2.500", ((8 + 10) / 2) * 12},

--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -817,6 +817,12 @@ func TestGroupByNodes(t *testing.T) {
 			{"pod2.400", 40 * 12},
 			{"pod2.500", 10 * 12},
 		}},
+		{"median", []int{2, 4}, []result{ // test with different function
+			{"pod1.400",  ((20 + 30) / 2) * 12},
+			{"pod1.500", 4 * 12},
+			{"pod2.400", 40 * 12},
+			{"pod2.500", ((8 + 10) / 2) * 12},
+		}},
 		{"max", []int{2, 4, 100}, []result{ // test with a node number that exceeds num parts
 			{"pod1.400.", 30 * 12},
 			{"pod1.500.", 6 * 12},

--- a/src/query/graphite/native/summarize.go
+++ b/src/query/graphite/native/summarize.go
@@ -206,10 +206,6 @@ func lastSpecificationFunc(series ts.SeriesList) string {
 	return wrapPathExpr("lastSeries", series)
 }
 
-func medianSpecificationFunc(series ts.SeriesList) string {
-	return wrapPathExpr("medianSeries", series)
-}
-
 type funcInfo struct {
 	fname             string
 	consolidationFunc ts.ConsolidationFunc
@@ -242,11 +238,6 @@ var (
 		consolidationFunc: ts.Avg,
 		specificationFunc: averageSpecificationFunc,
 	}
-	medianFuncInfo = funcInfo{
-		fname: "median",
-		// median does not have a consolidationFunc
-		specificationFunc: medianSpecificationFunc,
-	}
 
 	summarizeFuncs = map[string]funcInfo{
 		"sum":           sumFuncInfo,
@@ -257,7 +248,6 @@ var (
 		"average":       avgFuncInfo,
 		"sumSeries":     sumFuncInfo,
 		"maxSeries":     maxFuncInfo,
-		"median":        medianFuncInfo,
 		"minSeries":     minFuncInfo,
 		"averageSeries": avgFuncInfo,
 		"":              sumFuncInfo,

--- a/src/query/graphite/native/summarize_test.go
+++ b/src/query/graphite/native/summarize_test.go
@@ -150,20 +150,6 @@ func TestSmartSummarize(t *testing.T) {
 			end,
 			[]float64{15, 51},
 		},
-		{"smartSummarize(foo, \"40s\", \"median\")",
-			"40s",
-			"median",
-			start,
-			end,
-			[]float64{1.5, 5.5, 9.5},
-		},
-		{"smartSummarize(foo, \"30s\", \"median\")",
-			"30s",
-			"median",
-			start,
-			end,
-			[]float64{1, 4, 7, 10},
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes NPE bug when query groupByNodes using median aggregation function. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
