### PR TITLE
[dbnode] Fix tag decoder reuse which leads to ref count error for repair code path

### DIFF
--- a/src/dbnode/client/session_fetch_metadata_test.go
+++ b/src/dbnode/client/session_fetch_metadata_test.go
@@ -97,7 +97,7 @@ func TestPeerBlockMetadataIter(t *testing.T) {
 
 	var actual []testHostBlock
 	it := newMetadataIter(inputCh, errCh,
-		testTagDecodingPool.Get(), testIDPool)
+		testTagDecodingPool, testIDPool)
 	for it.Next() {
 		host, curr := it.Current()
 		result := block.NewMetadata(curr.ID, curr.Tags, curr.Start, curr.Size,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This fixes concurrent calls to `addBlockFromPeer` on `streamBlocksResult` resulting in reuse of a tag decoder during active an active repair call which leads to a ref count error. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
