### PR TITLE
[coordinator] Ensure rewrite middleware doesn't set the body on a GET

### DIFF
--- a/src/query/api/v1/middleware/rewrite.go
+++ b/src/query/api/v1/middleware/rewrite.go
@@ -101,6 +101,10 @@ func rewriteRangeDuration(
 			r.Form.Del(endParam)
 		}
 
+		if r.Method == "GET" {
+			return
+		}
+
 		body := r.Form.Encode()
 		r.Body = ioutil.NopCloser(bytes.NewBufferString(body))
 	}()

--- a/src/query/api/v1/middleware/rewrite_test.go
+++ b/src/query/api/v1/middleware/rewrite_test.go
@@ -215,6 +215,10 @@ func TestPrometheusRangeRewrite(t *testing.T) {
 					// query, potentially.
 					require.Equal(t, params.Encode(), string(body))
 				}
+
+				if r.Method == "GET" {
+					require.Equal(t, http.NoBody, r.Body)
+				}
 			}))
 			path := "/query_range"
 			if tt.instant {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Setting the body on a GET request can sometimes cause
"http: invalid Read on closed Body" errors within the Golang
HTTP client. As such, ensure that if processing a GET request
the body is not set.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
