### PR TITLE
[tools] Reduce read_data_files mem overhead

### DIFF
--- a/src/cmd/tools/read_commitlog/main/main.go
+++ b/src/cmd/tools/read_commitlog/main/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pborman/getopt"
 	"go.uber.org/zap"
 
-	"github.com/m3db/m3/src/cmd/tools"
 	"github.com/m3db/m3/src/dbnode/persist/fs/commitlog"
 )
 
@@ -54,9 +53,6 @@ func main() {
 		getopt.Usage()
 		os.Exit(1)
 	}
-
-	bytesPool := tools.NewCheckedBytesPool()
-	bytesPool.Init()
 
 	opts := commitlog.NewReaderOptions(commitlog.NewOptions(), false)
 	reader := commitlog.NewReader(opts)

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -113,9 +113,6 @@ func main() {
 
 	// Not using bytes pool with streaming reads/writes to avoid the fixed memory overhead.
 	var bytesPool pool.CheckedBytesPool
-	//bytesPool := tools.NewCheckedBytesPool()
-	//bytesPool.Init()
-
 	encodingOpts := encoding.NewOptions().SetBytesPool(bytesPool)
 
 	fsOpts := fs.NewOptions().SetFilePathPrefix(*optPathPrefix)

--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -29,13 +29,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/m3db/m3/src/cmd/tools"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/encoding/m3tsz"
 	"github.com/m3db/m3/src/dbnode/persist"
 	"github.com/m3db/m3/src/dbnode/persist/fs"
 	"github.com/m3db/m3/src/dbnode/x/xio"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/pool"
 	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/pborman/getopt"
@@ -111,8 +111,10 @@ func main() {
 		log.Fatalf("unknown benchmark type: %s", *benchmark)
 	}
 
-	bytesPool := tools.NewCheckedBytesPool()
-	bytesPool.Init()
+	// Not using bytes pool with streaming reads/writes to avoid the fixed memory overhead.
+	var bytesPool pool.CheckedBytesPool
+	//bytesPool := tools.NewCheckedBytesPool()
+	//bytesPool.Init()
 
 	encodingOpts := encoding.NewOptions().SetBytesPool(bytesPool)
 

--- a/src/cmd/tools/util.go
+++ b/src/cmd/tools/util.go
@@ -32,35 +32,35 @@ func NewCheckedBytesPool() pool.CheckedBytesPool {
 		SetRefillHighWatermark(0.07)
 
 	bytesPool := pool.NewCheckedBytesPool([]pool.Bucket{
-		pool.Bucket{
+		{
 			Capacity: 16,
 			Count:    262144,
 		},
-		pool.Bucket{
+		{
 			Capacity: 32,
 			Count:    262144,
 		},
-		pool.Bucket{
+		{
 			Capacity: 64,
 			Count:    262144,
 		},
-		pool.Bucket{
+		{
 			Capacity: 128,
 			Count:    262144,
 		},
-		pool.Bucket{
+		{
 			Capacity: 256,
 			Count:    262144,
 		},
-		pool.Bucket{
+		{
 			Capacity: 1440,
 			Count:    262144,
 		},
-		pool.Bucket{
+		{
 			Capacity: 4096,
 			Count:    262144,
 		},
-		pool.Bucket{
+		{
 			Capacity: 8192,
 			Count:    65536,
 		},

--- a/src/cmd/tools/verify_data_files/main/main.go
+++ b/src/cmd/tools/verify_data_files/main/main.go
@@ -44,9 +44,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const snapshotType = "snapshot"
-const flushType = "flush"
-
 func main() {
 	var (
 		optPathPrefix          = getopt.StringLong("path-prefix", 'p', "/var/lib/m3db", "Path prefix [e.g. /var/lib/m3db]")

--- a/src/cmd/tools/verify_index_files/main/main.go
+++ b/src/cmd/tools/verify_index_files/main/main.go
@@ -246,7 +246,7 @@ func parseShards(shards string) []uint32 {
 		return []uint32{}
 	}
 
-	// Handle commda-delimited shard list 1,3,5, etc
+	// Handle comma-delimited shard list 1,3,5, etc
 	for _, shard := range strings.Split(shards, ",") {
 		shard = strings.TrimSpace(shard)
 		if shard == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduces memory overhead of `read_data_files` command line utility by ~5 GB. The overhead was being caused by allocating byte pool which is no longer needed after the switch to streaming reads in this utility. 
Also did some cleanup in other command line utils.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE