### PR TITLE
Fix for index block appearing as a flushed index block, now explicit check has on disk segment

### DIFF
--- a/src/dbnode/integration/index_active_block_rotate_test.go
+++ b/src/dbnode/integration/index_active_block_rotate_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/dbnode/retention"
@@ -41,7 +42,6 @@ import (
 	xclock "github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/ident"
 	xtime "github.com/m3db/m3/src/x/time"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestIndexActiveBlockRotate(t *testing.T) {
@@ -160,7 +160,7 @@ func TestIndexActiveBlockRotate(t *testing.T) {
 
 	prevLog := log
 	for i := 0; i < 4; i++ {
-		log := prevLog.With(zap.Int("checkIteration", i))
+		log = prevLog.With(zap.Int("checkIteration", i))
 
 		// Progress to next time just before a flush and freeze (using setTime).
 		prevTime := nowFn()
@@ -251,7 +251,7 @@ func TestIndexActiveBlockRotate(t *testing.T) {
 		require.True(t, warmFlushed,
 			fmt.Sprintf("warm flush stats: current=%d, previous=%d", counter, prevWarmFlushes))
 		log.Info("verified data has been warm flushed", zap.Duration("took", time.Since(start)))
-		prevWarmFlushes = int(counter)
+		prevWarmFlushes = counter
 
 		start = time.Now()
 		log.Info("waiting for GC of series")
@@ -267,7 +267,7 @@ func TestIndexActiveBlockRotate(t *testing.T) {
 				numGCSeries, expectedNumGCSeries))
 		require.True(t, numGCSeries >= expectedNumGCSeries)
 		log.Info("verified series have been GC'd", zap.Duration("took", time.Since(start)))
-		prevNumGCSeries = int(numGCSeries)
+		prevNumGCSeries = numGCSeries
 
 		require.Equal(t, 0, logs.Len(), "errors found in logs during flush/indexing")
 

--- a/src/dbnode/integration/index_active_block_rotate_test.go
+++ b/src/dbnode/integration/index_active_block_rotate_test.go
@@ -174,8 +174,7 @@ func TestIndexActiveBlockRotate(t *testing.T) {
 
 		start := time.Now()
 		log.Info("writing test data")
-		// t0 := newTime.Add(-indexBlockSize / 2)
-		// t1 := newTime
+
 		t0 := xtime.ToUnixNano(newTime.Add(-1 * (bufferPast / 2)))
 		t1 := xtime.ToUnixNano(newTime)
 		writesPeriodIter := GenerateTestIndexWrite(i, numWrites, numTags, t0, t1)
@@ -283,12 +282,6 @@ func TestIndexActiveBlockRotate(t *testing.T) {
 	}
 
 	log.Info("checks passed")
-}
-
-func logCounterValues(s tally.TestScope, log *zap.Logger) {
-	for k, v := range s.Snapshot().Counters() {
-		log.Info("counter", zap.String("key", k), zap.Int64("value", v.Value()))
-	}
 }
 
 func counterValue(t *testing.T, r tally.TestScope, key string) int {

--- a/src/dbnode/integration/index_active_block_rotate_test.go
+++ b/src/dbnode/integration/index_active_block_rotate_test.go
@@ -24,7 +24,6 @@ package integration
 
 import (
 	"fmt"
-	"go.uber.org/atomic"
 	"sync"
 	"testing"
 	"time"
@@ -32,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 

--- a/src/dbnode/integration/index_active_block_rotate_test.go
+++ b/src/dbnode/integration/index_active_block_rotate_test.go
@@ -1,0 +1,298 @@
+// +build integration
+//
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"fmt"
+	"go.uber.org/atomic"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/retention"
+	"github.com/m3db/m3/src/dbnode/storage/index/compaction"
+	xclock "github.com/m3db/m3/src/x/clock"
+	"github.com/m3db/m3/src/x/ident"
+	xtime "github.com/m3db/m3/src/x/time"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestIndexActiveBlockRotate(t *testing.T) {
+	var (
+		testNsID       = ident.StringID("testns")
+		numWrites      = 50
+		numTags        = 10
+		blockSize      = 2 * time.Hour
+		indexBlockSize = blockSize
+		bufferPast     = 10 * time.Minute
+		rOpts          = retention.NewOptions().
+				SetRetentionPeriod(blockSize).
+				SetBlockSize(blockSize).
+				SetBufferPast(bufferPast)
+
+		idxOpts = namespace.NewIndexOptions().SetEnabled(true).SetBlockSize(indexBlockSize)
+		nsOpts  = namespace.NewOptions().
+			SetRetentionOptions(rOpts).
+			SetIndexOptions(idxOpts).
+			SetColdWritesEnabled(true)
+
+		defaultTimeout = time.Minute
+		// verifyTimeout  = time.Minute
+	)
+	ns, err := namespace.NewMetadata(testNsID, nsOpts)
+	require.NoError(t, err)
+
+	// Set time to next warm flushable block transition
+	// (i.e. align by block + bufferPast - time.Second)
+	currTime := time.Now().UTC()
+	progressTime := false
+	progressTimeDelta := time.Duration(0)
+	lockTime := sync.RWMutex{}
+	setTime := func(t time.Time) {
+		lockTime.Lock()
+		defer lockTime.Unlock()
+		progressTime = false
+		currTime = t.UTC()
+	}
+	setProgressTime := func() {
+		lockTime.Lock()
+		defer lockTime.Unlock()
+		progressTime = true
+		actualNow := time.Now().UTC()
+		progressTimeDelta = currTime.Sub(actualNow)
+	}
+	nowFn := func() time.Time {
+		lockTime.RLock()
+		at := currTime
+		progress := progressTime
+		progressDelta := progressTimeDelta
+		lockTime.RUnlock()
+		if progress {
+			return time.Now().UTC().Add(progressDelta)
+		}
+		return at
+	}
+
+	testOpts := NewTestOptions(t).
+		SetNamespaces([]namespace.Metadata{ns}).
+		SetWriteNewSeriesAsync(true).
+		SetNowFn(nowFn)
+
+	testSetup, err := NewTestSetup(t, testOpts, nil)
+	require.NoError(t, err)
+	defer testSetup.Close()
+
+	// Set foreground compaction planner options to force index compaction.
+	minCompactSize := 10
+	foregroundCompactionOpts := compaction.DefaultOptions
+	foregroundCompactionOpts.Levels = []compaction.Level{
+		{
+			MinSizeInclusive: 0,
+			MaxSizeExclusive: int64(minCompactSize),
+		},
+	}
+	indexOpts := testSetup.StorageOpts().IndexOptions().
+		SetForegroundCompactionPlannerOptions(foregroundCompactionOpts)
+	testSetup.SetStorageOpts(testSetup.StorageOpts().SetIndexOptions(indexOpts))
+
+	// Configure log capture
+	log := testSetup.StorageOpts().InstrumentOptions().Logger()
+	captureCore, logs := observer.New(zapcore.ErrorLevel)
+	zapOpt := zap.WrapCore(func(existingCore zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(existingCore, captureCore)
+	})
+	log = log.WithOptions(zapOpt)
+
+	// Wire up logger.
+	instrumentOpts := testSetup.StorageOpts().InstrumentOptions().
+		SetLogger(log)
+	testSetup.SetStorageOpts(testSetup.StorageOpts().SetInstrumentOptions(instrumentOpts))
+	scope := testSetup.Scope()
+
+	// Start the server.
+	require.NoError(t, testSetup.StartServer())
+
+	// Stop the server.
+	defer func() {
+		require.NoError(t, testSetup.StopServer())
+		log.Debug("server is now down")
+	}()
+
+	// Write test data.
+	session, err := testSetup.M3DBClient().DefaultSession()
+	require.NoError(t, err)
+
+	var (
+		metricGCSeries   = "index.block.active-block.gc-series+namespace=" + testNsID.String()
+		metricFlushIndex = "database.flushIndex.success+namespace=" + testNsID.String()
+	)
+	prevWarmFlushes := counterValue(t, scope, metricFlushIndex)
+	prevNumGCSeries := 0
+	numGCSeries := counterValue(t, scope, metricGCSeries)
+	require.Equal(t, 0, numGCSeries)
+
+	prevLog := log
+	for i := 0; i < 4; i++ {
+		log := prevLog.With(zap.Int("checkIteration", i))
+
+		// Progress to next time just before a flush and freeze (using setTime).
+		prevTime := nowFn()
+		newTime := prevTime.
+			Truncate(indexBlockSize).
+			Add(2 * indexBlockSize)
+		setTime(newTime)
+		log.Info("progressing time to before next block edge",
+			zap.Stringer("prevTime", prevTime),
+			zap.Stringer("newTime", newTime))
+
+		start := time.Now()
+		log.Info("writing test data")
+		// t0 := newTime.Add(-indexBlockSize / 2)
+		// t1 := newTime
+		t0 := xtime.ToUnixNano(newTime.Add(-1 * (bufferPast / 2)))
+		t1 := xtime.ToUnixNano(newTime)
+		writesPeriodIter := GenerateTestIndexWrite(i, numWrites, numTags, t0, t1)
+		writesPeriodIter.Write(t, testNsID, session)
+		log.Info("test data written", zap.Duration("took", time.Since(start)))
+
+		log.Info("waiting till data is indexed")
+		indexed := xclock.WaitUntil(func() bool {
+			indexedPeriod := writesPeriodIter.NumIndexed(t, testNsID, session)
+			return indexedPeriod == len(writesPeriodIter)
+		}, 15*time.Second)
+		require.True(t, indexed,
+			fmt.Sprintf("unexpected data indexed: actual=%d, expected=%d",
+				writesPeriodIter.NumIndexedWithOptions(t, testNsID, session, NumIndexedOptions{Logger: log}),
+				len(writesPeriodIter)))
+		log.Info("verified data is indexed", zap.Duration("took", time.Since(start)))
+
+		newTime = prevTime.
+			Truncate(indexBlockSize).
+			Add(2 * indexBlockSize).
+			Add(bufferPast).
+			Add(-100 * time.Millisecond)
+		setTime(newTime)
+		log.Info("progressing time to before next flush",
+			zap.Stringer("prevTime", prevTime),
+			zap.Stringer("newTime", newTime))
+
+		log.Info("waiting till warm flush occurs")
+
+		// Resume time progressing by wall clock.
+		setProgressTime()
+
+		// Start checks to ensure metrics are visible the whole time.
+		checkFailed := atomic.NewUint64(0)
+		checkIndexable := func() {
+			numGCSeriesBefore := counterValue(t, scope, metricGCSeries)
+			indexedPeriod := writesPeriodIter.NumIndexed(t, testNsID, session)
+			numGCSeriesAfter := counterValue(t, scope, metricGCSeries)
+			if len(writesPeriodIter) != indexedPeriod {
+				assert.Equal(t, len(writesPeriodIter), indexedPeriod,
+					fmt.Sprintf("some metrics not indexed/visible: actual=%d, expected=%d, numGCBefore=%d, numGCAfter=%d",
+						writesPeriodIter.NumIndexedWithOptions(t, testNsID, session, NumIndexedOptions{Logger: log}),
+						len(writesPeriodIter),
+						numGCSeriesBefore,
+						numGCSeriesAfter))
+				checkFailed.Inc()
+			}
+		}
+
+		ticker := time.NewTicker(10 * time.Millisecond)
+		stopTickCh := make(chan struct{})
+		closedTickCh := make(chan struct{})
+		go func() {
+			defer func() {
+				ticker.Stop()
+				close(closedTickCh)
+			}()
+
+			for {
+				select {
+				case <-ticker.C:
+					checkIndexable()
+				case <-stopTickCh:
+					return
+				}
+			}
+		}()
+
+		start = time.Now()
+		warmFlushed := xclock.WaitUntil(func() bool {
+			return counterValue(t, scope, metricFlushIndex)-prevWarmFlushes > 0
+		}, defaultTimeout)
+		counter := counterValue(t, scope, metricFlushIndex)
+		require.True(t, warmFlushed,
+			fmt.Sprintf("warm flush stats: current=%d, previous=%d", counter, prevWarmFlushes))
+		log.Info("verified data has been warm flushed", zap.Duration("took", time.Since(start)))
+		prevWarmFlushes = int(counter)
+
+		start = time.Now()
+		log.Info("waiting for GC of series")
+
+		expectedNumGCSeries := prevNumGCSeries + numWrites - minCompactSize
+		gcSeries := xclock.WaitUntil(func() bool {
+			numGCSeries := counterValue(t, scope, metricGCSeries)
+			return numGCSeries >= expectedNumGCSeries
+		}, defaultTimeout)
+		numGCSeries := counterValue(t, scope, metricGCSeries)
+		require.True(t, gcSeries,
+			fmt.Sprintf("unexpected num gc series: actual=%d, expected=%d",
+				numGCSeries, expectedNumGCSeries))
+		require.True(t, numGCSeries >= expectedNumGCSeries)
+		log.Info("verified series have been GC'd", zap.Duration("took", time.Since(start)))
+		prevNumGCSeries = int(numGCSeries)
+
+		require.Equal(t, 0, logs.Len(), "errors found in logs during flush/indexing")
+
+		// Keep running indexable check for a few seconds, then progress next iter.
+		time.Sleep(5 * time.Second)
+		close(stopTickCh)
+		<-closedTickCh
+
+		// Ensure check did not fail.
+		require.True(t, checkFailed.Load() == 0,
+			fmt.Sprintf("check indexable errors: %d", checkFailed.Load()))
+	}
+
+	log.Info("checks passed")
+}
+
+func logCounterValues(s tally.TestScope, log *zap.Logger) {
+	for k, v := range s.Snapshot().Counters() {
+		log.Info("counter", zap.String("key", k), zap.Int64("value", v.Value()))
+	}
+}
+
+func counterValue(t *testing.T, r tally.TestScope, key string) int {
+	v, ok := r.Snapshot().Counters()[key]
+	require.True(t, ok)
+	return int(v.Value())
+}

--- a/src/dbnode/integration/index_helpers.go
+++ b/src/dbnode/integration/index_helpers.go
@@ -171,7 +171,7 @@ type NumIndexedOptions struct {
 	Logger *zap.Logger
 }
 
-// NumIndexed gets number of indexed series.
+// NumIndexedWithOptions gets number of indexed series with a set of options.
 func (w TestIndexWrites) NumIndexedWithOptions(
 	t *testing.T,
 	ns ident.ID,

--- a/src/dbnode/integration/index_helpers.go
+++ b/src/dbnode/integration/index_helpers.go
@@ -29,14 +29,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/storage/index"
 	"github.com/m3db/m3/src/m3ninx/idx"
+	"github.com/m3db/m3/src/query/storage/m3/consolidators"
 	"github.com/m3db/m3/src/x/ident"
 	xtime "github.com/m3db/m3/src/x/time"
-
-	"github.com/stretchr/testify/require"
 )
 
 // TestIndexWrites holds index writes for testing.
@@ -161,6 +163,21 @@ func (w TestIndexWrites) Write(t *testing.T, ns ident.ID, s client.Session) {
 
 // NumIndexed gets number of indexed series.
 func (w TestIndexWrites) NumIndexed(t *testing.T, ns ident.ID, s client.Session) int {
+	return w.NumIndexedWithOptions(t, ns, s, NumIndexedOptions{})
+}
+
+// NumIndexedOptions is options when performing num indexed check.
+type NumIndexedOptions struct {
+	Logger *zap.Logger
+}
+
+// NumIndexed gets number of indexed series.
+func (w TestIndexWrites) NumIndexedWithOptions(
+	t *testing.T,
+	ns ident.ID,
+	s client.Session,
+	opts NumIndexedOptions,
+) int {
 	numFound := 0
 	for i := 0; i < len(w); i++ {
 		wi := w[i]
@@ -173,19 +190,42 @@ func (w TestIndexWrites) NumIndexed(t *testing.T, ns ident.ID, s client.Session)
 				SeriesLimit:    10,
 			})
 		if err != nil {
+			if l := opts.Logger; l != nil {
+				l.Error("fetch tagged IDs error", zap.Error(err))
+			}
 			continue
 		}
 		if !iter.Next() {
+			if l := opts.Logger; l != nil {
+				l.Warn("missing result",
+					zap.String("queryID", wi.ID.String()),
+					zap.ByteString("queryTags", consolidators.MustIdentTagIteratorToTags(wi.Tags, nil).ID()))
+			}
 			continue
 		}
 		cuNs, cuID, cuTag := iter.Current()
 		if ns.String() != cuNs.String() {
+			if l := opts.Logger; l != nil {
+				l.Warn("namespace mismatch",
+					zap.String("queryNamespace", ns.String()),
+					zap.String("resultNamespace", cuNs.String()))
+			}
 			continue
 		}
 		if wi.ID.String() != cuID.String() {
+			if l := opts.Logger; l != nil {
+				l.Warn("id mismatch",
+					zap.String("queryID", wi.ID.String()),
+					zap.String("resultID", cuID.String()))
+			}
 			continue
 		}
 		if !ident.NewTagIterMatcher(wi.Tags).Matches(cuTag) {
+			if l := opts.Logger; l != nil {
+				l.Warn("tag mismatch",
+					zap.ByteString("queryTags", consolidators.MustIdentTagIteratorToTags(wi.Tags, nil).ID()),
+					zap.ByteString("resultTags", consolidators.MustIdentTagIteratorToTags(cuTag, nil).ID()))
+			}
 			continue
 		}
 		numFound++

--- a/src/dbnode/storage/index_block_test.go
+++ b/src/dbnode/storage/index_block_test.go
@@ -558,7 +558,7 @@ func TestNamespaceIndexTick(t *testing.T) {
 		NumDocs:     10,
 		NumSegments: 2,
 	}, nil)
-	b0.EXPECT().IsSealed().Return(false).Times(2)
+	b0.EXPECT().IsSealed().Return(false).Times(1)
 	b0.EXPECT().Seal().Return(nil).AnyTimes()
 	result, err = idx.Tick(c, xtime.ToUnixNano(nowFn()))
 	require.NoError(t, err)
@@ -573,8 +573,6 @@ func TestNamespaceIndexTick(t *testing.T) {
 		NumDocs:     10,
 		NumSegments: 2,
 	}, nil)
-	b0.EXPECT().IsSealed().Return(true).Times(2)
-	b0.EXPECT().NeedsMutableSegmentsEvicted().Return(true)
 	result, err = idx.Tick(c, xtime.ToUnixNano(nowFn()))
 	require.NoError(t, err)
 	require.Equal(t, namespaceIndexTickResult{

--- a/src/query/storage/m3/consolidators/convert.go
+++ b/src/query/storage/m3/consolidators/convert.go
@@ -45,3 +45,18 @@ func FromIdentTagIteratorToTags(
 
 	return tags, nil
 }
+
+// MustIdentTagIteratorToTags converts ident tags to coordinator tags.
+func MustIdentTagIteratorToTags(
+	identTags ident.TagIterator,
+	tagOptions models.TagOptions,
+) models.Tags {
+	if tagOptions == nil {
+		tagOptions = models.NewTagOptions()
+	}
+	tags, err := FromIdentTagIteratorToTags(identTags, tagOptions)
+	if err != nil {
+		panic(err)
+	}
+	return tags
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This changes the logic to detect whether a block is flushed or not (and consequently can GC in-memory series from index). Previously was checking that the block had been sealed (had at least started transition to on disk segment) and that no in-memory series were held by block any longer. This is a poor check since in-memory series are held by the active block not the block for that block start, so would return true even though the block had not been flushed.

Now the check is much more robust since it checks the result of the call to `block.Tick(...)` which explicitly returns whether it has a bootstrapped segment (i.e. a segment which is an on disk segment) held as a reference or not, which is the root for the source of truth on whether the in-memory series for that block start can be GC'd or not.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
