### PR TITLE
[dbnode] Add IndexChecksum to StreamedMetadataEntry

### DIFF
--- a/src/dbnode/persist/fs/read.go
+++ b/src/dbnode/persist/fs/read.go
@@ -473,7 +473,7 @@ func (r *reader) StreamingReadMetadata() (StreamedMetadataEntry, error) {
 		EncodedTags:   r.streamingTags,
 		Length:        int(entry.Size),
 		DataChecksum:  uint32(entry.DataChecksum),
-		IndexChecksum: entry.IndexChecksum,
+		IndexChecksum: uint32(entry.IndexChecksum),
 	}, nil
 }
 

--- a/src/dbnode/persist/fs/read.go
+++ b/src/dbnode/persist/fs/read.go
@@ -469,10 +469,11 @@ func (r *reader) StreamingReadMetadata() (StreamedMetadataEntry, error) {
 	r.metadataRead++
 
 	return StreamedMetadataEntry{
-		ID:           r.streamingID,
-		EncodedTags:  r.streamingTags,
-		Length:       int(entry.Size),
-		DataChecksum: uint32(entry.DataChecksum),
+		ID:            r.streamingID,
+		EncodedTags:   r.streamingTags,
+		Length:        int(entry.Size),
+		DataChecksum:  uint32(entry.DataChecksum),
+		IndexChecksum: entry.IndexChecksum,
 	}, nil
 }
 
@@ -536,7 +537,7 @@ func (r *reader) entryClonedEncodedTagsIter(encodedTags []byte) ident.TagIterato
 	return decoder
 }
 
-// NB(xichen): Validate should be called after all data is read because
+// Validate should be called after all data is read because
 // the digest is calculated for the entire data file.
 func (r *reader) Validate() error {
 	var multiErr xerrors.MultiError
@@ -545,7 +546,7 @@ func (r *reader) Validate() error {
 	return multiErr.FinalError()
 }
 
-// NB(r): ValidateMetadata can be called immediately after Open(...) since
+// ValidateMetadata can be called immediately after Open(...) since
 // the metadata is read upfront.
 func (r *reader) ValidateMetadata() error {
 	err := r.indexDecoderStream.reader().Validate(r.expectedIndexDigest)
@@ -555,7 +556,7 @@ func (r *reader) ValidateMetadata() error {
 	return nil
 }
 
-// NB(xichen): ValidateData should be called after all data is read because
+// ValidateData should be called after all data is read because
 // the digest is calculated for the entire data file.
 func (r *reader) ValidateData() error {
 	err := r.dataReader.Validate(r.expectedDataDigest)

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -704,7 +704,7 @@ type StreamedMetadataEntry struct {
 	EncodedTags   ts.EncodedTags
 	Length        int
 	DataChecksum  uint32
-	IndexChecksum int64
+	IndexChecksum uint32
 }
 
 // NewReaderFn creates a new DataFileSetReader.

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -700,10 +700,11 @@ type StreamedDataEntry struct {
 // StreamedMetadataEntry contains the metadata of single entry returned by streaming method.
 // The underlying data slices are reused and invalidated on every read.
 type StreamedMetadataEntry struct {
-	ID           ident.BytesID
-	EncodedTags  ts.EncodedTags
-	Length       int
-	DataChecksum uint32
+	ID            ident.BytesID
+	EncodedTags   ts.EncodedTags
+	Length        int
+	DataChecksum  uint32
+	IndexChecksum int64
 }
 
 // NewReaderFn creates a new DataFileSetReader.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `IndexChecksum` to `StreamedMetadataEntry`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE