### PR TITLE
Revert "[dbnode] Add IndexChecksum to StreamedMetadataEntry (#3627)"

### DIFF
--- a/src/dbnode/persist/fs/read.go
+++ b/src/dbnode/persist/fs/read.go
@@ -469,11 +469,10 @@ func (r *reader) StreamingReadMetadata() (StreamedMetadataEntry, error) {
 	r.metadataRead++
 
 	return StreamedMetadataEntry{
-		ID:            r.streamingID,
-		EncodedTags:   r.streamingTags,
-		Length:        int(entry.Size),
-		DataChecksum:  uint32(entry.DataChecksum),
-		IndexChecksum: uint32(entry.IndexChecksum),
+		ID:           r.streamingID,
+		EncodedTags:  r.streamingTags,
+		Length:       int(entry.Size),
+		DataChecksum: uint32(entry.DataChecksum),
 	}, nil
 }
 
@@ -537,7 +536,7 @@ func (r *reader) entryClonedEncodedTagsIter(encodedTags []byte) ident.TagIterato
 	return decoder
 }
 
-// Validate should be called after all data is read because
+// NB(xichen): Validate should be called after all data is read because
 // the digest is calculated for the entire data file.
 func (r *reader) Validate() error {
 	var multiErr xerrors.MultiError
@@ -546,7 +545,7 @@ func (r *reader) Validate() error {
 	return multiErr.FinalError()
 }
 
-// ValidateMetadata can be called immediately after Open(...) since
+// NB(r): ValidateMetadata can be called immediately after Open(...) since
 // the metadata is read upfront.
 func (r *reader) ValidateMetadata() error {
 	err := r.indexDecoderStream.reader().Validate(r.expectedIndexDigest)
@@ -556,7 +555,7 @@ func (r *reader) ValidateMetadata() error {
 	return nil
 }
 
-// ValidateData should be called after all data is read because
+// NB(xichen): ValidateData should be called after all data is read because
 // the digest is calculated for the entire data file.
 func (r *reader) ValidateData() error {
 	err := r.dataReader.Validate(r.expectedDataDigest)

--- a/src/dbnode/persist/fs/types.go
+++ b/src/dbnode/persist/fs/types.go
@@ -700,11 +700,10 @@ type StreamedDataEntry struct {
 // StreamedMetadataEntry contains the metadata of single entry returned by streaming method.
 // The underlying data slices are reused and invalidated on every read.
 type StreamedMetadataEntry struct {
-	ID            ident.BytesID
-	EncodedTags   ts.EncodedTags
-	Length        int
-	DataChecksum  uint32
-	IndexChecksum uint32
+	ID           ident.BytesID
+	EncodedTags  ts.EncodedTags
+	Length       int
+	DataChecksum uint32
 }
 
 // NewReaderFn creates a new DataFileSetReader.


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit 743cec50145777fc7d08a10e7c8e6f2a1034ba94.

**Special notes for your reviewer**:
I've realized that this change would be useless for checking index entries across different filesets because the checksum includes data entry offset which would vary in different filesets.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
