### PR TITLE
[aggregator] Do not eagerly connect to aggregator instances in TCP client

### DIFF
--- a/src/aggregator/client/conn.go
+++ b/src/aggregator/client/conn.go
@@ -105,12 +105,6 @@ func newConnection(addr string, opts ConnectionOptions) *connection {
 	c.connectWithLockFn = c.connectWithLock
 	c.writeWithLockFn = c.writeWithLock
 
-	c.Lock()
-	if err := c.connectWithLockFn(); err != nil {
-		c.numFailures++
-	}
-	c.Unlock()
-
 	return c
 }
 

--- a/src/aggregator/client/conn_options.go
+++ b/src/aggregator/client/conn_options.go
@@ -21,7 +21,6 @@
 package client
 
 import (
-	"math"
 	"time"
 
 	"github.com/m3db/m3/src/x/clock"
@@ -31,13 +30,13 @@ import (
 )
 
 const (
-	defaultConnectionTimeout            = 2 * time.Second
+	defaultConnectionTimeout            = 1 * time.Second
 	defaultConnectionKeepAlive          = true
-	defaultWriteTimeout                 = time.Duration(0)
-	defaultInitReconnectThreshold       = 2
-	defaultMaxReconnectThreshold        = 5000
+	defaultWriteTimeout                 = 15 * time.Second
+	defaultInitReconnectThreshold       = 1
+	defaultMaxReconnectThreshold        = 4
 	defaultReconnectThresholdMultiplier = 2
-	defaultMaxReconnectDuration         = math.MaxInt64
+	defaultMaxReconnectDuration         = 20 * time.Second
 	defaultWriteRetryInitialBackoff     = 0
 	defaultWriteRetryBackoffFactor      = 2
 	defaultWriteRetryMaxBackoff         = time.Second

--- a/src/aggregator/client/conn_test.go
+++ b/src/aggregator/client/conn_test.go
@@ -60,7 +60,10 @@ func TestConnectionDontReconnectProperties(t *testing.T) {
 	  - increment the number of failures`,
 		prop.ForAll(
 			func(numFailures int32) (bool, error) {
-				conn := newConnection(testFakeServerAddr, testConnectionOptions())
+				conn := newConnection(testFakeServerAddr,
+					testConnectionOptions().
+						SetMaxReconnectDuration(time.Duration(math.MaxInt64)),
+				)
 				conn.connectWithLockFn = func() error { return errTestConnect }
 				conn.numFailures = int(numFailures)
 				conn.threshold = testReconnectThreshold
@@ -136,6 +139,7 @@ func TestConnectionNumFailuresThresholdReconnectProperty(t *testing.T) {
 				// Exhausted max threshold
 				conn.threshold = int(threshold)
 				conn.maxThreshold = conn.threshold
+				conn.maxDuration = math.MaxInt64
 				conn.numFailures = conn.maxThreshold + 1
 
 				if err := conn.Write(nil); !errors.Is(err, errNoActiveConnection) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Right now placement initialization/update depends on blocking, synchronous connection creation, which can be *very* slow on high-latency links and huge placements, due to this call chain: 

`(placement update hook) -> writerManager.AddInstances -> newRefCountedWriter -> newInstanceWriter -> newInstanceQueue -> newConnection`

Connection state is always checked in Write() method, and writes are called concurrently, so this PR greatly speeds up both placement init and any subsequent changes, as placement updates no longer depend on blocking IO.

Writer instance removal and cleanup has always been async, so everything is flushed in the background and never blocks placement updates themselves:
```
func (rcWriter *refCountedWriter) Close() {
	// NB: closing the writer needs to be done asynchronously because it may
	// be called by writer manager while holding a lock that blocks any writes
	// from proceeding.
	go rcWriter.instanceWriter.Close() // nolint: errcheck
}
```

Also, update default connection settings to be sane - defaultMaxReconnectDuration set to math.MaxInt64 is... bad, as well as no timeouts on write ops whatsoever.