### PR TITLE
[query] Add Graphite find integration test that verifies complex trees return valid results

### DIFF
--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -30,7 +30,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"runtime"
 	"sort"
@@ -138,7 +137,6 @@ local:
 	ns, err := namespace.NewMetadata(ident.StringID("testns"), nOpts)
 	require.NoError(t, err)
 
-	os.Setenv("TEST_DEBUG_LOG", "true")
 	opts := NewTestOptions(tt).
 		SetNamespaces([]namespace.Metadata{ns})
 
@@ -278,8 +276,8 @@ local:
 	}
 	type checkFailure struct {
 		expected graphiteFindResults
-		actual graphiteFindResults
-		failMsg string
+		actual   graphiteFindResults
+		failMsg  string
 	}
 	var (
 		verifyFindQueries         func(node *graphiteNode, level int) (checkResult, *checkFailure, error)
@@ -307,15 +305,15 @@ local:
 			}
 
 			var (
-				result checkResult
+				result  checkResult
 				failure = &checkFailure{}
-				err  = fmt.Errorf("initial error")
+				err     = fmt.Errorf("initial error")
 			)
 			for attempt := 0; (failure != nil || err != nil) && attempt < 2; attempt++ {
 				if attempt > 0 {
-					// Retry transient errors (should add a strict mode for this test 
+					// Retry transient errors (should add a strict mode for this test
 					// avoid allowing transient errors too).
-					time.Sleep(5*time.Millsecond)
+					time.Sleep(5 * time.Millisecond)
 				}
 				result, failure, err = verifyFindQueries(node, level)
 			}
@@ -380,7 +378,7 @@ local:
 			return r, nil, err
 		}
 		if res.StatusCode != http.StatusOK {
-			return r, nil, fmt.Errorf("bad response code: expected=%d, actual=%d", 
+			return r, nil, fmt.Errorf("bad response code: expected=%d, actual=%d",
 				http.StatusOK, res.StatusCode)
 		}
 
@@ -416,8 +414,8 @@ local:
 					xtest.MustPrettyJSONObject(t, actual)))
 			return r, &checkFailure{
 				expected: expected,
-				actual: actual,
-				failMsg: failMsg,
+				actual:   actual,
+				failMsg:  failMsg,
 			}, nil
 		}
 

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 // Copyright (c) 2021 Uber Technologies, Inc.
@@ -23,6 +24,7 @@
 package integration
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -122,7 +124,7 @@ local:
 		levels             = 5
 		entriesPerLevelMin = 6
 		entriesPerLevelMax = 9
-		randConstSeedSrc   = rand.NewSource(123456789)
+		randConstSeedSrc   = rand.NewSource(123456789) // nolint: gosec
 		randGen            = rand.New(randConstSeedSrc)
 		rootNode           = &graphiteNode{}
 		buildNodes         func(node *graphiteNode, level int)
@@ -270,7 +272,8 @@ local:
 		url := fmt.Sprintf("http://%s%s?%s", setup.QueryAddress(),
 			graphitehandler.FindURL, params.Encode())
 
-		req, err := http.NewRequest(http.MethodGet, url, nil)
+		req, err := http.NewRequestWithContext(context.Background(),
+			http.MethodGet, url, nil)
 		require.NoError(t, err)
 
 		res, err := httpClient.Do(req)

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -30,6 +30,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"runtime"
 	"sort"
@@ -137,6 +138,7 @@ local:
 	ns, err := namespace.NewMetadata(ident.StringID("testns"), nOpts)
 	require.NoError(t, err)
 
+	os.Setenv("TEST_DEBUG_LOG", "true")
 	opts := NewTestOptions(tt).
 		SetNamespaces([]namespace.Metadata{ns})
 

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -1,0 +1,381 @@
+// +build integration
+
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+
+	"github.com/m3db/m3/src/dbnode/integration/generate"
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/retention"
+	graphitehandler "github.com/m3db/m3/src/query/api/v1/handler/graphite"
+	"github.com/m3db/m3/src/query/graphite/graphite"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/net/http"
+	xsync "github.com/m3db/m3/src/x/sync"
+	xtest "github.com/m3db/m3/src/x/test"
+)
+
+func TestGraphiteFind(tt *testing.T) {
+	if testing.Short() {
+		tt.SkipNow() // Just skip if we're doing a short run
+	}
+
+	// Make sure that parallel assertions fail test immediately
+	// by using a TestingT that panics when FailNow is called.
+	t := xtest.FailNowPanicsTestingT(tt)
+
+	const queryConfigYAML = `
+listenAddress: 127.0.0.1:7201
+
+logging:
+  level: info
+
+metrics:
+  scope:
+    prefix: "coordinator"
+  prometheus:
+    handlerPath: /metrics
+    listenAddress: "127.0.0.1:0"
+  sanitization: prometheus
+  samplingRate: 1.0
+
+local:
+  namespaces:
+    - namespace: testns
+      type: unaggregated
+      retention: 12h
+`
+
+	var (
+		blockSize       = 2 * time.Hour
+		retentionPeriod = 6 * blockSize
+		rOpts           = retention.NewOptions().
+				SetRetentionPeriod(retentionPeriod).
+				SetBlockSize(blockSize)
+		idxOpts = namespace.NewIndexOptions().
+			SetEnabled(true).
+			SetBlockSize(2 * blockSize)
+		nOpts = namespace.NewOptions().
+			SetRetentionOptions(rOpts).
+			SetIndexOptions(idxOpts)
+	)
+	ns, err := namespace.NewMetadata(ident.StringID("testns"), nOpts)
+	require.NoError(t, err)
+
+	opts := NewTestOptions(tt).
+		SetNamespaces([]namespace.Metadata{ns})
+
+	// Test setup.
+	setup, err := NewTestSetup(tt, opts, nil)
+	require.NoError(t, err)
+	defer setup.Close()
+
+	log := setup.StorageOpts().InstrumentOptions().Logger().
+		With(zap.String("ns", ns.ID().String()))
+
+	require.NoError(t, setup.InitializeBootstrappers(InitializeBootstrappersOptions{
+		WithFileSystem: true,
+	}))
+
+	// Write test data.
+	now := setup.NowFn()()
+
+	// Create graphite node tree for tests.
+	var (
+		levels             = 5
+		entriesPerLevelMin = 6
+		entriesPerLevelMax = 9
+		randConstSeedSrc   = rand.NewSource(123456789)
+		randGen            = rand.New(randConstSeedSrc)
+		rootNode           = &graphiteNode{}
+		buildNodes         func(node *graphiteNode, level int)
+		generateSeries     []generate.Series
+	)
+	buildNodes = func(node *graphiteNode, level int) {
+		entries := entriesPerLevelMin +
+			randGen.Intn(entriesPerLevelMax-entriesPerLevelMin)
+		for entry := 0; entry < entries; entry++ {
+			name := fmt.Sprintf("lvl%02d_entry%02d", level, entry)
+
+			// Create a directory node and spawn more underneath.
+			if nextLevel := level + 1; nextLevel <= levels {
+				childDir := node.child(name+"_dir", graphiteNodeChildOptions{
+					isLeaf: false,
+				})
+				buildNodes(childDir, nextLevel)
+			}
+
+			// Create a leaf node.
+			childLeaf := node.child(name+"_leaf", graphiteNodeChildOptions{
+				isLeaf: true,
+			})
+
+			// Create series to generate data for the leaf node.
+			tags := make([]ident.Tag, 0, len(childLeaf.pathParts))
+			for i, pathPartValue := range childLeaf.pathParts {
+				tags = append(tags, ident.Tag{
+					Name:  graphite.TagNameID(i),
+					Value: ident.StringID(pathPartValue),
+				})
+			}
+			series := generate.Series{
+				ID:   ident.StringID(strings.Join(childLeaf.pathParts, ".")),
+				Tags: ident.NewTags(tags...),
+			}
+			generateSeries = append(generateSeries, series)
+		}
+	}
+
+	// Build tree.
+	log.Info("building graphite data set series")
+	buildNodes(rootNode, 0)
+
+	// Generate and write test data.
+	log.Info("generating graphite data set datapoints",
+		zap.Int("seriesSize", len(generateSeries)))
+	generateBlocks := make([]generate.BlockConfig, 0, len(generateSeries))
+	for _, series := range generateSeries {
+		generateBlocks = append(generateBlocks, []generate.BlockConfig{
+			{
+				IDs:       []string{series.ID.String()},
+				Tags:      series.Tags,
+				NumPoints: 1,
+				Start:     now.Add(-1 * blockSize),
+			},
+			{
+				IDs:       []string{series.ID.String()},
+				Tags:      series.Tags,
+				NumPoints: 1,
+				Start:     now,
+			},
+		}...)
+	}
+	seriesMaps := generate.BlocksByStart(generateBlocks)
+	log.Info("writing graphite data set to disk",
+		zap.Int("seriesMapSize", len(seriesMaps)))
+	require.NoError(t, writeTestDataToDisk(ns, setup, seriesMaps, 0))
+
+	// Start the server with filesystem bootstrapper.
+	log.Info("starting server")
+	require.NoError(t, setup.StartServer())
+	log.Info("server is now up")
+
+	// Stop the server.
+	defer func() {
+		require.NoError(t, setup.StopServer())
+		log.Info("server is now down")
+	}()
+
+	// Start the query server
+	log.Info("starting query server")
+	require.NoError(t, setup.StartQuery(queryConfigYAML))
+	log.Info("started query server", zap.String("addr", setup.QueryAddress()))
+
+	// Stop the query server.
+	defer func() {
+		require.NoError(t, setup.StopQuery())
+		log.Info("query server is now down")
+	}()
+
+	// Check each level of the tree can answer expected queries.
+	var (
+		verifyFindQueries         func(node *graphiteNode, level int)
+		parallelVerifyFindQueries func(node *graphiteNode, level int)
+		checkedSeriesAbort        = atomic.NewBool(false)
+		numSeriesChecking         = uint64(len(generateSeries))
+		checkedSeriesLogEvery     = numSeriesChecking / 10
+		checkedSeries             = atomic.NewUint64(0)
+		checkedSeriesLog          = atomic.NewUint64(0)
+		// Use custom http client for higher number of max idle conns.
+		httpClient        = xhttp.NewHTTPClient(xhttp.DefaultHTTPClientOptions())
+		wg                sync.WaitGroup
+		workerConcurrency = runtime.NumCPU()
+		workerPool        = xsync.NewWorkerPool(workerConcurrency)
+	)
+	workerPool.Init()
+	parallelVerifyFindQueries = func(node *graphiteNode, level int) {
+		wg.Add(1)
+		workerPool.Go(func() {
+			verifyFindQueries(node, level)
+			wg.Done()
+		})
+
+		// Verify children of children.
+		for _, child := range node.children {
+			parallelVerifyFindQueries(child, level+1)
+		}
+	}
+	verifyFindQueries = func(node *graphiteNode, level int) {
+		if checkedSeriesAbort.Load() {
+			// Do not execute if aborted.
+			return
+		}
+
+		// Write progress report if progress made.
+		checked := checkedSeries.Load()
+		nextLog := checked - (checked % checkedSeriesLogEvery)
+		if lastLog := checkedSeriesLog.Swap(nextLog); lastLog < nextLog {
+			log.Info("checked series progressing", zap.Int("checked", int(checked)))
+		}
+
+		// Verify at depth.
+		numPathParts := len(node.pathParts)
+		queryPathParts := make([]string, 0, 1+numPathParts)
+		if numPathParts > 0 {
+			queryPathParts = append(queryPathParts, node.pathParts...)
+		}
+		queryPathParts = append(queryPathParts, "*")
+		query := strings.Join(queryPathParts, ".")
+
+		params := make(url.Values)
+		params.Set("query", query)
+
+		url := fmt.Sprintf("http://%s%s?%s", setup.QueryAddress(),
+			graphitehandler.FindURL, params.Encode())
+
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+
+		res, err := httpClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		defer res.Body.Close()
+
+		// Compare results.
+		var actual graphiteFindResults
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&actual))
+
+		expected := make(graphiteFindResults, 0, len(node.children))
+		leaves := 0
+		for _, child := range node.children {
+			leaf := 0
+			if child.isLeaf {
+				leaf = 1
+				leaves++
+			}
+			expected = append(expected, graphiteFindResult{
+				Text: child.name,
+				Leaf: leaf,
+			})
+		}
+
+		sortGraphiteFindResults(actual)
+		sortGraphiteFindResults(expected)
+
+		failMsg := fmt.Sprintf("invalid results: level=%d, parts=%d, query=%s",
+			level, len(node.pathParts), query)
+		failMsg += fmt.Sprintf("\n\ndiff:\n%s\n\n",
+			xtest.Diff(xtest.MustPrettyJSONObject(t, expected),
+				xtest.MustPrettyJSONObject(t, actual)))
+		if !reflect.DeepEqual(expected, actual) {
+			// Bail parallel execution (failed require/assert won't stop execution).
+			if checkedSeriesAbort.CAS(false, true) {
+				// Assert an error result and log once.
+				assert.Equal(t, expected, actual, failMsg)
+				log.Error("aborting checks")
+			}
+			return
+		}
+
+		// Account for series checked (for progress report).
+		checkedSeries.Add(uint64(leaves))
+	}
+
+	// Check all top level entries and recurse.
+	log.Info("checking series",
+		zap.Int("workerConcurrency", workerConcurrency),
+		zap.Uint64("numSeriesChecking", numSeriesChecking))
+	parallelVerifyFindQueries(rootNode, 0)
+
+	// Wait for execution.
+	wg.Wait()
+
+	// Allow for debugging by issuing queries, etc.
+	if DebugTest() {
+		log.Info("debug test set, pausing for investigate")
+		<-make(chan struct{})
+	}
+}
+
+type graphiteFindResults []graphiteFindResult
+
+type graphiteFindResult struct {
+	Text string `json:"text"`
+	Leaf int    `json:"leaf"`
+}
+
+func sortGraphiteFindResults(r graphiteFindResults) {
+	sort.Slice(r, func(i, j int) bool {
+		if r[i].Leaf != r[j].Leaf {
+			return r[i].Leaf < r[j].Leaf
+		}
+		return r[i].Text < r[j].Text
+	})
+}
+
+type graphiteNode struct {
+	name      string
+	pathParts []string
+	isLeaf    bool
+	children  []*graphiteNode
+}
+
+type graphiteNodeChildOptions struct {
+	isLeaf bool
+}
+
+func (n *graphiteNode) child(
+	name string,
+	opts graphiteNodeChildOptions,
+) *graphiteNode {
+	pathParts := append(make([]string, 0, 1+len(n.pathParts)), n.pathParts...)
+	pathParts = append(pathParts, name)
+
+	child := &graphiteNode{
+		name:      name,
+		pathParts: pathParts,
+		isLeaf:    opts.isLeaf,
+	}
+
+	n.children = append(n.children, child)
+
+	return child
+}

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -38,6 +38,7 @@ import (
 	"testing"
 	"time"
 
+	// nolint: gci
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -126,7 +127,8 @@ local:
 	// Create graphite node tree for tests.
 	var (
 		// nolint: gosec
-		randConstSeedSrc   = rand.NewSource(123456789)
+		randConstSeedSrc = rand.NewSource(123456789)
+		// nolint: gosec
 		randGen            = rand.New(randConstSeedSrc)
 		levels             = 5
 		entriesPerLevelMin = 6

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -170,9 +170,9 @@ local:
 	)
 	switch testOpts.datasetSize {
 	case smallDatasetSize:
-		levels = 5
-		entriesPerLevelMin = 5
-		entriesPerLevelMax = 7
+		levels = 4
+		entriesPerLevelMin = 7
+		entriesPerLevelMax = 10
 	case largeDatasetSize:
 		// Ideally we'd always use a large dataset size, however you do need
 		// high concurrency to validate this entire dataset and CI can't seem
@@ -334,7 +334,8 @@ local:
 					assert.NoError(t, err)
 					log.Error("aborting checks due to error")
 				default:
-
+					require.FailNow(t, "unknown error condition")
+					log.Error("aborting checks due to unknown condition")
 				}
 			}
 		})

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -80,9 +80,13 @@ metrics:
 
 local:
   namespaces:
-    - namespace: testns
+    - namespace: default
       type: unaggregated
       retention: 12h
+    - namespace: testns
+      type: aggregated
+      retention: 12h
+      resolution: 1m
 `
 
 	var (

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -310,12 +310,12 @@ local:
 		sortGraphiteFindResults(actual)
 		sortGraphiteFindResults(expected)
 
-		failMsg := fmt.Sprintf("invalid results: level=%d, parts=%d, query=%s",
-			level, len(node.pathParts), query)
-		failMsg += fmt.Sprintf("\n\ndiff:\n%s\n\n",
-			xtest.Diff(xtest.MustPrettyJSONObject(t, expected),
-				xtest.MustPrettyJSONObject(t, actual)))
 		if !reflect.DeepEqual(expected, actual) {
+			failMsg := fmt.Sprintf("invalid results: level=%d, parts=%d, query=%s",
+				level, len(node.pathParts), query)
+			failMsg += fmt.Sprintf("\n\ndiff:\n%s\n\n",
+				xtest.Diff(xtest.MustPrettyJSONObject(t, expected),
+					xtest.MustPrettyJSONObject(t, actual)))
 			// Bail parallel execution (failed require/assert won't stop execution).
 			if checkedSeriesAbort.CAS(false, true) {
 				// Assert an error result and log once.

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -49,7 +49,7 @@ import (
 	graphitehandler "github.com/m3db/m3/src/query/api/v1/handler/graphite"
 	"github.com/m3db/m3/src/query/graphite/graphite"
 	"github.com/m3db/m3/src/x/ident"
-	"github.com/m3db/m3/src/x/net/http"
+	xhttp "github.com/m3db/m3/src/x/net/http"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtest "github.com/m3db/m3/src/x/test"
 )
@@ -125,11 +125,12 @@ local:
 
 	// Create graphite node tree for tests.
 	var (
+		// nolint: gosec
+		randConstSeedSrc   = rand.NewSource(123456789)
+		randGen            = rand.New(randConstSeedSrc)
 		levels             = 5
 		entriesPerLevelMin = 6
 		entriesPerLevelMax = 9
-		randConstSeedSrc   = rand.NewSource(123456789) // nolint: gosec
-		randGen            = rand.New(randConstSeedSrc)
 		rootNode           = &graphiteNode{}
 		buildNodes         func(node *graphiteNode, level int)
 		generateSeries     []generate.Series

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -304,20 +304,7 @@ local:
 				return
 			}
 
-			var (
-				result  checkResult
-				failure = &checkFailure{}
-				err     = fmt.Errorf("initial error")
-			)
-			for attempt := 0; (failure != nil || err != nil) && attempt < 3; attempt++ {
-				if attempt > 0 {
-					// Retry transient errors (should add a strict mode for this test
-					// avoid allowing transient errors too).
-					seconds := 5 * attempt
-					time.Sleep(time.Duration(seconds) * time.Second)
-				}
-				result, failure, err = verifyFindQueries(node, level)
-			}
+			result, failure, err := verifyFindQueries(node, level)
 			if failure == nil && err == nil {
 				// Account for series checked (for progress report).
 				checkedSeries.Add(uint64(result.leavesVerified))

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -309,11 +309,11 @@ local:
 				failure = &checkFailure{}
 				err     = fmt.Errorf("initial error")
 			)
-			for attempt := 0; (failure != nil || err != nil) && attempt < 2; attempt++ {
+			for attempt := 0; (failure != nil || err != nil) && attempt < 3; attempt++ {
 				if attempt > 0 {
 					// Retry transient errors (should add a strict mode for this test
 					// avoid allowing transient errors too).
-					time.Sleep(5 * time.Millisecond)
+					time.Sleep(time.Duration(attempt) * 500 * time.Millisecond)
 				}
 				result, failure, err = verifyFindQueries(node, level)
 			}

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -171,8 +171,8 @@ local:
 	switch testOpts.datasetSize {
 	case smallDatasetSize:
 		levels = 4
-		entriesPerLevelMin = 7
-		entriesPerLevelMax = 10
+		entriesPerLevelMin = 5
+		entriesPerLevelMax = 7
 	case largeDatasetSize:
 		// Ideally we'd always use a large dataset size, however you do need
 		// high concurrency to validate this entire dataset and CI can't seem

--- a/src/dbnode/integration/graphite_find_test.go
+++ b/src/dbnode/integration/graphite_find_test.go
@@ -313,7 +313,8 @@ local:
 				if attempt > 0 {
 					// Retry transient errors (should add a strict mode for this test
 					// avoid allowing transient errors too).
-					time.Sleep(time.Duration(attempt) * 500 * time.Millisecond)
+					seconds := 5 * attempt
+					time.Sleep(time.Duration(seconds) * time.Second)
 				}
 				result, failure, err = verifyFindQueries(node, level)
 			}

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -1266,7 +1266,7 @@ func newTestFile(t *testing.T, fileName, contents string) (*os.File, closeFn) {
 	tmpFile, err := ioutil.TempFile("", fileName)
 	require.NoError(t, err)
 
-	_, err = tmpFile.Write([]byte(contents))
+	_, err = tmpFile.WriteString(contents)
 	require.NoError(t, err)
 
 	return tmpFile, func() {

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -861,8 +861,8 @@ func (ts *testSetup) StartQuery(configYAML string) error {
 		return fmt.Errorf("dbnode admin client not set")
 	}
 
-	configFile, close := newTestFile(ts.t, "config.yaml", configYAML)
-	defer close()
+	configFile, cleanup := newTestFile(ts.t, "config.yaml", configYAML)
+	defer cleanup()
 
 	var cfg queryconfig.Configuration
 	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -75,12 +75,6 @@ import (
 	"github.com/m3db/m3/src/x/instrument"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
-
-	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
-	"github.com/uber/tchannel-go"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var (

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 	"time"
 
+	// nolint: gci
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"

--- a/src/dbnode/storage/coldflush.go
+++ b/src/dbnode/storage/coldflush.go
@@ -108,9 +108,9 @@ func (m *coldFlushManager) Run(t xtime.UnixNano) bool {
 		m.Unlock()
 	}()
 
-	debugLog := m.log.Check(zapcore.DebugLevel, "cold flush run")
-	if debugLog != nil {
-		debugLog.Write(zap.String("status", "starting cold flush"), zap.Time("time", t.ToTime()))
+	
+	if log := m.log.Check(zapcore.DebugLevel, "cold flush run start"); log != nil {
+		log.Write(zap.Time("time", t.ToTime()))
 	}
 
 	// NB(xichen): perform data cleanup and flushing sequentially to minimize the impact of disk seeks.
@@ -132,9 +132,9 @@ func (m *coldFlushManager) Run(t xtime.UnixNano) bool {
 					zap.Time("time", t.ToTime()), zap.Error(err))
 			})
 	}
-
-	if debugLog != nil {
-		debugLog.Write(zap.String("status", "completed cold flush"), zap.Time("time", t.ToTime()))
+	
+	if log := m.log.Check(zapcore.DebugLevel, "cold flush run complete"); log != nil {
+		log.Write(zap.Time("time", t.ToTime()))
 	}
 
 	return true

--- a/src/dbnode/storage/coldflush.go
+++ b/src/dbnode/storage/coldflush.go
@@ -108,7 +108,6 @@ func (m *coldFlushManager) Run(t xtime.UnixNano) bool {
 		m.Unlock()
 	}()
 
-	
 	if log := m.log.Check(zapcore.DebugLevel, "cold flush run start"); log != nil {
 		log.Write(zap.Time("time", t.ToTime()))
 	}
@@ -132,7 +131,7 @@ func (m *coldFlushManager) Run(t xtime.UnixNano) bool {
 					zap.Time("time", t.ToTime()), zap.Error(err))
 			})
 	}
-	
+
 	if log := m.log.Check(zapcore.DebugLevel, "cold flush run complete"); log != nil {
 		log.Write(zap.Time("time", t.ToTime()))
 	}

--- a/src/m3ninx/index/segment/fst/segment.go
+++ b/src/m3ninx/index/segment/fst/segment.go
@@ -873,10 +873,9 @@ var _ sgmt.Reader = (*fsSegmentReader)(nil)
 // fsSegmentReader is not thread safe for use and relies on the underlying
 // segment for synchronization.
 type fsSegmentReader struct {
-	closed        bool
-	ctx           context.Context
-	fsSegment     *fsSegment
-	termsIterable *termsIterable
+	closed    bool
+	ctx       context.Context
+	fsSegment *fsSegment
 }
 
 func newReader(
@@ -927,9 +926,9 @@ func (sr *fsSegmentReader) FieldsPostingsList() (sgmt.FieldsPostingsListIterator
 	if sr.closed {
 		return nil, errReaderClosed
 	}
-	fieldsIterable := newTermsIterable(sr.fsSegment)
+	iterable := newTermsIterable(sr.fsSegment)
 	sr.fsSegment.RLock()
-	iter, err := fieldsIterable.fieldsNotClosedMaybeFinalizedWithRLock()
+	iter, err := iterable.fieldsNotClosedMaybeFinalizedWithRLock()
 	sr.fsSegment.RUnlock()
 	return iter, err
 }
@@ -938,11 +937,9 @@ func (sr *fsSegmentReader) Terms(field []byte) (sgmt.TermsIterator, error) {
 	if sr.closed {
 		return nil, errReaderClosed
 	}
-	if sr.termsIterable == nil {
-		sr.termsIterable = newTermsIterable(sr.fsSegment)
-	}
+	iterable := newTermsIterable(sr.fsSegment)
 	sr.fsSegment.RLock()
-	iter, err := sr.termsIterable.termsNotClosedMaybeFinalizedWithRLock(field)
+	iter, err := iterable.termsNotClosedMaybeFinalizedWithRLock(field)
 	sr.fsSegment.RUnlock()
 	return iter, err
 }

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -474,9 +474,10 @@ func Run(runOpts RunOptions) RunResult {
 	case "", config.M3DBStorageType:
 		// For m3db backend, we need to make connections to the m3db cluster
 		// which generates a session and use the storage with the session.
-		m3dbClusters, clusterNamespacesWatcher, m3dbPoolWrapper, err = initClusters(cfg,
-			runOpts.DBConfig, runOpts.DBClient, encodingOpts, runOpts.LocalSessionReadyCh,
-			instrumentOptions, tsdbOpts.CustomAdminOptions())
+		m3dbClusters, m3dbPoolWrapper, err = initClusters(cfg, runOpts.DBConfig,
+			clusterNamespacesWatcher, runOpts.DBClient, encodingOpts,
+			runOpts.LocalSessionReadyCh, instrumentOptions,
+			tsdbOpts.CustomAdminOptions())
 		if err != nil {
 			logger.Fatal("unable to init clusters", zap.Error(err))
 		}

--- a/src/query/stores/m3db/async_session.go
+++ b/src/query/stores/m3db/async_session.go
@@ -64,9 +64,7 @@ func NewAsyncSession(fn NewClientFn, done chan<- struct{}) *AsyncSession {
 
 	go func() {
 		if asyncSession.done != nil {
-			defer func() {
-				asyncSession.done <- struct{}{}
-			}()
+			defer close(asyncSession.done)
 		}
 
 		c, err := fn()

--- a/src/x/test/diff.go
+++ b/src/x/test/diff.go
@@ -22,12 +22,11 @@ package test
 
 import (
 	"encoding/json"
-	"testing"
-
-	xjson "github.com/m3db/m3/src/x/json"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/stretchr/testify/require"
+
+	xjson "github.com/m3db/m3/src/x/json"
 )
 
 // Diff is a helper method to print a terminal pretty diff of two strings
@@ -39,21 +38,28 @@ func Diff(expected, actual string) string {
 }
 
 // MustPrettyJSONMap returns an indented JSON string of the object.
-func MustPrettyJSONMap(t *testing.T, value xjson.Map) string {
+func MustPrettyJSONMap(t require.TestingT, value xjson.Map) string {
 	pretty, err := json.MarshalIndent(value, "", "  ")
 	require.NoError(t, err)
 	return string(pretty)
 }
 
 // MustPrettyJSONArray returns an indented JSON string of the object.
-func MustPrettyJSONArray(t *testing.T, value xjson.Array) string {
+func MustPrettyJSONArray(t require.TestingT, value xjson.Array) string {
+	pretty, err := json.MarshalIndent(value, "", "  ")
+	require.NoError(t, err)
+	return string(pretty)
+}
+
+// MustPrettyJSONObject returns an indented JSON string of the object.
+func MustPrettyJSONObject(t require.TestingT, value interface{}) string {
 	pretty, err := json.MarshalIndent(value, "", "  ")
 	require.NoError(t, err)
 	return string(pretty)
 }
 
 // MustPrettyJSONString returns an indented version of the JSON.
-func MustPrettyJSONString(t *testing.T, str string) string {
+func MustPrettyJSONString(t require.TestingT, str string) string {
 	var unmarshalled map[string]interface{}
 	err := json.Unmarshal([]byte(str), &unmarshalled)
 	require.NoError(t, err)

--- a/src/x/test/util.go
+++ b/src/x/test/util.go
@@ -22,8 +22,30 @@ package test
 
 import (
 	"reflect"
+	"testing"
 	"unsafe"
+
+	"github.com/stretchr/testify/require"
 )
+
+// FailNowPanicsTestingT returns a TestingT that panics on a failed assertion.
+// This is useful for aborting a test on failed assertions from an asynchronous
+// goroutine (since stretchr calls FailNow on testing.T but it will not abort
+// the test unless the goroutine is the one running the benchmark or test).
+// For more info see: https://github.com/stretchr/testify/issues/652.
+func FailNowPanicsTestingT(t *testing.T) require.TestingT {
+	return failNowPanicsTestingT{TestingT: t}
+}
+
+var _ require.TestingT = failNowPanicsTestingT{}
+
+type failNowPanicsTestingT struct {
+	require.TestingT
+}
+
+func (t failNowPanicsTestingT) FailNow() {
+	panic("failed assertion")
+}
 
 // ByteSlicesBackedBySameData returns a bool indicating if the raw backing bytes
 // under the []byte slice point to the same memory.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Previously we only had quite basic coverage of simple cases with the `carbon` docker integration tests for the find API (see https://github.com/m3db/m3/tree/v1.1.0/scripts/docker-integration-tests/carbon). 

This adds a much more comprehensive and complex integration test that tests a complex tree and verifies all results in the tree are correctly returned when walking the tree and issuing queries.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
