### PR TITLE
[query] Fix groupByNodes to get proper first path

### DIFF
--- a/src/query/graphite/native/aggregation_functions.go
+++ b/src/query/graphite/native/aggregation_functions.go
@@ -609,9 +609,8 @@ func getAggregationKey(series *ts.Series, nodes []int) (string, error) {
 	metricsPath, err := getFirstPathExpression(seriesName)
 	if err != nil {
 		return "", err
-	} else {
-		seriesName = metricsPath
 	}
+	seriesName = metricsPath
 
 	parts := strings.Split(seriesName, ".")
 

--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -836,12 +836,14 @@ func TestGroupByNodes(t *testing.T) {
 			{"pod2.500", 8 * 12},
 		}},
 		{"sum", []int{}, []result{ // test empty slice handing.
-			{"sumSeries(transformNull(servers.foo-1.pod1.status.500)," +
-				"scaleToSeconds(servers.foo-2.pod1.status.500,1)," +
-				"servers.foo-3.pod1.status.500,servers.foo-1.pod2.status.500," +
-				"servers.foo-2.pod2.status.500,servers.foo-1.pod1.status.400," +
-				"servers.foo-2.pod1.status.400,servers.foo-3.pod2.status.400)",
-				(2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},
+			{
+				"sumSeries(transformNull(servers.foo-1.pod1.status.500)," +
+					"scaleToSeconds(servers.foo-2.pod1.status.500,1)," +
+					"servers.foo-3.pod1.status.500,servers.foo-1.pod2.status.500," +
+					"servers.foo-2.pod2.status.500,servers.foo-1.pod1.status.400," +
+					"servers.foo-2.pod1.status.400,servers.foo-3.pod2.status.400)",
+				(2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12,
+			},
 		}},
 		{"sum", []int{100}, []result{ // test all nodes out of bounds
 			{"", (2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},

--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -776,7 +776,7 @@ func TestGroupByNodes(t *testing.T) {
 		inputs   = []*ts.Series{
 			ts.NewSeries(ctx, "transformNull(servers.foo-1.pod1.status.500)", start,
 				ts.NewConstantValues(ctx, 2, 12, 10000)),
-			ts.NewSeries(ctx, "servers.foo-2.pod1.status.500", start,
+			ts.NewSeries(ctx, "scaleToSeconds(servers.foo-2.pod1.status.500,1)", start,
 				ts.NewConstantValues(ctx, 4, 12, 10000)),
 			ts.NewSeries(ctx, "servers.foo-3.pod1.status.500", start,
 				ts.NewConstantValues(ctx, 6, 12, 10000)),
@@ -836,7 +836,7 @@ func TestGroupByNodes(t *testing.T) {
 			{"pod2.500", 8 * 12},
 		}},
 		{"sum", []int{}, []result{ // test empty slice handing.
-			{"sumSeries(transformNull(servers.foo-1.pod1.status.500),servers.foo-2.pod1.status.500,servers.foo-3.pod1.status.500,servers.foo-1.pod2.status.500,servers.foo-2.pod2.status.500,servers.foo-1.pod1.status.400,servers.foo-2.pod1.status.400,servers.foo-3.pod2.status.400)", (2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},
+			{"sumSeries(transformNull(servers.foo-1.pod1.status.500),scaleToSeconds(servers.foo-2.pod1.status.500,1),servers.foo-3.pod1.status.500,servers.foo-1.pod2.status.500,servers.foo-2.pod2.status.500,servers.foo-1.pod1.status.400,servers.foo-2.pod1.status.400,servers.foo-3.pod2.status.400)", (2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},
 		}},
 		{"sum", []int{100}, []result{ // test all nodes out of bounds
 			{"", (2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},

--- a/src/query/graphite/native/aggregation_functions_test.go
+++ b/src/query/graphite/native/aggregation_functions_test.go
@@ -836,7 +836,12 @@ func TestGroupByNodes(t *testing.T) {
 			{"pod2.500", 8 * 12},
 		}},
 		{"sum", []int{}, []result{ // test empty slice handing.
-			{"sumSeries(transformNull(servers.foo-1.pod1.status.500),scaleToSeconds(servers.foo-2.pod1.status.500,1),servers.foo-3.pod1.status.500,servers.foo-1.pod2.status.500,servers.foo-2.pod2.status.500,servers.foo-1.pod1.status.400,servers.foo-2.pod1.status.400,servers.foo-3.pod2.status.400)", (2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},
+			{"sumSeries(transformNull(servers.foo-1.pod1.status.500)," +
+				"scaleToSeconds(servers.foo-2.pod1.status.500,1)," +
+				"servers.foo-3.pod1.status.500,servers.foo-1.pod2.status.500," +
+				"servers.foo-2.pod2.status.500,servers.foo-1.pod1.status.400," +
+				"servers.foo-2.pod1.status.400,servers.foo-3.pod2.status.400)",
+				(2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},
 		}},
 		{"sum", []int{100}, []result{ // test all nodes out of bounds
 			{"", (2 + 4 + 6 + 8 + 10 + 20 + 30 + 40) * 12},

--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -1033,7 +1033,10 @@ func asPercent(ctx *common.Context, input singlePathSpec, total genericInterface
 	}
 
 	if len(nodes) > 0 {
-		metaSeries := getMetaSeriesGrouping(input, nodes)
+		metaSeries, err := getMetaSeriesGrouping(input, nodes)
+		if err != nil {
+			return ts.NewSeriesList(), err
+		}
 		totalSeries := make(map[string]*ts.Series)
 
 		switch totalArg := total.(type) {
@@ -1057,7 +1060,10 @@ func asPercent(ctx *common.Context, input singlePathSpec, total genericInterface
 			case singlePathSpec:
 				total = ts.SeriesList(v)
 			}
-			totalGroups := getMetaSeriesGrouping(singlePathSpec(total), nodes)
+			totalGroups, err := getMetaSeriesGrouping(singlePathSpec(total), nodes)
+			if err != nil {
+				return ts.NewSeriesList(), err
+			}
 			for k, series := range totalGroups {
 				if len(series) == 1 {
 					totalSeries[k] = series[0]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fix groupByNodes to get proper first path, both in normal cases and special cases like `scaleToSeconds(servers.foo-2.pod1.status.500,1)`

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
