### PR TITLE
[dbnode] Add logs for the effective query index concurrency and max worker time at startup

### DIFF
--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -466,12 +466,20 @@ func Run(runOpts RunOptions) {
 	maxIdxConcurrency := int(math.Ceil(float64(runtime.NumCPU()) / 2))
 	if cfg.Index.MaxQueryIDsConcurrency > 0 {
 		maxIdxConcurrency = cfg.Index.MaxQueryIDsConcurrency
+		logger.Info("max index query IDs concurrency set",
+			zap.Int("maxIdxConcurrency", maxIdxConcurrency))
 	} else {
-		logger.Warn("max index query IDs concurrency was not set, falling back to default value")
+		logger.Info("max index query IDs concurrency was not set, falling back to default value",
+			zap.Int("maxIdxConcurrency", maxIdxConcurrency))
 	}
 	maxWorkerTime := time.Second
 	if cfg.Index.MaxWorkerTime > 0 {
 		maxWorkerTime = cfg.Index.MaxWorkerTime
+		logger.Info("max index worker time set",
+			zap.Duration("maxWorkerTime", maxWorkerTime))
+	} else {
+		logger.Info("max index worker time was not set, falling back to default value",
+			zap.Duration("maxWorkerTime", maxWorkerTime))
 	}
 	opts = opts.SetPermitsOptions(permitOptions.SetIndexQueryPermitsManager(
 		permits.NewFixedPermitsManager(maxIdxConcurrency, int64(maxWorkerTime), iOpts)))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds some minor logs on the effective query index concurrency and index max worker time.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
