### PR TITLE
[query] Fix Graphite divideSeriesList to return deterministic results

### DIFF
--- a/src/query/graphite/native/aggregation_functions.go
+++ b/src/query/graphite/native/aggregation_functions.go
@@ -261,6 +261,19 @@ func divideSeriesLists(ctx *common.Context, dividendSeriesList, divisorSeriesLis
 			"divideSeriesLists both SeriesLists must have exactly the same length"))
 		return ts.NewSeriesList(), err
 	}
+
+	// If either list is not sorted yet then apply a default sort for deterministic results.
+	if !dividendSeriesList.SortApplied {
+		// Use sort.Stable for deterministic output.
+		sort.Stable(ts.SeriesByName(dividendSeriesList.Values))
+		dividendSeriesList.SortApplied = true
+	}
+	if !divisorSeriesList.SortApplied {
+		// Use sort.Stable for deterministic output.
+		sort.Stable(ts.SeriesByName(divisorSeriesList.Values))
+		divisorSeriesList.SortApplied = true
+	}
+
 	results := make([]*ts.Series, len(dividendSeriesList.Values))
 	for idx, dividendSeries := range dividendSeriesList.Values {
 		divisorSeries := divisorSeriesList.Values[idx]
@@ -273,6 +286,8 @@ func divideSeriesLists(ctx *common.Context, dividendSeriesList, divisorSeriesLis
 	}
 
 	r := ts.SeriesList(dividendSeriesList)
+	// Set sorted as we sorted any input that wasn't already sorted.
+	r.SortApplied = true
 	r.Values = results
 	return r, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Previously `divideSeriesList` would not return deterministic results (since sometimes input might not be sorted). This changes that behavior to make sure at least a default sort of name occurs if input is not sorted.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
