### PR TITLE
[query] Fix Graphite relative time parsing not respecting TZ env var

### DIFF
--- a/docker/m3coordinator/Dockerfile
+++ b/docker/m3coordinator/Dockerfile
@@ -18,6 +18,11 @@ RUN cd /go/src/github.com/m3db/m3/ && \
 FROM alpine:3.11
 LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 
+# Provide timezone data to allow TZ environment variable to be set
+# for parsing relative times such as "9am" correctly and respect
+# the TZ environment variable.
+RUN apk add --no-cache tzdata
+
 EXPOSE 7201/tcp 7203/tcp
 
 COPY --from=builder /go/src/github.com/m3db/m3/bin/m3coordinator /bin/

--- a/docker/m3coordinator/development.Dockerfile
+++ b/docker/m3coordinator/development.Dockerfile
@@ -3,6 +3,11 @@ LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 
 EXPOSE 7201/tcp 7203/tcp
 
+# Provide timezone data to allow TZ environment variable to be set
+# for parsing relative times such as "9am" correctly and respect
+# the TZ environment variable.
+RUN apk add --no-cache tzdata
+
 ADD ./m3coordinator /bin/m3coordinator
 ADD ./config/m3coordinator-local-etcd.yml /etc/m3coordinator/m3coordinator.yml
 

--- a/docker/m3dbnode/Dockerfile
+++ b/docker/m3dbnode/Dockerfile
@@ -22,7 +22,10 @@ ENV GODEBUG madvdontneed=1
 
 EXPOSE 2379/tcp 2380/tcp 7201/tcp 7203/tcp 9000-9004/tcp
 
-RUN apk add --no-cache curl jq
+# Provide timezone data to allow TZ environment variable to be set
+# for parsing relative times such as "9am" correctly and respect
+# the TZ environment variable.
+RUN apk add --no-cache tzdata curl jq
 
 COPY --from=builder /go/src/github.com/m3db/m3/src/dbnode/config/m3dbnode-local-etcd.yml /etc/m3dbnode/m3dbnode.yml
 COPY --from=builder /go/src/github.com/m3db/m3/bin/m3dbnode \

--- a/docker/m3dbnode/Dockerfile-setcap
+++ b/docker/m3dbnode/Dockerfile-setcap
@@ -29,7 +29,10 @@ COPY --from=builder /go/src/github.com/m3db/m3/bin/m3dbnode \
 
 # Use setcap to set +e "effective" and +p "permitted" to adjust the SYS_RESOURCE
 # so the process can raise the hard file limit with setrlimit.
-RUN apk add --no-cache curl jq libcap && \
+# Also provide timezone data to allow TZ environment variable to be set
+# for parsing relative times such as "9am" correctly and respect
+# the TZ environment variable.
+RUN apk add --no-cache tzdata curl jq libcap && \
   setcap cap_sys_resource=+ep /bin/m3dbnode
 
 ENV GODEBUG madvdontneed=1

--- a/docker/m3dbnode/development.Dockerfile
+++ b/docker/m3dbnode/development.Dockerfile
@@ -3,7 +3,10 @@ LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 
 ENV GODEBUG madvdontneed=1
 
-RUN apk add --no-cache curl jq
+# Provide timezone data to allow TZ environment variable to be set
+# for parsing relative times such as "9am" correctly and respect
+# the TZ environment variable.
+RUN apk add --no-cache tzdata curl jq
 
 # Add m3dbnode binary
 ADD ./m3dbnode /bin/m3dbnode

--- a/docker/m3query/Dockerfile
+++ b/docker/m3query/Dockerfile
@@ -20,6 +20,11 @@ LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 
 EXPOSE 7201/tcp 7203/tcp
 
+# Provide timezone data to allow TZ environment variable to be set
+# for parsing relative times such as "9am" correctly and respect
+# the TZ environment variable.
+RUN apk add --no-cache tzdata
+
 COPY --from=builder /go/src/github.com/m3db/m3/bin/m3query /bin/
 COPY --from=builder /go/src/github.com/m3db/m3/src/query/config/m3query-local-etcd.yml /etc/m3query/m3query.yml
 

--- a/docker/m3query/development.Dockerfile
+++ b/docker/m3query/development.Dockerfile
@@ -3,6 +3,11 @@ LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 
 EXPOSE 7201/tcp 7203/tcp
 
+# Provide timezone data to allow TZ environment variable to be set
+# for parsing relative times such as "9am" correctly and respect
+# the TZ environment variable.
+RUN apk add --no-cache tzdata
+
 ADD ./m3query /bin/m3query
 ADD ./config/m3query-local-etcd.yml /etc/m3query/m3query.yml
 

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -570,8 +570,10 @@ func (h *Handler) registerHealthEndpoints() error {
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			json.NewEncoder(w).Encode(struct {
 				Uptime string `json:"uptime"`
+				Now    string `json:"now"`
 			}{
 				Uptime: time.Since(h.options.CreatedAt()).String(),
+				Now:    time.Now().String(),
 			})
 		}),
 		Methods: methods(http.MethodGet),

--- a/src/query/graphite/graphite/timespec.go
+++ b/src/query/graphite/graphite/timespec.go
@@ -166,7 +166,7 @@ func ParseTime(s string, now time.Time, absoluteOffset time.Duration) (time.Time
 
 	n, err := strconv.ParseInt(s, 10, 64)
 	if err == nil {
-		return time.Unix(n, 0).UTC(), nil
+		return time.Unix(n, 0), nil
 	}
 
 	s = strings.Replace(strings.Replace(strings.ToLower(s), ",", "", -1), " ", "", -1)

--- a/src/query/graphite/graphite/timespec_test.go
+++ b/src/query/graphite/graphite/timespec_test.go
@@ -59,10 +59,13 @@ func TestParseTime(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		s := test.timespec
-		parsed, err := ParseTime(s, relativeTo, 0)
-		assert.Nil(t, err, "error parsing %s", s)
-		assert.Equal(t, test.expectedTime, parsed, "incorrect parsed value for %s", s)
+		test := test
+		t.Run(test.timespec, func(t *testing.T) {
+			s := test.timespec
+			parsed, err := ParseTime(s, relativeTo, 0)
+			assert.Nil(t, err, "error parsing %s", s)
+			assert.True(t, test.expectedTime.Equal(parsed), "incorrect parsed value for %s", s)
+		})
 	}
 }
 

--- a/src/query/graphite/native/aggregation_functions.go
+++ b/src/query/graphite/native/aggregation_functions.go
@@ -558,6 +558,7 @@ func applyByNode(ctx *common.Context, seriesList singlePathSpec, nodeNum int, te
 		}
 
 		for _, prefix := range prefixChunk {
+			prefix := prefix // Capture for lambda.
 			newTarget := strings.ReplaceAll(templateFunction, "%", prefix)
 			wg.Add(1)
 			go func() {

--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -462,7 +462,7 @@ func timeSlice(ctx *common.Context, inputPath singlePathSpec, start string, end 
 		}
 
 		slicedSeries := ts.NewSeries(ctx, series.Name(), series.StartTime(), truncatedValues)
-		renamedSlicedSeries := slicedSeries.RenamedTo(fmt.Sprintf("timeSlice(%s, %s, %s)", slicedSeries.Name(), start, end))
+		renamedSlicedSeries := slicedSeries.RenamedTo(fmt.Sprintf("timeSlice(%s, %q, %q)", slicedSeries.Name(), start, end))
 		output = append(output, renamedSlicedSeries)
 	}
 	input.Values = output

--- a/src/query/graphite/native/builtin_functions_test.go
+++ b/src/query/graphite/native/builtin_functions_test.go
@@ -4445,7 +4445,10 @@ func TestTimeSlice(t *testing.T) {
 	values := []float64{math.NaN(), 1.0, 2.0, 3.0, math.NaN(), 5.0, 6.0, math.NaN(), 7.0, 8.0, 9.0}
 	expected := []float64{math.NaN(), math.NaN(), math.NaN(), 3.0, math.NaN(), 5.0, 6.0, math.NaN(), 7.0, math.NaN(), math.NaN()}
 
-	testGeneralFunction(t, "timeSlice(foo.bar.baz, '-9min','-3min')", "timeSlice(foo.bar.baz, -9min, -3min)", values, expected)
+	testGeneralFunction(t,
+		"timeSlice(foo.bar.baz, '-9min','-3min')",
+		`timeSlice(foo.bar.baz, "-9min", "-3min")`,
+		values, expected)
 }
 
 func TestDashed(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The docker images for the query service and services that embedded the query service (such as coordinator and dbnode) were missing timezone info. This meant that the images would not respect the TZ environment variable which would mean that relative times used with graphite (for parameters to functions like `timeSlice`) would use UTC time even if the TZ environment variable was set.

This fixes that issue by adding the timezone info into the docker images.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
