### PR TITLE
[dbnode] Increase readerDecoderStream.buf length to 64

### DIFF
--- a/src/dbnode/persist/fs/read_decode_stream.go
+++ b/src/dbnode/persist/fs/read_decode_stream.go
@@ -41,7 +41,7 @@ type readerDecoderStream struct {
 	bytesReader      *bytes.Reader
 	readerWithDigest digest.ReaderWithDigest
 	backingBytes     []byte
-	buf              [8]byte
+	buf              [64]byte
 	lastReadByte     int
 	unreadByte       int
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
I've noticed that `readerDecoderStream` is using [a very small (8 bytes) buffer](https://github.com/m3db/m3/blob/18430610ed4501dcef1b8da39291dd6cc527681c/src/dbnode/persist/fs/read_decode_stream.go#L44) which does not perform very well with `adler32` hash implementation. Increasing this buffer to 64 bytes gives a very noticeable performance boost for `DataFileSetReader`.

**Special notes for your reviewer**:
I've chosen 64 bytes as a compromise between buffer size and diminishing performance improvements.
Benchmarking results using `read_data_files` utility in `series` benchmarking mode (no datapoint decoding):
```
read_data_files -b 1596009600000000000 -p ~/testdata/m3db -s 4 -B series
```
| len(buf) | running time |
|----|----|
| 8 | 42 ms |
| 16 | 36 ms |
| 32 | 31 ms |
| 64 | 28 ms |
| 128 | 27 ms |
| 256 | 26 ms |

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
