### PR TITLE
[query] Fix Graphite aliasByNode when sub-expr returns a pattern in an arg of fn that is itself the name of a fn

### DIFF
--- a/src/query/graphite/native/alias_functions_test.go
+++ b/src/query/graphite/native/alias_functions_test.go
@@ -258,6 +258,7 @@ func TestAliasByNodeWitCallSubExpressions(t *testing.T) {
 // quotes the time shift arg so that it appears as a string and can be used to find
 // the inner path expression without failing compilation when aliasByNode finds the
 // first path element.
+// nolint: dupl
 func TestAliasByNodeAndTimeShift(t *testing.T) {
 	ctrl := xgomock.NewController(t)
 	defer ctrl.Finish()
@@ -284,6 +285,7 @@ func TestAliasByNodeAndTimeShift(t *testing.T) {
 // return of a sub-expression ends up as a function name (i.e. identity) but
 // is not a function call it's simply a pattern returned from result of
 // something like groupByNodes.
+// nolint: dupl
 func TestAliasByNodeAndPatternThatMatchesFunctionName(t *testing.T) {
 	ctrl := xgomock.NewController(t)
 	defer ctrl.Finish()

--- a/src/query/graphite/native/alias_functions_test.go
+++ b/src/query/graphite/native/alias_functions_test.go
@@ -254,11 +254,11 @@ func TestAliasByNodeWitCallSubExpressions(t *testing.T) {
 	assert.Equal(t, "foo02", results.Values[1].Name())
 }
 
-// TestExecuteAliasByNodeAndTimeShift tests that the output of timeshift properly
+// TestAliasByNodeAndTimeShift tests that the output of timeshift properly
 // quotes the time shift arg so that it appears as a string and can be used to find
 // the inner path expression without failing compilation when aliasByNode finds the
 // first path element.
-func TestExecuteAliasByNodeAndTimeShift(t *testing.T) {
+func TestAliasByNodeAndTimeShift(t *testing.T) {
 	ctrl := xgomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -273,7 +273,36 @@ func TestExecuteAliasByNodeAndTimeShift(t *testing.T) {
 		buildTestSeriesFn(stepSize, "foo.bar.q.zed", "foo.bar.g.zed",
 			"foo.bar.x.zed"))
 
-	expr, err := engine.Compile("aliasByNode(timeShift(foo.bar.*.zed,'-7d'), 0)")
+	expr, err := engine.Compile("aliasByNode(timeShift(foo.bar.*.zed,'-7d'), 2)")
+	require.NoError(t, err)
+
+	_, err = expr.Execute(ctx)
+	require.NoError(t, err)
+}
+
+// TestAliasByNodeAndPatternThatMatchesFunctionName test the case where the
+// return of a sub-expression ends up as a function name (i.e. identity) but
+// is not a function call it's simply a pattern returned from result of
+// something like groupByNodes.
+func TestAliasByNodeAndPatternThatMatchesFunctionName(t *testing.T) {
+	ctrl := xgomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := storage.NewMockStorage(ctrl)
+
+	engine := NewEngine(store, CompileOptions{})
+
+	ctx := common.NewContext(common.ContextOptions{Start: time.Now().Add(-1 * time.Hour), End: time.Now(), Engine: engine})
+
+	stepSize := int((10 * time.Minute) / time.Millisecond)
+	store.EXPECT().FetchByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		buildTestSeriesFn(stepSize,
+			"foo.bar.a.zed",
+			"foo.bar.b.zed",
+			"foo.bar.identity.zed",
+		))
+
+	expr, err := engine.Compile("aliasByNode(summarize(groupByNode(foo.bar.*.zed, 2, 'average'), '5min', 'avg'), 0)")
 	require.NoError(t, err)
 
 	_, err = expr.Execute(ctx)

--- a/src/query/graphite/native/summarize.go
+++ b/src/query/graphite/native/summarize.go
@@ -62,7 +62,7 @@ func summarize(
 
 	results := make([]*ts.Series, len(series.Values))
 	for i, series := range series.Values {
-		name := fmt.Sprintf("summarize(%s, \"%s\", \"%s\"%s)", series.Name(), intervalS, fname, alignString)
+		name := fmt.Sprintf("summarize(%s, %q, %q%s)", series.Name(), intervalS, fname, alignString)
 		results[i] = summarizeTimeSeries(ctx, name, series, interval, safeAggFn, alignToFrom)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Previously compiler was trying to compile any fetch or pattern that matches name of a function, this caused sub-expressions that matched the name of a function (e.g. identity) to cause aliasByNode to fail since they wouldn't compile as sub-expressions as the pattern would tried to be compiled to a function arg but would fail.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
