### PR TITLE
[query] Fix Graphite compiler eagerly parsing identifier as function call and not considering pattern

### DIFF
--- a/src/query/graphite/native/alias_functions_test.go
+++ b/src/query/graphite/native/alias_functions_test.go
@@ -311,6 +311,11 @@ func TestAliasByNodeAndPatternThatMatchesFunctionName(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestGroupByNodeAndAliasMetric tests the case when compiling an identifier
+// immediately in groupByNode when doing meta series grouping and finding the
+// first inner metrics path.
+// It tries to compile as function call but needs to back out when if a function
+// matches but it's actually just a pattern instead.
 // nolint: dupl
 func TestGroupByNodeAndAliasMetric(t *testing.T) {
 	ctrl := xgomock.NewController(t)
@@ -325,12 +330,12 @@ func TestGroupByNodeAndAliasMetric(t *testing.T) {
 	stepSize := int((10 * time.Minute) / time.Millisecond)
 	store.EXPECT().FetchByQuery(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		buildTestSeriesFn(stepSize,
-			"system.service.env.region.handler.rpc.foo.request.lat.p95",
-			"system.service.env.region.handler.rpc.foo.request.lat.max",
-			"system.service.env.region.handler.rpc.foo.request.lat.mean",
+			"handler.rpc.foo.request.lat.p95",
+			"handler.rpc.foo.request.lat.max",
+			"handler.rpc.foo.request.lat.mean",
 		))
 
-	expr, err := engine.Compile("groupByNode(aliasByMetric(system.service.env.region.handler.handler.rpc.*.request.lat.{p*,max,mean}), -1, 'max')")
+	expr, err := engine.Compile("groupByNode(aliasByMetric(handler.rpc.*.request.lat.{p*,max,mean}), -1, 'max')")
 	require.NoError(t, err)
 
 	_, err = expr.Execute(ctx)

--- a/src/query/graphite/native/compiler.go
+++ b/src/query/graphite/native/compiler.go
@@ -138,8 +138,13 @@ func (c *compiler) compileExpression() (Expression, error) {
 		fc, err := c.compileFunctionCall(token.Value())
 		fetchCandidate := false
 		if err != nil {
-			var notFoundErr *errFuncNotFound
-			if goerrors.As(err, &notFoundErr) && c.canCompileAsFetch(token.Value()) {
+			var (
+				notFuncErr    *errNotFuncCall
+				notFoundErr   *errFuncNotFound
+				isNotFuncErr  = goerrors.As(err, &notFuncErr)
+				isNotFoundErr = goerrors.As(err, &notFoundErr)
+			)
+			if (isNotFuncErr || isNotFoundErr) && c.canCompileAsFetch(token.Value()) {
 				fetchCandidate = true
 				expr = newFetchExpression(token.Value())
 			} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes the case where Graphite compiler eagerly parses an identifier that matches a function name (i.e. max) but is actually just an identifier.

Added unit test that covers this case.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
