### PR TITLE
[dbnode] Clone namespace, ID, tags in replicatedSession

### DIFF
--- a/src/dbnode/client/replicated_session_test.go
+++ b/src/dbnode/client/replicated_session_test.go
@@ -182,7 +182,8 @@ func (s *replicatedSessionTestSuite) TestReplicate() {
 
 	var newSessionFunc = func(opts Options) (clientSession, error) {
 		s := NewMockclientSession(s.mockCtrl)
-		s.EXPECT().Write(namespace, id, now, value, unit, annotation).Return(nil)
+		s.EXPECT().Write(ident.NewIDMatcher(namespace.String()), ident.NewIDMatcher(id.String()),
+			now, value, unit, annotation).Return(nil)
 		return s, nil
 	}
 

--- a/src/dbnode/client/replicated_session_test.go
+++ b/src/dbnode/client/replicated_session_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/m3db/m3/src/dbnode/environment"
@@ -172,18 +173,23 @@ func (s *replicatedSessionTestSuite) TestSetAsyncSessions() {
 }
 
 func (s *replicatedSessionTestSuite) TestReplicate() {
-	asyncCount := 2
-	namespace := ident.StringID("foo")
-	id := ident.StringID("bar")
-	now := xtime.Now()
-	value := float64(123)
-	unit := xtime.Nanosecond
-	annotation := []byte{}
+	var (
+		asyncCount = 2
+		namespace  = ident.StringID("foo")
+		id         = ident.StringID("bar")
+		now        = xtime.Now()
+		value      = float64(123)
+		unit       = xtime.Nanosecond
+		annotation = []byte("annotation")
+	)
 
 	var newSessionFunc = func(opts Options) (clientSession, error) {
 		s := NewMockclientSession(s.mockCtrl)
-		s.EXPECT().Write(ident.NewIDMatcher(namespace.String()), ident.NewIDMatcher(id.String()),
-			now, value, unit, annotation).Return(nil)
+		s.EXPECT().Write(
+			ident.NewIDMatcher(namespace.String()),
+			ident.NewIDMatcher(id.String()),
+			now, value, unit, annotation,
+		).Return(nil)
 		return s, nil
 	}
 
@@ -194,15 +200,40 @@ func (s *replicatedSessionTestSuite) TestReplicate() {
 	err := s.replicatedSession.Write(namespace, id, now, value, unit, annotation)
 	s.NoError(err)
 
-	t := time.NewTimer(1 * time.Second) // Allow async expectations to occur before ending test
-	for i := 0; i < asyncCount; i++ {
-		select {
-		case err := <-s.replicatedSession.outCh:
-			s.NoError(err)
-		case <-t.C:
-			break
-		}
+	s.waitForAsyncSessions(asyncCount)
+}
+
+func (s *replicatedSessionTestSuite) TestReplicateTagged() {
+	var (
+		asyncCount = 2
+		namespace  = ident.StringID("foo")
+		id         = ident.StringID("bar")
+		tags       = ident.NewFieldsTagsIterator([]doc.Field{{[]byte("k"), []byte("v")}})
+		now        = xtime.Now()
+		value      = float64(123)
+		unit       = xtime.Nanosecond
+		annotation = []byte("annotation")
+	)
+
+	var newSessionFunc = func(opts Options) (clientSession, error) {
+		s := NewMockclientSession(s.mockCtrl)
+		s.EXPECT().WriteTagged(
+			ident.NewIDMatcher(namespace.String()),
+			ident.NewIDMatcher(id.String()),
+			ident.NewTagIterMatcher(tags),
+			now, value, unit, annotation,
+		).Return(nil)
+		return s, nil
 	}
+
+	opts := optionsWithAsyncSessions(true, asyncCount)
+	s.initReplicatedSession(opts, newSessionFunc)
+	s.replicatedSession.outCh = make(chan error)
+
+	err := s.replicatedSession.WriteTagged(namespace, id, tags, now, value, unit, annotation)
+	s.NoError(err)
+
+	s.waitForAsyncSessions(asyncCount)
 }
 
 func (s *replicatedSessionTestSuite) TestOpenReplicatedSession() {
@@ -249,4 +280,16 @@ func (s *replicatedSessionTestSuite) TestOpenReplicatedSessionAsyncError() {
 	sessions[1].EXPECT().Open().Return(errors.New("an error"))
 	sessions[2].EXPECT().Open().Return(nil)
 	s.replicatedSession.Open()
+}
+
+func (s *replicatedSessionTestSuite) waitForAsyncSessions(asyncCount int) {
+	t := time.NewTimer(1 * time.Second) // Allow async expectations to occur before ending test
+	for i := 0; i < asyncCount; i++ {
+		select {
+		case err := <-s.replicatedSession.outCh:
+			s.NoError(err)
+		case <-t.C:
+			break
+		}
+	}
 }

--- a/src/dbnode/client/replicated_session_test.go
+++ b/src/dbnode/client/replicated_session_test.go
@@ -183,7 +183,7 @@ func (s *replicatedSessionTestSuite) TestReplicate() {
 		annotation = []byte("annotation")
 	)
 
-	var newSessionFunc = func(opts Options) (clientSession, error) {
+	newSessionFunc := func(opts Options) (clientSession, error) {
 		s := NewMockclientSession(s.mockCtrl)
 		s.EXPECT().Write(
 			ident.NewIDMatcher(namespace.String()),
@@ -215,7 +215,7 @@ func (s *replicatedSessionTestSuite) TestReplicateTagged() {
 		annotation = []byte("annotation")
 	)
 
-	var newSessionFunc = func(opts Options) (clientSession, error) {
+	newSessionFunc := func(opts Options) (clientSession, error) {
 		s := NewMockclientSession(s.mockCtrl)
 		s.EXPECT().WriteTagged(
 			ident.NewIDMatcher(namespace.String()),

--- a/src/dbnode/client/replicated_session_test.go
+++ b/src/dbnode/client/replicated_session_test.go
@@ -26,11 +26,11 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/m3db/m3/src/dbnode/environment"
 	"github.com/m3db/m3/src/dbnode/topology"
+	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 	xsync "github.com/m3db/m3/src/x/sync"
@@ -208,7 +208,7 @@ func (s *replicatedSessionTestSuite) TestReplicateTagged() {
 		asyncCount = 2
 		namespace  = ident.StringID("foo")
 		id         = ident.StringID("bar")
-		tags       = ident.NewFieldsTagsIterator([]doc.Field{{[]byte("k"), []byte("v")}})
+		tags       = ident.NewFieldsTagsIterator([]doc.Field{{Name: []byte("k"), Value: []byte("v")}})
 		now        = xtime.Now()
 		value      = float64(123)
 		unit       = xtime.Nanosecond
@@ -283,13 +283,15 @@ func (s *replicatedSessionTestSuite) TestOpenReplicatedSessionAsyncError() {
 }
 
 func (s *replicatedSessionTestSuite) waitForAsyncSessions(asyncCount int) {
-	t := time.NewTimer(1 * time.Second) // Allow async expectations to occur before ending test
+	t := time.NewTimer(1 * time.Second)
+
+	// Allow async expectations to occur before ending test.
 	for i := 0; i < asyncCount; i++ {
 		select {
 		case err := <-s.replicatedSession.outCh:
 			s.NoError(err)
 		case <-t.C:
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When writing to async sessions, use cloned values of namespace, id and tags because their lifecycle differs from the main write (sync) flow.

**Special notes for your reviewer**:
This PR replaces the experimental https://github.com/m3db/m3/pull/3637 with the added benefit that it has no effect or resource overhead in cases when async session is not in use.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
