### PR TITLE
Fix list type and buffer check for TimedWithStagedMetadatas

### DIFF
--- a/scripts/docker-integration-tests/aggregator/m3aggregator.yml
+++ b/scripts/docker-integration-tests/aggregator/m3aggregator.yml
@@ -121,6 +121,7 @@ aggregator:
   bufferDurationBeforeShardCutover: 10m
   bufferDurationAfterShardCutoff: 10m
   bufferDurationForFutureTimedMetric: 10m # Allow test to write into future.
+  bufferDurationForPastTimedMetric: 10s # Don't wait too long for timed metrics to flush.
   resignTimeout: 1m
   flushTimesManager:
     kvConfig:

--- a/src/aggregator/aggregator/entry.go
+++ b/src/aggregator/aggregator/entry.go
@@ -456,7 +456,7 @@ func (e *Entry) addUntimed(
 
 	if e.shouldUpdateStagedMetadatasWithLock(sm) {
 		err := e.updateStagedMetadatasWithLock(metric.ID, metric.Type,
-			hasDefaultMetadatas, sm)
+			hasDefaultMetadatas, sm, false)
 		if err != nil {
 			// NB(xichen): if an error occurred during policy update, the policies
 			// will remain as they are, i.e., there are no half-updated policies.
@@ -613,6 +613,7 @@ func (e *Entry) updateStagedMetadatasWithLock(
 	metricType metric.Type,
 	hasDefaultMetadatas bool,
 	sm metadata.StagedMetadata,
+	timed bool,
 ) error {
 	var (
 		elemID          = e.maybeCopyIDWithLock(metricID)
@@ -629,9 +630,16 @@ func (e *Entry) updateStagedMetadatasWithLock(
 				pipeline:           sm.Pipelines[i].Pipeline,
 				idPrefixSuffixType: WithPrefixWithSuffix,
 			}
-			listID := standardMetricListID{
-				resolution: storagePolicies[j].Resolution().Window,
-			}.toMetricListID()
+			var listID metricListID
+			if timed {
+				listID = timedMetricListID{
+					resolution: storagePolicies[j].Resolution().Window,
+				}.toMetricListID()
+			} else {
+				listID = standardMetricListID{
+					resolution: storagePolicies[j].Resolution().Window,
+				}.toMetricListID()
+			}
 			var err error
 			newAggregations, err = e.addNewAggregationKeyWithLock(metricType, elemID, key, listID, newAggregations)
 			if err != nil {
@@ -683,17 +691,6 @@ func (e *Entry) addTimed(
 		e.RUnlock()
 		timeLock.RUnlock()
 		return errEntryClosed
-	}
-
-	// Reject datapoints that arrive too late or too early.
-	if err := e.checkTimestampForTimedMetric(
-		metric,
-		currTime.UnixNano(),
-		metadata.StoragePolicy.Resolution().Window,
-	); err != nil {
-		e.RUnlock()
-		timeLock.RUnlock()
-		return err
 	}
 
 	// Only apply processing of staged metadatas if has sent staged metadatas
@@ -755,7 +752,7 @@ func (e *Entry) addTimed(
 
 		if e.shouldUpdateStagedMetadatasWithLock(sm) {
 			err := e.updateStagedMetadatasWithLock(metric.ID, metric.Type,
-				hasDefaultMetadatas, sm)
+				hasDefaultMetadatas, sm, true)
 			if err != nil {
 				// NB(xichen): if an error occurred during policy update, the policies
 				// will remain as they are, i.e., there are no half-updated policies.
@@ -814,6 +811,7 @@ func (e *Entry) addTimed(
 	return err
 }
 
+// Reject datapoints that arrive too late or too early.
 func (e *Entry) checkTimestampForTimedMetric(
 	metric aggregated.Metric,
 	currNanos int64,
@@ -893,15 +891,23 @@ func (e *Entry) addTimedWithLock(
 	metric aggregated.Metric,
 ) error {
 	timestamp := time.Unix(0, metric.TimeNanos)
+	err := e.checkTimestampForTimedMetric(metric, e.nowFn().UnixNano(), value.key.storagePolicy.Resolution().Window)
+	if err != nil {
+		return err
+	}
 	return value.elem.Value.(metricElem).AddValue(timestamp, metric.Value, metric.Annotation)
 }
 
-func (e *Entry) addTimedWithStagedMetadatasAndLock(
-	metric aggregated.Metric,
-) error {
+func (e *Entry) addTimedWithStagedMetadatasAndLock(metric aggregated.Metric) error {
 	timestamp := time.Unix(0, metric.TimeNanos)
 	multiErr := xerrors.NewMultiError()
 	for i := range e.aggregations {
+		err := e.checkTimestampForTimedMetric(metric, e.nowFn().UnixNano(),
+			e.aggregations[i].key.storagePolicy.Resolution().Window)
+		if err != nil {
+			multiErr = multiErr.Add(err)
+			continue
+		}
 		if err := e.aggregations[i].elem.Value.(metricElem).AddValue(timestamp, metric.Value, metric.Annotation); err != nil {
 			multiErr = multiErr.Add(err)
 		}


### PR DESCRIPTION
This fixes 2 bugs with the function AddTimedWithStagedMetadatas:
1. Use the Resolution from the active StagedMetadata when checking the
   buffer past. Previously it would use the Resolution from the
TimedMetadata which is always zero for StagedMetadata. This required
moving the buffer past check, so it runs after the active staged
metadata is computed.
2. Use a timedMetricList instead of a standardMetricList. This is
   required so the flusher does not flush aggregated values until after
the buffer past for timed metrics.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
