### PR TITLE
[dbnode] Fix entries count when reusing streamingWriter

### DIFF
--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -188,6 +188,11 @@ func main() {
 		seriesCount++
 	}
 
+	if seriesCount != reader.Entries() {
+		log.Fatalf("actual time series count (%d) did not match info file data (%d)",
+			seriesCount, reader.Entries())
+	}
+
 	if benchMode != benchmarkNone {
 		runTime := time.Since(start)
 		fmt.Printf("Running time: %s\n", runTime)     // nolint: forbidigo

--- a/src/cmd/tools/split_shards/main/main.go
+++ b/src/cmd/tools/split_shards/main/main.go
@@ -265,6 +265,7 @@ func verifySplitShards(
 		return fmt.Errorf("unable to open srcReader: %w", err)
 	}
 
+	dstEntries := 0
 	for i := range dstReaders {
 		dstReadOpts := fs.DataReaderOpenOptions{
 			Identifier: fs.FileSetFileIdentifier{
@@ -279,6 +280,11 @@ func verifySplitShards(
 		if err := dstReaders[i].Open(dstReadOpts); err != nil {
 			return fmt.Errorf("unable to open dstReaders[%d]: %w", i, err)
 		}
+		dstEntries += dstReaders[i].Entries()
+	}
+
+	if srcReader.Entries() != dstEntries {
+		return fmt.Errorf("entry count mismatch: src %d != dst %d", srcReader.Entries(), dstEntries)
 	}
 
 	for {

--- a/src/dbnode/persist/fs/streaming_write.go
+++ b/src/dbnode/persist/fs/streaming_write.go
@@ -123,9 +123,12 @@ func (w *streamingWriter) Open(opts StreamingWriterOpenOptions) error {
 	if err := w.writer.Open(writerOpts); err != nil {
 		return err
 	}
+
+	w.currIdx = 0
 	w.indexOffset = 0
 	w.summaries = 0
 	w.prevIDBytes = nil
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Entry counter was not being reset on `streamingWriter` reuse.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
