### PR TITLE
Move addToReset migration to the aggregationKey.Pipeline

### DIFF
--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -166,7 +166,6 @@ type elemBase struct {
 	idPrefixSuffixType              IDPrefixSuffixType
 	writeForwardedMetricFn          writeForwardedMetricFn
 	onForwardedAggregationWrittenFn onForwardedAggregationDoneFn
-	addToReset                      bool
 
 	// Mutable states.
 	tombstoned           bool
@@ -180,7 +179,6 @@ func newElemBase(opts Options) elemBase {
 		opts:         opts,
 		aggTypesOpts: opts.AggregationTypesOptions(),
 		aggOpts:      raggregation.NewOptions(opts.InstrumentOptions()),
-		addToReset:   opts.AddToReset(),
 	}
 }
 
@@ -199,13 +197,6 @@ func (e *elemBase) resetSetData(
 		l := e.opts.InstrumentOptions().Logger()
 		l.Error("error parsing pipeline", zap.Error(err))
 		return err
-	}
-	if e.addToReset {
-		for i := range parsed.Transformations {
-			if parsed.Transformations[i].Type() == transformation.Add {
-				parsed.Transformations[i], _ = transformation.Reset.NewOp()
-			}
-		}
 	}
 	e.id = id
 	e.sp = sp

--- a/src/aggregator/aggregator/elem_base_test.go
+++ b/src/aggregator/aggregator/elem_base_test.go
@@ -572,25 +572,3 @@ func TestParsePipelineTransformationDerivativeOrderTooHigh(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "transformation derivative order is 2 higher than supported 1"))
 }
-
-func TestAddToRestOption(t *testing.T) {
-	p := applied.NewPipeline([]applied.OpUnion{
-		{
-			Type:           pipeline.TransformationOpType,
-			Transformation: pipeline.TransformationOp{Type: transformation.Add},
-		},
-		{
-			Type:           pipeline.TransformationOpType,
-			Transformation: pipeline.TransformationOp{Type: transformation.Increase},
-		},
-	})
-	e := newElemBase(newTestOptions().SetAddToReset(false))
-	e.resetSetData(testCounterID, testStoragePolicy, testAggregationTypesExpensive, false, p, 3, WithPrefixWithSuffix)
-	require.Equal(t, transformation.Add, e.parsedPipeline.Transformations[0].Type())
-	require.Equal(t, transformation.Increase, e.parsedPipeline.Transformations[1].Type())
-
-	e = newElemBase(newTestOptions().SetAddToReset(true))
-	e.resetSetData(testCounterID, testStoragePolicy, testAggregationTypesExpensive, false, p, 3, WithPrefixWithSuffix)
-	require.Equal(t, transformation.Reset, e.parsedPipeline.Transformations[0].Type())
-	require.Equal(t, transformation.Increase, e.parsedPipeline.Transformations[1].Type())
-}

--- a/src/aggregator/aggregator/entry.go
+++ b/src/aggregator/aggregator/entry.go
@@ -621,13 +621,16 @@ func (e *Entry) updateStagedMetadatasWithLock(
 	)
 
 	// Update the metadatas.
-	for i := range sm.Pipelines {
-		storagePolicies := e.storagePolicies(sm.Pipelines[i].StoragePolicies)
+	for _, p := range sm.Pipelines {
+		if e.opts.AddToReset() {
+			p.Pipeline = p.Pipeline.WithResets()
+		}
+		storagePolicies := e.storagePolicies(p.StoragePolicies)
 		for j := range storagePolicies {
 			key := aggregationKey{
-				aggregationID:      sm.Pipelines[i].AggregationID,
+				aggregationID:      p.AggregationID,
 				storagePolicy:      storagePolicies[j],
-				pipeline:           sm.Pipelines[i].Pipeline,
+				pipeline:           p.Pipeline,
 				idPrefixSuffixType: WithPrefixWithSuffix,
 			}
 			var listID metricListID

--- a/src/aggregator/aggregator/entry_test.go
+++ b/src/aggregator/aggregator/entry_test.go
@@ -1818,6 +1818,54 @@ func TestEntryMaybeExpireWithExpiry(t *testing.T) {
 	}
 }
 
+func TestEntry_AddToReset(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cases := []struct {
+		name       string
+		addToReset bool
+	}{
+		{
+			name:       "add to reset enabled",
+			addToReset: true,
+		},
+		{
+			name:       "add to reset disabled",
+			addToReset: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			timed, _, _ := testEntry(ctrl, testEntryOptions{
+				options: testOptions(ctrl).SetAddToReset(tc.addToReset),
+			})
+			untimed, _, _ := testEntry(ctrl, testEntryOptions{
+				options: testOptions(ctrl).SetAddToReset(tc.addToReset),
+			})
+
+			sms := testCustomStagedMetadatas
+			p := testPipeline
+			p.Operations[0].Transformation.Type = transformation.Add
+			sms[0].Metadata.Pipelines[0].Pipeline = p
+			require.NoError(t, timed.AddTimedWithStagedMetadatas(testTimedMetric, sms))
+			require.NoError(t, untimed.addUntimed(testUntimedMetric, sms))
+
+			if tc.addToReset {
+				require.Equal(t, timed.aggregations[0].key.pipeline.Operations[0].Transformation.Type, transformation.Reset)
+				require.Equal(t, untimed.aggregations[0].key.pipeline.Operations[0].Transformation.Type, transformation.Reset)
+			} else {
+				require.Equal(t, timed.aggregations[0].key.pipeline.Operations[0].Transformation.Type, transformation.Add)
+				require.Equal(t, untimed.aggregations[0].key.pipeline.Operations[0].Transformation.Type, transformation.Add)
+			}
+			require.Equal(t, timed.aggregations[0].key.pipeline.Operations[1].Transformation.Type, transformation.PerSecond)
+			require.Equal(t, untimed.aggregations[0].key.pipeline.Operations[1].Transformation.Type, transformation.PerSecond)
+		})
+	}
+}
+
 func TestEntryMaybeCopyIDWithLock(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/src/metrics/pipeline/applied/type.go
+++ b/src/metrics/pipeline/applied/type.go
@@ -287,6 +287,18 @@ func (p Pipeline) IsMappingRule() bool {
 	return true
 }
 
+// WithResets returns a new Pipeline with Add transformations replaced with Reset transformations.
+// See transformReset for why Reset should be used instead of Add.
+func (p Pipeline) WithResets() Pipeline {
+	for i, o := range p.Operations {
+		if o.Transformation.Type == transformation.Add {
+			o.Transformation.Type = transformation.Reset
+			p.Operations[i] = o
+		}
+	}
+	return p
+}
+
 // OperationsFromProto converts a list of protobuf AppliedPipelineOps, used in optimized staged metadata methods.
 func OperationsFromProto(pb []pipelinepb.AppliedPipelineOp, ops []OpUnion) error {
 	numOps := len(pb)

--- a/src/metrics/pipeline/applied/type_test.go
+++ b/src/metrics/pipeline/applied/type_test.go
@@ -657,3 +657,42 @@ func TestPipelineRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+func TestPipeline_WithResets(t *testing.T) {
+	p := Pipeline{
+		Operations: []OpUnion{
+			{
+				Type: pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{
+					Type: transformation.Add,
+				},
+			},
+			{
+				Type: pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{
+					Type: transformation.PerSecond,
+				},
+			},
+		},
+	}
+	copyP := p
+	expected := Pipeline{
+		Operations: []OpUnion{
+			{
+				Type: pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{
+					Type: transformation.Reset,
+				},
+			},
+			{
+				Type: pipeline.TransformationOpType,
+				Transformation: pipeline.TransformationOp{
+					Type: transformation.PerSecond,
+				},
+			},
+		},
+	}
+	require.Equal(t, expected, p.WithResets())
+	// make sure the original pipeline doesn't change.
+	require.Equal(t, copyP, p)
+}


### PR DESCRIPTION
This will allow removing the migration in the future. This is a noop
change.

At the moment the aggregationKey still contains Adds instead of Resets,
which makes it impossible to seamlessly transition the rollup rules to
explicitly use Reset instead of Add, since the AggregationKey will change.
If the AggregationKey changes it will result in split aggregations
during the deploy.

Once this has been deployed to the aggregator, the rollup rules in the
coordinator can be changed to use Reset explicilty and the
AggregationKey won't change in the Aggregator. The boolean can then be
dropped once all rules are using Reset instead of Add.

When this change rolls out to the aggregator it will change the
AggregationKey for incoming metrics. However, it will only affect the
follower and once the follower changes to the leader, the new
AggregationKey is fine to use.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
