### PR TITLE
[aggregator] Add interrupt channel for Aggregator shutdown

### DIFF
--- a/src/cmd/services/m3aggregator/main/main.go
+++ b/src/cmd/services/m3aggregator/main/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3/src/cmd/services/m3aggregator/config"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/config/configflag"
+	xos "github.com/m3db/m3/src/x/os"
 )
 
 func main() {
@@ -43,6 +44,7 @@ func main() {
 	}
 
 	server.Run(server.RunOptions{
-		Config: cfg,
+		Config:      cfg,
+		InterruptCh: xos.NewInterruptChannel(1),
 	})
 }

--- a/src/cmd/services/m3dbnode/main/main.go
+++ b/src/cmd/services/m3dbnode/main/main.go
@@ -24,9 +24,6 @@ import (
 	"flag"
 	"log"
 	_ "net/http/pprof" // pprof: for debug listen server if configured
-	"os"
-	"os/signal"
-	"syscall"
 
 	clusterclient "github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cmd/services/m3dbnode/config"
@@ -96,10 +93,4 @@ func main() {
 	} else if cfg.Coordinator != nil {
 		<-coordinatorDoneCh
 	}
-}
-
-func interrupt() <-chan os.Signal {
-	c := make(chan os.Signal)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-	return c
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Instead of watching for interrupts directly within the
server.Run method. Allow for an interruptCh to be passed
as a RunOption. This will allow the aggregator to be started
and shutdown programatically which will be useful as
we improve upon our integration tests. This pattern is already
used for both the coordinator and db nodes.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
