### PR TITLE
[aggregator] Use WaitForInterrupt to handle interrupts

### DIFF
--- a/src/aggregator/server/server.go
+++ b/src/aggregator/server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/m3db/m3/src/x/clock"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/instrument"
+	xos "github.com/m3db/m3/src/x/os"
 
 	"go.uber.org/zap"
 )
@@ -182,7 +183,9 @@ func Run(opts RunOptions) {
 	}()
 
 	// Handle interrupts.
-	logger.Warn("interrupt", zap.Error(<-opts.InterruptCh))
+	xos.WaitForInterrupt(logger, xos.InterruptOptions{
+		InterruptCh: opts.InterruptCh,
+	})
 
 	if s := cfg.Aggregator.ShutdownWaitTimeout; s != 0 {
 		sigC := make(chan os.Signal, 1)

--- a/src/cmd/services/m3aggregator/main/main.go
+++ b/src/cmd/services/m3aggregator/main/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/m3db/m3/src/cmd/services/m3aggregator/config"
 	xconfig "github.com/m3db/m3/src/x/config"
 	"github.com/m3db/m3/src/x/config/configflag"
-	xos "github.com/m3db/m3/src/x/os"
 )
 
 func main() {
@@ -44,7 +43,6 @@ func main() {
 	}
 
 	server.Run(server.RunOptions{
-		Config:      cfg,
-		InterruptCh: xos.NewInterruptChannel(1),
+		Config: cfg,
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
WaitForInterrupt is the more idiomatic way for us to
handle interrupts and also more gracefully handles
a nil interruptCh.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
