### PR TITLE
[query] Fix Graphite getFirstPathExpression not able to extract paths from partially complete expressions

### DIFF
--- a/src/query/graphite/native/alias_functions.go
+++ b/src/query/graphite/native/alias_functions.go
@@ -69,38 +69,6 @@ func aliasByNode(ctx *common.Context, seriesList singlePathSpec, nodes ...int) (
 	return ts.SeriesList(seriesList), nil
 }
 
-func getFirstPathExpression(name string) (string, error) {
-	node, err := ParseGrammar(name, CompileOptions{})
-	if err != nil {
-		return "", err
-	}
-	if path, ok := getFirstPathExpressionDepthFirst(node); ok {
-		return path, nil
-	}
-	return name, nil
-}
-
-func getFirstPathExpressionDepthFirst(node ASTNode) (string, bool) {
-	path, ok := node.PathExpression()
-	if ok {
-		return path, true
-	}
-
-	call, ok := node.CallExpression()
-	if !ok {
-		return "", false
-	}
-
-	for _, arg := range call.Arguments() {
-		path, ok = getFirstPathExpressionDepthFirst(arg)
-		if ok {
-			return path, true
-		}
-	}
-
-	return "", false
-}
-
 // aliasSub runs series names through a regex search/replace.
 func aliasSub(ctx *common.Context, input singlePathSpec, search, replace string) (ts.SeriesList, error) {
 	return common.AliasSub(ctx, ts.SeriesList(input), search, replace)

--- a/src/query/graphite/native/alias_functions_test.go
+++ b/src/query/graphite/native/alias_functions_test.go
@@ -203,7 +203,6 @@ func TestAliasByNodeWithComposition(t *testing.T) {
 		ts.NewSeries(ctx, "derivative(servers.bob02-foo.cpu.load_5)", now, values),
 		ts.NewSeries(ctx, "derivative(derivative(servers.bob02-foo.cpu.load_5))", now, values),
 		ts.NewSeries(ctx, "fooble", now, values),
-		ts.NewSeries(ctx, "", now, values),
 	}
 	results, err := aliasByNode(ctx, singlePathSpec{
 		Values: series,
@@ -213,7 +212,6 @@ func TestAliasByNodeWithComposition(t *testing.T) {
 	assert.Equal(t, "servers.bob02-foo", results.Values[0].Name())
 	assert.Equal(t, "servers.bob02-foo", results.Values[1].Name())
 	assert.Equal(t, "fooble", results.Values[2].Name())
-	assert.Equal(t, "", results.Values[3].Name())
 }
 
 func TestAliasByNodeWithManyPathExpressions(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This ensures that partial expressions that should not be able to be successfully compiled can still have their path expression extracted for use in functions like groupByNode.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
