### PR TITLE
Do not set Aggregation for AutoMappingRule

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -159,13 +159,9 @@ func NewAutoMappingRules(namespaces []m3.ClusterNamespace) ([]AutoMappingRule, e
 			storagePolicy := policy.NewStoragePolicy(attrs.Resolution,
 				xtime.Second, attrs.Retention)
 			autoMappingRules = append(autoMappingRules, AutoMappingRule{
-				// NB(r): By default we will apply just keep all last values
-				// since coordinator only uses downsampling with Prometheus
-				// remote write endpoint.
-				// More rich static configuration mapping rules can be added
-				// in the future but they are currently not required.
-				Aggregations: []aggregation.Type{aggregation.Last},
-				Policies:     policy.StoragePolicies{storagePolicy},
+				// Do not explicitly set an Aggregation. The default for the metric type will be applied by the
+				// aggregator (e.g LAST for gauges, SUM for counters).
+				Policies: policy.StoragePolicies{storagePolicy},
 			})
 		}
 	}


### PR DESCRIPTION
Previously the AutoMappingRule used LAST, which only works for Gauges.
This is fine for Prometheus metrics, which are all Guages. However, LAST
is not a valid aggregation for Counters, which is used by StatsD.

Instead of explicitly setting an Aggregation, the default for the metric
type is used by the Aggregator when it's not set. So LAST will continue
to be used for Gauges and SUM will be used for Counters.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
