### PR TITLE
[aggregator][dbnode][query] Improve resource cleanup flow on shutdown

### DIFF
--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -107,6 +107,7 @@ import (
 const (
 	bootstrapConfigInitTimeout       = 10 * time.Second
 	serverGracefulCloseTimeout       = 10 * time.Second
+	debugServerGracefulCloseTimeout  = 2 * time.Second
 	bgProcessLimitInterval           = 10 * time.Second
 	maxBgProcessLimitMonitorDuration = 5 * time.Minute
 	cpuProfileDuration               = 5 * time.Second
@@ -864,23 +865,8 @@ func Run(runOpts RunOptions) {
 			}
 		}
 
-		go func() {
-			mux := http.DefaultServeMux
-			if debugWriter != nil {
-				if err := debugWriter.RegisterHandler(xdebug.DebugURL, mux); err != nil {
-					logger.Error("unable to register debug writer endpoint", zap.Error(err))
-				}
-			}
-
-			if err := http.ListenAndServe(debugListenAddress, mux); err != nil {
-				logger.Error("debug server could not listen",
-					zap.String("address", debugListenAddress), zap.Error(err))
-			} else {
-				logger.Info("debug server listening",
-					zap.String("address", debugListenAddress),
-				)
-			}
-		}()
+		debugClose := startDebugServer(debugWriter, logger, debugListenAddress)
+		defer debugClose()
 	}
 
 	topo, err := syncCfg.TopologyInitializer.Init()
@@ -1114,7 +1100,36 @@ func Run(runOpts RunOptions) {
 	case <-time.After(closeTimeout):
 		logger.Error("server closed after timeout", zap.Duration("timeout", closeTimeout))
 	}
+}
 
+func startDebugServer(
+	debugWriter xdebug.ZipWriter,
+	logger *zap.Logger,
+	debugListenAddress string,
+) func() {
+	mux := http.DefaultServeMux
+	server := http.Server{Addr: debugListenAddress, Handler: mux}
+
+	if debugWriter != nil {
+		if err := debugWriter.RegisterHandler(xdebug.DebugURL, mux); err != nil {
+			logger.Error("unable to register debug writer endpoint", zap.Error(err))
+		}
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("debug server could not listen",
+				zap.String("address", debugListenAddress), zap.Error(err))
+		}
+	}()
+
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), debugServerGracefulCloseTimeout)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			logger.Warn("debug server failed to shutdown gracefully")
+		} else {
+			logger.Info("debug server closed")
 		}
 	}
 }

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -204,6 +204,20 @@ func Run(runOpts RunOptions) RunResult {
 		os.Exit(1)
 	}
 
+	// NB(nate): Register shutdown notification defer function first so that
+	// it's the last defer to fire before terminating. This allows other defer methods
+	// that clean up resources to execute first.
+	if runOpts.ShutdownCh != nil {
+		defer func() {
+			select {
+			case runOpts.ShutdownCh <- struct{}{}:
+				break
+			default:
+				logger.Warn("could not send shutdown notification as channel was full")
+			}
+		}()
+	}
+
 	defer logger.Sync()
 
 	cfg.Debug.SetRuntimeValues(logger)
@@ -658,15 +672,6 @@ func Run(runOpts RunOptions) RunResult {
 	xos.WaitForInterrupt(logger, xos.InterruptOptions{
 		InterruptCh: runOpts.InterruptCh,
 	})
-
-	if runOpts.ShutdownCh != nil {
-		select {
-		case runOpts.ShutdownCh <- struct{}{}:
-			break
-		default:
-			logger.Warn("could not send shutdown notification as channel was full")
-		}
-	}
 
 	return runResult
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR lands a couple changes that makes restarting the process in-memory easier by improving resource cleanup. This is primarily for the sake of integration testing. Commits:

```
Ensure shutdown notication sent after resource cleanup

This commit moves the shutdown notification to a deferred
function, and ensures that the function is the last deferred
function called by registering it first. This ensures that
all cleanup behavior happening in deferred functions are
complete before we send a shutdown notification.
```

```
Ensure dbnode debug server shutdown on server shutdown

This commit calls server.Shutdown for the debug server
once the main dbnode server is shutdown. Additionally,
use do not register debug routes on global DefaultServeMux
object. Both of these changes make it easier to restart
a DB node process in-memory without running causing errors.
```


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
