### PR TITLE
[dbnode] DedicatedConnection to bootstrapped nodes option

### DIFF
--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -766,7 +766,7 @@ func (s *session) DedicatedConnection(
 			return
 		}
 
-		if err := s.healthCheckNewConnFn(client, s.opts); err != nil {
+		if err := s.healthCheckNewConnFn(client, s.opts, opts.BootstrappedNodesOnly); err != nil {
 			multiErr = multiErr.Add(err)
 			return
 		}

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -340,7 +340,8 @@ type WithBorrowConnectionResult struct {
 
 // DedicatedConnectionOptions are options used for getting a dedicated connection.
 type DedicatedConnectionOptions struct {
-	ShardStateFilter shard.State
+	ShardStateFilter      shard.State
+	BootstrappedNodesOnly bool
 }
 
 // Options is a set of client options.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an option to consider only the nodes that are fully bootstrapped (via `NodeHealthResult_.Bootstrapped` field) when acquiring a `DedicatedConnection`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE