### PR TITLE
[aggregator] Write data concurrently in integration tests

### DIFF
--- a/src/aggregator/integration/custom_aggregations_test.go
+++ b/src/aggregator/integration/custom_aggregations_test.go
@@ -167,9 +167,9 @@ func testCustomAggregations(t *testing.T, metadataFns [4]metadataFn) {
 	for _, dataset := range inputs {
 		for _, data := range dataset {
 			clock.SetNow(data.timestamp)
-			for _, mm := range data.metricWithMetadatas {
+			applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 				require.NoError(t, client.writeUntimedMetricWithMetadatas(mm.metric.untimed, mm.metadata.stagedMetadatas))
-			}
+			})
 			require.NoError(t, client.flush())
 
 			// Give server some time to process the incoming packets.

--- a/src/aggregator/integration/metadata_change_test.go
+++ b/src/aggregator/integration/metadata_change_test.go
@@ -126,9 +126,9 @@ func testMetadataChange(t *testing.T, oldMetadataFn, newMetadataFn metadataFn) {
 	for _, dataset := range inputs {
 		for _, data := range dataset {
 			clock.SetNow(data.timestamp)
-			for _, mm := range data.metricWithMetadatas {
+			applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 				require.NoError(t, client.writeUntimedMetricWithMetadatas(mm.metric.untimed, mm.metadata.stagedMetadatas))
-			}
+			})
 			require.NoError(t, client.flush())
 
 			// Give server some time to process the incoming packets.

--- a/src/aggregator/integration/multi_client_one_type_test.go
+++ b/src/aggregator/integration/multi_client_one_type_test.go
@@ -111,11 +111,11 @@ func testMultiClientOneType(t *testing.T, metadataFn metadataFn) {
 	})
 	for _, data := range dataset {
 		clock.SetNow(data.timestamp)
-		for _, mm := range data.metricWithMetadatas {
+		applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 			// Randomly pick one client to write the metric.
 			client := clients[rand.Int63n(int64(numClients))]
 			require.NoError(t, client.writeUntimedMetricWithMetadatas(mm.metric.untimed, mm.metadata.stagedMetadatas))
-		}
+		})
 		for _, client := range clients {
 			require.NoError(t, client.flush())
 		}

--- a/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
+++ b/src/aggregator/integration/multi_server_forwarding_pipeline_test.go
@@ -305,9 +305,9 @@ func testMultiServerForwardingPipeline(t *testing.T, discardNaNAggregatedValues 
 	for _, data := range dataset {
 		clock.SetNow(data.timestamp)
 
-		for _, mm := range data.metricWithMetadatas {
+		applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 			require.NoError(t, client.writeUntimedMetricWithMetadatas(mm.metric.untimed, mm.metadata.stagedMetadatas))
-		}
+		})
 		require.NoError(t, client.flush())
 
 		// Give server some time to process the incoming packets.
@@ -429,5 +429,5 @@ func testMultiServerForwardingPipeline(t *testing.T, discardNaNAggregatedValues 
 	}
 	sort.Sort(byTimeIDPolicyAscending(expectedResultsFlattened))
 	actual := destinationServer.sortedResults()
-	require.True(t, cmp.Equal(expectedResultsFlattened, actual, testCmpOpts...))
+	require.True(t, cmp.Equal(expectedResultsFlattened, actual, testCmpOpts...), cmp.Diff(expectedResultsFlattened, actual, testCmpOpts...))
 }

--- a/src/aggregator/integration/one_client_multi_type_forwarded_test.go
+++ b/src/aggregator/integration/one_client_multi_type_forwarded_test.go
@@ -111,9 +111,9 @@ func TestOneClientMultiTypeForwardedMetrics(t *testing.T) {
 	})
 	for _, data := range dataset {
 		clock.SetNow(data.timestamp)
-		for _, mm := range data.metricWithMetadatas {
+		applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 			require.NoError(t, client.writeForwardedMetricWithMetadata(mm.metric.forwarded, mm.metadata.forwardMetadata))
-		}
+		})
 		require.NoError(t, client.flush())
 
 		// Give server some time to process the incoming packets.

--- a/src/aggregator/integration/one_client_multi_type_timed_test.go
+++ b/src/aggregator/integration/one_client_multi_type_timed_test.go
@@ -109,9 +109,9 @@ func TestOneClientMultiTypeTimedMetrics(t *testing.T) {
 	})
 	for _, data := range dataset {
 		clock.SetNow(data.timestamp)
-		for _, mm := range data.metricWithMetadatas {
+		applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 			require.NoError(t, client.writeTimedMetricWithMetadata(mm.metric.timed, mm.metadata.timedMetadata))
-		}
+		})
 		require.NoError(t, client.flush())
 
 		// Give server some time to process the incoming packets.

--- a/src/aggregator/integration/one_client_multi_type_untimed_test.go
+++ b/src/aggregator/integration/one_client_multi_type_untimed_test.go
@@ -103,9 +103,9 @@ func testOneClientMultiType(t *testing.T, metadataFn metadataFn) {
 	})
 	for _, data := range dataset {
 		clock.SetNow(data.timestamp)
-		for _, mm := range data.metricWithMetadatas {
+		applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 			require.NoError(t, client.writeUntimedMetricWithMetadatas(mm.metric.untimed, mm.metadata.stagedMetadatas))
-		}
+		})
 		require.NoError(t, client.flush())
 
 		// Give server some time to process the incoming packets.

--- a/src/aggregator/integration/one_client_passthru_test.go
+++ b/src/aggregator/integration/one_client_passthru_test.go
@@ -113,9 +113,9 @@ func TestOneClientPassthroughMetrics(t *testing.T) {
 
 	for _, data := range dataset {
 		clock.SetNow(data.timestamp)
-		for _, mm := range data.metricWithMetadatas {
+		applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 			require.NoError(t, client.writePassthroughMetricWithMetadata(mm.metric.passthrough, mm.metadata.passthroughMetadata))
-		}
+		})
 		require.NoError(t, client.flush())
 
 		// Give server some time to process the incoming packets.

--- a/src/aggregator/integration/placement_change_test.go
+++ b/src/aggregator/integration/placement_change_test.go
@@ -236,10 +236,10 @@ func TestPlacementChange(t *testing.T) {
 	for _, data := range datasets[0] {
 		clock.SetNow(data.timestamp)
 
-		for _, mm := range data.metricWithMetadatas {
+		applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 			idx := getServerIndex(mm.metric.ID(), initialPlacement)
 			require.NoError(t, clients[idx].writeTimedMetricWithMetadata(mm.metric.timed, mm.metadata.timedMetadata))
-		}
+		})
 		for _, c := range clients {
 			require.NoError(t, c.flush())
 		}

--- a/src/aggregator/integration/same_id_multi_type_test.go
+++ b/src/aggregator/integration/same_id_multi_type_test.go
@@ -127,9 +127,9 @@ func testSameIDMultiType(t *testing.T, metadataFn metadataFn) {
 	})
 	for _, data := range dataset {
 		clock.SetNow(data.timestamp)
-		for _, mm := range data.metricWithMetadatas {
+		applyConcurrently(data.metricWithMetadatas, func(mm metricWithMetadataUnion) {
 			require.NoError(t, client.writeUntimedMetricWithMetadatas(mm.metric.untimed, mm.metadata.stagedMetadatas))
-		}
+		})
 		require.NoError(t, client.flush())
 
 		// Give server some time to process the incoming packets.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Updates aggregator integration tests to write data concurrently. This should make it more likely for tests to reveal concurrency issues.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
