### PR TITLE
Add support for querying specific namespaces

### DIFF
--- a/src/query/api/v1/handler/graphite/render.go
+++ b/src/query/api/v1/handler/graphite/render.go
@@ -131,6 +131,7 @@ func (h *renderHandler) serveHTTP(
 		Timeout:       p.Timeout,
 		Limit:         limit,
 		MaxDataPoints: p.MaxDataPoints,
+		FetchOpts:     fetchOpts,
 	})
 
 	// Set the request context.

--- a/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
@@ -372,7 +372,7 @@ func (b fetchOptionsBuilder) newFetchOptions(
 			sp, err := policy.ParseStoragePolicy(policyStr)
 			if err != nil {
 				err = fmt.Errorf(
-					"could not parse storage policy: input=%s, err=%v", str, err)
+					"could not parse storage policy: input=%s, err=%w", str, err)
 				return nil, nil, err
 			}
 			restrictByTypes = append(

--- a/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
@@ -321,7 +321,12 @@ func (b fetchOptionsBuilder) newFetchOptions(
 
 	fetchOpts.RequireNoWait = requireNoWait
 
+	var (
+		metricsTypeHeaderFound          bool
+		metricsStoragePolicyHeaderFound bool
+	)
 	if str := req.Header.Get(headers.MetricsTypeHeader); str != "" {
+		metricsTypeHeaderFound = true
 		mt, err := storagemetadata.ParseMetricsType(str)
 		if err != nil {
 			err = fmt.Errorf(
@@ -336,6 +341,7 @@ func (b fetchOptionsBuilder) newFetchOptions(
 	}
 
 	if str := req.Header.Get(headers.MetricsStoragePolicyHeader); str != "" {
+		metricsStoragePolicyHeaderFound = true
 		sp, err := policy.ParseStoragePolicy(str)
 		if err != nil {
 			err = fmt.Errorf(
@@ -347,6 +353,42 @@ func (b fetchOptionsBuilder) newFetchOptions(
 		fetchOpts.RestrictQueryOptions.RestrictByType =
 			newOrExistingRestrictQueryOptionsRestrictByType(fetchOpts)
 		fetchOpts.RestrictQueryOptions.RestrictByType.StoragePolicy = sp
+	}
+
+	if str := req.Header.Get(headers.MetricsRestrictByPoliciesHeader); str != "" {
+		if metricsTypeHeaderFound || metricsStoragePolicyHeaderFound {
+			err = fmt.Errorf(
+				"restrict by policies is incompatible with M3-Metrics-Type and M3-Storage-Policy headers")
+			return nil, nil, err
+		}
+		policyStrs := strings.Split(str, ";")
+		if len(policyStrs) == 0 {
+			err = fmt.Errorf(
+				"no policies specified with restrict by policies header")
+			return nil, nil, err
+		}
+		restrictByTypes := make([]*storage.RestrictByType, 0, len(policyStrs))
+		for _, policyStr := range policyStrs {
+			sp, err := policy.ParseStoragePolicy(policyStr)
+			if err != nil {
+				err = fmt.Errorf(
+					"could not parse storage policy: input=%s, err=%v", str, err)
+				return nil, nil, err
+			}
+			restrictByTypes = append(
+				restrictByTypes,
+				&storage.RestrictByType{
+					MetricsType:   storagemetadata.AggregatedMetricsType,
+					StoragePolicy: sp,
+				})
+		}
+
+		fetchOpts.RestrictQueryOptions = newOrExistingRestrictQueryOptions(fetchOpts)
+		fetchOpts.RestrictQueryOptions.RestrictByTypes =
+			newOrExistingRestrictQueryOptionsRestrictByTypes(fetchOpts)
+		fetchOpts.RestrictQueryOptions.RestrictByTypes = append(
+			fetchOpts.RestrictQueryOptions.RestrictByTypes, restrictByTypes...,
+		)
 	}
 
 	if str := req.Header.Get(headers.RestrictByTagsJSONHeader); str != "" {
@@ -420,6 +462,15 @@ func newOrExistingRestrictQueryOptionsRestrictByType(
 		return v
 	}
 	return &storage.RestrictByType{}
+}
+
+func newOrExistingRestrictQueryOptionsRestrictByTypes(
+	fetchOpts *storage.FetchOptions,
+) []*storage.RestrictByType {
+	if v := fetchOpts.RestrictQueryOptions.RestrictByTypes; v != nil {
+		return v
+	}
+	return make([]*storage.RestrictByType, 0)
 }
 
 // contextWithRequestAndTimeout sets up a context with the request's context

--- a/src/query/api/v1/handler/prometheus/handleroptions/fetch_options_test.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/fetch_options_test.go
@@ -240,6 +240,68 @@ func TestFetchOptionsBuilder(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "restrict by policies with metrics type",
+			headers: map[string]string{
+				headers.MetricsTypeHeader:               "aggregated",
+				headers.MetricsRestrictByPoliciesHeader: "10m:60d",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "restrict by policies with storage policy",
+			headers: map[string]string{
+				headers.MetricsStoragePolicyHeader:      "10m:60d",
+				headers.MetricsRestrictByPoliciesHeader: "10m:60d",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "restrict by policies - invalid policy",
+			headers: map[string]string{
+				headers.MetricsRestrictByPoliciesHeader: "10m",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "restrict by policies - invalid delimiter",
+			headers: map[string]string{
+				headers.MetricsRestrictByPoliciesHeader: "10m:60d,5m:30d",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "restrict by policies - single policy",
+			headers: map[string]string{
+				headers.MetricsRestrictByPoliciesHeader: "10m:60d",
+			},
+			expectedRestrict: &storage.RestrictQueryOptions{
+				RestrictByTypes: []*storage.RestrictByType{
+					{
+						MetricsType:   storagemetadata.AggregatedMetricsType,
+						StoragePolicy: policy.MustParseStoragePolicy("10m:60d"),
+					},
+				},
+			},
+		},
+		{
+			name: "restrict by policies - multiple policy",
+			headers: map[string]string{
+				headers.MetricsRestrictByPoliciesHeader: "10m:60d;5m:30d",
+			},
+			expectedRestrict: &storage.RestrictQueryOptions{
+				RestrictByTypes: []*storage.RestrictByType{
+					{
+						MetricsType:   storagemetadata.AggregatedMetricsType,
+						StoragePolicy: policy.MustParseStoragePolicy("10m:60d"),
+					},
+					{
+						MetricsType:   storagemetadata.AggregatedMetricsType,
+						StoragePolicy: policy.MustParseStoragePolicy("5m:30d"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/src/query/graphite/common/context.go
+++ b/src/query/graphite/common/context.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/query/graphite/context"
+	"github.com/m3db/m3/src/query/storage"
 )
 
 // contextBase are the real content of a Context, minus the lock so that we
@@ -63,6 +64,9 @@ type contextBase struct {
 	// MaxDataPoints is the max datapoints for the query.
 	MaxDataPoints int64
 
+	// FetchOpts are the fetch options to use for the query.
+	FetchOpts *storage.FetchOptions
+
 	parent         *Context
 	reqCtx         ctx.Context
 	storageContext context.Context
@@ -82,6 +86,7 @@ type ContextOptions struct {
 	Timeout       time.Duration
 	Limit         int
 	MaxDataPoints int64
+	FetchOpts     *storage.FetchOptions
 }
 
 // TimeRangeAdjustment is an applied time range adjustment.
@@ -105,6 +110,7 @@ func NewContext(options ContextOptions) *Context {
 			Timeout:        options.Timeout,
 			Limit:          options.Limit,
 			MaxDataPoints:  options.MaxDataPoints,
+			FetchOpts:      options.FetchOpts,
 		},
 	}
 }

--- a/src/query/graphite/common/context.go
+++ b/src/query/graphite/common/context.go
@@ -55,9 +55,6 @@ type contextBase struct {
 	// specify zero to indicate default timeout or a positive value
 	Timeout time.Duration
 
-	// Limit provides a cap on the number of results returned from the database.
-	Limit int
-
 	// Source is the query source.
 	Source []byte
 
@@ -84,7 +81,6 @@ type ContextOptions struct {
 	End           time.Time
 	Engine        QueryEngine
 	Timeout       time.Duration
-	Limit         int
 	MaxDataPoints int64
 	FetchOpts     *storage.FetchOptions
 }
@@ -108,7 +104,6 @@ func NewContext(options ContextOptions) *Context {
 			Engine:         options.Engine,
 			storageContext: context.New(),
 			Timeout:        options.Timeout,
-			Limit:          options.Limit,
 			MaxDataPoints:  options.MaxDataPoints,
 			FetchOpts:      options.FetchOpts,
 		},

--- a/src/query/graphite/native/expression.go
+++ b/src/query/graphite/native/expression.go
@@ -117,9 +117,7 @@ func (f *fetchExpression) Execute(ctx *common.Context) (ts.SeriesList, error) {
 		EndTime:   ctx.EndTime,
 		DataOptions: storage.DataOptions{
 			Timeout: ctx.Timeout,
-			Limit:   ctx.Limit,
 		},
-		Source:         ctx.Source,
 		QueryFetchOpts: ctx.FetchOpts,
 	}
 

--- a/src/query/graphite/native/expression.go
+++ b/src/query/graphite/native/expression.go
@@ -119,7 +119,8 @@ func (f *fetchExpression) Execute(ctx *common.Context) (ts.SeriesList, error) {
 			Timeout: ctx.Timeout,
 			Limit:   ctx.Limit,
 		},
-		Source: ctx.Source,
+		Source:         ctx.Source,
+		QueryFetchOpts: ctx.FetchOpts,
 	}
 
 	result, err := ctx.Engine.FetchByQuery(ctx, f.pathArg.path, opts)

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -452,7 +452,12 @@ func (s *m3WrappedStore) FetchByQuery(
 		defer cancel()
 	}
 
-	fetchOptions := fetchOpts.QueryFetchOpts.Clone()
+	var fetchOptions *storage.FetchOptions
+	if fetchOpts.QueryFetchOpts != nil {
+		fetchOptions = fetchOpts.QueryFetchOpts.Clone()
+	} else {
+		fetchOptions = storage.NewFetchOptions()
+	}
 
 	// NB: ensure single block return.
 	fetchOptions.BlockType = models.TypeSingleBlock

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -452,7 +452,7 @@ func (s *m3WrappedStore) FetchByQuery(
 		defer cancel()
 	}
 
-	fetchOptions := fetchOpts.QueryFetchOpts
+	fetchOptions := fetchOpts.QueryFetchOpts.Clone()
 
 	// NB: ensure single block return.
 	fetchOptions.BlockType = models.TypeSingleBlock

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -454,8 +454,12 @@ func (s *m3WrappedStore) FetchByQuery(
 
 	fetchOptions := fetchOpts.QueryFetchOpts
 
-	fmt.Printf("fetch options are %v\n", fetchOptions)
-	fmt.Printf("restrict query options are %v\n", fetchOptions.RestrictQueryOptions)
+	fmt.Printf("fetch options are %+v\n", fetchOptions)
+	if fetchOptions.RestrictQueryOptions != nil {
+		for _, option := range fetchOptions.RestrictQueryOptions.RestrictByTypes {
+			fmt.Printf("restrict query options are %+v\n", option)
+		}
+	}
 
 	// NB: ensure single block return.
 	fetchOptions.BlockType = models.TypeSingleBlock

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -454,13 +454,6 @@ func (s *m3WrappedStore) FetchByQuery(
 
 	fetchOptions := fetchOpts.QueryFetchOpts
 
-	fmt.Printf("fetch options are %+v\n", fetchOptions)
-	if fetchOptions.RestrictQueryOptions != nil {
-		for _, option := range fetchOptions.RestrictQueryOptions.RestrictByTypes {
-			fmt.Printf("restrict query options are %+v\n", option)
-		}
-	}
-
 	// NB: ensure single block return.
 	fetchOptions.BlockType = models.TypeSingleBlock
 	fetchOptions.FanoutOptions = s.fanoutOptions()

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -453,8 +453,6 @@ func (s *m3WrappedStore) FetchByQuery(
 	}
 
 	fetchOptions := fetchOpts.QueryFetchOpts
-	fetchOptions.SeriesLimit = fetchOpts.Limit
-	fetchOptions.Source = fetchOpts.Source
 
 	fmt.Printf("fetch options are %v\n", fetchOptions)
 	fmt.Printf("restrict query options are %v\n", fetchOptions.RestrictQueryOptions)

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/m3db/m3/src/m3ninx/doc"
 	"github.com/m3db/m3/src/query/block"
 	xctx "github.com/m3db/m3/src/query/graphite/context"
@@ -42,8 +44,6 @@ import (
 	"github.com/m3db/m3/src/query/util/logging"
 	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
-
-	"go.uber.org/zap"
 )
 
 var errSeriesNoResolution = errors.New("series has no resolution set")
@@ -452,9 +452,12 @@ func (s *m3WrappedStore) FetchByQuery(
 		defer cancel()
 	}
 
-	fetchOptions := storage.NewFetchOptions()
+	fetchOptions := fetchOpts.QueryFetchOpts
 	fetchOptions.SeriesLimit = fetchOpts.Limit
 	fetchOptions.Source = fetchOpts.Source
+
+	fmt.Printf("fetch options are %v\n", fetchOptions)
+	fmt.Printf("restrict query options are %v\n", fetchOptions.RestrictQueryOptions)
 
 	// NB: ensure single block return.
 	fetchOptions.BlockType = models.TypeSingleBlock

--- a/src/query/graphite/storage/m3_wrapper_test.go
+++ b/src/query/graphite/storage/m3_wrapper_test.go
@@ -234,6 +234,7 @@ func TestFetchByQuery(t *testing.T) {
 		DataOptions: DataOptions{
 			Timeout: time.Minute,
 		},
+		QueryFetchOpts: storage.NewFetchOptions(),
 	}
 
 	query := "a*b"

--- a/src/query/graphite/storage/storage.go
+++ b/src/query/graphite/storage/storage.go
@@ -42,6 +42,8 @@ type FetchOptions struct {
 	DataOptions
 	// Source is the query source.
 	Source []byte
+	// QueryFetchOpts are the query storage fetch options.
+	QueryFetchOpts *querystorage.FetchOptions
 }
 
 // DataOptions provide data context.

--- a/src/query/graphite/storage/storage.go
+++ b/src/query/graphite/storage/storage.go
@@ -40,8 +40,6 @@ type FetchOptions struct {
 	EndTime time.Time
 	// DataOptions are the options for the fetch.
 	DataOptions
-	// Source is the query source.
-	Source []byte
 	// QueryFetchOpts are the query storage fetch options.
 	QueryFetchOpts *querystorage.FetchOptions
 }
@@ -51,8 +49,6 @@ type DataOptions struct {
 	// Timeout determines a custom timeout for the context. If set to 0, uses
 	// the default timeout.
 	Timeout time.Duration
-	// Limit is the limit for number of datapoints to retrieve.
-	Limit int
 }
 
 // Storage provides an interface for retrieving timeseries values or names

--- a/src/query/storage/fetch.go
+++ b/src/query/storage/fetch.go
@@ -23,10 +23,10 @@ package storage
 import (
 	"time"
 
+	"github.com/uber-go/tally"
+
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
-
-	"github.com/uber-go/tally"
 )
 
 // NewFetchOptions creates a new fetch options.

--- a/src/query/storage/m3/cluster_resolver_test.go
+++ b/src/query/storage/m3/cluster_resolver_test.go
@@ -373,6 +373,51 @@ var testCases = []struct {
 		expectedErrContains:      "could not find namespace for storage policy:",
 		expectedErrInvalidParams: true,
 	},
+	{
+		name:        "restrict to multiple aggregate",
+		queryLength: time.Hour * 1000,
+		restrict: &storage.RestrictQueryOptions{
+			RestrictByTypes: []*storage.RestrictByType{
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					StoragePolicy: policy.MustParseStoragePolicy(
+						genResolution.String() + ":" + genRetentionFiltered.String()),
+				},
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					StoragePolicy: policy.MustParseStoragePolicy(
+						(genResolution + time.Second).String() + ":" + genRetentionUnfiltered.String()),
+				},
+			},
+		},
+		expectedType:         consolidators.NamespaceCoversPartialQueryRange,
+		expectedClusterNames: []string{"AGG_FILTERED", "AGG_NO_FILTER_COMPLETE"},
+	},
+	{
+		name:        "restrict to multiple aggregate all range",
+		queryLength: time.Minute,
+		opts: &storage.FanoutOptions{
+			FanoutUnaggregated:        storage.FanoutForceDisable,
+			FanoutAggregated:          storage.FanoutDefault,
+			FanoutAggregatedOptimized: storage.FanoutForceDisable,
+		},
+		restrict: &storage.RestrictQueryOptions{
+			RestrictByTypes: []*storage.RestrictByType{
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					StoragePolicy: policy.MustParseStoragePolicy(
+						(genResolution + time.Second).String() + ":" + genRetentionFiltered.String()),
+				},
+				{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					StoragePolicy: policy.MustParseStoragePolicy(
+						(genResolution + time.Second).String() + ":" + genRetentionUnfiltered.String()),
+				},
+			},
+		},
+		expectedType:         consolidators.NamespaceCoversAllQueryRange,
+		expectedClusterNames: []string{"AGG_FILTERED_COMPLETE", "AGG_NO_FILTER_COMPLETE"},
+	},
 }
 
 func TestResolveClusterNamespacesForQueryWithOptions(t *testing.T) {

--- a/src/query/storage/restrict_query_options.go
+++ b/src/query/storage/restrict_query_options.go
@@ -34,11 +34,9 @@ func (o *RestrictQueryOptions) Validate() error {
 	if o.RestrictByType != nil {
 		return o.RestrictByType.Validate()
 	}
-	if len(o.RestrictByTypes) > 0 {
-		for _, r := range o.RestrictByTypes {
-			if err := r.Validate(); err != nil {
-				return err
-			}
+	for _, r := range o.RestrictByTypes {
+		if err := r.Validate(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/src/query/storage/restrict_query_options.go
+++ b/src/query/storage/restrict_query_options.go
@@ -34,7 +34,13 @@ func (o *RestrictQueryOptions) Validate() error {
 	if o.RestrictByType != nil {
 		return o.RestrictByType.Validate()
 	}
-
+	if len(o.RestrictByTypes) > 0 {
+		for _, r := range o.RestrictByTypes {
+			if err := r.Validate(); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -45,6 +51,15 @@ func (o *RestrictQueryOptions) GetRestrictByType() *RestrictByType {
 	}
 
 	return o.RestrictByType
+}
+
+// GetRestrictByTypes provides the types restrictions if present; nil otherwise.
+func (o *RestrictQueryOptions) GetRestrictByTypes() []*RestrictByType {
+	if o == nil {
+		return nil
+	}
+
+	return o.RestrictByTypes
 }
 
 // GetRestrictByTag provides the tag restrictions if present; nil otherwise.

--- a/src/query/storage/restrict_query_options_test.go
+++ b/src/query/storage/restrict_query_options_test.go
@@ -23,7 +23,9 @@ package storage
 import (
 	"testing"
 
+	"github.com/m3db/m3/src/metrics/policy"
 	"github.com/m3db/m3/src/query/models"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 
 	"github.com/stretchr/testify/require"
 )
@@ -32,10 +34,12 @@ func TestGetRestrict(t *testing.T) {
 	var opts *RestrictQueryOptions
 	require.Nil(t, opts.GetRestrictByTag())
 	require.Nil(t, opts.GetRestrictByType())
+	require.Nil(t, opts.GetRestrictByTypes())
 
 	opts = &RestrictQueryOptions{}
 	require.Nil(t, opts.GetRestrictByTag())
 	require.Nil(t, opts.GetRestrictByType())
+	require.Nil(t, opts.GetRestrictByTypes())
 
 	opts.RestrictByTag = &RestrictByTag{}
 	require.NotNil(t, opts.GetRestrictByTag())
@@ -50,4 +54,13 @@ func TestGetRestrict(t *testing.T) {
 	byType := &RestrictByType{}
 	opts.RestrictByType = byType
 	require.Equal(t, byType, opts.GetRestrictByType())
+
+	byTypes := []*RestrictByType{
+		{
+			MetricsType:   storagemetadata.AggregatedMetricsType,
+			StoragePolicy: policy.MustParseStoragePolicy("10s:4d"),
+		},
+	}
+	opts.RestrictByTypes = byTypes
+	require.Equal(t, byTypes, opts.GetRestrictByTypes())
 }

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -205,6 +205,9 @@ type RestrictQueryOptions struct {
 	// RestrictByTag are specific restrictions to enforce behavior for given
 	// tags.
 	RestrictByTag *RestrictByTag
+	// RestrictByTypes are specific restrictions to stick to different data
+	// types.
+	RestrictByTypes []*RestrictByType
 }
 
 // Querier handles queries against a storage.

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -205,7 +205,7 @@ type RestrictQueryOptions struct {
 	// RestrictByTag are specific restrictions to enforce behavior for given
 	// tags.
 	RestrictByTag *RestrictByTag
-	// RestrictByTypes are specific restrictions to stick to different data
+	// RestrictByTypes are specific restrictions to query from specified data
 	// types.
 	RestrictByTypes []*RestrictByType
 }

--- a/src/x/headers/headers.go
+++ b/src/x/headers/headers.go
@@ -76,6 +76,11 @@ const (
 	// metrics type.
 	MetricsStoragePolicyHeader = M3HeaderPrefix + "Storage-Policy"
 
+	// MetricsRestrictByPoliciesHeader provides the policies options to enforce
+	// on queries, in the form of a list of storage policies.
+	// "1m:14d;5m:60d"
+	MetricsRestrictByPoliciesHeader = M3HeaderPrefix + "Restrict-By-Policies"
+
 	// RestrictByTagsJSONHeader provides tag options to enforces on queries,
 	// in JSON format. See `handler.stringTagOptions` for definitions.`
 	RestrictByTagsJSONHeader = M3HeaderPrefix + "Restrict-By-Tags-JSON"


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds support for querying specific namespaces by
means of headers. It additionally adds support for graphite to use
the full fetch options.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
