### PR TITLE
[*] Remove uses of http.DefaultServeMux

### DIFF
--- a/src/aggregator/server/http/options.go
+++ b/src/aggregator/server/http/options.go
@@ -64,7 +64,7 @@ func NewOptions() Options {
 	return &options{
 		readTimeout:  defaultReadTimeout,
 		writeTimeout: defaultWriteTimeout,
-		mux:          http.DefaultServeMux,
+		mux:          http.NewServeMux(),
 	}
 }
 
@@ -96,5 +96,4 @@ func (o *options) SetMux(value *http.ServeMux) Options {
 	opts := *o
 	opts.mux = value
 	return &opts
-
 }

--- a/src/aggregator/server/http/options.go
+++ b/src/aggregator/server/http/options.go
@@ -48,8 +48,6 @@ type Options interface {
 	Mux() *http.ServeMux
 
 	// SetMux sets the http mux for the server.
-	// This option exists to allow overriding in tests. Prod code should not set this and use the
-	// http.DefaultServerMux instead. std pkgs like pprof assume the default mux.
 	SetMux(value *http.ServeMux) Options
 }
 

--- a/src/cmd/services/m3aggregator/main/main.go
+++ b/src/cmd/services/m3aggregator/main/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"flag"
 	"log"
-	_ "net/http/pprof" // pprof: for debug listen server if configured
 
 	"github.com/m3db/m3/src/aggregator/server"
 	"github.com/m3db/m3/src/cmd/services/m3aggregator/config"

--- a/src/cmd/services/m3aggregator/serve/serve.go
+++ b/src/cmd/services/m3aggregator/serve/serve.go
@@ -27,6 +27,7 @@ import (
 	httpserver "github.com/m3db/m3/src/aggregator/server/http"
 	m3msgserver "github.com/m3db/m3/src/aggregator/server/m3msg"
 	rawtcpserver "github.com/m3db/m3/src/aggregator/server/rawtcp"
+	xdebug "github.com/m3db/m3/src/x/debug"
 
 	"go.uber.org/zap"
 )
@@ -66,6 +67,7 @@ func Serve(
 
 	if httpAddr := opts.HTTPAddr(); httpAddr != "" {
 		serverOpts := opts.HTTPServerOpts()
+		xdebug.RegisterPProfHandlers(serverOpts.Mux())
 		httpServer := httpserver.NewServer(httpAddr, aggregator, serverOpts, iOpts)
 		if err := httpServer.ListenAndServe(); err != nil {
 			return fmt.Errorf("could not start http server at: addr=%s, err=%v", httpAddr, err)

--- a/src/cmd/services/m3coordinator/main/main.go
+++ b/src/cmd/services/m3coordinator/main/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"flag"
 	"log"
-	_ "net/http/pprof" // pprof: for debug listen server if configured
 
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
 	"github.com/m3db/m3/src/query/server"

--- a/src/cmd/services/m3query/main/main.go
+++ b/src/cmd/services/m3query/main/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"flag"
 	"log"
-	_ "net/http/pprof" // pprof: for debug listen server if configured
 
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
 	"github.com/m3db/m3/src/query/server"

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -1112,6 +1112,7 @@ func startDebugServer(
 	debugListenAddress string,
 	mux *http.ServeMux,
 ) func() {
+	xdebug.RegisterPProfHandlers(mux)
 	server := http.Server{Addr: debugListenAddress, Handler: mux}
 
 	if debugWriter != nil {

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -572,9 +572,12 @@ func (h *Handler) registerHealthEndpoints() error {
 
 // Endpoints useful for profiling the service.
 func (h *Handler) registerProfileEndpoints() error {
+	debugHandler := http.NewServeMux()
+	xdebug.RegisterPProfHandlers(debugHandler)
+
 	return h.registry.Register(queryhttp.RegisterOptions{
 		PathPrefix: "/debug/pprof",
-		Handler:    http.NewServeMux(),
+		Handler:    debugHandler,
 	})
 }
 

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -574,7 +574,7 @@ func (h *Handler) registerHealthEndpoints() error {
 func (h *Handler) registerProfileEndpoints() error {
 	return h.registry.Register(queryhttp.RegisterOptions{
 		PathPrefix: "/debug/pprof",
-		Handler:    http.DefaultServeMux,
+		Handler:    http.NewServeMux(),
 	})
 }
 

--- a/src/x/debug/pprof.go
+++ b/src/x/debug/pprof.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2021  Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,36 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+// Package debug contains debug helpers for M3 components.
+package debug
 
 import (
-	"flag"
-	"log"
-
-	"github.com/m3db/m3/src/cmd/services/m3dbnode/config"
-	"github.com/m3db/m3/src/cmd/services/m3dbnode/server"
-	xconfig "github.com/m3db/m3/src/x/config"
-	"github.com/m3db/m3/src/x/config/configflag"
-	xos "github.com/m3db/m3/src/x/os"
+	"net/http"
+	"net/http/pprof"
 )
 
-func main() {
-	var cfgOpts configflag.Options
-	cfgOpts.Register()
-
-	flag.Parse()
-
-	var cfg config.Configuration
-	if err := cfgOpts.MainLoad(&cfg, xconfig.Options{}); err != nil {
-		log.Fatalf("error loading config: %v", err)
-	}
-
-	if err := cfg.Validate(); err != nil {
-		log.Fatalf("error validating config: %v", err)
-	}
-
-	server.RunComponents(server.Options{
-		Configuration: cfg,
-		InterruptCh:   xos.NewInterruptChannel(cfg.Components()),
-	})
+// RegisterPProfHandlers registers pprof endpoints on the ServeMux
+// provided. Use this instead of just importing net/http/pprof if you'd
+// like to register endpoints on a ServeMux other than http.DefaultServeMux.
+func RegisterPProfHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }

--- a/src/x/instrument/config.go
+++ b/src/x/instrument/config.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"time"
 
 	prom "github.com/m3db/prometheus_client_golang/prometheus"
@@ -35,9 +36,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	errNoReporterConfigured = errors.New("no reporter configured")
-)
+var errNoReporterConfigured = errors.New("no reporter configured")
 
 // ScopeConfiguration configures a metric scope.
 type ScopeConfiguration struct {
@@ -101,6 +100,7 @@ type MetricsConfigurationPrometheusReporter struct {
 // NewRootScopeAndReportersOptions is a set of options.
 type NewRootScopeAndReportersOptions struct {
 	PrometheusHandlerListener    net.Listener
+	PrometheusDefaultServeMux    *http.ServeMux
 	PrometheusExternalRegistries []PrometheusExternalRegistry
 	PrometheusOnError            func(e error)
 	// CommonLabels will be appended to every metric gathered.
@@ -162,6 +162,7 @@ func (mc *MetricsConfiguration) NewRootScopeAndReporters(
 			Registry:           registry,
 			ExternalRegistries: opts.PrometheusExternalRegistries,
 			HandlerListener:    opts.PrometheusHandlerListener,
+			DefaultServeMux:    opts.PrometheusDefaultServeMux,
 			OnError:            onError,
 			CommonLabels:       opts.CommonLabels,
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Using the global http.DefaultServeMux causes issues with duplicate route registration when an M3 component is restarted within process (e.g. during integration tests). This PR replaces all uses of the global http.DefaultServeMux with a locally scoped default ServeMux that gets destroyed on component shutdown.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
