### PR TITLE
Add graphite query router support

### DIFF
--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -27,6 +27,10 @@ import (
 	_ "net/http/pprof" // needed for pprof handler registration
 	"time"
 
+	"github.com/gorilla/mux"
+	"github.com/jonboulle/clockwork"
+	"go.uber.org/zap"
+
 	"github.com/m3db/m3/src/cluster/placementhandler"
 	"github.com/m3db/m3/src/cluster/placementhandler/handleroptions"
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
@@ -48,10 +52,6 @@ import (
 	xdebug "github.com/m3db/m3/src/x/debug"
 	extdebug "github.com/m3db/m3/src/x/debug/ext"
 	xhttp "github.com/m3db/m3/src/x/net/http"
-
-	"github.com/gorilla/mux"
-	"github.com/jonboulle/clockwork"
-	"go.uber.org/zap"
 )
 
 const (
@@ -331,17 +331,23 @@ func (h *Handler) RegisterRoutes() error {
 		return err
 	}
 
-	// Graphite endpoints.
+	// Graphite routable endpoints.
+	h.options.GraphiteRenderRouter().Setup(options.GraphiteRenderRouterOptions{
+		RenderHandler: graphite.NewRenderHandler(h.options).ServeHTTP,
+	})
+	h.options.GraphiteFindRouter().Setup(options.GraphiteFindRouterOptions{
+		FindHandler: graphite.NewFindHandler(h.options).ServeHTTP,
+	})
 	if err := h.registry.Register(queryhttp.RegisterOptions{
 		Path:    graphite.ReadURL,
-		Handler: graphite.NewRenderHandler(h.options),
+		Handler: h.options.GraphiteRenderRouter(),
 		Methods: graphite.ReadHTTPMethods,
 	}); err != nil {
 		return err
 	}
 	if err := h.registry.Register(queryhttp.RegisterOptions{
 		Path:    graphite.FindURL,
-		Handler: graphite.NewFindHandler(h.options),
+		Handler: h.options.GraphiteFindRouter(),
 		Methods: graphite.FindHTTPMethods,
 	}); err != nil {
 		return err

--- a/src/query/api/v1/httpd/router_test.go
+++ b/src/query/api/v1/httpd/router_test.go
@@ -25,14 +25,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/m3db/m3/src/query/api/v1/options"
-	"github.com/m3db/m3/src/x/headers"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/m3db/m3/src/query/api/v1/options"
+	"github.com/m3db/m3/src/x/headers"
 )
 
-func TestHanlerSwitch(t *testing.T) {
+func TestHandlerSwitch(t *testing.T) {
 	promqlCalled := 0
 	promqlHandler := func(w http.ResponseWriter, req *http.Request) {
 		promqlCalled++

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -580,7 +580,7 @@ func Run(runOpts RunOptions) RunResult {
 		runOpts.DBConfig, fetchOptsBuilder, graphiteFindFetchOptsBuilder, graphiteRenderFetchOptsBuilder,
 		queryCtxOpts, instrumentOptions, cpuProfileDuration, []string{handleroptions3.M3DBServiceName},
 		serviceOptionDefaults, httpd.NewQueryRouter(), httpd.NewQueryRouter(),
-		graphiteStorageOpts, tsdbOpts)
+		graphiteStorageOpts, tsdbOpts, httpd.NewGraphiteRenderRouter(), httpd.NewGraphiteFindRouter())
 	if err != nil {
 		logger.Fatal("unable to set up handler options", zap.Error(err))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds query routers for graphite endpoints, allowing us
to add additional logic to the graphite endpoints.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
NONE
```
