### PR TITLE
[dbnode] Fix markWarmFlushStateSuccess

### DIFF
--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -2690,7 +2690,7 @@ func (s *dbShard) AggregateTiles(
 		// has been created. This will block until all leasers have relinquished their
 		// leases.
 		// NB: markWarmFlushStateSuccess=true because there are no flushes happening in this
-		// flow and we need to set WarmStatus to fileOpSuccess explicitly in order to make
+		// flow, and we need to set WarmStatus to fileOpSuccess explicitly in order to make
 		// the new blocks readable.
 		if err = s.finishWriting(opts.Start, nextVolume, true); err != nil {
 			multiErr = multiErr.Add(err)

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -2776,6 +2776,7 @@ func (s *dbShard) finishWriting(
 ) error {
 	if markWarmFlushStateSuccess {
 		s.markWarmDataFlushStateSuccess(blockStart)
+		s.markWarmIndexFlushStateSuccess(blockStart)
 	}
 
 	// After writing the full block successfully update the ColdVersionFlushed number. This will

--- a/src/dbnode/storage/shard_test.go
+++ b/src/dbnode/storage/shard_test.go
@@ -1944,6 +1944,12 @@ func TestShardAggregateTiles(t *testing.T) {
 		ctx, sourceNs, targetNs, targetShard.ID(), noOpColdFlushNs, opts)
 	require.NoError(t, err)
 	assert.Equal(t, expectedProcessedTileCount, processedTileCount)
+
+	flushState, ok := targetShard.flushState.statesByTime[start]
+	require.True(t, ok)
+	assert.Equal(t, fileOpSuccess, flushState.WarmStatus.DataFlushed)
+	assert.Equal(t, fileOpSuccess, flushState.WarmStatus.IndexFlushed)
+	assert.Zero(t, flushState.NumFailures)
 }
 
 func TestOpenStreamingReader(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
During active index block refactoring shard flush state was split into two separate states for data and index. In this specific flow, only the data state was being marked as success, missing the index state.
This PR modifies the flow to also set the index state.

**Special notes for your reviewer**:
The original implementation was introduced with https://github.com/m3db/m3/pull/2777
The split of `markWarmFlushStateSuccess` into index/data parts happened here: https://github.com/m3db/m3/pull/3464/files#diff-f8370647cf96e48d3ddfbaa013d3139017115829ecabdc59a7adad783c7affefL2499

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
