### PR TITLE
[dbnode] Add AggregateTilesOptions.Backfill field

### DIFF
--- a/src/dbnode/storage/types.go
+++ b/src/dbnode/storage/types.go
@@ -1493,6 +1493,7 @@ type AggregateTilesOptions struct {
 	// Step is the downsampling step.
 	Step       time.Duration
 	InsOptions instrument.Options
+	Backfill   bool
 }
 
 // TileAggregator is the interface for AggregateTiles.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `AggregateTilesOptions.Backfill` field.

**Special notes for your reviewer**:
Only planning to use it for logging and enriching the metrics.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
