### PR TITLE
[dbnode] Remove redundant aggregate tiles metrics

### DIFF
--- a/src/dbnode/storage/database.go
+++ b/src/dbnode/storage/database.go
@@ -1305,10 +1305,8 @@ func (d *db) AggregateTiles(
 			zap.String("targetNs", targetNsID.String()),
 			zap.Error(err),
 		)
-		opts.InsOptions.MetricsScope().Counter("aggregation.errors").Inc(1)
-	} else {
-		opts.InsOptions.MetricsScope().Counter("aggregation.success").Inc(1)
 	}
+
 	return processedTileCount, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There are also more detailed metrics `aggregate-tiles.sucsess/error` reported from `namespace.AggregateTiles`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE