### PR TITLE
Fix inconsistent StagedMetadatas.ResendEnabled naming in JSON

### DIFF
--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -94,7 +94,7 @@ type PipelineMetadata struct {
 	GraphitePrefix [][]byte `json:"graphitePrefix,omitempty"`
 
 	// ResendEnabled is true if the Pipeline supports resending aggregate values after the initial flush.
-	ResendEnabled bool
+	ResendEnabled bool `json:"resendEnabled,omitempty"`
 }
 
 func (m PipelineMetadata) String() string {

--- a/src/metrics/metadata/metadata_test.go
+++ b/src/metrics/metadata/metadata_test.go
@@ -1156,8 +1156,8 @@ func TestVersionedStagedMetadatasMarshalJSON(t *testing.T) {
 		`{"version":12,` +
 			`"stagedMetadatas":` +
 			`[{"metadata":{"pipelines":[` +
-			`{"aggregation":["Sum"],"storagePolicies":["1s:1h","1m:12h"],"ResendEnabled":true},` +
-			`{"aggregation":null,"storagePolicies":["10s:1h"],"ResendEnabled":false}]},` +
+			`{"aggregation":["Sum"],"storagePolicies":["1s:1h","1m:12h"],"resendEnabled":true},` +
+			`{"aggregation":null,"storagePolicies":["10s:1h"]}]},` +
 			`"cutoverNanos":4567,` +
 			`"tombstoned":true}]}`
 	require.Equal(t, expected, string(res))


### PR DESCRIPTION
hope it's not too late to fix this - the diff just makes the capitalization consistent with the rest of the payload, and omits the field if not set, like for all other optional fields.