### PR TITLE
Make TagIteratorPool.Close idempotent

### DIFF
--- a/src/dbnode/network/server/tchannelthrift/cluster/service.go
+++ b/src/dbnode/network/server/tchannelthrift/cluster/service.go
@@ -140,6 +140,8 @@ func (s *service) Query(tctx thrift.Context, req *rpc.QueryRequest) (*rpc.QueryR
 			return nil, convert.ToRPCError(err)
 		}
 
+		defer results.Finalize()
+
 		result := &rpc.QueryResult_{
 			Exhaustive: metadata.Exhaustive,
 		}
@@ -160,7 +162,6 @@ func (s *service) Query(tctx thrift.Context, req *rpc.QueryRequest) (*rpc.QueryR
 			if err := tags.Err(); err != nil {
 				return nil, convert.ToRPCError(err)
 			}
-			tags.Close()
 		}
 
 		if err := results.Err(); err != nil {
@@ -175,6 +176,7 @@ func (s *service) Query(tctx thrift.Context, req *rpc.QueryRequest) (*rpc.QueryR
 	if err != nil {
 		return nil, convert.ToRPCError(err)
 	}
+	defer results.Close()
 
 	result := &rpc.QueryResult_{
 		Results:    make([]*rpc.QueryResultElement, 0, results.Len()),
@@ -197,7 +199,6 @@ func (s *service) Query(tctx thrift.Context, req *rpc.QueryRequest) (*rpc.QueryR
 		if err := tags.Err(); err != nil {
 			return nil, convert.ToRPCError(err)
 		}
-		tags.Close()
 
 		var datapoints []*rpc.Datapoint
 		for series.Next() {
@@ -220,7 +221,6 @@ func (s *service) Query(tctx thrift.Context, req *rpc.QueryRequest) (*rpc.QueryR
 		curr.Datapoints = datapoints
 	}
 
-	results.Close()
 	return result, nil
 }
 


### PR DESCRIPTION
Previously a double call to Close would result in the tag iterator being
added back to the pool twice, which would then result in the same
iterator being given back out to multiple callers later.

Additionally removed the unnecessary call to tagIter.Close() in
Cluster.Query, since closing the results will close the tag iterator.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
