### PR TITLE
[all] Use runtime.GOMAXPROC instead of runtime.NumCPU

### DIFF
--- a/src/aggregator/aggregator/flush_mgr_options.go
+++ b/src/aggregator/aggregator/flush_mgr_options.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	defaultWorkerPoolSize = int(math.Max(float64(runtime.NumCPU()/8), 1.0))
+	defaultWorkerPoolSize = int(math.Max(float64(runtime.GOMAXPROCS(0)/8), 1.0))
 )
 
 // FlushJitterFn determines the jitter based on the flush interval.

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -828,7 +828,7 @@ func (c flushManagerConfiguration) NewFlushManagerOptions(
 		opts = opts.SetMaxJitterFn(maxJitterFn)
 	}
 	if c.NumWorkersPerCPU != 0 {
-		runtimeCPU := float64(runtime.NumCPU())
+		runtimeCPU := float64(runtime.GOMAXPROCS(0))
 		numWorkers := c.NumWorkersPerCPU * runtimeCPU
 		workerPoolSize := int(math.Ceil(numWorkers))
 		if workerPoolSize < 1 {

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -91,7 +91,7 @@ const (
 )
 
 var (
-	numShards                   = runtime.NumCPU()
+	numShards                   = runtime.GOMAXPROCS(0)
 	defaultNamespaceTag         = metric.M3MetricsPrefixString + "_namespace__"
 	defaultFilterOutTagPrefixes = [][]byte{
 		metric.M3MetricsPrefix,

--- a/src/cmd/tools/query_index_segments/main/main.go
+++ b/src/cmd/tools/query_index_segments/main/main.go
@@ -47,7 +47,7 @@ import (
 )
 
 var (
-	halfCPUs     = int(math.Max(float64(runtime.NumCPU()/2), 1))
+	halfCPUs     = int(math.Max(float64(runtime.GOMAXPROCS(0)/2), 1))
 	endlineBytes = []byte("\n")
 )
 

--- a/src/cmd/tools/read_index_segments/main/main.go
+++ b/src/cmd/tools/read_index_segments/main/main.go
@@ -43,7 +43,7 @@ import (
 )
 
 var (
-	halfCPUs     = int(math.Max(float64(runtime.NumCPU()/2), 1))
+	halfCPUs     = int(math.Max(float64(runtime.GOMAXPROCS(0)/2), 1))
 	endlineBytes = []byte("\n")
 )
 

--- a/src/dbnode/client/host_queue_bench_test.go
+++ b/src/dbnode/client/host_queue_bench_test.go
@@ -30,12 +30,12 @@ const baseline = 1024
 
 func BenchmarkEnqueueChannel(b *testing.B) {
 	work := baseline * b.N
-	workerTarget := work / runtime.NumCPU()
+	workerTarget := work / runtime.GOMAXPROCS(0)
 	actual := 0
 	// expected = (((n^2)+n)/2) * workers
-	expected := (((workerTarget * workerTarget) + workerTarget) / 2) * runtime.NumCPU()
+	expected := (((workerTarget * workerTarget) + workerTarget) / 2) * runtime.GOMAXPROCS(0)
 
-	q := make(chan int, work/runtime.NumCPU())
+	q := make(chan int, work/runtime.GOMAXPROCS(0))
 
 	flushingL := sync.Mutex{}
 
@@ -54,7 +54,7 @@ func BenchmarkEnqueueChannel(b *testing.B) {
 
 	var wg sync.WaitGroup
 
-	for w := 0; w < runtime.NumCPU(); w++ {
+	for w := 0; w < runtime.GOMAXPROCS(0); w++ {
 		wg.Add(1)
 		go func() {
 			for i := 0; i < workerTarget; i++ {
@@ -81,13 +81,13 @@ func BenchmarkEnqueueChannel(b *testing.B) {
 
 func BenchmarkEnqueueMutex(b *testing.B) {
 	work := baseline * b.N
-	workerTarget := work / runtime.NumCPU()
+	workerTarget := work / runtime.GOMAXPROCS(0)
 	actual := 0
 	// expected = (((n^2)+n)/2) * workers
-	expected := (((workerTarget * workerTarget) + workerTarget) / 2) * runtime.NumCPU()
+	expected := (((workerTarget * workerTarget) + workerTarget) / 2) * runtime.GOMAXPROCS(0)
 
-	q := make([]int, 0, work/runtime.NumCPU())
-	qCopy := make([]int, 0, work/runtime.NumCPU())
+	q := make([]int, 0, work/runtime.GOMAXPROCS(0))
+	qCopy := make([]int, 0, work/runtime.GOMAXPROCS(0))
 	l := sync.RWMutex{}
 	flushingL := sync.Mutex{}
 
@@ -101,7 +101,7 @@ func BenchmarkEnqueueMutex(b *testing.B) {
 
 	var wg sync.WaitGroup
 
-	for w := 0; w < runtime.NumCPU(); w++ {
+	for w := 0; w < runtime.GOMAXPROCS(0); w++ {
 		wg.Add(1)
 		go func() {
 			for i := 0; i < workerTarget; i++ {

--- a/src/dbnode/client/options.go
+++ b/src/dbnode/client/options.go
@@ -188,7 +188,7 @@ var (
 	}
 
 	// defaultFetchSeriesBlocksBatchConcurrency is the default fetch series blocks in batch parallel concurrency limit
-	defaultFetchSeriesBlocksBatchConcurrency = int(math.Max(1, float64(runtime.NumCPU())/2))
+	defaultFetchSeriesBlocksBatchConcurrency = int(math.Max(1, float64(runtime.GOMAXPROCS(0))/2))
 
 	// defaultSeriesIteratorArrayPoolBuckets is the default pool buckets for the series iterator array pool
 	defaultSeriesIteratorArrayPoolBuckets = []pool.Bucket{}

--- a/src/dbnode/integration/wide_query_test.go
+++ b/src/dbnode/integration/wide_query_test.go
@@ -344,7 +344,7 @@ func TestWideFetch(t *testing.T) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var multiErr xerrors.MultiError
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
 		q := index.Query{Query: idx.NewAllQuery()}
 		expected := buildExpectedChecksumsByShard(
 			ids, nil, testSetup.ShardSet(), batchSize)

--- a/src/dbnode/persist/fs/commitlog/options.go
+++ b/src/dbnode/persist/fs/commitlog/options.go
@@ -56,7 +56,7 @@ const (
 
 var (
 	// defaultBacklogQueueSize is the default commit log backlog queue size.
-	defaultBacklogQueueSize = 1024 * runtime.NumCPU()
+	defaultBacklogQueueSize = 1024 * runtime.GOMAXPROCS(0)
 
 	// defaultBacklogQueueChannelSize is the default commit log backlog queue channel size.
 	defaultBacklogQueueChannelSize = int(float64(defaultBacklogQueueSize) / MaximumQueueSizeQueueChannelSizeRatio)

--- a/src/dbnode/persist/fs/migration/options.go
+++ b/src/dbnode/persist/fs/migration/options.go
@@ -27,7 +27,7 @@ import (
 )
 
 // defaultMigrationConcurrency is the default number of concurrent workers to perform migrations.
-var defaultMigrationConcurrency = int(math.Ceil(float64(runtime.NumCPU()) / 2))
+var defaultMigrationConcurrency = int(math.Ceil(float64(runtime.GOMAXPROCS(0)) / 2))
 
 type options struct {
 	targetMigrationVersion MigrationVersion

--- a/src/dbnode/persist/fs/retriever_options.go
+++ b/src/dbnode/persist/fs/retriever_options.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	// Allow max concurrency to match available CPUs.
-	defaultFetchConcurrency = runtime.NumCPU()
+	defaultFetchConcurrency = runtime.GOMAXPROCS(0)
 	defaultCacheOnRetrieve  = false
 
 	errBlockLeaseManagerNotSet = errors.New("block lease manager is not set")

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -487,7 +487,7 @@ func Run(runOpts RunOptions) {
 	)
 
 	permitOptions := opts.PermitsOptions().SetSeriesReadPermitsManager(seriesReadPermits)
-	maxIdxConcurrency := int(math.Ceil(float64(runtime.NumCPU()) / 2))
+	maxIdxConcurrency := int(math.Ceil(float64(runtime.GOMAXPROCS(0)) / 2))
 	if cfg.Index.MaxQueryIDsConcurrency > 0 {
 		maxIdxConcurrency = cfg.Index.MaxQueryIDsConcurrency
 		logger.Info("max index query IDs concurrency set",
@@ -640,7 +640,7 @@ func Run(runOpts RunOptions) {
 	case config.CalculationTypeFixed:
 		commitLogQueueSize = specified
 	case config.CalculationTypePerCPU:
-		commitLogQueueSize = specified * runtime.NumCPU()
+		commitLogQueueSize = specified * runtime.GOMAXPROCS(0)
 	default:
 		logger.Fatal("unknown commit log queue size type",
 			zap.Any("type", cfgCommitLog.Queue.CalculationType))
@@ -653,7 +653,7 @@ func Run(runOpts RunOptions) {
 		case config.CalculationTypeFixed:
 			commitLogQueueChannelSize = specified
 		case config.CalculationTypePerCPU:
-			commitLogQueueChannelSize = specified * runtime.NumCPU()
+			commitLogQueueChannelSize = specified * runtime.GOMAXPROCS(0)
 		default:
 			logger.Fatal("unknown commit log queue channel size type",
 				zap.Any("type", cfgCommitLog.Queue.CalculationType))

--- a/src/dbnode/storage/bootstrap/bootstrapper/commitlog/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/commitlog/options.go
@@ -42,7 +42,7 @@ var (
 	errRuntimeOptsMgrNotSet          = errors.New("runtime options manager is not set")
 
 	// defaultAccumulateConcurrency determines how fast to accumulate results.
-	defaultAccumulateConcurrency = int(math.Max(float64(goruntime.NumCPU())*0.75, 1))
+	defaultAccumulateConcurrency = int(math.Max(float64(goruntime.GOMAXPROCS(0))*0.75, 1))
 )
 
 type options struct {

--- a/src/dbnode/storage/bootstrap/bootstrapper/fs/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/fs/options.go
@@ -48,7 +48,7 @@ var (
 	errMigrationOptionsNotSet   = errors.New("migration options not set")
 
 	// DefaultIndexSegmentConcurrency defines the default index segment building concurrency.
-	DefaultIndexSegmentConcurrency = int(math.Min(2, float64(goruntime.NumCPU())))
+	DefaultIndexSegmentConcurrency = int(math.Min(2, float64(goruntime.GOMAXPROCS(0))))
 
 	// defaultIndexSegmentsVerify defines default for index segments validation.
 	defaultIndexSegmentsVerify = false

--- a/src/dbnode/storage/bootstrap/bootstrapper/peers/options.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/peers/options.go
@@ -43,12 +43,12 @@ var (
 	// for in memory data being streamed between peers (most recent block).
 	// Update BootstrapPeersConfiguration comment in
 	// src/cmd/services/m3dbnode/config package if this is changed.
-	DefaultShardConcurrency = runtime.NumCPU()
+	DefaultShardConcurrency = runtime.GOMAXPROCS(0)
 	// DefaultShardPersistenceConcurrency controls how many shards in parallel to stream
 	// for historical data being streamed between peers (historical blocks).
 	// Update BootstrapPeersConfiguration comment in
 	// src/cmd/services/m3dbnode/config package if this is changed.
-	DefaultShardPersistenceConcurrency = int(math.Max(1, float64(runtime.NumCPU())/2))
+	DefaultShardPersistenceConcurrency = int(math.Max(1, float64(runtime.GOMAXPROCS(0))/2))
 	defaultPersistenceMaxQueueSize     = 0
 	// DefaultShardPersistenceFlushConcurrency controls how many shards in parallel to flush
 	// for historical data being streamed between peers (historical blocks).

--- a/src/dbnode/storage/index.go
+++ b/src/dbnode/storage/index.go
@@ -1021,7 +1021,7 @@ func (i *nsIndex) WarmFlush(
 	// Determine the current flush indexing concurrency.
 	namespaceRuntimeOpts := i.namespaceRuntimeOptsMgr.Get()
 	perCPUFraction := namespaceRuntimeOpts.FlushIndexingPerCPUConcurrencyOrDefault()
-	cpus := math.Ceil(perCPUFraction * float64(goruntime.NumCPU()))
+	cpus := math.Ceil(perCPUFraction * float64(goruntime.GOMAXPROCS(0)))
 	concurrency := int(math.Max(1, cpus))
 
 	builderOpts := i.opts.IndexOptions().SegmentBuilderOptions().

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -240,7 +240,7 @@ func NewBlock(
 	scope := iopts.MetricsScope().SubScope("index").SubScope("block")
 	iopts = iopts.SetMetricsScope(scope)
 
-	cpus := int(math.Max(1, math.Ceil(0.25*float64(runtime.NumCPU()))))
+	cpus := int(math.Max(1, math.Ceil(0.25*float64(runtime.GOMAXPROCS(0)))))
 	cachedSearchesWorkers := xsync.NewWorkerPool(cpus)
 	cachedSearchesWorkers.Init()
 

--- a/src/dbnode/storage/index/mutable_segments.go
+++ b/src/dbnode/storage/index/mutable_segments.go
@@ -206,7 +206,7 @@ func (m *mutableSegments) SetNamespaceRuntimeOptions(opts namespace.RuntimeOptio
 	m.Lock()
 	// Update current runtime opts for segment builders created in future.
 	perCPUFraction := opts.WriteIndexingPerCPUConcurrencyOrDefault()
-	cpus := math.Ceil(perCPUFraction * float64(runtime.NumCPU()))
+	cpus := math.Ceil(perCPUFraction * float64(runtime.GOMAXPROCS(0)))
 	m.writeIndexingConcurrency = int(math.Max(1, cpus))
 	segmentBuilder := m.compact.segmentBuilder
 	m.Unlock()

--- a/src/dbnode/storage/namespace.go
+++ b/src/dbnode/storage/namespace.go
@@ -338,7 +338,7 @@ func newDatabaseNamespace(
 
 	scope := iops.MetricsScope().SubScope("database")
 
-	tickWorkersConcurrency := int(math.Max(1, float64(runtime.NumCPU())/8))
+	tickWorkersConcurrency := int(math.Max(1, float64(runtime.GOMAXPROCS(0))/8))
 	tickWorkers := xsync.NewWorkerPool(tickWorkersConcurrency)
 	tickWorkers.Init()
 
@@ -1058,7 +1058,7 @@ func (n *dbNamespace) Bootstrap(
 	}
 
 	// Bootstrap shards using at least half the CPUs available
-	workers := xsync.NewWorkerPool(int(math.Ceil(float64(runtime.NumCPU()) / 2)))
+	workers := xsync.NewWorkerPool(int(math.Ceil(float64(runtime.GOMAXPROCS(0)) / 2)))
 	workers.Init()
 
 	var (

--- a/src/m3ninx/index/segment/builder/builder.go
+++ b/src/m3ninx/index/segment/builder/builder.go
@@ -96,7 +96,7 @@ func (w *indexWorkers) registerBuilder() {
 
 	// Need to initialize structures, prepare all num CPU
 	// worker queues, even if we don't use all of them.
-	n := runtime.NumCPU()
+	n := runtime.GOMAXPROCS(0)
 	if cap(w.queues) == 0 {
 		w.queues = make([]chan indexJob, 0, n)
 	} else {

--- a/src/m3ninx/index/segment/builder/options.go
+++ b/src/m3ninx/index/segment/builder/options.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	defaultConcurrency = runtime.NumCPU()
+	defaultConcurrency = runtime.GOMAXPROCS(0)
 )
 
 // Options is a collection of options for segment building.

--- a/src/query/functions/temporal/base.go
+++ b/src/query/functions/temporal/base.go
@@ -135,7 +135,7 @@ func (c *baseNode) Process(
 		resultMeta:  resultMeta,
 	}
 
-	concurrency := runtime.NumCPU()
+	concurrency := runtime.GOMAXPROCS(0)
 	var builder block.Builder
 	batches, err := b.MultiSeriesIter(concurrency)
 	if err != nil {

--- a/src/query/graphite/native/aggregation_functions.go
+++ b/src/query/graphite/native/aggregation_functions.go
@@ -576,7 +576,7 @@ func applyByNode(ctx *common.Context, seriesList singlePathSpec, nodeNum int, te
 		multiErr xerrors.MultiError
 
 		output         = make([]*ts.Series, 0, len(prefixes))
-		maxConcurrency = runtime.NumCPU() / 2
+		maxConcurrency = runtime.GOMAXPROCS(0) / 2
 	)
 	for _, prefixChunk := range chunkArrayHelper(prefixes, maxConcurrency) {
 		if multiErr.LastError() != nil {

--- a/src/query/graphite/native/builtin_functions.go
+++ b/src/query/graphite/native/builtin_functions.go
@@ -156,7 +156,7 @@ func useSeriesAbove(
 		multiErr       xerrors.MultiError
 		newNames       []string
 		output         = make([]*ts.Series, 0, len(seriesList.Values))
-		maxConcurrency = runtime.NumCPU() / 2
+		maxConcurrency = runtime.GOMAXPROCS(0) / 2
 	)
 
 	for _, series := range seriesList.Values {

--- a/src/query/remote/server_test.go
+++ b/src/query/remote/server_test.go
@@ -167,7 +167,7 @@ func checkErrorFetch(ctx context.Context, t *testing.T, client Client,
 }
 
 func buildClient(t *testing.T, hosts []string) Client {
-	readWorkerPool, err := xsync.NewPooledWorkerPool(runtime.NumCPU(),
+	readWorkerPool, err := xsync.NewPooledWorkerPool(runtime.GOMAXPROCS(0),
 		xsync.NewPooledWorkerPoolOptions())
 	readWorkerPool.Init()
 	require.NoError(t, err)

--- a/src/query/storage/m3/encoded_step_iterator_test.go
+++ b/src/query/storage/m3/encoded_step_iterator_test.go
@@ -612,7 +612,7 @@ func benchmarkNextIteration(b *testing.B, iterations int, t iterType) {
 	}
 
 	if t == seriesBatch {
-		batches, err := bl.MultiSeriesIter(runtime.NumCPU())
+		batches, err := bl.MultiSeriesIter(runtime.GOMAXPROCS(0))
 		require.NoError(b, err)
 
 		var wg sync.WaitGroup

--- a/src/x/sync/options.go
+++ b/src/x/sync/options.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	defaultNumShards = int64(runtime.NumCPU())
+	defaultNumShards = int64(runtime.GOMAXPROCS(0))
 	defaultNowFn     = time.Now
 )
 
@@ -46,8 +46,8 @@ func NewPooledWorkerPoolOptions() PooledWorkerPoolOptions {
 		growOnDemand:          defaultGrowOnDemand,
 		numShards:             defaultNumShards,
 		killWorkerProbability: defaultKillWorkerProbability,
-		nowFn: defaultNowFn,
-		iOpts: instrument.NewOptions(),
+		nowFn:                 defaultNowFn,
+		iOpts:                 instrument.NewOptions(),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Containerized Go applications usually also apply cgroup quotas or use cpusets - which are not reflected correctly in runtime at all, so it's common to set expected number of physical threads to use for runtime via GOMAXPROC env var. Using runtime.NumCPU in that context can be counterproductive - eg. a 4-core container on a 64 core machine will be grossly overestimating # of CPUs to use for sharding and worker pools.
There is no change in environments that don't explicitly override GOMAXPROCS, as the default value is equal to # of CPU threads, same as runtime.NumCPU().

This PR replaces all usages of NumCPU with GOMAXPROCS, except for code in `src/query/server/multi_process.go` that is meant to spawn/manage multiprocessing by itself.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Per-CPU values are now based on GOMAXPROCS limit, not just physical host CPU count.
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
