### PR TITLE
[aggregator] Move some struct members around using fieldalignment tool

### DIFF
--- a/src/aggregator/aggregation/counter.go
+++ b/src/aggregator/aggregation/counter.go
@@ -30,14 +30,13 @@ import (
 // Counter aggregates counter values.
 type Counter struct {
 	Options
-
 	lastAt     time.Time
+	annotation []byte
 	sum        int64
 	sumSq      int64
 	count      int64
 	max        int64
 	min        int64
-	annotation []byte
 }
 
 // NewCounter creates a new counter.

--- a/src/aggregator/aggregation/counter.go
+++ b/src/aggregator/aggregation/counter.go
@@ -30,6 +30,7 @@ import (
 // Counter aggregates counter values.
 type Counter struct {
 	Options
+
 	lastAt     time.Time
 	annotation []byte
 	sum        int64

--- a/src/aggregator/aggregation/gauge.go
+++ b/src/aggregator/aggregation/gauge.go
@@ -30,15 +30,14 @@ import (
 // Gauge aggregates gauge values.
 type Gauge struct {
 	Options
-
 	lastAt     time.Time
-	last       float64
+	annotation []byte
 	sum        float64
 	sumSq      float64
 	count      int64
 	max        float64
 	min        float64
-	annotation []byte
+	last       float64
 }
 
 // NewGauge creates a new gauge.

--- a/src/aggregator/aggregation/gauge.go
+++ b/src/aggregator/aggregation/gauge.go
@@ -30,6 +30,7 @@ import (
 // Gauge aggregates gauge values.
 type Gauge struct {
 	Options
+
 	lastAt     time.Time
 	annotation []byte
 	sum        float64

--- a/src/aggregator/aggregation/options.go
+++ b/src/aggregator/aggregation/options.go
@@ -33,11 +33,11 @@ var (
 
 // Options is the options for aggregations.
 type Options struct {
+	// Metrics is as set of aggregation metrics.
+	Metrics Metrics
 	// HasExpensiveAggregations means expensive (multiplication／division)
 	// aggregation types are enabled.
 	HasExpensiveAggregations bool
-	// Metrics is as set of aggregation metrics.
-	Metrics Metrics
 }
 
 // Metrics is a set of metrics that can be used by elements.

--- a/src/aggregator/aggregation/quantile/cm/options.go
+++ b/src/aggregator/aggregation/quantile/cm/options.go
@@ -37,10 +37,10 @@ var (
 )
 
 type options struct {
+	streamPool             StreamPool
 	eps                    float64
 	capacity               int
 	insertAndCompressEvery int
-	streamPool             StreamPool
 }
 
 // NewOptions creates a new options.

--- a/src/aggregator/aggregation/quantile/cm/sample.go
+++ b/src/aggregator/aggregation/quantile/cm/sample.go
@@ -22,10 +22,10 @@ package cm
 
 // Sample represents a sampled value.
 type Sample struct {
+	prev     *Sample // previous sample
+	next     *Sample // next sample
 	value    float64 // sampled value
 	numRanks int64   // number of ranks represented
 	delta    int64   // delta between min rank and max rank
-	prev     *Sample // previous sample
-	next     *Sample // next sample
 	idx      int32
 }

--- a/src/aggregator/aggregation/quantile/cm/stream.go
+++ b/src/aggregator/aggregation/quantile/cm/stream.go
@@ -39,20 +39,20 @@ type threshold struct {
 
 // Stream represents a data stream.
 type Stream struct {
+	compressCursor           *Sample // compression cursor
 	streamPool               StreamPool
-	eps                      float64     // desired epsilon for errors
-	quantiles                []float64   // sorted target quantiles
+	insertCursor             *Sample
+	samples                  sampleList
 	computedQuantiles        []float64   // sorted computed target quantiles
 	thresholdBuf             []threshold // temporary buffer for computed thresholds
-	capacity                 int         // initial stream sample buffer capacity
-	insertAndCompressEvery   int         // stream insertion and compression frequency
-	insertAndCompressCounter int         // insertion and compression counter
-	numValues                int64       // number of values inserted into the sorted stream
 	bufLess                  minHeap     // sample buffer whose value is less than that at the insertion cursor
 	bufMore                  minHeap     // sample buffer whose value is more than that at the insertion cursor
-	samples                  sampleList  // sample list
-	insertCursor             *Sample     // insertion cursor
-	compressCursor           *Sample     // compression cursor
+	quantiles                []float64   // sorted target quantiles
+	numValues                int64       // number of values inserted into the sorted stream
+	insertAndCompressCounter int         // insertion and compression counter
+	insertAndCompressEvery   int         // stream insertion and compression frequency
+	capacity                 int         // initial stream sample buffer capacity
+	eps                      float64     // desired epsilon for errors
 	compressMinRank          int64       // compression min rank
 	closed                   bool        // whether the stream is closed
 	flushed                  bool        // whether the stream is flushed

--- a/src/aggregator/aggregation/timer.go
+++ b/src/aggregator/aggregation/timer.go
@@ -30,11 +30,11 @@ import (
 // Timer aggregates timer values. Timer APIs are not thread-safe.
 type Timer struct {
 	lastAt                   time.Time
-	count                    int64      // Number of values received.
-	sum                      float64    // Sum of the values.
-	sumSq                    float64    // Sum of squared values.
 	stream                   *cm.Stream // Stream of values received.
 	annotation               []byte
+	count                    int64   // Number of values received.
+	sum                      float64 // Sum of the values.
+	sumSq                    float64 // Sum of squared values.
 	hasExpensiveAggregations bool
 }
 

--- a/src/aggregator/bitset/bitset.go
+++ b/src/aggregator/bitset/bitset.go
@@ -28,9 +28,9 @@ import (
 // range of values in the bitset is small (e.g., [0, 64)). It falls back to
 // github.com/willf/bitset for large value ranges.
 type BitSet struct {
-	smallRange bool
-	val        uint64
 	bs         *bitset.BitSet
+	val        uint64
+	smallRange bool
 }
 
 // New can be used to keep track of values between [0, maxExclusive).

--- a/src/aggregator/client/conn.go
+++ b/src/aggregator/client/conn.go
@@ -53,31 +53,27 @@ type (
 // connection is a persistent connection that retries establishing
 // connection with exponential backoff if the connection goes down.
 type connection struct {
-	sync.Mutex
-
-	addr           string
-	connTimeout    time.Duration
-	writeTimeout   time.Duration
-	keepAlive      bool
-	initThreshold  int
-	multiplier     int
-	maxThreshold   int
-	maxDuration    time.Duration
-	writeRetryOpts retry.Options
-	rngFn          retry.RngFn
-
-	conn                    *net.TCPConn
+	metrics                 connectionMetrics
+	writeRetryOpts          retry.Options
 	writer                  xio.ResettableWriter
-	numFailures             int
+	connectWithLockFn       connectWithLockFn
+	sleepFn                 sleepFn
+	nowFn                   clock.NowFn
+	conn                    *net.TCPConn
+	rngFn                   retry.RngFn
+	writeWithLockFn         writeWithLockFn
+	addr                    string
+	maxDuration             time.Duration
+	maxThreshold            int
+	multiplier              int
+	initThreshold           int
 	threshold               int
 	lastConnectAttemptNanos int64
-	metrics                 connectionMetrics
-
-	// These are for testing purposes.
-	nowFn             clock.NowFn
-	sleepFn           sleepFn
-	connectWithLockFn connectWithLockFn
-	writeWithLockFn   writeWithLockFn
+	writeTimeout            time.Duration
+	connTimeout             time.Duration
+	numFailures             int
+	sync.Mutex
+	keepAlive bool
 }
 
 // newConnection creates a new connection.

--- a/src/aggregator/client/options.go
+++ b/src/aggregator/client/options.go
@@ -229,23 +229,23 @@ type Options interface {
 }
 
 type options struct {
-	aggregatorClientType       AggregatorClientType
+	watcherOpts                placement.WatcherOptions
 	clockOpts                  clock.Options
 	instrumentOpts             instrument.Options
 	encoderOpts                protobuf.UnaggregatedOptions
-	shardFn                    sharding.ShardFn
-	shardCutoverWarmupDuration time.Duration
-	shardCutoffLingerDuration  time.Duration
-	watcherOpts                placement.WatcherOptions
+	m3msgOptions               M3MsgOptions
 	connOpts                   ConnectionOptions
-	flushWorkerCount           int
+	rwOpts                     xio.Options
+	shardFn                    sharding.ShardFn
+	shardCutoffLingerDuration  time.Duration
+	shardCutoverWarmupDuration time.Duration
 	forceFlushEvery            time.Duration
 	maxTimerBatchSize          int
 	instanceQueueSize          int
 	dropType                   DropType
 	maxBatchSize               int
-	m3msgOptions               M3MsgOptions
-	rwOpts                     xio.Options
+	flushWorkerCount           int
+	aggregatorClientType       AggregatorClientType
 }
 
 // NewOptions creates a new set of client options.

--- a/src/aggregator/client/payload.go
+++ b/src/aggregator/client/payload.go
@@ -40,8 +40,8 @@ const (
 )
 
 type untimedPayload struct {
-	metric    unaggregated.MetricUnion
 	metadatas metadata.StagedMetadatas
+	metric    unaggregated.MetricUnion
 }
 
 type forwardedPayload struct {
@@ -65,10 +65,10 @@ type passthroughPayload struct {
 }
 
 type payloadUnion struct {
-	forwarded                forwardedPayload
 	untimed                  untimedPayload
-	timed                    timedPayload
 	timedWithStagedMetadatas timedWithStagedMetadatas
+	forwarded                forwardedPayload
 	passthrough              passthroughPayload
+	timed                    timedPayload
 	payloadType              payloadType
 }

--- a/src/aggregator/client/queue.go
+++ b/src/aggregator/client/queue.go
@@ -121,15 +121,15 @@ type instanceQueue interface {
 type writeFn func([]byte) error
 
 type queue struct {
-	mtx      sync.Mutex
-	closed   atomic.Bool
+	metrics  queueMetrics
+	instance placement.Instance
 	conn     *connection
 	log      *zap.Logger
-	metrics  queueMetrics
-	dropType DropType
-	buf      qbuf
-	instance placement.Instance
 	writeFn  writeFn
+	buf      qbuf
+	dropType DropType
+	closed   atomic.Bool
+	mtx      sync.Mutex
 }
 
 func newInstanceQueue(instance placement.Instance, opts Options) instanceQueue {

--- a/src/aggregator/client/writer.go
+++ b/src/aggregator/client/writer.go
@@ -62,18 +62,16 @@ type instanceWriter interface {
 type newLockedEncoderFn func(protobuf.UnaggregatedOptions) *lockedEncoder
 
 type writer struct {
-	sync.RWMutex
-
-	log               *zap.Logger
-	metrics           writerMetrics
-	encoderOpts       protobuf.UnaggregatedOptions
-	queue             instanceQueue
-	maxBatchSize      int
-	maxTimerBatchSize int
-
+	metrics            writerMetrics
+	encoderOpts        protobuf.UnaggregatedOptions
+	queue              instanceQueue
+	log                *zap.Logger
 	encodersByShard    map[uint32]*lockedEncoder
 	newLockedEncoderFn newLockedEncoderFn
-	closed             bool
+	maxTimerBatchSize  int
+	maxBatchSize       int
+	sync.RWMutex
+	closed bool
 }
 
 func newInstanceWriter(instance placement.Instance, opts Options) instanceWriter {
@@ -414,9 +412,9 @@ func newLockedEncoder(encoderOpts protobuf.UnaggregatedOptions) *lockedEncoder {
 }
 
 type refCountedWriter struct {
-	dirty atomic.Bool
 	instanceWriter
 	refCount
+	dirty atomic.Bool
 }
 
 func newRefCountedWriter(instance placement.Instance, opts Options) *refCountedWriter {

--- a/src/metrics/encoding/protobuf/aggregated_encoder.go
+++ b/src/metrics/encoding/protobuf/aggregated_encoder.go
@@ -38,9 +38,8 @@ type AggregatedEncoder interface {
 
 type aggregatedEncoder struct {
 	pool pool.BytesPool
-
-	pb  metricpb.AggregatedMetric
-	buf []byte
+	buf  []byte
+	pb   metricpb.AggregatedMetric
 }
 
 // NewAggregatedEncoder creates a new aggregated encoder.

--- a/src/metrics/encoding/protobuf/buffer.go
+++ b/src/metrics/encoding/protobuf/buffer.go
@@ -31,8 +31,8 @@ type PoolReleaseFn func([]byte)
 
 // Buffer contains a byte slice backed by an optional bytes pool.
 type Buffer struct {
-	buf       []byte
 	finalizer PoolReleaseFn
+	buf       []byte
 }
 
 // NewBuffer create a new buffer.

--- a/src/metrics/encoding/protobuf/unaggregated_encoder.go
+++ b/src/metrics/encoding/protobuf/unaggregated_encoder.go
@@ -59,22 +59,20 @@ type UnaggregatedEncoder interface {
 }
 
 type unaggregatedEncoder struct {
-	pool           pool.BytesPool
-	initBufSize    int
-	maxMessageSize int
-
-	cm   metricpb.CounterWithMetadatas
-	bm   metricpb.BatchTimerWithMetadatas
-	gm   metricpb.GaugeWithMetadatas
-	fm   metricpb.ForwardedMetricWithMetadata
-	tm   metricpb.TimedMetricWithMetadata
-	tms  metricpb.TimedMetricWithMetadatas
-	pm   metricpb.TimedMetricWithStoragePolicy
-	buf  []byte
-	used int
-
+	pool                pool.BytesPool
 	encodeMessageSizeFn func(int)
 	encodeMessageFn     func(metricpb.MetricWithMetadatas) error
+	bm                  metricpb.BatchTimerWithMetadatas
+	tms                 metricpb.TimedMetricWithMetadatas
+	cm                  metricpb.CounterWithMetadatas
+	gm                  metricpb.GaugeWithMetadatas
+	buf                 []byte
+	fm                  metricpb.ForwardedMetricWithMetadata
+	pm                  metricpb.TimedMetricWithStoragePolicy
+	tm                  metricpb.TimedMetricWithMetadata
+	used                int
+	initBufSize         int
+	maxMessageSize      int
 }
 
 // NewUnaggregatedEncoder creates a new unaggregated encoder.

--- a/src/metrics/encoding/protobuf/unaggregated_iterator.go
+++ b/src/metrics/encoding/protobuf/unaggregated_iterator.go
@@ -32,15 +32,14 @@ import (
 
 // UnaggregatedIterator decodes unaggregated metrics.
 type UnaggregatedIterator struct {
+	pb             metricpb.MetricWithMetadatas
 	reader         encoding.ByteReadScanner
 	bytesPool      pool.BytesPool
+	err            error
+	buf            []byte
+	msg            encoding.UnaggregatedMessageUnion
 	maxMessageSize int
-
-	closed bool
-	pb     metricpb.MetricWithMetadatas
-	msg    encoding.UnaggregatedMessageUnion
-	buf    []byte
-	err    error
+	closed         bool
 }
 
 // NewUnaggregatedIterator creates a new unaggregated iterator.

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -75,24 +75,18 @@ var (
 
 // PipelineMetadata contains pipeline metadata.
 type PipelineMetadata struct {
-	// List of aggregation types.
-	AggregationID aggregation.ID `json:"aggregation,omitempty"`
-
 	// List of storage policies.
 	StoragePolicies policy.StoragePolicies `json:"storagePolicies,omitempty"`
-
 	// Pipeline operations.
-	Pipeline applied.Pipeline `json:"-"` // NB: not needed for JSON marshaling for now.
-
-	// Drop policy.
-	DropPolicy policy.DropPolicy `json:"dropPolicy,omitempty"`
-
+	Pipeline applied.Pipeline `json:"-"`
 	// Tags.
 	Tags []models.Tag `json:"tags,omitempty"`
-
 	// GraphitePrefix is the list of graphite prefixes to apply.
 	GraphitePrefix [][]byte `json:"graphitePrefix,omitempty"`
-
+	// List of aggregation types.
+	AggregationID aggregation.ID `json:"aggregation,omitempty"`
+	// Drop policy.
+	DropPolicy policy.DropPolicy `json:"dropPolicy,omitempty"`
 	// ResendEnabled is true if the Pipeline supports resending aggregate values after the initial flush.
 	ResendEnabled bool `json:"resendEnabled,omitempty"`
 }
@@ -392,21 +386,16 @@ func (m *Metadata) FromProto(pb metricpb.Metadata) error {
 
 // ForwardMetadata represents the metadata information associated with forwarded metrics.
 type ForwardMetadata struct {
-	// List of aggregation types.
-	AggregationID aggregation.ID
-
-	// Storage policy.
-	StoragePolicy policy.StoragePolicy
-
 	// Pipeline of operations that may be applied to the metric.
 	Pipeline applied.Pipeline
-
-	// Metric source id that refers to the unique id of the source producing this metric.
-	SourceID uint32
-
+	// Storage policy.
+	StoragePolicy policy.StoragePolicy
+	// List of aggregation types.
+	AggregationID aggregation.ID
 	// Number of times this metric has been forwarded.
 	NumForwardedTimes int
-
+	// Metric source id that refers to the unique id of the source producing this metric.
+	SourceID uint32
 	// ResendEnabled is true if the Pipeline supports resending aggregate values after the initial flush.
 	ResendEnabled bool
 }
@@ -649,8 +638,8 @@ func (sms *StagedMetadatas) fromProto(pb metricpb.StagedMetadatas) error {
 
 // VersionedStagedMetadatas is a versioned staged metadatas.
 type VersionedStagedMetadatas struct {
-	Version         int             `json:"version"`
 	StagedMetadatas StagedMetadatas `json:"stagedMetadatas"`
+	Version         int             `json:"version"`
 }
 
 // TimedMetadata represents the metadata information associated with timed metrics.

--- a/src/metrics/metadata/metadata_test.go
+++ b/src/metrics/metadata/metadata_test.go
@@ -1152,14 +1152,15 @@ func TestVersionedStagedMetadatasMarshalJSON(t *testing.T) {
 	res, err := json.Marshal(vs)
 	require.NoError(t, err)
 
-	expected :=
-		`{"version":12,` +
-			`"stagedMetadatas":` +
-			`[{"metadata":{"pipelines":[` +
-			`{"aggregation":["Sum"],"storagePolicies":["1s:1h","1m:12h"],"resendEnabled":true},` +
-			`{"aggregation":null,"storagePolicies":["10s:1h"]}]},` +
-			`"cutoverNanos":4567,` +
-			`"tombstoned":true}]}`
+	expected := `{` +
+		`"stagedMetadatas":` +
+		`[{"metadata":{"pipelines":[` +
+		`{"storagePolicies":["1s:1h","1m:12h"],"aggregation":["Sum"],"resendEnabled":true},` +
+		`{"storagePolicies":["10s:1h"],"aggregation":null}]},` +
+		`"cutoverNanos":4567,` +
+		`"tombstoned":true}],` +
+		`"version":12` +
+		`}`
 	require.Equal(t, expected, string(res))
 }
 

--- a/src/metrics/metric/aggregated/types.go
+++ b/src/metrics/metric/aggregated/types.go
@@ -40,11 +40,11 @@ var (
 
 // Metric is a metric, which is essentially a named value at certain time.
 type Metric struct {
-	Type       metric.Type
 	ID         id.RawID
+	Annotation []byte
+	Type       metric.Type
 	TimeNanos  int64
 	Value      float64
-	Annotation []byte
 }
 
 // ToProto converts the metric to a protobuf message in place.
@@ -84,9 +84,9 @@ func (m Metric) String() string {
 // ChunkedMetric is a metric with a chunked ID.
 type ChunkedMetric struct {
 	id.ChunkedID
+	Annotation []byte
 	TimeNanos  int64
 	Value      float64
-	Annotation []byte
 }
 
 // RawMetric is a metric in its raw form (e.g., encoded bytes associated with
@@ -147,12 +147,12 @@ type ChunkedMetricWithStoragePolicy struct {
 
 // ForwardedMetric is a forwarded metric.
 type ForwardedMetric struct {
-	Type       metric.Type
 	ID         id.RawID
-	TimeNanos  int64
 	Values     []float64
 	PrevValues []float64
 	Annotation []byte
+	Type       metric.Type
+	TimeNanos  int64
 	Version    uint32
 }
 
@@ -247,8 +247,8 @@ func (tm *TimedMetricWithMetadata) FromProto(pb *metricpb.TimedMetricWithMetadat
 
 // TimedMetricWithMetadatas is a timed metric with staged metadatas.
 type TimedMetricWithMetadatas struct {
-	Metric
 	metadata.StagedMetadatas
+	Metric
 }
 
 // ToProto converts the timed metric with metadata to a protobuf message in place.

--- a/src/metrics/metric/id/m3/id.go
+++ b/src/metrics/metric/id/m3/id.go
@@ -103,8 +103,8 @@ func IsRollupID(name []byte, tags []byte, iterPool id.SortedTagIteratorPool) boo
 
 // TODO(xichen): pool the mids.
 type metricID struct {
-	id       []byte
 	iterPool id.SortedTagIteratorPool
+	id       []byte
 }
 
 // NewID creates a new m3 metric id.
@@ -150,12 +150,12 @@ func NameAndTags(id []byte) ([]byte, []byte, error) {
 }
 
 type sortedTagIterator struct {
-	sortedTagPairs []byte
-	idx            int
-	tagName        []byte
-	tagValue       []byte
 	err            error
 	pool           id.SortedTagIteratorPool
+	sortedTagPairs []byte
+	tagName        []byte
+	tagValue       []byte
+	idx            int
 }
 
 // NewSortedTagIterator creates a new sorted tag iterator.

--- a/src/metrics/metric/unaggregated/types.go
+++ b/src/metrics/metric/unaggregated/types.go
@@ -42,8 +42,8 @@ var (
 // Counter is a counter containing the counter ID and the counter value.
 type Counter struct {
 	ID              id.RawID
-	Value           int64
 	Annotation      []byte
+	Value           int64
 	ClientTimeNanos xtime.UnixNano
 }
 
@@ -111,8 +111,8 @@ func (t *BatchTimer) FromProto(pb metricpb.BatchTimer) {
 // Gauge is a gauge containing the gauge ID and the value at certain time.
 type Gauge struct {
 	ID              id.RawID
-	Value           float64
 	Annotation      []byte
+	Value           float64
 	ClientTimeNanos xtime.UnixNano
 }
 
@@ -145,26 +145,26 @@ func (g *Gauge) FromProto(pb metricpb.Gauge) {
 
 // CounterWithPoliciesList is a counter with applicable policies list.
 type CounterWithPoliciesList struct {
-	Counter
 	policy.PoliciesList
+	Counter
 }
 
 // BatchTimerWithPoliciesList is a batch timer with applicable policies list.
 type BatchTimerWithPoliciesList struct {
-	BatchTimer
 	policy.PoliciesList
+	BatchTimer
 }
 
 // GaugeWithPoliciesList is a gauge with applicable policies list.
 type GaugeWithPoliciesList struct {
-	Gauge
 	policy.PoliciesList
+	Gauge
 }
 
 // CounterWithMetadatas is a counter with applicable metadatas.
 type CounterWithMetadatas struct {
-	Counter
 	metadata.StagedMetadatas
+	Counter
 }
 
 // ToProto converts the counter with metadatas to a protobuf message in place.
@@ -190,8 +190,8 @@ func (cm *CounterWithMetadatas) FromProto(pb *metricpb.CounterWithMetadatas) err
 
 // BatchTimerWithMetadatas is a batch timer with applicable metadatas.
 type BatchTimerWithMetadatas struct {
-	BatchTimer
 	metadata.StagedMetadatas
+	BatchTimer
 }
 
 // ToProto converts the batch timer with metadatas to a protobuf message in place.
@@ -217,8 +217,8 @@ func (bm *BatchTimerWithMetadatas) FromProto(pb *metricpb.BatchTimerWithMetadata
 
 // GaugeWithMetadatas is a gauge with applicable metadatas.
 type GaugeWithMetadatas struct {
-	Gauge
 	metadata.StagedMetadatas
+	Gauge
 }
 
 // ToProto converts the gauge with metadatas to a protobuf message in place.
@@ -248,13 +248,13 @@ func (gm *GaugeWithMetadatas) FromProto(pb *metricpb.GaugeWithMetadatas) error {
 // allocated from a pool, the TimerValPool should be set to the originating pool,
 // and the caller is responsible for returning the timer values to the pool.
 type MetricUnion struct {
-	Type            metric.Type
-	ID              id.RawID
-	CounterVal      int64
-	BatchTimerVal   []float64
-	GaugeVal        float64
 	TimerValPool    pool.FloatsPool
 	Annotation      []byte
+	ID              id.RawID
+	BatchTimerVal   []float64
+	CounterVal      int64
+	GaugeVal        float64
+	Type            metric.Type
 	ClientTimeNanos xtime.UnixNano
 }
 

--- a/src/metrics/pipeline/applied/type.go
+++ b/src/metrics/pipeline/applied/type.go
@@ -82,9 +82,9 @@ func (op *RollupOp) FromProto(pb pipelinepb.AppliedRollupOp) error {
 
 // OpUnion is a union of different types of operation.
 type OpUnion struct {
+	Rollup         RollupOp
 	Type           pipeline.OpType
 	Transformation pipeline.TransformationOp
-	Rollup         RollupOp
 }
 
 // Equal determines whether two operation unions are equal.

--- a/src/metrics/pipeline/type.go
+++ b/src/metrics/pipeline/type.go
@@ -404,9 +404,9 @@ func (op RollupOp) MarshalYAML() (interface{}, error) {
 }
 
 type rollupMarshaler struct {
+	Type          RollupType     `json:"type" yaml:"type"`
 	NewName       string         `json:"newName" yaml:"newName"`
 	Tags          []string       `json:"tags" yaml:"tags"`
-	Type          RollupType     `json:"type" yaml:"type"`
 	AggregationID aggregation.ID `json:"aggregation,omitempty" yaml:"aggregation"`
 }
 
@@ -425,10 +425,10 @@ func (m rollupMarshaler) RollupOp() (RollupOp, error) {
 
 // OpUnion is a union of different types of operation.
 type OpUnion struct {
+	Rollup         RollupOp
 	Type           OpType
 	Aggregation    AggregationOp
 	Transformation TransformationOp
-	Rollup         RollupOp
 }
 
 // NewOpUnionFromProto creates a new operation union from proto.

--- a/src/metrics/pipeline/type.go
+++ b/src/metrics/pipeline/type.go
@@ -193,15 +193,14 @@ const (
 
 // RollupOp is a rollup operation.
 type RollupOp struct {
-	// Type is the rollup type.
-	Type RollupType
 	// Dimensions along which the rollup is performed.
 	Tags [][]byte
-	// Types of aggregation performed within each unique dimension combination.
-	AggregationID aggregation.ID
-
 	// New metric name generated as a result of the rollup.
-	newName          []byte
+	newName []byte
+	// Type is the rollup type.
+	Type RollupType
+	// Types of aggregation performed within each unique dimension combination.
+	AggregationID    aggregation.ID
 	newNameTemplated bool
 }
 
@@ -405,9 +404,9 @@ func (op RollupOp) MarshalYAML() (interface{}, error) {
 }
 
 type rollupMarshaler struct {
-	Type          RollupType     `json:"type" yaml:"type"`
 	NewName       string         `json:"newName" yaml:"newName"`
 	Tags          []string       `json:"tags" yaml:"tags"`
+	Type          RollupType     `json:"type" yaml:"type"`
 	AggregationID aggregation.ID `json:"aggregation,omitempty" yaml:"aggregation"`
 }
 

--- a/src/metrics/transformation/type.go
+++ b/src/metrics/transformation/type.go
@@ -221,12 +221,11 @@ func ParseType(str string) (Type, error) {
 
 // Op represents a transform operation.
 type Op struct {
-	opType Type
-
-	// has one of the following
 	unary      UnaryTransform
 	binary     BinaryTransform
 	unaryMulti UnaryMultiOutputTransform
+	// opType determines which one of the above transformations are applied
+	opType Type
 }
 
 // Type returns the op type.


### PR DESCRIPTION
Went through a couple of packages with `fieldalignment -fix` that are commonly used. Unlike `maligned`, it also moves pointers to the front of the struct to reduce amount of bytes GC has to scan.
Microbenchmarks (that exist) are really boring and don't show anything, except for one that churns through a lot of data and does actually GC:
```
name                                                              old time/op    new time/op    delta
TimerAddBatch/100k_samples_1000_batch_size-12                       1.92ms ± 7%    1.65ms ± 4%  -13.83%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..1,000,000_range-12    1.92ms ± 3%    1.67ms ± 7%  -12.88%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..100,000_range-12      1.93ms ± 6%    1.83ms ± 1%   -5.10%  (p=0.016 n=5+5)
TimerAddBatch/10k_samples_1000_batch_size-12                         315µs ± 8%     291µs ± 2%   -7.61%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size-12                          315µs ± 2%     300µs ± 1%   -4.99%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size_with_negative_values-12     143µs ± 2%     142µs ± 2%     ~     (p=1.000 n=5+5)
TimerAddBatch/1k_samples_100_batch_size-12                          12.5µs ± 1%    12.1µs ± 2%   -3.40%  (p=0.008 n=5+5)

name                                                              old speed      new speed      delta
TimerAddBatch/100k_samples_1000_batch_size-12                      418MB/s ± 6%   484MB/s ± 4%  +15.94%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..1,000,000_range-12   418MB/s ± 3%   480MB/s ± 7%  +14.90%  (p=0.008 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..100,000_range-12     416MB/s ± 6%   438MB/s ± 1%   +5.25%  (p=0.016 n=5+5)
TimerAddBatch/10k_samples_1000_batch_size-12                       255MB/s ± 7%   275MB/s ± 2%   +8.09%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size-12                        254MB/s ± 2%   267MB/s ± 1%   +5.22%  (p=0.008 n=5+5)
TimerAddBatch/10k_samples_100_batch_size_with_negative_values-12   561MB/s ± 2%   563MB/s ± 2%     ~     (p=1.000 n=5+5)
TimerAddBatch/1k_samples_100_batch_size-12                         639MB/s ± 1%   662MB/s ± 2%   +3.54%  (p=0.008 n=5+5)

name                                                              old alloc/op   new alloc/op   delta
TimerAddBatch/100k_samples_1000_batch_size-12                        527kB ± 0%     527kB ± 0%     ~     (p=0.222 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..1,000,000_range-12     527kB ± 0%     527kB ± 0%     ~     (p=0.421 n=5+5)
TimerAddBatch/100k_samples_1000_batch_size_0..100,000_range-12       527kB ± 0%     527kB ± 0%     ~     (p=1.000 n=5+5)
TimerAddBatch/10k_samples_1000_batch_size-12                         531kB ± 0%     531kB ± 0%     ~     (p=0.548 n=5+5)
TimerAddBatch/10k_samples_100_batch_size-12                          530kB ± 0%     530kB ± 0%     ~     (p=0.548 n=5+5)
TimerAddBatch/10k_samples_100_batch_size_with_negative_values-12      197B ± 1%      200B ± 2%     ~     (p=0.079 n=5+5)
TimerAddBatch/1k_samples_100_batch_size-12                           96.0B ± 0%     96.0B ± 0%     ~     (all equal)
```

Report output:
```
src/aggregator/aggregation/counter.go:31:14: struct with 112 pointer bytes could be 72
src/aggregator/aggregation/gauge.go:31:12: struct with 120 pointer bytes could be 72
src/aggregator/aggregation/options.go:35:14: struct with 40 pointer bytes could be 32
src/aggregator/aggregation/timer.go:31:12: struct with 64 pointer bytes could be 40

src/aggregator/bitset/bitset.go:30:13: struct with 24 pointer bytes could be 8

src/aggregator/client/payload.go:42:21: struct with 128 pointer bytes could be 120
src/aggregator/client/payload.go:67:19: struct with 600 pointer bytes could be 592
src/aggregator/client/queue.go:123:12: struct with 192 pointer bytes could be 144
src/aggregator/client/writer.go:64:13: struct with 160 pointer bytes could be 120
src/aggregator/client/writer.go:416:23: struct with 32 pointer bytes could be 24

src/aggregator/aggregation/quantile/cm/options.go:39:14: struct with 32 pointer bytes could be 8
src/aggregator/aggregation/quantile/cm/sample.go:24:13: struct with 40 pointer bytes could be 16
src/aggregator/aggregation/quantile/cm/stream.go:41:13: struct with 248 pointer bytes could be 192

src/metrics/pipeline/type.go:195:15: struct with 48 pointer bytes could be 32
src/metrics/pipeline/type.go:407:22: struct with 32 pointer bytes could be 24
src/metrics/pipeline/type.go:428:14: struct with 72 pointer bytes could be 48
src/metrics/pipeline/applied/type.go:84:14: struct with 24 pointer bytes could be 8
src/metrics/metadata/metadata.go:77:23: struct with 96 pointer bytes could be 80
src/metrics/metadata/metadata.go:394:22: struct of size 80 could be 72
src/metrics/metadata/metadata.go:651:31: struct with 16 pointer bytes could be 8
src/metrics/transformation/type.go:223:9: struct with 56 pointer bytes could be 48
src/metrics/encoding/protobuf/aggregated_encoder.go:39:24: struct with 128 pointer bytes could be 96
src/metrics/encoding/protobuf/buffer.go:33:13: struct with 32 pointer bytes could be 16
src/metrics/encoding/protobuf/unaggregated_encoder.go:61:26: struct with 848 pointer bytes could be 776
src/metrics/encoding/protobuf/unaggregated_iterator.go:34:27: struct with 928 pointer bytes could be 848
src/metrics/metric/aggregated/types.go:42:13: struct with 56 pointer bytes could be 32
src/metrics/metric/aggregated/types.go:85:20: struct with 96 pointer bytes could be 80
src/metrics/metric/aggregated/types.go:149:22: struct with 96 pointer bytes could be 80
src/metrics/metric/id/m3/id.go:105:15: struct with 40 pointer bytes could be 24
src/metrics/metric/id/m3/id.go:152:24: struct with 112 pointer bytes could be 88
src/metrics/metric/unaggregated/types.go:43:14: struct with 40 pointer bytes could be 32
src/metrics/metric/unaggregated/types.go:112:12: struct with 40 pointer bytes could be 32
src/metrics/metric/unaggregated/types.go:147:30: struct with 72 pointer bytes could be 64
src/metrics/metric/unaggregated/types.go:153:33: struct with 88 pointer bytes could be 80
src/metrics/metric/unaggregated/types.go:159:28: struct with 72 pointer bytes could be 64
src/metrics/metric/unaggregated/types.go:165:27: struct with 72 pointer bytes could be 64
src/metrics/metric/unaggregated/types.go:192:30: struct with 88 pointer bytes could be 80
src/metrics/metric/unaggregated/types.go:219:25: struct with 72 pointer bytes could be 64
src/metrics/metric/unaggregated/types.go:250:18: struct with 96 pointer bytes could be 72
```