### PR TITLE
[query] Ensure metrics server always gets closed

### DIFF
--- a/src/cmd/services/m3dbnode/server/server.go
+++ b/src/cmd/services/m3dbnode/server/server.go
@@ -38,6 +38,10 @@ type Options struct {
 	// InterruptCh is a programmatic interrupt channel to supply to
 	// interrupt and shutdown the server.
 	InterruptCh <-chan error
+
+	// ShutdownCh is an optional channel to supply if interested in receiving
+	// a notification that the server has shutdown.
+	ShutdownCh chan<- struct{}
 }
 
 // RunComponents runs the appropriate M3 components based on the configuration.
@@ -46,6 +50,7 @@ func RunComponents(opts Options) {
 	var (
 		cfg         = opts.Configuration
 		interruptCh = opts.InterruptCh
+		shutdownCh  = opts.ShutdownCh
 
 		dbClientCh        chan client.Client
 		clusterClientCh   chan clusterclient.Client
@@ -66,6 +71,7 @@ func RunComponents(opts Options) {
 				DBClient:      dbClientCh,
 				ClusterClient: clusterClientCh,
 				InterruptCh:   interruptCh,
+				ShutdownCh:    shutdownCh,
 			})
 			coordinatorDoneCh <- struct{}{}
 		}()
@@ -77,6 +83,7 @@ func RunComponents(opts Options) {
 			ClientCh:        dbClientCh,
 			ClusterClientCh: clusterClientCh,
 			InterruptCh:     interruptCh,
+			ShutdownCh:      shutdownCh,
 		})
 	} else if cfg.Coordinator != nil {
 		<-coordinatorDoneCh

--- a/src/x/instrument/config_prometheus.go
+++ b/src/x/instrument/config_prometheus.go
@@ -21,8 +21,10 @@
 package instrument
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -110,10 +112,26 @@ type PrometheusExternalRegistry struct {
 	SubScope string
 }
 
+type reporterCloser struct {
+	closeFn func() error
+}
+
+func newReporterCloser() reporterCloser {
+	return reporterCloser{
+		closeFn: func() error {
+			return nil
+		},
+	}
+}
+
+func (r reporterCloser) Close() error {
+	return r.closeFn()
+}
+
 // NewReporter creates a new M3 Prometheus reporter from this configuration.
 func (c PrometheusConfiguration) NewReporter(
 	configOpts PrometheusConfigurationOptions,
-) (prometheus.Reporter, error) {
+) (prometheus.Reporter, io.Closer, error) {
 	registry := configOpts.Registry
 	if registry == nil {
 		registry = prom.NewRegistry()
@@ -178,11 +196,12 @@ func (c PrometheusConfiguration) NewReporter(
 	handler := promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{})
 
 	addr := strings.TrimSpace(c.ListenAddress)
+	closer := newReporterCloser()
 	if addr == "" && configOpts.HandlerListener == nil {
 		// If address not specified and server not specified, register
 		// on default mux.
 		if configOpts.DefaultServeMux == nil {
-			return nil, errors.New(
+			return nil, nil, errors.New(
 				"must specify a DefaultServeMux option when not specifying a listener",
 			)
 		}
@@ -197,20 +216,23 @@ func (c PrometheusConfiguration) NewReporter(
 			var err error
 			listener, err = net.Listen("tcp", addr)
 			if err != nil {
-				return nil, fmt.Errorf(
+				return nil, nil, fmt.Errorf(
 					"prometheus handler listen address error: %v", err)
 			}
 		}
 
+		server := &http.Server{Handler: mux}
 		go func() {
-			server := &http.Server{Handler: mux}
-			if err := server.Serve(listener); err != nil {
+			if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				opts.OnRegisterError(err)
 			}
 		}()
+		closer.closeFn = func() error {
+			return server.Shutdown(context.Background())
+		}
 	}
 
-	return reporter, nil
+	return reporter, closer, nil
 }
 
 func newMultiGatherer(

--- a/src/x/instrument/config_test.go
+++ b/src/x/instrument/config_test.go
@@ -110,7 +110,9 @@ func TestPrometheusExternalRegistries(t *testing.T) {
 	baz.Inc()
 
 	// Wait for report.
-	require.NoError(t, closer.Close())
+	mClosers, ok := closer.(metricsClosers)
+	require.True(t, ok)
+	require.NoError(t, mClosers.reporterCloser.Close())
 
 	expected := map[string]xjson.Map{
 		"foo": {
@@ -164,6 +166,7 @@ func TestPrometheusExternalRegistries(t *testing.T) {
 	}
 
 	assertMetricsEqual(t, listener, expected)
+	require.NoError(t, mClosers.Close())
 }
 
 func TestCommonLabelsAdded(t *testing.T) {
@@ -191,7 +194,9 @@ func TestCommonLabelsAdded(t *testing.T) {
 	bar.Inc()
 
 	// Wait for report.
-	require.NoError(t, closer.Close())
+	mClosers, ok := closer.(metricsClosers)
+	require.True(t, ok)
+	require.NoError(t, mClosers.reporterCloser.Close())
 
 	expected := map[string]xjson.Map{
 		"foo": {
@@ -229,6 +234,7 @@ func TestCommonLabelsAdded(t *testing.T) {
 	}
 
 	assertMetricsEqual(t, listener, expected)
+	require.NoError(t, mClosers.Close())
 }
 
 func startMetricsEndpoint(t *testing.T) (MetricsConfiguration, net.Listener) {
@@ -256,7 +262,7 @@ func newConfiguration() MetricsConfiguration {
 
 func assertMetricsEqual(t *testing.T, listener net.Listener, expected map[string]xjson.Map) {
 	url := fmt.Sprintf("http://%s/metrics", listener.Addr().String()) //nolint
-	resp, err := http.Get(url) //nolint
+	resp, err := http.Get(url)                                        //nolint
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This commit ensures that the metrics http server is closed
if one is created as a part of creating a new prometheus.Reporter.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
