### PR TITLE
[tests] Add coordinator capable of being started in-process.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/apache/thrift v0.14.2
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
 	github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae
+	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/davecgh/go-spew v1.1.1

--- a/src/integration/resources/common/coordinator_client.go
+++ b/src/integration/resources/common/coordinator_client.go
@@ -1,0 +1,559 @@
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package common contains shared logic between docker and in-process M3
+// implementations.
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/common/model"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/m3db/m3/src/cluster/generated/proto/placementpb"
+	"github.com/m3db/m3/src/integration/resources"
+	"github.com/m3db/m3/src/query/generated/proto/admin"
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+	xhttp "github.com/m3db/m3/src/x/net/http"
+)
+
+// RetryFunc is a function that retries the provided
+// operation until successful.
+type RetryFunc func(op func() error) error
+
+// ZapMethod appends the method as a log field.
+func ZapMethod(s string) zapcore.Field { return zap.String("method", s) }
+
+// CoordinatorClient is a client use to invoke API calls
+// on a coordinator
+type CoordinatorClient struct {
+	client    *http.Client
+	httpPort  int
+	logger    *zap.Logger
+	retryFunc RetryFunc
+}
+
+// CoordinatorClientOptions are the options for the CoordinatorClient.
+type CoordinatorClientOptions struct {
+	Client    *http.Client
+	HTTPPort  int
+	Logger    *zap.Logger
+	RetryFunc RetryFunc
+}
+
+// NewCoordinatorClient creates a new CoordinatorClient.
+func NewCoordinatorClient(opts CoordinatorClientOptions) CoordinatorClient {
+	return CoordinatorClient{
+		client:    opts.Client,
+		httpPort:  opts.HTTPPort,
+		logger:    opts.Logger,
+		retryFunc: opts.RetryFunc,
+	}
+}
+
+func (c *CoordinatorClient) makeURL(resource string) string {
+	return fmt.Sprintf("http://0.0.0.0:%d/%s", c.httpPort, resource)
+}
+
+//nolint:dupl
+// GetNamespace gets namespaces.
+func (c *CoordinatorClient) GetNamespace() (admin.NamespaceGetResponse, error) {
+	url := c.makeURL("api/v1/services/m3db/namespace")
+	logger := c.logger.With(
+		ZapMethod("getNamespace"), zap.String("url", url))
+
+	//nolint:noctx
+	resp, err := c.client.Get(url)
+	if err != nil {
+		logger.Error("failed get", zap.Error(err))
+		return admin.NamespaceGetResponse{}, err
+	}
+
+	var response admin.NamespaceGetResponse
+	if err := toResponse(resp, &response, logger); err != nil {
+		return admin.NamespaceGetResponse{}, err
+	}
+
+	return response, nil
+}
+
+//nolint:dupl
+// GetPlacement gets placements.
+func (c *CoordinatorClient) GetPlacement() (admin.PlacementGetResponse, error) {
+	url := c.makeURL("api/v1/services/m3db/placement")
+	logger := c.logger.With(
+		ZapMethod("getPlacement"), zap.String("url", url))
+
+	//nolint:noctx
+	resp, err := c.client.Get(url)
+	if err != nil {
+		logger.Error("failed get", zap.Error(err))
+		return admin.PlacementGetResponse{}, err
+	}
+
+	var response admin.PlacementGetResponse
+	if err := toResponse(resp, &response, logger); err != nil {
+		return admin.PlacementGetResponse{}, err
+	}
+
+	return response, nil
+}
+
+// WaitForNamespace blocks until the given namespace is enabled.
+// NB: if the name string is empty, this will instead
+// check for a successful response.
+func (c *CoordinatorClient) WaitForNamespace(name string) error {
+	logger := c.logger.With(ZapMethod("waitForNamespace"))
+	return c.retryFunc(func() error {
+		ns, err := c.GetNamespace()
+		if err != nil {
+			return err
+		}
+
+		// If no name passed in, instad just check for success.
+		if len(name) == 0 {
+			return nil
+		}
+
+		nss := ns.GetRegistry().GetNamespaces()
+		namespace, found := nss[name]
+		if !found {
+			err := fmt.Errorf("no namespace with name %s", name)
+			logger.Error("could not get namespace", zap.Error(err))
+			return err
+		}
+
+		enabled := namespace.GetIndexOptions().GetEnabled()
+		if !enabled {
+			err := fmt.Errorf("namespace %s not enabled", name)
+			logger.Error("namespace not enabled", zap.Error(err))
+			return err
+		}
+
+		logger.Info("namespace ready", zap.String("namespace", name))
+		return nil
+	})
+}
+
+// WaitForInstances blocks until the given instance is available.
+func (c *CoordinatorClient) WaitForInstances(
+	ids []string,
+) error {
+	logger := c.logger.With(ZapMethod("waitForPlacement"))
+	return c.retryFunc(func() error {
+		placement, err := c.GetPlacement()
+		if err != nil {
+			logger.Error("retrying get placement", zap.Error(err))
+			return err
+		}
+
+		logger.Info("got placement", zap.Any("placement", placement))
+		instances := placement.GetPlacement().GetInstances()
+		for _, id := range ids {
+			placement, found := instances[id]
+			if !found {
+				err = fmt.Errorf("no instance with id %s", id)
+				logger.Error("could not get instance", zap.Error(err))
+				return err
+			}
+
+			if pID := placement.GetId(); pID != id {
+				err = fmt.Errorf("id mismatch: instance(%s) != placement(%s)", id, pID)
+				logger.Error("could not get instance", zap.Error(err))
+				return err
+			}
+		}
+
+		logger.Info("instances ready")
+		return nil
+	})
+}
+
+// WaitForShardsReady waits until all shards gets ready.
+func (c *CoordinatorClient) WaitForShardsReady() error {
+	logger := c.logger.With(ZapMethod("waitForShards"))
+	return c.retryFunc(func() error {
+		placement, err := c.GetPlacement()
+		if err != nil {
+			logger.Error("retrying get placement", zap.Error(err))
+			return err
+		}
+
+		for _, instance := range placement.Placement.Instances {
+			for _, shard := range instance.Shards {
+				if shard.State == placementpb.ShardState_INITIALIZING {
+					err = fmt.Errorf("at least shard %d of dbnode %s still initializing", shard.Id, instance.Id)
+					logger.Error("shards still are initializing", zap.Error(err))
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// CreateDatabase creates a database.
+func (c *CoordinatorClient) CreateDatabase(
+	addRequest admin.DatabaseCreateRequest,
+) (admin.DatabaseCreateResponse, error) {
+	url := c.makeURL("api/v1/database/create")
+	logger := c.logger.With(
+		ZapMethod("createDatabase"), zap.String("url", url),
+		zap.String("request", addRequest.String()))
+
+	resp, err := c.makeRequest(logger, url, http.MethodPost, &addRequest)
+	if err != nil {
+		logger.Error("failed post", zap.Error(err))
+		return admin.DatabaseCreateResponse{}, err
+	}
+
+	var response admin.DatabaseCreateResponse
+	if err := toResponse(resp, &response, logger); err != nil {
+		logger.Error("failed response", zap.Error(err))
+		return admin.DatabaseCreateResponse{}, err
+	}
+
+	if err = c.setNamespaceReady(addRequest.NamespaceName); err != nil {
+		logger.Error("failed to set namespace to ready state",
+			zap.Error(err),
+			zap.String("namespace", addRequest.NamespaceName),
+		)
+		return response, err
+	}
+
+	logger.Info("created database")
+	return response, nil
+}
+
+// AddNamespace adds a namespace.
+func (c *CoordinatorClient) AddNamespace(
+	addRequest admin.NamespaceAddRequest,
+) (admin.NamespaceGetResponse, error) {
+	url := c.makeURL("api/v1/services/m3db/namespace")
+	logger := c.logger.With(
+		ZapMethod("addNamespace"), zap.String("url", url),
+		zap.String("request", addRequest.String()))
+
+	resp, err := c.makeRequest(logger, url, http.MethodPost, &addRequest)
+	if err != nil {
+		logger.Error("failed post", zap.Error(err))
+		return admin.NamespaceGetResponse{}, err
+	}
+
+	var response admin.NamespaceGetResponse
+	if err := toResponse(resp, &response, logger); err != nil {
+		return admin.NamespaceGetResponse{}, err
+	}
+
+	if err = c.setNamespaceReady(addRequest.Name); err != nil {
+		logger.Error("failed to set namespace to ready state", zap.Error(err), zap.String("namespace", addRequest.Name))
+		return response, err
+	}
+
+	return response, nil
+}
+
+// UpdateNamespace updates the namespace.
+func (c *CoordinatorClient) UpdateNamespace(
+	req admin.NamespaceUpdateRequest,
+) (admin.NamespaceGetResponse, error) {
+	url := c.makeURL("api/v1/services/m3db/namespace")
+	logger := c.logger.With(
+		ZapMethod("updateNamespace"), zap.String("url", url),
+		zap.String("request", req.String()))
+
+	resp, err := c.makeRequest(logger, url, http.MethodPut, &req)
+	if err != nil {
+		logger.Error("failed to update namespace", zap.Error(err))
+		return admin.NamespaceGetResponse{}, err
+	}
+
+	var response admin.NamespaceGetResponse
+	if err := toResponse(resp, &response, logger); err != nil {
+		return admin.NamespaceGetResponse{}, err
+	}
+
+	return response, nil
+}
+
+func (c *CoordinatorClient) setNamespaceReady(name string) error {
+	url := c.makeURL("api/v1/services/m3db/namespace/ready")
+	logger := c.logger.With(
+		ZapMethod("setNamespaceReady"), zap.String("url", url),
+		zap.String("namespace", name))
+
+	_, err := c.makeRequest(logger, url, http.MethodPost, // nolint: bodyclose
+		&admin.NamespaceReadyRequest{
+			Name:  name,
+			Force: true,
+		})
+	return err
+}
+
+// DeleteNamespace removes the namespace.
+func (c *CoordinatorClient) DeleteNamespace(namespaceID string) error {
+	url := c.makeURL("api/v1/services/m3db/namespace/" + namespaceID)
+	logger := c.logger.With(ZapMethod("deleteNamespace"), zap.String("url", url))
+
+	if _, err := c.makeRequest(logger, url, http.MethodDelete, nil); err != nil { // nolint: bodyclose
+		logger.Error("failed to delete namespace", zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+// WriteCarbon writes a carbon metric datapoint at a given time.
+func (c *CoordinatorClient) WriteCarbon(
+	url string, metric string, v float64, t time.Time,
+) error {
+	logger := c.logger.With(
+		ZapMethod("writeCarbon"), zap.String("url", url),
+		zap.String("at time", time.Now().String()),
+		zap.String("at ts", t.String()))
+
+	con, err := net.Dial("tcp", url)
+	if err != nil {
+		logger.Error("could not dial", zap.Error(err))
+		return err
+	}
+
+	write := fmt.Sprintf("%s %f %d", metric, v, t.Unix())
+	logger.Info("writing", zap.String("metric", write))
+	n, err := con.Write([]byte(write))
+	if err != nil {
+		logger.Error("could not write", zap.Error(err))
+	}
+
+	if n != len(write) {
+		err := fmt.Errorf("wrote %d, wanted %d", n, len(write))
+		logger.Error("write failure", zap.Error(err))
+		return err
+	}
+
+	logger.Info("write success", zap.Int("bytes written", n))
+	return con.Close()
+}
+
+// WriteProm writes a prometheus metric.
+func (c *CoordinatorClient) WriteProm(name string, tags map[string]string, samples []prompb.Sample) error {
+	var (
+		url       = c.makeURL("api/v1/prom/remote/write")
+		reqLabels = []prompb.Label{{Name: []byte(model.MetricNameLabel), Value: []byte(name)}}
+	)
+
+	for tag, value := range tags {
+		reqLabels = append(reqLabels, prompb.Label{
+			Name:  []byte(tag),
+			Value: []byte(value),
+		})
+	}
+	writeRequest := prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels:  reqLabels,
+				Samples: samples,
+			},
+		},
+	}
+
+	logger := c.logger.With(
+		ZapMethod("createDatabase"), zap.String("url", url),
+		zap.String("request", writeRequest.String()))
+
+	body, err := proto.Marshal(&writeRequest)
+	if err != nil {
+		logger.Error("failed marshaling request message", zap.Error(err))
+		return err
+	}
+	data := bytes.NewBuffer(snappy.Encode(nil, body))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, data)
+	if err != nil {
+		logger.Error("failed constructing request", zap.Error(err))
+		return err
+	}
+	req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeProtobuf)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		logger.Error("failed making a request", zap.Error(err))
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		logger.Error("status code not 2xx",
+			zap.Int("status code", resp.StatusCode),
+			zap.String("status", resp.Status))
+		return fmt.Errorf("status code %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (c *CoordinatorClient) makeRequest(
+	logger *zap.Logger,
+	url string,
+	method string,
+	body proto.Message,
+) (*http.Response, error) {
+	data := bytes.NewBuffer(nil)
+	if body != nil {
+		if err := (&jsonpb.Marshaler{}).Marshal(data, body); err != nil {
+			logger.Error("failed to marshal", zap.Error(err))
+
+			return nil, fmt.Errorf("failed to marshal: %w", err)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), method, url, data)
+	if err != nil {
+		logger.Error("failed to construct request", zap.Error(err))
+
+		return nil, fmt.Errorf("failed to construct request: %w", err)
+	}
+
+	req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeJSON)
+
+	return c.client.Do(req)
+}
+
+// ApplyKVUpdate applies a KV update.
+func (c *CoordinatorClient) ApplyKVUpdate(update string) error {
+	url := c.makeURL("api/v1/kvstore")
+
+	logger := c.logger.With(
+		ZapMethod("ApplyKVUpdate"), zap.String("url", url),
+		zap.String("update", update))
+
+	data := bytes.NewBuffer([]byte(update))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, data)
+	if err != nil {
+		logger.Error("failed to construct request", zap.Error(err))
+		return fmt.Errorf("failed to construct request: %w", err)
+	}
+
+	req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeJSON)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		logger.Error("failed to apply request", zap.Error(err))
+		return fmt.Errorf("failed to apply request: %w", err)
+	}
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("failed to read body", zap.Error(err))
+		return fmt.Errorf("failed to read body: %w", err)
+	}
+
+	logger.Info("applied KV update", zap.ByteString("response", bs))
+	_ = resp.Body.Close()
+	return nil
+}
+
+func (c *CoordinatorClient) query(
+	verifier resources.ResponseVerifier, query string, headers map[string][]string,
+) error {
+	url := c.makeURL(query)
+	logger := c.logger.With(
+		ZapMethod("query"), zap.String("url", url), zap.Any("headers", headers))
+	logger.Info("running")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if headers != nil {
+		req.Header = headers
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		logger.Error("failed get", zap.Error(err))
+		return err
+	}
+
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+
+	return verifier(resp.StatusCode, resp.Header, string(b), err)
+}
+
+// RunQuery runs the given query with a given verification function.
+func (c *CoordinatorClient) RunQuery(
+	verifier resources.ResponseVerifier, query string, headers map[string][]string,
+) error {
+	logger := c.logger.With(ZapMethod("runQuery"),
+		zap.String("query", query))
+	err := c.retryFunc(func() error {
+		err := c.query(verifier, query, headers)
+		if err != nil {
+			logger.Info("retrying", zap.Error(err))
+		}
+
+		return err
+	})
+	if err != nil {
+		logger.Error("failed run", zap.Error(err))
+	}
+
+	return err
+}
+
+func toResponse(
+	resp *http.Response,
+	response proto.Message,
+	logger *zap.Logger,
+) error {
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logger.Error("could not read body", zap.Error(err))
+		return err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		logger.Error("status code not 2xx",
+			zap.Int("status code", resp.StatusCode),
+			zap.String("status", resp.Status))
+		return fmt.Errorf("status code %d", resp.StatusCode)
+	}
+
+	err = jsonpb.Unmarshal(bytes.NewReader(b), response)
+	if err != nil {
+		logger.Error("unable to unmarshal response",
+			zap.Error(err),
+			zap.Any("response", response))
+		return err
+	}
+
+	return nil
+}

--- a/src/integration/resources/docker/coordinator.go
+++ b/src/integration/resources/docker/coordinator.go
@@ -21,26 +21,16 @@
 package docker
 
 import (
-	"bytes"
-	"context"
 	"fmt"
-	"io/ioutil"
-	"net"
 	"net/http"
 	"time"
 
-	"github.com/m3db/m3/src/cluster/generated/proto/placementpb"
+	"github.com/ory/dockertest/v3"
+
 	"github.com/m3db/m3/src/integration/resources"
+	"github.com/m3db/m3/src/integration/resources/common"
 	"github.com/m3db/m3/src/query/generated/proto/admin"
 	"github.com/m3db/m3/src/query/generated/proto/prompb"
-	xhttp "github.com/m3db/m3/src/x/net/http"
-
-	"github.com/gogo/protobuf/jsonpb"
-	"github.com/gogo/protobuf/proto"
-	"github.com/golang/snappy"
-	"github.com/ory/dockertest/v3"
-	"github.com/prometheus/common/model"
-	"go.uber.org/zap"
 )
 
 const (
@@ -60,6 +50,7 @@ var (
 
 type coordinator struct {
 	resource *dockerResource
+	client   common.CoordinatorClient
 }
 
 func newDockerHTTPCoordinator(
@@ -76,6 +67,12 @@ func newDockerHTTPCoordinator(
 
 	return &coordinator{
 		resource: resource,
+		client: common.NewCoordinatorClient(common.CoordinatorClientOptions{
+			Client:    http.DefaultClient,
+			HTTPPort:  7201,
+			Logger:    resource.logger,
+			RetryFunc: resource.pool.Retry,
+		}),
 	}, nil
 }
 
@@ -84,22 +81,7 @@ func (c *coordinator) GetNamespace() (admin.NamespaceGetResponse, error) {
 		return admin.NamespaceGetResponse{}, errClosed
 	}
 
-	url := c.resource.getURL(7201, "api/v1/services/m3db/namespace")
-	logger := c.resource.logger.With(
-		zapMethod("getNamespace"), zap.String("url", url))
-
-	resp, err := http.Get(url)
-	if err != nil {
-		logger.Error("failed get", zap.Error(err))
-		return admin.NamespaceGetResponse{}, err
-	}
-
-	var response admin.NamespaceGetResponse
-	if err := toResponse(resp, &response, logger); err != nil {
-		return admin.NamespaceGetResponse{}, err
-	}
-
-	return response, nil
+	return c.client.GetNamespace()
 }
 
 func (c *coordinator) GetPlacement() (admin.PlacementGetResponse, error) {
@@ -107,22 +89,7 @@ func (c *coordinator) GetPlacement() (admin.PlacementGetResponse, error) {
 		return admin.PlacementGetResponse{}, errClosed
 	}
 
-	url := c.resource.getURL(7201, "api/v1/services/m3db/placement")
-	logger := c.resource.logger.With(
-		zapMethod("getPlacement"), zap.String("url", url))
-
-	resp, err := http.Get(url)
-	if err != nil {
-		logger.Error("failed get", zap.Error(err))
-		return admin.PlacementGetResponse{}, err
-	}
-
-	var response admin.PlacementGetResponse
-	if err := toResponse(resp, &response, logger); err != nil {
-		return admin.PlacementGetResponse{}, err
-	}
-
-	return response, nil
+	return c.client.GetPlacement()
 }
 
 func (c *coordinator) WaitForNamespace(name string) error {
@@ -130,36 +97,7 @@ func (c *coordinator) WaitForNamespace(name string) error {
 		return errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("waitForNamespace"))
-	return c.resource.pool.Retry(func() error {
-		ns, err := c.GetNamespace()
-		if err != nil {
-			return err
-		}
-
-		// If no name passed in, instad just check for success.
-		if len(name) == 0 {
-			return nil
-		}
-
-		nss := ns.GetRegistry().GetNamespaces()
-		namespace, found := nss[name]
-		if !found {
-			err := fmt.Errorf("no namespace with name %s", name)
-			logger.Error("could not get namespace", zap.Error(err))
-			return err
-		}
-
-		enabled := namespace.GetIndexOptions().GetEnabled()
-		if !enabled {
-			err := fmt.Errorf("namespace %s not enabled", name)
-			logger.Error("namespace not enabled", zap.Error(err))
-			return err
-		}
-
-		logger.Info("namespace ready", zap.String("namespace", name))
-		return nil
-	})
+	return c.client.WaitForNamespace(name)
 }
 
 func (c *coordinator) WaitForInstances(
@@ -169,34 +107,7 @@ func (c *coordinator) WaitForInstances(
 		return errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("waitForPlacement"))
-	return c.resource.pool.Retry(func() error {
-		placement, err := c.GetPlacement()
-		if err != nil {
-			logger.Error("retrying get placement", zap.Error(err))
-			return err
-		}
-
-		logger.Info("got placement", zap.Any("placement", placement))
-		instances := placement.GetPlacement().GetInstances()
-		for _, id := range ids {
-			placement, found := instances[id]
-			if !found {
-				err = fmt.Errorf("no instance with id %s", id)
-				logger.Error("could not get instance", zap.Error(err))
-				return err
-			}
-
-			if pID := placement.GetId(); pID != id {
-				err = fmt.Errorf("id mismatch: instance(%s) != placement(%s)", id, pID)
-				logger.Error("could not get instance", zap.Error(err))
-				return err
-			}
-		}
-
-		logger.Info("instances ready")
-		return nil
-	})
+	return c.client.WaitForInstances(ids)
 }
 
 func (c *coordinator) WaitForShardsReady() error {
@@ -204,25 +115,7 @@ func (c *coordinator) WaitForShardsReady() error {
 		return errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("waitForShards"))
-	return c.resource.pool.Retry(func() error {
-		placement, err := c.GetPlacement()
-		if err != nil {
-			logger.Error("retrying get placement", zap.Error(err))
-			return err
-		}
-
-		for _, instance := range placement.Placement.Instances {
-			for _, shard := range instance.Shards {
-				if shard.State == placementpb.ShardState_INITIALIZING {
-					err = fmt.Errorf("at least shard %d of dbnode %s still initializing", shard.Id, instance.Id)
-					logger.Error("shards still are initializing", zap.Error(err))
-					return err
-				}
-			}
-		}
-		return nil
-	})
+	return c.client.WaitForShardsReady()
 }
 
 func (c *coordinator) CreateDatabase(
@@ -232,33 +125,7 @@ func (c *coordinator) CreateDatabase(
 		return admin.DatabaseCreateResponse{}, errClosed
 	}
 
-	url := c.resource.getURL(7201, "api/v1/database/create")
-	logger := c.resource.logger.With(
-		zapMethod("createDatabase"), zap.String("url", url),
-		zap.String("request", addRequest.String()))
-
-	resp, err := makeRequest(logger, url, http.MethodPost, &addRequest)
-	if err != nil {
-		logger.Error("failed post", zap.Error(err))
-		return admin.DatabaseCreateResponse{}, err
-	}
-
-	var response admin.DatabaseCreateResponse
-	if err := toResponse(resp, &response, logger); err != nil {
-		logger.Error("failed response", zap.Error(err))
-		return admin.DatabaseCreateResponse{}, err
-	}
-
-	if err = c.setNamespaceReady(addRequest.NamespaceName); err != nil {
-		logger.Error("failed to set namespace to ready state",
-			zap.Error(err),
-			zap.String("namespace", addRequest.NamespaceName),
-		)
-		return response, err
-	}
-
-	logger.Info("created database")
-	return response, nil
+	return c.client.CreateDatabase(addRequest)
 }
 
 func (c *coordinator) AddNamespace(
@@ -268,28 +135,7 @@ func (c *coordinator) AddNamespace(
 		return admin.NamespaceGetResponse{}, errClosed
 	}
 
-	url := c.resource.getURL(7201, "api/v1/services/m3db/namespace")
-	logger := c.resource.logger.With(
-		zapMethod("addNamespace"), zap.String("url", url),
-		zap.String("request", addRequest.String()))
-
-	resp, err := makeRequest(logger, url, http.MethodPost, &addRequest)
-	if err != nil {
-		logger.Error("failed post", zap.Error(err))
-		return admin.NamespaceGetResponse{}, err
-	}
-
-	var response admin.NamespaceGetResponse
-	if err := toResponse(resp, &response, logger); err != nil {
-		return admin.NamespaceGetResponse{}, err
-	}
-
-	if err = c.setNamespaceReady(addRequest.Name); err != nil {
-		logger.Error("failed to set namespace to ready state", zap.Error(err), zap.String("namespace", addRequest.Name))
-		return response, err
-	}
-
-	return response, nil
+	return c.client.AddNamespace(addRequest)
 }
 
 func (c *coordinator) UpdateNamespace(
@@ -299,37 +145,7 @@ func (c *coordinator) UpdateNamespace(
 		return admin.NamespaceGetResponse{}, errClosed
 	}
 
-	url := c.resource.getURL(7201, "api/v1/services/m3db/namespace")
-	logger := c.resource.logger.With(
-		zapMethod("updateNamespace"), zap.String("url", url),
-		zap.String("request", req.String()))
-
-	resp, err := makeRequest(logger, url, http.MethodPut, &req)
-	if err != nil {
-		logger.Error("failed to update namespace", zap.Error(err))
-		return admin.NamespaceGetResponse{}, err
-	}
-
-	var response admin.NamespaceGetResponse
-	if err := toResponse(resp, &response, logger); err != nil {
-		return admin.NamespaceGetResponse{}, err
-	}
-
-	return response, nil
-}
-
-func (c *coordinator) setNamespaceReady(name string) error {
-	url := c.resource.getURL(7201, "api/v1/services/m3db/namespace/ready")
-	logger := c.resource.logger.With(
-		zapMethod("setNamespaceReady"), zap.String("url", url),
-		zap.String("namespace", name))
-
-	_, err := makeRequest(logger, url, http.MethodPost, // nolint: bodyclose
-		&admin.NamespaceReadyRequest{
-			Name:  name,
-			Force: true,
-		})
-	return err
+	return c.client.UpdateNamespace(req)
 }
 
 func (c *coordinator) DeleteNamespace(namespaceID string) error {
@@ -337,14 +153,7 @@ func (c *coordinator) DeleteNamespace(namespaceID string) error {
 		return errClosed
 	}
 
-	url := c.resource.getURL(7201, "api/v1/services/m3db/namespace/"+namespaceID)
-	logger := c.resource.logger.With(zapMethod("deleteNamespace"), zap.String("url", url))
-
-	if _, err := makeRequest(logger, url, http.MethodDelete, nil); err != nil { // nolint: bodyclose
-		logger.Error("failed to delete namespace", zap.Error(err))
-		return err
-	}
-	return nil
+	return c.client.DeleteNamespace(namespaceID)
 }
 
 func (c *coordinator) WriteCarbon(
@@ -355,33 +164,8 @@ func (c *coordinator) WriteCarbon(
 	}
 
 	url := c.resource.resource.GetHostPort(fmt.Sprintf("%d/tcp", port))
-	logger := c.resource.logger.With(
-		zapMethod("writeCarbon"), zap.String("url", url),
-		zap.String("at time", time.Now().String()),
-		zap.String("at ts", t.String()))
 
-	con, err := net.Dial("tcp", url)
-	if err != nil {
-		logger.Error("could not dial", zap.Error(err))
-		return err
-	}
-
-	write := fmt.Sprintf("%s %f %d", metric, v, t.Unix())
-	logger.Info("writing", zap.String("metric", write))
-	n, err := con.Write([]byte(write))
-	if err != nil {
-		logger.Error("could not write", zap.Error(err))
-	}
-
-	if n != len(write) {
-		err := fmt.Errorf("wrote %d, wanted %d", n, len(write))
-		logger.Error("write failure", zap.Error(err))
-		return err
-	}
-
-	logger.Info("write success", zap.Int("bytes written", n))
-	return con.Close()
-	// return nil
+	return c.client.WriteCarbon(url, metric, v, t)
 }
 
 func (c *coordinator) WriteProm(name string, tags map[string]string, samples []prompb.Sample) error {
@@ -389,80 +173,7 @@ func (c *coordinator) WriteProm(name string, tags map[string]string, samples []p
 		return errClosed
 	}
 
-	var (
-		url       = c.resource.getURL(7201, "api/v1/prom/remote/write")
-		reqLabels = []prompb.Label{{Name: []byte(model.MetricNameLabel), Value: []byte(name)}}
-	)
-
-	for tag, value := range tags {
-		reqLabels = append(reqLabels, prompb.Label{
-			Name:  []byte(tag),
-			Value: []byte(value),
-		})
-	}
-	writeRequest := prompb.WriteRequest{
-		Timeseries: []prompb.TimeSeries{
-			{
-				Labels:  reqLabels,
-				Samples: samples,
-			},
-		},
-	}
-
-	logger := c.resource.logger.With(
-		zapMethod("createDatabase"), zap.String("url", url),
-		zap.String("request", writeRequest.String()))
-
-	body, err := proto.Marshal(&writeRequest)
-	if err != nil {
-		logger.Error("failed marshaling request message", zap.Error(err))
-		return err
-	}
-	data := bytes.NewBuffer(snappy.Encode(nil, body))
-
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, data)
-	if err != nil {
-		logger.Error("failed constructing request", zap.Error(err))
-		return err
-	}
-	req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeProtobuf)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		logger.Error("failed making a request", zap.Error(err))
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		logger.Error("status code not 2xx",
-			zap.Int("status code", resp.StatusCode),
-			zap.String("status", resp.Status))
-		return fmt.Errorf("status code %d", resp.StatusCode)
-	}
-
-	return nil
-}
-
-func makeRequest(logger *zap.Logger, url string, method string, body proto.Message) (*http.Response, error) {
-	data := bytes.NewBuffer(nil)
-	if body != nil {
-		if err := (&jsonpb.Marshaler{}).Marshal(data, body); err != nil {
-			logger.Error("failed to marshal", zap.Error(err))
-
-			return nil, fmt.Errorf("failed to marshal: %w", err)
-		}
-	}
-
-	req, err := http.NewRequestWithContext(context.Background(), method, url, data)
-	if err != nil {
-		logger.Error("failed to construct request", zap.Error(err))
-
-		return nil, fmt.Errorf("failed to construct request: %w", err)
-	}
-
-	req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeJSON)
-
-	return http.DefaultClient.Do(req)
+	return c.client.WriteProm(name, tags, samples)
 }
 
 func (c *coordinator) ApplyKVUpdate(update string) error {
@@ -470,68 +181,7 @@ func (c *coordinator) ApplyKVUpdate(update string) error {
 		return errClosed
 	}
 
-	url := c.resource.getURL(7201, "api/v1/kvstore")
-
-	logger := c.resource.logger.With(
-		zapMethod("ApplyKVUpdate"), zap.String("url", url),
-		zap.String("update", update))
-
-	data := bytes.NewBuffer([]byte(update))
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, data)
-	if err != nil {
-		logger.Error("failed to construct request", zap.Error(err))
-		return fmt.Errorf("failed to construct request: %w", err)
-	}
-
-	req.Header.Add(xhttp.HeaderContentType, xhttp.ContentTypeJSON)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		logger.Error("failed to apply request", zap.Error(err))
-		return fmt.Errorf("failed to apply request: %w", err)
-	}
-
-	bs, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		logger.Error("failed to read body", zap.Error(err))
-		return fmt.Errorf("failed to read body: %w", err)
-	}
-
-	logger.Info("applied KV update", zap.ByteString("response", bs))
-	_ = resp.Body.Close()
-	return nil
-}
-
-func (c *coordinator) query(
-	verifier resources.ResponseVerifier, query string, headers map[string][]string,
-) error {
-	if c.resource.closed {
-		return errClosed
-	}
-
-	url := c.resource.getURL(7201, query)
-	logger := c.resource.logger.With(
-		zapMethod("query"), zap.String("url", url), zap.Any("headers", headers))
-	logger.Info("running")
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-
-	if headers != nil {
-		req.Header = headers
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		logger.Error("failed get", zap.Error(err))
-		return err
-	}
-
-	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
-
-	return verifier(resp.StatusCode, resp.Header, string(b), err)
+	return c.client.ApplyKVUpdate(update)
 }
 
 func (c *coordinator) RunQuery(
@@ -541,21 +191,7 @@ func (c *coordinator) RunQuery(
 		return errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("runQuery"),
-		zap.String("query", query))
-	err := c.resource.pool.Retry(func() error {
-		err := c.query(verifier, query, headers)
-		if err != nil {
-			logger.Info("retrying", zap.Error(err))
-		}
-
-		return err
-	})
-	if err != nil {
-		logger.Error("failed run", zap.Error(err))
-	}
-
-	return err
+	return c.client.RunQuery(verifier, query, headers)
 }
 
 func (c *coordinator) Close() error {

--- a/src/integration/resources/docker/dbnode.go
+++ b/src/integration/resources/docker/dbnode.go
@@ -27,6 +27,7 @@ import (
 	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
 	"github.com/m3db/m3/src/dbnode/integration"
 	"github.com/m3db/m3/src/integration/resources"
+	"github.com/m3db/m3/src/integration/resources/common"
 	"github.com/m3db/m3/src/query/generated/proto/admin"
 
 	"github.com/ory/dockertest/v3"
@@ -107,7 +108,7 @@ func (c *dbNode) Health() (*rpc.NodeHealthResult_, error) {
 		return nil, errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("health"))
+	logger := c.resource.logger.With(common.ZapMethod("health"))
 	res, err := c.tchanClient.TChannelClientHealth(timeout)
 	if err != nil {
 		logger.Error("failed get", zap.Error(err), zap.Any("res", res))
@@ -121,7 +122,7 @@ func (c *dbNode) WaitForBootstrap() error {
 		return errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("waitForBootstrap"))
+	logger := c.resource.logger.With(common.ZapMethod("waitForBootstrap"))
 	return c.resource.pool.Retry(func() error {
 		health, err := c.Health()
 		if err != nil {
@@ -143,7 +144,7 @@ func (c *dbNode) WritePoint(req *rpc.WriteRequest) error {
 		return errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("write"))
+	logger := c.resource.logger.With(common.ZapMethod("write"))
 	err := c.tchanClient.TChannelClientWrite(timeout, req)
 	if err != nil {
 		logger.Error("could not write", zap.Error(err))
@@ -159,7 +160,7 @@ func (c *dbNode) WriteTaggedPoint(req *rpc.WriteTaggedRequest) error {
 		return errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("write-tagged"))
+	logger := c.resource.logger.With(common.ZapMethod("write-tagged"))
 	err := c.tchanClient.TChannelClientWriteTagged(timeout, req)
 	if err != nil {
 		logger.Error("could not write-tagged", zap.Error(err))
@@ -175,7 +176,7 @@ func (c *dbNode) AggregateTiles(req *rpc.AggregateTilesRequest) (int64, error) {
 		return 0, errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("aggregate-tiles"))
+	logger := c.resource.logger.With(common.ZapMethod("aggregate-tiles"))
 	rsp, err := c.tchanClient.TChannelClientAggregateTiles(timeout, req)
 	if err != nil {
 		logger.Error("could not aggregate tiles", zap.Error(err))
@@ -191,7 +192,7 @@ func (c *dbNode) Fetch(req *rpc.FetchRequest) (*rpc.FetchResult_, error) {
 		return nil, errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("fetch"))
+	logger := c.resource.logger.With(common.ZapMethod("fetch"))
 	dps, err := c.tchanClient.TChannelClientFetch(timeout, req)
 	if err != nil {
 		logger.Error("could not fetch", zap.Error(err))
@@ -207,7 +208,7 @@ func (c *dbNode) FetchTagged(req *rpc.FetchTaggedRequest) (*rpc.FetchTaggedResul
 		return nil, errClosed
 	}
 
-	logger := c.resource.logger.With(zapMethod("fetchtagged"))
+	logger := c.resource.logger.With(common.ZapMethod("fetchtagged"))
 	result, err := c.tchanClient.TChannelClientFetchTagged(timeout, req)
 	if err != nil {
 		logger.Error("could not fetch", zap.Error(err))
@@ -224,7 +225,7 @@ func (c *dbNode) Restart() error {
 	}
 
 	cName := c.resource.resource.Container.Name
-	logger := c.resource.logger.With(zapMethod("restart"))
+	logger := c.resource.logger.With(common.ZapMethod("restart"))
 	logger.Info("restarting container", zap.String("container", cName))
 	err := c.resource.pool.Client.RestartContainer(cName, 60)
 	if err != nil {

--- a/src/integration/resources/docker/docker_resource.go
+++ b/src/integration/resources/docker/docker_resource.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/m3db/m3/src/integration/resources"
+	"github.com/m3db/m3/src/integration/resources/common"
 )
 
 type dockerResource struct {
@@ -124,7 +125,7 @@ func (c *dockerResource) exec(commands ...string) (string, error) {
 
 	// NB: this is prefixed with a `/` that should be trimmed off.
 	name := strings.TrimLeft(c.resource.Container.Name, "/")
-	logger := c.logger.With(zapMethod("exec"))
+	logger := c.logger.With(common.ZapMethod("exec"))
 	client := c.pool.Client
 	exec, err := client.CreateExec(dc.CreateExecOptions{
 		AttachStdout: true,
@@ -174,7 +175,7 @@ func (c *dockerResource) goalStateExec(
 		return errClosed
 	}
 
-	logger := c.logger.With(zapMethod("goalStateExec"))
+	logger := c.logger.With(common.ZapMethod("goalStateExec"))
 	return c.pool.Retry(func() error {
 		err := verifier(c.exec(commands...))
 		if err != nil {

--- a/src/integration/resources/inprocess/coordinator.go
+++ b/src/integration/resources/inprocess/coordinator.go
@@ -1,0 +1,308 @@
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package inprocess contains code for spinning up M3 resources in-process for
+// the sake of integration testing.
+package inprocess
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/cenkalti/backoff/v3"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+
+	"github.com/m3db/m3/src/cmd/services/m3query/config"
+	"github.com/m3db/m3/src/integration/resources"
+	"github.com/m3db/m3/src/integration/resources/common"
+	nettest "github.com/m3db/m3/src/integration/resources/net"
+	"github.com/m3db/m3/src/query/generated/proto/admin"
+	"github.com/m3db/m3/src/query/generated/proto/prompb"
+	"github.com/m3db/m3/src/query/server"
+	xconfig "github.com/m3db/m3/src/x/config"
+)
+
+const (
+	interruptTimeout = 5 * time.Second
+	shutdownTimeout  = time.Minute
+
+	retryMaxInterval = 5 * time.Second
+	retryMaxTime     = time.Minute
+)
+
+// coordinator is an in-process implementation of resources.Coordinator for use
+// in integration tests.
+type coordinator struct {
+	cfg     config.Configuration
+	client  common.CoordinatorClient
+	logger  *zap.Logger
+	tmpDirs []string
+
+	interruptCh chan<- error
+	shutdownCh  <-chan struct{}
+}
+
+// CoordinatorOptions are options for starting a coordinator server.
+type CoordinatorOptions struct {
+	// Logger is the logger to use for the coordinator. If not provided,
+	// a default one will be created.
+	Logger *zap.Logger
+}
+
+// NewCoordinatorFromConfigFile creates a new in-process coordinator based on the config file
+// and options provided.
+func NewCoordinatorFromConfigFile(pathToCfg string, opts CoordinatorOptions) (resources.Coordinator, error) {
+	var cfg config.Configuration
+	if err := xconfig.LoadFile(&cfg, pathToCfg, xconfig.Options{}); err != nil {
+		return nil, err
+	}
+
+	return NewCoordinator(cfg, opts)
+}
+
+// NewCoordinatorFromYAML creates a new in-process coordinator based on the YAML configuration string
+// and options provided.
+func NewCoordinatorFromYAML(yamlCfg string, opts CoordinatorOptions) (resources.Coordinator, error) {
+	var cfg config.Configuration
+	if err := yaml.Unmarshal([]byte(yamlCfg), &cfg); err != nil {
+		return nil, err
+	}
+
+	return NewCoordinator(cfg, opts)
+}
+
+// NewCoordinator creates a new in-process coordinator based on the configuration
+// and options provided. Use NewCoordinator or any of the convenience constructors
+// (e.g. NewCoordinatorFromYAML, NewCoordinatorFromConfigFile) to get a running
+// coordinator.
+//
+// The most typical usage of this method will be in an integration test to validate
+// some behavior. For example, assuming we have a running DB node already, we could
+// do the following to create a new namespace and write to it (note: ignoring error checking):
+//
+//    coord, _ := NewCoordinatorFromYAML(defaultCoordConfig, CoordinatorOptions{})
+//    coord.AddNamespace(admin.NamespaceAddRequest{...})
+//    coord.WaitForNamespace(namespaceName)
+//    coord.WriteProm("cpu", map[string]string{"host", host}, samples)
+//
+// The coordinator will start up as you specify in your config. However, there is some
+// helper logic to avoid port and filesystem collisions when spinning up multiple components
+// within the process. If you specify a port of 0 in any address, 0 will be automatically
+// replace with an open port. This is similar to the behavior net.Listen provides for you.
+// Similarly, for filepaths, if a "*" is specified in the config, then that field will
+// be updated with a temp directory that will be cleaned up when the coordinator is destroyed.
+// This should ensure that many of the same component can be spun up in-process without any
+// issues with collisions.
+func NewCoordinator(cfg config.Configuration, opts CoordinatorOptions) (resources.Coordinator, error) {
+	// Replace any "0" ports with an open port
+	cfg, err := updateCoordinatorPorts(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace any "*" filepath with a temporary directory
+	cfg, tmpDirs, err := updateCoordinatorFilepaths(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure logger
+	if opts.Logger == nil {
+		opts.Logger, err = zap.NewDevelopment()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Get HTTP port
+	_, p, err := net.SplitHostPort(cfg.ListenAddressOrDefault())
+	if err != nil {
+		return nil, err
+	}
+
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start the coordinator
+	coord := &coordinator{
+		cfg: cfg,
+		client: common.NewCoordinatorClient(common.CoordinatorClientOptions{
+			Client:    &http.Client{},
+			HTTPPort:  port,
+			Logger:    opts.Logger,
+			RetryFunc: retry,
+		}),
+		logger:  opts.Logger,
+		tmpDirs: tmpDirs,
+	}
+	coord.start()
+
+	return coord, nil
+}
+
+func (c *coordinator) start() {
+	interruptCh := make(chan error, 1)
+	shutdownCh := make(chan struct{}, 1)
+
+	go func() {
+		server.Run(server.RunOptions{
+			Config:      c.cfg,
+			InterruptCh: interruptCh,
+			ShutdownCh:  shutdownCh,
+		})
+	}()
+
+	c.interruptCh = interruptCh
+	c.shutdownCh = shutdownCh
+}
+
+func (c *coordinator) GetNamespace() (admin.NamespaceGetResponse, error) {
+	return c.client.GetNamespace()
+}
+
+func (c *coordinator) WaitForNamespace(name string) error {
+	return c.client.WaitForNamespace(name)
+}
+
+func (c *coordinator) AddNamespace(request admin.NamespaceAddRequest) (admin.NamespaceGetResponse, error) {
+	return c.client.AddNamespace(request)
+}
+
+func (c *coordinator) UpdateNamespace(request admin.NamespaceUpdateRequest) (admin.NamespaceGetResponse, error) {
+	return c.client.UpdateNamespace(request)
+}
+
+func (c *coordinator) DeleteNamespace(namespaceID string) error {
+	return c.client.DeleteNamespace(namespaceID)
+}
+
+func (c *coordinator) CreateDatabase(request admin.DatabaseCreateRequest) (admin.DatabaseCreateResponse, error) {
+	return c.client.CreateDatabase(request)
+}
+
+func (c *coordinator) GetPlacement() (admin.PlacementGetResponse, error) {
+	return c.client.GetPlacement()
+}
+
+func (c *coordinator) WaitForInstances(ids []string) error {
+	return c.client.WaitForInstances(ids)
+}
+
+func (c *coordinator) WaitForShardsReady() error {
+	return c.client.WaitForShardsReady()
+}
+
+func (c *coordinator) Close() error {
+	defer func() {
+		for _, dir := range c.tmpDirs {
+			if err := os.RemoveAll(dir); err != nil {
+				c.logger.Error("error removing temp directory", zap.String("dir", dir), zap.Error(err))
+			}
+		}
+	}()
+
+	// TODO: confirm this works correctly when using an embedded coordinator
+	select {
+	case c.interruptCh <- errors.New("in-process coordinator being shut down"):
+	case <-time.After(interruptTimeout):
+		return errors.New("timeout sending interrupt. closing without graceful shutdown")
+	}
+
+	select {
+	case <-c.shutdownCh:
+	case <-time.After(shutdownTimeout):
+		return errors.New("timeout waiting for shutdown notification. server closing may" +
+			" not be completely graceful")
+	}
+
+	return nil
+}
+
+func (c *coordinator) ApplyKVUpdate(update string) error {
+	return c.client.ApplyKVUpdate(update)
+}
+
+func (c *coordinator) WriteCarbon(port int, metric string, v float64, t time.Time) error {
+	return c.client.WriteCarbon(fmt.Sprintf("http://0.0.0.0/%d", port), metric, v, t)
+}
+
+func (c *coordinator) WriteProm(name string, tags map[string]string, samples []prompb.Sample) error {
+	return c.client.WriteProm(name, tags, samples)
+}
+
+func (c *coordinator) RunQuery(
+	verifier resources.ResponseVerifier,
+	query string,
+	headers map[string][]string,
+) error {
+	return c.client.RunQuery(verifier, query, headers)
+}
+
+func updateCoordinatorPorts(cfg config.Configuration) (config.Configuration, error) {
+	if cfg.ListenAddress != nil {
+		addr, _, _, err := nettest.MaybeGeneratePort(*cfg.ListenAddress)
+		if err != nil {
+			return cfg, err
+		}
+
+		cfg.ListenAddress = &addr
+	}
+
+	return cfg, nil
+}
+
+func updateCoordinatorFilepaths(cfg config.Configuration) (config.Configuration, []string, error) {
+	tmpDirs := make([]string, 0, 1)
+
+	for _, cluster := range cfg.Clusters {
+		ec := cluster.Client.EnvironmentConfig
+		if ec != nil {
+			for _, svc := range ec.Services {
+				if svc != nil && svc.Service != nil && svc.Service.CacheDir == "*" {
+					dir, err := ioutil.TempDir("", "m3kv-*")
+					if err != nil {
+						return cfg, tmpDirs, err
+					}
+
+					tmpDirs = append(tmpDirs, dir)
+					svc.Service.CacheDir = dir
+				}
+			}
+		}
+	}
+
+	return cfg, tmpDirs, nil
+}
+
+func retry(op func() error) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxInterval = retryMaxInterval
+	bo.MaxElapsedTime = retryMaxTime
+	return backoff.Retry(op, bo)
+}

--- a/src/integration/resources/inprocess/coordinator_test.go
+++ b/src/integration/resources/inprocess/coordinator_test.go
@@ -1,0 +1,61 @@
+// +build integration_v2
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inprocess
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCoordinator(t *testing.T) {
+	coord, err := NewCoordinatorFromYAML(defaultCoordConfig, CoordinatorOptions{})
+	require.NoError(t, err)
+	require.NoError(t, coord.Close())
+}
+
+func TestCreateAnotherCoordinatorInProcess(t *testing.T) {
+	coord, err := NewCoordinatorFromYAML(defaultCoordConfig, CoordinatorOptions{})
+	require.NoError(t, err)
+	require.NoError(t, coord.Close())
+}
+
+// TODO(nate): add more tests exercising other endpoints once dbnode impl is landed
+
+const defaultCoordConfig = `
+clusters:
+  - namespaces:
+      - namespace: default
+        type: unaggregated
+        retention: 1h
+    client:
+      config:
+        service:
+          env: default_env
+          zone: embedded
+          service: m3db
+          cacheDir: "*"
+          etcdClusters:
+            - zone: embedded
+              endpoints:
+                - 127.0.0.1:2379
+`

--- a/src/integration/resources/net/net.go
+++ b/src/integration/resources/net/net.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package net contains network-related helpers for integration testing.
+package net
+
+import (
+	"net"
+	"strconv"
+)
+
+// GetAvailablePort retrieves an available port on the host machine. This
+// delegates the port selection to the golang net library by starting a server and
+// then checking the port that the server is using.
+func GetAvailablePort() (int, error) {
+	l, err := net.Listen("tcp", ":0") // nolint: gosec
+	if err != nil {
+		return 0, nil
+	}
+	defer l.Close() // nolint: errcheck
+
+	_, p, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		return 0, err
+	}
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return 0, err
+	}
+	return port, nil
+}
+
+// MaybeGeneratePort takes an address and generates a new version of
+// that address with the port replaced with an open port if the original
+// port was 0. Otherwise, the address is returned unchanged.
+// This method returns the potentially updated address, the potentially
+// updated port, a boolean indicating if the address was changed, and
+// an error in case the method failed
+func MaybeGeneratePort(address string) (string, int, bool, error) {
+	h, p, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", 0, false, err
+	}
+
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return "", 0, false, err
+	}
+
+	if port == 0 {
+		newPort, err := GetAvailablePort()
+		if err != nil {
+			return address, 0, false, err
+		}
+
+		newAddr := net.JoinHostPort(h, strconv.Itoa(newPort))
+
+		return newAddr, newPort, true, nil
+	}
+
+	return address, port, false, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This commit adds an implementation of resources.Coordinator
that is capable of being started in-process as opposed to
being started via a Docker container.

Additionally, adds helper functions for getting an open
port and updating a host:port string where the port is 0
with an actual usuable port.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
