### PR TITLE
[tests] Add dbnode capable of being started in-process.

### DIFF
--- a/src/integration/resources/inprocess/dbnode.go
+++ b/src/integration/resources/inprocess/dbnode.go
@@ -1,0 +1,329 @@
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inprocess
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"time"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+
+	"github.com/m3db/m3/src/cmd/services/m3dbnode/config"
+	"github.com/m3db/m3/src/cmd/services/m3dbnode/server"
+	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
+	"github.com/m3db/m3/src/dbnode/integration"
+	"github.com/m3db/m3/src/integration/resources"
+	nettest "github.com/m3db/m3/src/integration/resources/net"
+	"github.com/m3db/m3/src/query/generated/proto/admin"
+	xconfig "github.com/m3db/m3/src/x/config"
+)
+
+// TODO(nate): make configurable
+const defaultRPCTimeout = time.Minute
+
+type dbNode struct {
+	cfg     config.Configuration
+	logger  *zap.Logger
+	tmpDirs []string
+
+	interruptCh chan<- error
+	shutdownCh  <-chan struct{}
+	tchanClient *integration.TestTChannelClient
+}
+
+// DBNodeOptions are options for starting a DB node server.
+type DBNodeOptions struct {
+	// Logger is the logger to use for the dbnode. If not provided,
+	// a default one will be created.
+	Logger *zap.Logger
+}
+
+// NewDBNodeFromConfigFile creates a new in-process DB node based on the config file
+// and options provided.
+func NewDBNodeFromConfigFile(pathToCfg string, opts DBNodeOptions) (resources.Node, error) {
+	var cfg config.Configuration
+	if err := xconfig.LoadFile(&cfg, pathToCfg, xconfig.Options{}); err != nil {
+		return nil, err
+	}
+
+	return NewDBNode(cfg, opts)
+}
+
+// NewDBNodeFromYAML creates a new in-process DB node based on the YAML configuration string
+// and options provided.
+func NewDBNodeFromYAML(yamlCfg string, opts DBNodeOptions) (resources.Node, error) {
+	var cfg config.Configuration
+	if err := yaml.Unmarshal([]byte(yamlCfg), &cfg); err != nil {
+		return nil, err
+	}
+
+	return NewDBNode(cfg, opts)
+}
+
+// NewDBNode creates a new in-process DB node based on the configuration
+// and options provided. Use NewDBNode or any of the convenience constructors
+// (e.g. NewDBNodeFromYAML, NewDBNodeFromConfigFile) to get a running
+// dbnode.
+//
+// The most typical usage of this method will be in an integration test to validate
+// some behavior. For example, assuming we have a valid placement available already we
+// could do the following to read and write to a namespace (note: ignoring error checking):
+//
+//    dbnode, _ := NewDBNodeFromYAML(defaultDBNodeConfig, DBNodeOptions{})
+//    dbnode.WaitForBootstrap()
+//    dbnode.WriteTaggedPoint(&rpc.WriteTaggedRequest{...}))
+//    res, _ = dbnode.FetchTagged(&rpc.FetchTaggedRequest{...})
+//
+// The dbnode will start up as you specify in your config. However, there is some
+// helper logic to avoid port and filesystem collisions when spinning up multiple components
+// within the process. If you specify a port of 0 in any address, 0 will be automatically
+// replaced with an open port. This is similar to the behavior net.Listen provides for you.
+// Similarly, for filepaths, if a "*" is specified in the config, then that field will
+// be updated with a temp directory that will be cleaned up when the dbnode is destroyed.
+// This should ensure that many of the same component can be spun up in-process without any
+// issues with collisions.
+func NewDBNode(cfg config.Configuration, opts DBNodeOptions) (resources.Node, error) {
+	// Replace any "0" ports with an open port
+	cfg, err := updateDBNodePorts(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace any "*" filepath with a temporary directory
+	cfg, tmpDirs, err := updateDBNodeFilepaths(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure TChannel client for hitting the DB node.
+	tchanClient, err := integration.NewTChannelClient("client", cfg.DB.ListenAddressOrDefault())
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure logger
+	if opts.Logger == nil {
+		opts.Logger, err = zap.NewDevelopment()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Start the DB node
+	node := &dbNode{
+		cfg:         cfg,
+		logger:      opts.Logger,
+		tchanClient: tchanClient,
+		tmpDirs:     tmpDirs,
+	}
+	node.start()
+
+	return node, nil
+}
+
+func (d *dbNode) start() {
+	interruptCh := make(chan error, d.cfg.Components())
+	shutdownCh := make(chan struct{}, d.cfg.Components())
+	go func() {
+		server.RunComponents(server.Options{
+			Configuration: d.cfg,
+			InterruptCh:   interruptCh,
+			ShutdownCh:    shutdownCh,
+		})
+	}()
+
+	d.interruptCh = interruptCh
+	d.shutdownCh = shutdownCh
+}
+
+func (d *dbNode) HostDetails(port int) (*admin.Host, error) {
+	// TODO(nate): implement once working on helpers for spinning up
+	// a multi-node cluster since that's what it's currently being
+	// used for based on the docker-based implementation.
+	// NOTES:
+	// - id we can generate
+	// - isolation_group set a constant?
+	// - weight just use 1024?
+	// - address is 0.0.0.0
+	// - port is the listen address (get from config)
+
+	return &admin.Host{
+		Id:             "foo",
+		IsolationGroup: "foo-a",
+		Zone:           "embedded",
+		Weight:         1024,
+		Address:        "0.0.0.0",
+		Port:           uint32(port),
+	}, nil
+}
+
+func (d *dbNode) Health() (*rpc.NodeHealthResult_, error) {
+	return d.tchanClient.TChannelClientHealth(defaultRPCTimeout)
+}
+
+func (d *dbNode) WaitForBootstrap() error {
+	return retry(func() error {
+		health, err := d.Health()
+		if err != nil {
+			return err
+		}
+
+		if !health.GetBootstrapped() {
+			err = fmt.Errorf("not bootstrapped")
+			d.logger.Error("node not bootstrapped", zap.Error(err))
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (d *dbNode) WritePoint(req *rpc.WriteRequest) error {
+	return d.tchanClient.TChannelClientWrite(defaultRPCTimeout, req)
+}
+
+func (d *dbNode) WriteTaggedPoint(req *rpc.WriteTaggedRequest) error {
+	return d.tchanClient.TChannelClientWriteTagged(defaultRPCTimeout, req)
+}
+
+func (d *dbNode) AggregateTiles(req *rpc.AggregateTilesRequest) (int64, error) {
+	res, err := d.tchanClient.TChannelClientAggregateTiles(defaultRPCTimeout, req)
+	if err != nil {
+		return 0, err
+	}
+
+	return res.ProcessedTileCount, nil
+}
+
+func (d *dbNode) Fetch(req *rpc.FetchRequest) (*rpc.FetchResult_, error) {
+	return d.tchanClient.TChannelClientFetch(defaultRPCTimeout, req)
+}
+
+func (d *dbNode) FetchTagged(req *rpc.FetchTaggedRequest) (*rpc.FetchTaggedResult_, error) {
+	return d.tchanClient.TChannelClientFetchTagged(defaultRPCTimeout, req)
+}
+
+func (d *dbNode) Exec(commands ...string) (string, error) {
+	//nolint:gosec
+	cmd := exec.Command(commands[0], commands[1:]...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return out.String(), nil
+}
+
+func (d *dbNode) GoalStateExec(verifier resources.GoalStateVerifier, commands ...string) error {
+	return retry(func() error {
+		if err := verifier(d.Exec(commands...)); err != nil {
+			d.logger.Info("goal state verification failed. retrying")
+			return err
+		}
+		return nil
+	})
+}
+
+func (d *dbNode) Restart() error {
+	if err := d.Close(); err != nil {
+		return err
+	}
+
+	d.start()
+
+	return nil
+}
+
+func (d *dbNode) Close() error {
+	defer func() {
+		for _, dir := range d.tmpDirs {
+			if err := os.RemoveAll(dir); err != nil {
+				d.logger.Error("error removing temp directory", zap.String("dir", dir), zap.Error(err))
+			}
+		}
+	}()
+
+	for i := 0; i < d.cfg.Components(); i++ {
+		select {
+		case d.interruptCh <- errors.New("in-process node being shut down"):
+		case <-time.After(interruptTimeout):
+			return errors.New("timeout sending interrupt. closing without graceful shutdown")
+		}
+	}
+
+	for i := 0; i < d.cfg.Components(); i++ {
+		select {
+		case <-d.shutdownCh:
+		case <-time.After(shutdownTimeout):
+			return errors.New("timeout waiting for shutdown notification. server closing may" +
+				" not be completely graceful")
+		}
+	}
+
+	return nil
+}
+
+func updateDBNodePorts(cfg config.Configuration) (config.Configuration, error) {
+	if cfg.DB.ListenAddress != nil {
+		addr, _, _, err := nettest.MaybeGeneratePort(*cfg.DB.ListenAddress)
+		if err != nil {
+			return cfg, err
+		}
+
+		cfg.DB.ListenAddress = &addr
+	}
+
+	if cfg.Coordinator != nil && cfg.Coordinator.ListenAddress != nil {
+		addr, _, _, err := nettest.MaybeGeneratePort(*cfg.Coordinator.ListenAddress)
+		if err != nil {
+			return cfg, err
+		}
+
+		cfg.Coordinator.ListenAddress = &addr
+	}
+
+	return cfg, nil
+}
+
+func updateDBNodeFilepaths(cfg config.Configuration) (config.Configuration, []string, error) {
+	tmpDirs := make([]string, 0, 1)
+
+	prefix := cfg.DB.Filesystem.FilePathPrefix
+	if prefix != nil && *prefix == "*" {
+		dir, err := ioutil.TempDir("", "m3db-*")
+		if err != nil {
+			return cfg, tmpDirs, err
+		}
+
+		tmpDirs = append(tmpDirs, dir)
+		cfg.DB.Filesystem.FilePathPrefix = &dir
+	}
+
+	return cfg, tmpDirs, nil
+}

--- a/src/integration/resources/inprocess/dbnode.go
+++ b/src/integration/resources/inprocess/dbnode.go
@@ -52,6 +52,7 @@ type dbNode struct {
 
 	interruptCh chan<- error
 	shutdownCh  <-chan struct{}
+	// tchanClient is an RPC client used for hitting the DB nodes RPC API.
 	tchanClient *integration.TestTChannelClient
 }
 

--- a/src/integration/resources/inprocess/dbnode_test.go
+++ b/src/integration/resources/inprocess/dbnode_test.go
@@ -1,0 +1,203 @@
+// +build integration_v2
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inprocess
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
+	"github.com/m3db/m3/src/integration/resources"
+	"github.com/m3db/m3/src/m3ninx/idx"
+	"github.com/m3db/m3/src/query/generated/proto/admin"
+	"github.com/m3db/m3/src/x/checked"
+	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/serialize"
+)
+
+func TestNewDBNode(t *testing.T) {
+	_, closer := setupNode(t)
+	closer()
+}
+
+func TestHealth(t *testing.T) {
+	dbnode, closer := setupNode(t)
+	defer closer()
+
+	res, err := dbnode.Health()
+	require.NoError(t, err)
+
+	require.True(t, res.Ok)
+}
+
+func TestWaitForBootstrap(t *testing.T) {
+	dbnode, closer := setupNode(t)
+	defer closer()
+
+	res, err := dbnode.Health()
+	require.NoError(t, err)
+
+	require.Equal(t, true, res.Bootstrapped)
+}
+
+func TestWriteFetchRoundtrip(t *testing.T) {
+	dbnode, closer := setupNode(t)
+	defer closer()
+
+	var (
+		id  = "foo"
+		ts  = time.Now()
+		val = 1.0
+	)
+	req := &rpc.WriteRequest{
+		NameSpace: resources.UnaggName,
+		ID:        id,
+		Datapoint: &rpc.Datapoint{
+			Timestamp: ts.Unix(),
+			Value:     val,
+		},
+	}
+	require.NoError(t, dbnode.WritePoint(req))
+
+	freq := &rpc.FetchRequest{
+		RangeStart: ts.Add(-1 * time.Minute).Unix(),
+		RangeEnd:   ts.Add(1 * time.Minute).Unix(),
+		NameSpace:  resources.UnaggName,
+		ID:         id,
+	}
+	res, err := dbnode.Fetch(freq)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(res.Datapoints))
+	require.Equal(t, rpc.FetchResult_{
+		Datapoints: []*rpc.Datapoint{
+			{Timestamp: ts.Unix(), Value: val},
+		},
+	}, res.Datapoints[0])
+}
+
+func TestWriteTaggedFetchTaggedRoundtrip(t *testing.T) {
+	dbnode, closer := setupNode(t)
+	defer closer()
+
+	var (
+		id  = "fooTagged"
+		ts  = time.Now()
+		val = 1.0
+	)
+	req := &rpc.WriteTaggedRequest{
+		NameSpace: resources.UnaggName,
+		ID:        id,
+		Datapoint: &rpc.Datapoint{
+			Timestamp:         ts.UnixNano(),
+			TimestampTimeType: rpc.TimeType_UNIX_NANOSECONDS,
+			Value:             val,
+		},
+		Tags: []*rpc.Tag{
+			{Name: "__name__", Value: id},
+			{Name: "job", Value: "bar"},
+		},
+	}
+	require.NoError(t, dbnode.WriteTaggedPoint(req))
+
+	query := idx.NewTermQuery([]byte("job"), []byte("bar"))
+	encoded, err := idx.Marshal(query)
+	require.NoError(t, err)
+
+	freq := &rpc.FetchTaggedRequest{
+		RangeStart:    ts.Add(-1 * time.Minute).UnixNano(),
+		RangeEnd:      ts.Add(1 * time.Minute).UnixNano(),
+		NameSpace:     []byte(resources.UnaggName),
+		RangeTimeType: rpc.TimeType_UNIX_NANOSECONDS,
+		FetchData:     true,
+		Query:         encoded,
+	}
+	res, err := dbnode.FetchTagged(freq)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(res.Elements))
+	require.Equal(t, id, string(res.Elements[0].ID))
+	require.Equal(t, resources.UnaggName, string(res.Elements[0].NameSpace))
+
+	// Validate Tags
+	testTagDecoderPool := serialize.NewTagDecoderPool(
+		serialize.NewTagDecoderOptions(serialize.TagDecoderOptionsConfig{}),
+		pool.NewObjectPoolOptions())
+	testTagDecoderPool.Init()
+
+	dec := testTagDecoderPool.Get()
+	dec.Reset(checked.NewBytes(res.Elements[0].EncodedTags, nil))
+
+	require.True(t, dec.Next())
+	validateTag(t, dec.Current(), "__name__", id)
+	require.True(t, dec.Next())
+	validateTag(t, dec.Current(), "job", "bar")
+	require.False(t, dec.Next())
+}
+
+// TODO(nate): tests for remainder of interface
+
+func validateTag(t *testing.T, tag ident.Tag, name string, value string) {
+	require.Equal(t, name, tag.Name.String())
+	require.Equal(t, value, tag.Value.String())
+}
+
+func setupNode(t *testing.T) (resources.Node, func()) {
+	dbnode, err := NewDBNodeFromYAML(defaultDBNodeConfig, DBNodeOptions{})
+	require.NoError(t, err)
+
+	coord, err := NewCoordinatorFromYAML(defaultCoordConfig, CoordinatorOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, coord.WaitForNamespace(""))
+
+	host, err := dbnode.HostDetails(9000)
+	require.NoError(t, err)
+
+	_, err = coord.CreateDatabase(admin.DatabaseCreateRequest{
+		Type:              "cluster",
+		NamespaceName:     resources.UnaggName,
+		RetentionTime:     "1h",
+		NumShards:         4,
+		ReplicationFactor: 1,
+		Hosts:             []*admin.Host{host},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, dbnode.WaitForBootstrap())
+
+	return dbnode, func() {
+		assert.NoError(t, coord.Close())
+		assert.NoError(t, dbnode.Close())
+	}
+}
+
+const defaultDBNodeConfig = `
+db:
+  filesystem:
+    filePathPrefix: "*"
+  writeNewSeriesAsync: false
+`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This commit adds an implementation of resources.Node that
is capable of being started in-process as opposed to
being started via a Docker container.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
