### PR TITLE
[coordinator] Support multiple namespaces for prom-remote storage

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -776,7 +776,7 @@ type PrometheusRemoteBackendStoragePolicyConfiguration struct {
 	Resolution time.Duration `yaml:"resolution" validate:"nonzero"`
 	Retention  time.Duration `yaml:"retention" validate:"nonzero"`
 
-	// Downsample is downsampling options to use with the endpoint.
+	// Downsample is downsampling options to be used with this storage policy.
 	Downsample *m3.DownsampleClusterStaticNamespaceConfiguration `yaml:"downsample"`
 }
 

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -775,6 +775,9 @@ type PrometheusRemoteBackendEndpointConfiguration struct {
 type PrometheusRemoteBackendStoragePolicyConfiguration struct {
 	Resolution time.Duration `yaml:"resolution" validate:"nonzero"`
 	Retention  time.Duration `yaml:"retention" validate:"nonzero"`
+
+	// Downsample is downsampling options to use with the endpoint.
+	Downsample *m3.DownsampleClusterStaticNamespaceConfiguration `yaml:"downsample"`
 }
 
 // HTTPConfiguration is the HTTP configuration for configuring

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -506,7 +506,7 @@ func Run(runOpts RunOptions) RunResult {
 			zap.Int("numAggregatedClusterNamespaces", opts.Namespaces().NumAggregatedClusterNamespaces()))
 		err = clusterNamespacesWatcher.Update(opts.Namespaces())
 		if err != nil {
-			logger.Error("error when updating namespaces", zap.Error(err))
+			logger.Fatal("unable to update namespaces", zap.Error(err))
 		}
 
 		downsampler, clusterClient, err = newDownsamplerAsync(cfg.Downsample, cfg.ClusterManagement.Etcd, backendStorage,

--- a/src/query/storage/m3/cluster.go
+++ b/src/query/storage/m3/cluster.go
@@ -39,7 +39,10 @@ var (
 	errRetentionNotSet   = errors.New("retention not set")
 	errResolutionNotSet  = errors.New("resolution not set")
 
-	defaultClusterNamespaceDownsampleOptions = ClusterNamespaceDownsampleOptions{
+	// DefaultClusterNamespaceDownsampleOptions is a default options.
+	// NB(antanas): this was made public to access it in promremote storage.
+	// Ideally downsampling could be decoupled from m3 storage.
+	DefaultClusterNamespaceDownsampleOptions = ClusterNamespaceDownsampleOptions{
 		All: true,
 	}
 )
@@ -126,7 +129,7 @@ func (o ClusterNamespaceOptions) DownsampleOptions() (
 		return ClusterNamespaceDownsampleOptions{}, errNotAggregatedClusterNamespace
 	}
 	if o.downsample == nil {
-		return defaultClusterNamespaceDownsampleOptions, nil
+		return DefaultClusterNamespaceDownsampleOptions, nil
 	}
 	return *o.downsample, nil
 }

--- a/src/query/storage/m3/config.go
+++ b/src/query/storage/m3/config.go
@@ -112,7 +112,7 @@ func (c ClusterStaticNamespaceConfiguration) downsampleOptions() (
 		return ClusterNamespaceDownsampleOptions{}, errNotAggregatedClusterNamespace
 	}
 	if c.Downsample == nil {
-		return defaultClusterNamespaceDownsampleOptions, nil
+		return DefaultClusterNamespaceDownsampleOptions, nil
 	}
 
 	return c.Downsample.downsampleOptions(), nil

--- a/src/query/storage/promremote/options.go
+++ b/src/query/storage/promremote/options.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 	xhttp "github.com/m3db/m3/src/x/net/http"
 )
 
@@ -49,13 +50,18 @@ func NewOptions(
 			name:    endpoint.Name,
 			address: endpoint.Address,
 		}
+		attr := storagemetadata.Attributes{
+			MetricsType: storagemetadata.UnaggregatedMetricsType,
+		}
 		if endpoint.StoragePolicy != nil {
-			endpointOptions.resolution = endpoint.StoragePolicy.Resolution
-			endpointOptions.retention = endpoint.StoragePolicy.Retention
+			attr.MetricsType = storagemetadata.AggregatedMetricsType
+			attr.Resolution = endpoint.StoragePolicy.Resolution
+			attr.Retention = endpoint.StoragePolicy.Retention
 			if endpoint.StoragePolicy.Downsample != nil {
 				endpointOptions.downsampleAll = endpoint.StoragePolicy.Downsample.All
 			}
 		}
+		endpointOptions.attributes = attr
 		endpoints = append(endpoints, endpointOptions)
 	}
 	clientOpts := xhttp.DefaultHTTPClientOptions()

--- a/src/query/storage/promremote/options.go
+++ b/src/query/storage/promremote/options.go
@@ -46,23 +46,26 @@ func NewOptions(
 	endpoints := make([]EndpointOptions, 0, len(cfg.Endpoints))
 
 	for _, endpoint := range cfg.Endpoints {
-		endpointOptions := EndpointOptions{
-			name:    endpoint.Name,
-			address: endpoint.Address,
-		}
-		attr := storagemetadata.Attributes{
-			MetricsType: storagemetadata.UnaggregatedMetricsType,
-		}
+		var (
+			attr = storagemetadata.Attributes{
+				MetricsType: storagemetadata.UnaggregatedMetricsType,
+			}
+			downsampleAll = false
+		)
 		if endpoint.StoragePolicy != nil {
 			attr.MetricsType = storagemetadata.AggregatedMetricsType
 			attr.Resolution = endpoint.StoragePolicy.Resolution
 			attr.Retention = endpoint.StoragePolicy.Retention
-			if endpoint.StoragePolicy.Downsample != nil {
-				endpointOptions.downsampleAll = endpoint.StoragePolicy.Downsample.All
+			if downsample := endpoint.StoragePolicy.Downsample; downsample != nil {
+				downsampleAll = downsample.All
 			}
 		}
-		endpointOptions.attributes = attr
-		endpoints = append(endpoints, endpointOptions)
+		endpoints = append(endpoints, EndpointOptions{
+			name:          endpoint.Name,
+			address:       endpoint.Address,
+			attributes:    attr,
+			downsampleAll: downsampleAll,
+		})
 	}
 	clientOpts := xhttp.DefaultHTTPClientOptions()
 	if cfg.RequestTimeout != nil {

--- a/src/query/storage/promremote/options.go
+++ b/src/query/storage/promremote/options.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
+	"github.com/m3db/m3/src/query/storage/m3"
 	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 	xhttp "github.com/m3db/m3/src/x/net/http"
 )
@@ -50,21 +51,24 @@ func NewOptions(
 			attr = storagemetadata.Attributes{
 				MetricsType: storagemetadata.UnaggregatedMetricsType,
 			}
-			downsampleAll = false
+			downsampleOptions *m3.ClusterNamespaceDownsampleOptions
 		)
 		if endpoint.StoragePolicy != nil {
 			attr.MetricsType = storagemetadata.AggregatedMetricsType
 			attr.Resolution = endpoint.StoragePolicy.Resolution
 			attr.Retention = endpoint.StoragePolicy.Retention
+			downsampleOptions = &m3.DefaultClusterNamespaceDownsampleOptions
 			if downsample := endpoint.StoragePolicy.Downsample; downsample != nil {
-				downsampleAll = downsample.All
+				downsampleOptions = &m3.ClusterNamespaceDownsampleOptions{
+					All: downsample.All,
+				}
 			}
 		}
 		endpoints = append(endpoints, EndpointOptions{
-			name:          endpoint.Name,
-			address:       endpoint.Address,
-			attributes:    attr,
-			downsampleAll: downsampleAll,
+			name:              endpoint.Name,
+			address:           endpoint.Address,
+			attributes:        attr,
+			downsampleOptions: downsampleOptions,
 		})
 	}
 	clientOpts := xhttp.DefaultHTTPClientOptions()

--- a/src/query/storage/promremote/storage.go
+++ b/src/query/storage/promremote/storage.go
@@ -30,7 +30,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 
 	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/storage"
@@ -49,7 +51,13 @@ var errorReadingBody = []byte("error reading body")
 func NewStorage(opts Options) (storage.Storage, error) {
 	client := xhttp.NewHTTPClient(opts.httpOptions)
 	scope := opts.scope.SubScope(metricsScope)
-	s := &promStorage{opts: opts, client: client, endpointMetrics: initEndpointMetrics(opts.endpoints, scope)}
+	s := &promStorage{
+		opts:            opts,
+		client:          client,
+		endpointMetrics: initEndpointMetrics(opts.endpoints, scope),
+		droppedWrites:   scope.Counter("dropped_writes"),
+		logger:          opts.logger,
+	}
 	return s, nil
 }
 
@@ -58,6 +66,8 @@ type promStorage struct {
 	opts            Options
 	client          *http.Client
 	endpointMetrics map[string]instrument.MethodMetrics
+	droppedWrites   tally.Counter
+	logger          *zap.Logger
 }
 
 func (p *promStorage) Write(ctx context.Context, query *storage.WriteQuery) error {
@@ -69,12 +79,14 @@ func (p *promStorage) Write(ctx context.Context, query *storage.WriteQuery) erro
 	var wg sync.WaitGroup
 	multiErr := xerrors.NewMultiError()
 	var errLock sync.Mutex
+	atLeastOneEndpointMatched := false
 	for _, endpoint := range p.opts.endpoints {
 		endpoint := endpoint
 		if endpoint.resolution == query.Attributes().Resolution &&
 			endpoint.retention == query.Attributes().Retention {
 			metrics := p.endpointMetrics[endpoint.name]
 			wg.Add(1)
+			atLeastOneEndpointMatched = true
 			go func() {
 				defer wg.Done()
 				err := p.writeSingle(ctx, metrics, endpoint.address, bytes.NewBuffer(encoded))
@@ -90,6 +102,15 @@ func (p *promStorage) Write(ctx context.Context, query *storage.WriteQuery) erro
 
 	wg.Wait()
 
+	if !atLeastOneEndpointMatched {
+		p.droppedWrites.Inc(1)
+		multiErr = multiErr.Add(errors.Errorf("write did not match any of known endpoints"))
+		p.logger.Warn(
+			"write did not match any of known endpoints",
+			zap.Duration("retention", query.Attributes().Retention),
+			zap.Duration("resolution", query.Attributes().Resolution),
+		)
+	}
 	return multiErr.FinalError()
 }
 
@@ -135,7 +156,7 @@ func (p *promStorage) writeSingle(
 		metrics.ReportError(methodDuration)
 		response, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			// TODO(antanas): should log and return just generic error
+			p.logger.Error("error reading body", zap.Error(err))
 			response = errorReadingBody
 		}
 		return fmt.Errorf("expected status code 2XX: actual=%v, address=%v, resp=%s",

--- a/src/query/storage/promremote/storage.go
+++ b/src/query/storage/promremote/storage.go
@@ -94,7 +94,7 @@ func (p *promStorage) Write(ctx context.Context, query *storage.WriteQuery) erro
 		atLeastOneEndpointMatched = true
 		go func() {
 			defer wg.Done()
-			err := p.writeSingle(ctx, metrics, endpoint.address, bytes.NewBuffer(encoded))
+			err := p.writeSingle(ctx, metrics, endpoint.address, bytes.NewReader(encoded))
 			if err != nil {
 				errLock.Lock()
 				multiErr = multiErr.Add(err)

--- a/src/query/storage/promremote/storage.go
+++ b/src/query/storage/promremote/storage.go
@@ -90,8 +90,9 @@ func (p *promStorage) Write(ctx context.Context, query *storage.WriteQuery) erro
 		}
 
 		metrics := p.endpointMetrics[endpoint.name]
-		wg.Add(1)
 		atLeastOneEndpointMatched = true
+
+		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			err := p.writeSingle(ctx, metrics, endpoint.address, bytes.NewReader(encoded))

--- a/src/query/storage/promremote/storage_test.go
+++ b/src/query/storage/promremote/storage_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
@@ -42,6 +43,8 @@ import (
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
+var logger, _ = zap.NewDevelopment()
+
 func TestWrite(t *testing.T) {
 	fakeProm := promremotetest.NewServer(t)
 	defer fakeProm.Close()
@@ -50,6 +53,7 @@ func TestWrite(t *testing.T) {
 	promStorage, err := NewStorage(Options{
 		endpoints: []EndpointOptions{{name: "testEndpoint", address: fakeProm.WriteAddr()}},
 		scope:     scope,
+		logger:    logger,
 	})
 	require.NoError(t, err)
 	defer closeWithCheck(t, promStorage)
@@ -115,6 +119,7 @@ func TestWriteBasedOnRetention(t *testing.T) {
 		promLongRetention2.Reset()
 	}
 
+	scope := tally.NewTestScope("test_scope", map[string]string{})
 	promStorage, err := NewStorage(Options{
 		endpoints: []EndpointOptions{
 			{
@@ -138,7 +143,8 @@ func TestWriteBasedOnRetention(t *testing.T) {
 				resolution: 10 * time.Minute,
 			},
 		},
-		scope: tally.NoopScope,
+		scope:  scope,
+		logger: logger,
 	})
 	require.NoError(t, err)
 	defer closeWithCheck(t, promStorage)
@@ -205,15 +211,18 @@ func TestWriteBasedOnRetention(t *testing.T) {
 			Resolution: 5*time.Minute + 1,
 			Retention:  720 * time.Hour,
 		})
-		require.NoError(t, err)
+		require.Error(t, err)
 		err = sendWrite(storagemetadata.Attributes{
 			Resolution: 5 * time.Minute,
 			Retention:  720*time.Hour + 1,
 		})
-		require.NoError(t, err)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "write did not match any of known endpoints")
 		assert.Nil(t, promShortRetention.GetLastWriteRequest())
 		assert.Nil(t, promMediumRetention.GetLastWriteRequest())
 		assert.Nil(t, promLongRetention.GetLastWriteRequest())
+		const metricName = "test_scope.prom_remote_storage.dropped_writes"
+		tallytest.AssertCounterValue(t, 2, scope.Snapshot(), metricName, map[string]string{})
 	})
 
 	t.Run("error should not prevent sending to other instances", func(t *testing.T) {

--- a/src/query/storage/promremote/storage_test.go
+++ b/src/query/storage/promremote/storage_test.go
@@ -123,24 +123,36 @@ func TestWriteBasedOnRetention(t *testing.T) {
 	promStorage, err := NewStorage(Options{
 		endpoints: []EndpointOptions{
 			{
-				address:    promShortRetention.WriteAddr(),
-				retention:  120 * time.Hour,
-				resolution: 15 * time.Second,
+				address: promShortRetention.WriteAddr(),
+				attributes: storagemetadata.Attributes{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   120 * time.Hour,
+					Resolution:  15 * time.Second,
+				},
 			},
 			{
-				address:    promMediumRetention.WriteAddr(),
-				retention:  720 * time.Hour,
-				resolution: 5 * time.Minute,
+				address: promMediumRetention.WriteAddr(),
+				attributes: storagemetadata.Attributes{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   720 * time.Hour,
+					Resolution:  5 * time.Minute,
+				},
 			},
 			{
-				address:    promLongRetention.WriteAddr(),
-				retention:  8760 * time.Hour,
-				resolution: 10 * time.Minute,
+				address: promLongRetention.WriteAddr(),
+				attributes: storagemetadata.Attributes{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   8760 * time.Hour,
+					Resolution:  10 * time.Minute,
+				},
 			},
 			{
-				address:    promLongRetention2.WriteAddr(),
-				retention:  8760 * time.Hour,
-				resolution: 10 * time.Minute,
+				address: promLongRetention2.WriteAddr(),
+				attributes: storagemetadata.Attributes{
+					MetricsType: storagemetadata.AggregatedMetricsType,
+					Retention:   8760 * time.Hour,
+					Resolution:  10 * time.Minute,
+				},
 			},
 		},
 		scope:  scope,
@@ -221,8 +233,8 @@ func TestWriteBasedOnRetention(t *testing.T) {
 		assert.Nil(t, promShortRetention.GetLastWriteRequest())
 		assert.Nil(t, promMediumRetention.GetLastWriteRequest())
 		assert.Nil(t, promLongRetention.GetLastWriteRequest())
-		const metricName = "test_scope.prom_remote_storage.dropped_writes"
-		tallytest.AssertCounterValue(t, 2, scope.Snapshot(), metricName, map[string]string{})
+		const droppedWrites = "test_scope.prom_remote_storage.dropped_writes"
+		tallytest.AssertCounterValue(t, 2, scope.Snapshot(), droppedWrites, map[string]string{})
 	})
 
 	t.Run("error should not prevent sending to other instances", func(t *testing.T) {

--- a/src/query/storage/promremote/types.go
+++ b/src/query/storage/promremote/types.go
@@ -25,7 +25,12 @@ import (
 	"time"
 
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 
+	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/query/storage/m3"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
+	"github.com/m3db/m3/src/x/ident"
 	xhttp "github.com/m3db/m3/src/x/net/http"
 )
 
@@ -34,12 +39,61 @@ type Options struct {
 	endpoints   []EndpointOptions
 	httpOptions xhttp.HTTPClientOptions
 	scope       tally.Scope
+	logger      *zap.Logger
+}
+
+// Namespaces returns M3 namespaces from endpoint opts.
+func (o Options) Namespaces() m3.ClusterNamespaces {
+	namespaces := make(m3.ClusterNamespaces, len(o.endpoints))
+	for i, endpoint := range o.endpoints {
+		metricType := storagemetadata.AggregatedMetricsType
+		if endpoint.resolution == 0 {
+			metricType = storagemetadata.UnaggregatedMetricsType
+		}
+		namespaceOptions := m3.NewClusterNamespaceOptions(
+			storagemetadata.Attributes{
+				MetricsType: metricType,
+				Resolution:  endpoint.resolution,
+				Retention:   endpoint.retention,
+			},
+			&m3.ClusterNamespaceDownsampleOptions{
+				All: endpoint.downsampleAll,
+			},
+		)
+		// NB(antanas): NewOptions validates endpoint name to be unique in the list of endpoints.
+		namespaces[i] = promRemoteNamespace{
+			nsID:    ident.StringID(endpoint.name),
+			options: namespaceOptions,
+		}
+	}
+	return namespaces
 }
 
 // EndpointOptions for single prometheus remote write capable endpoint.
 type EndpointOptions struct {
-	name       string
-	address    string
-	retention  time.Duration
-	resolution time.Duration
+	name          string
+	address       string
+	retention     time.Duration
+	resolution    time.Duration
+	downsampleAll bool
 }
+
+type promRemoteNamespace struct {
+	nsID    ident.ID
+	options m3.ClusterNamespaceOptions
+}
+
+func (e promRemoteNamespace) NamespaceID() ident.ID {
+	return e.nsID
+}
+
+func (e promRemoteNamespace) Options() m3.ClusterNamespaceOptions {
+	return e.options
+}
+
+func (e promRemoteNamespace) Session() client.Session {
+	// NB(antanas): should never be called since there is no m3db backend in this case.
+	panic("M3DB client session can't be used when using prom remote storage backend")
+}
+
+var _ m3.ClusterNamespace = &promRemoteNamespace{}

--- a/src/query/storage/promremote/types.go
+++ b/src/query/storage/promremote/types.go
@@ -87,5 +87,3 @@ func (e promRemoteNamespace) Session() client.Session {
 	// NB(antanas): should never be called since there is no m3db backend in this case.
 	panic("M3DB client session can't be used when using prom remote storage backend")
 }
-
-var _ m3.ClusterNamespace = &promRemoteNamespace{}

--- a/src/query/storage/promremote/types.go
+++ b/src/query/storage/promremote/types.go
@@ -51,22 +51,17 @@ func (o Options) Namespaces() m3.ClusterNamespaces {
 
 // EndpointOptions for single prometheus remote write capable endpoint.
 type EndpointOptions struct {
-	name          string
-	address       string
-	attributes    storagemetadata.Attributes
-	downsampleAll bool
+	name              string
+	address           string
+	attributes        storagemetadata.Attributes
+	downsampleOptions *m3.ClusterNamespaceDownsampleOptions
 }
 
 func newClusterNamespace(endpoint EndpointOptions) m3.ClusterNamespace {
 	return promRemoteNamespace{
 		// NB(antanas): NewOptions validates endpoint name to be unique in the list of endpoints.
-		nsID: ident.StringID(endpoint.name),
-		options: m3.NewClusterNamespaceOptions(
-			endpoint.attributes,
-			&m3.ClusterNamespaceDownsampleOptions{
-				All: endpoint.downsampleAll,
-			},
-		),
+		nsID:    ident.StringID(endpoint.name),
+		options: m3.NewClusterNamespaceOptions(endpoint.attributes, endpoint.downsampleOptions),
 	}
 }
 

--- a/src/query/storage/promremote/types_test.go
+++ b/src/query/storage/promremote/types_test.go
@@ -42,8 +42,6 @@ func TestNamespaces(t *testing.T) {
 				name: "raw",
 				attributes: storagemetadata.Attributes{
 					MetricsType: storagemetadata.UnaggregatedMetricsType,
-					Resolution:  0,
-					Retention:   0,
 				},
 				downsampleAll: false,
 			},

--- a/src/query/storage/promremote/types_test.go
+++ b/src/query/storage/promremote/types_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+
+package promremote
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/m3db/m3/src/query/storage/m3"
+	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
+	"github.com/m3db/m3/src/x/ident"
+)
+
+var opts = Options{
+	endpoints: []EndpointOptions{
+		{
+			name:          "raw",
+			resolution:    0,
+			retention:     0,
+			downsampleAll: false,
+		},
+		{
+			name:          "downsampled1",
+			retention:     time.Second,
+			resolution:    time.Millisecond,
+			downsampleAll: true,
+		},
+		{
+			name:          "downsampled2",
+			retention:     time.Minute,
+			resolution:    time.Hour,
+			downsampleAll: false,
+		},
+	},
+}
+
+func TestNamespaces(t *testing.T) {
+	ns := opts.Namespaces()
+	downsampleTrue := true
+	downsampleFalse := false
+
+	assertNamespace(expectation{
+		t:          t,
+		ns:         ns[0],
+		expectedID: "raw",
+		expectedAttributes: storagemetadata.Attributes{
+			Retention:   0,
+			Resolution:  0,
+			MetricsType: storagemetadata.UnaggregatedMetricsType,
+		},
+		expectedDownsample: nil,
+	})
+
+	assertNamespace(expectation{
+		t:          t,
+		ns:         ns[1],
+		expectedID: "downsampled1",
+		expectedAttributes: storagemetadata.Attributes{
+			Retention:   time.Second,
+			Resolution:  time.Millisecond,
+			MetricsType: storagemetadata.AggregatedMetricsType,
+		},
+		expectedDownsample: &downsampleTrue,
+	})
+
+	assertNamespace(expectation{
+		t:          t,
+		ns:         ns[2],
+		expectedID: "downsampled2",
+		expectedAttributes: storagemetadata.Attributes{
+			Retention:   time.Minute,
+			Resolution:  time.Hour,
+			MetricsType: storagemetadata.AggregatedMetricsType,
+		},
+		expectedDownsample: &downsampleFalse,
+	})
+}
+
+func TestNewSessionPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Errorf("NewSession must panic")
+		}
+	}()
+
+	opts.Namespaces()[0].Session()
+}
+
+type expectation struct {
+	t                  *testing.T
+	ns                 m3.ClusterNamespace
+	expectedID         string
+	expectedAttributes storagemetadata.Attributes
+	expectedDownsample *bool
+}
+
+func assertNamespace(e expectation) {
+	assert.Equal(e.t, ident.StringID(e.expectedID), e.ns.NamespaceID())
+	assert.Equal(e.t, e.expectedAttributes, e.ns.Options().Attributes())
+	if e.expectedDownsample != nil {
+		ds, err := e.ns.Options().DownsampleOptions()
+		require.NoError(e.t, err)
+		assert.Equal(e.t, *e.expectedDownsample, ds.All)
+	} else {
+		_, err := e.ns.Options().DownsampleOptions()
+		require.Error(e.t, err)
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This is a continuation work for https://github.com/m3db/m3/pull/3742. This PR addresses 2 issues:
- adapts endpoints to M3 Namespaces so that downsampler is a aware of existance of different namespaces to properly downsample data
- returns error when none of the configured endpoints match the incoming write.

**Special notes for your reviewer**:

This implementation was manually tested. I will continue implementing docker integration tests to cover multiple namespaces.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
Additional downsample config option will be detailed in documentation.
```
