### PR TITLE
[dbnode,query] Allow blocking operations on main thread to be interrupted

### DIFF
--- a/src/cluster/kv/util/runtime/options.go
+++ b/src/cluster/kv/util/runtime/options.go
@@ -62,6 +62,12 @@ type Options interface {
 
 	// ProcessFn returns the process function.
 	ProcessFn() ProcessFn
+
+	// InterruptCh returns the interrupt channel.
+	InterruptCh() <-chan error
+
+	// SetInterruptCh sets the interrupt channel.
+	SetInterruptCh(value <-chan error) Options
 }
 
 type options struct {
@@ -70,6 +76,7 @@ type options struct {
 	kvStore          kv.Store
 	unmarshalFn      UnmarshalFn
 	processFn        ProcessFn
+	interruptCh      <-chan error
 }
 
 // NewOptions creates a new set of options.
@@ -128,4 +135,13 @@ func (o *options) SetProcessFn(value ProcessFn) Options {
 
 func (o *options) ProcessFn() ProcessFn {
 	return o.processFn
+}
+
+func (o *options) SetInterruptCh(ch <-chan error) Options {
+	o.interruptCh = ch
+	return o
+}
+
+func (o *options) InterruptCh() <-chan error {
+	return o.interruptCh
 }

--- a/src/cluster/kv/util/runtime/value.go
+++ b/src/cluster/kv/util/runtime/value.go
@@ -82,7 +82,8 @@ func (v *value) initValue() {
 		SetNewUpdatableFn(v.newUpdatableFn).
 		SetGetUpdateFn(v.getUpdateFn).
 		SetProcessFn(v.updateFn).
-		SetKey(v.key)
+		SetKey(v.key).
+		SetInterruptCh(v.opts.InterruptCh())
 	v.Value = watch.NewValue(valueOpts)
 }
 

--- a/src/cluster/services/options.go
+++ b/src/cluster/services/options.go
@@ -252,7 +252,17 @@ func NewQueryOptions() QueryOptions { return new(queryOptions) }
 
 type queryOptions struct {
 	includeUnhealthy bool
+	interruptCh      <-chan error
 }
 
 func (qo *queryOptions) IncludeUnhealthy() bool                  { return qo.includeUnhealthy }
 func (qo *queryOptions) SetIncludeUnhealthy(h bool) QueryOptions { qo.includeUnhealthy = h; return qo }
+
+func (qo *queryOptions) InterruptCh() <-chan error {
+	return qo.interruptCh
+}
+
+func (qo *queryOptions) SetInterruptCh(ch <-chan error) QueryOptions {
+	qo.interruptCh = ch
+	return qo
+}

--- a/src/cluster/services/services.go
+++ b/src/cluster/services/services.go
@@ -307,9 +307,9 @@ func (c *client) Watch(sid ServiceID, opts QueryOptions) (Watch, error) {
 		return nil, err
 	}
 
-	initValue, err := c.waitForInitValue(kvm.kv, placementWatch, sid, c.opts.InitTimeout())
+	initValue, err := c.waitForInitValue(kvm.kv, placementWatch, sid, c.opts.InitTimeout(), opts.InterruptCh())
 	if err != nil {
-		return nil, fmt.Errorf("could not get init value for '%s' within timeout, err: %v", key, err)
+		return nil, fmt.Errorf("could not get init value for '%s',  err: %w", key, err)
 	}
 
 	initService, err := getServiceFromValue(initValue, sid)
@@ -587,19 +587,37 @@ func getServiceFromValue(value kv.Value, sid ServiceID) (Service, error) {
 	return NewServiceFromPlacement(p, sid), nil
 }
 
-func (c *client) waitForInitValue(kvStore kv.Store, w kv.ValueWatch, sid ServiceID, timeout time.Duration) (kv.Value, error) {
+func (c *client) waitForInitValue(
+	kvStore kv.Store,
+	w kv.ValueWatch,
+	sid ServiceID,
+	timeout time.Duration,
+	interruptCh <-chan error,
+) (kv.Value, error) {
+	if interruptCh == nil {
+		// NB(nate): if no interrupt channel is provided, then this wait is not
+		// gracefully interruptable.
+		interruptCh = make(chan error)
+	}
+
 	if timeout < 0 {
 		timeout = defaultInitTimeout
 	} else if timeout == 0 {
 		// We want no timeout if specifically asking for none
-		<-w.C()
-		return w.Get(), nil
+		select {
+		case <-w.C():
+			return w.Get(), nil
+		case err := <-interruptCh:
+			return nil, err
+		}
 	}
 	select {
 	case <-w.C():
 		return w.Get(), nil
 	case <-time.After(timeout):
 		return kvStore.Get(c.placementKeyFn(sid))
+	case err := <-interruptCh:
+		return nil, err
 	}
 }
 

--- a/src/cluster/services/services_mock.go
+++ b/src/cluster/services/services_mock.go
@@ -1271,6 +1271,20 @@ func (mr *MockQueryOptionsMockRecorder) IncludeUnhealthy() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncludeUnhealthy", reflect.TypeOf((*MockQueryOptions)(nil).IncludeUnhealthy))
 }
 
+// InterruptCh mocks base method.
+func (m *MockQueryOptions) InterruptCh() <-chan error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InterruptCh")
+	ret0, _ := ret[0].(<-chan error)
+	return ret0
+}
+
+// InterruptCh indicates an expected call of InterruptCh.
+func (mr *MockQueryOptionsMockRecorder) InterruptCh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InterruptCh", reflect.TypeOf((*MockQueryOptions)(nil).InterruptCh))
+}
+
 // SetIncludeUnhealthy mocks base method.
 func (m *MockQueryOptions) SetIncludeUnhealthy(h bool) QueryOptions {
 	m.ctrl.T.Helper()
@@ -1283,6 +1297,20 @@ func (m *MockQueryOptions) SetIncludeUnhealthy(h bool) QueryOptions {
 func (mr *MockQueryOptionsMockRecorder) SetIncludeUnhealthy(h interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIncludeUnhealthy", reflect.TypeOf((*MockQueryOptions)(nil).SetIncludeUnhealthy), h)
+}
+
+// SetInterruptCh mocks base method.
+func (m *MockQueryOptions) SetInterruptCh(value <-chan error) QueryOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInterruptCh", value)
+	ret0, _ := ret[0].(QueryOptions)
+	return ret0
+}
+
+// SetInterruptCh indicates an expected call of SetInterruptCh.
+func (mr *MockQueryOptionsMockRecorder) SetInterruptCh(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInterruptCh", reflect.TypeOf((*MockQueryOptions)(nil).SetInterruptCh), value)
 }
 
 // MockMetadata is a mock of Metadata interface.

--- a/src/cluster/services/types.go
+++ b/src/cluster/services/types.go
@@ -287,6 +287,12 @@ type QueryOptions interface {
 
 	// SetIncludeUnhealthy sets the value of IncludeUnhealthy.
 	SetIncludeUnhealthy(h bool) QueryOptions
+
+	// InterruptCh returns the interrupt channel.
+	InterruptCh() <-chan error
+
+	// SetInterruptCh sets the interrupt channel.
+	SetInterruptCh(value <-chan error) QueryOptions
 }
 
 // Metadata contains the metadata for a service.

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -131,6 +131,7 @@ type DownsamplerOptions struct {
 	TagOptions                 models.TagOptions
 	MetricsAppenderPoolOptions pool.ObjectPoolOptions
 	RWOptions                  xio.Options
+	InterruptCh                <-chan error
 }
 
 // AutoMappingRule is a mapping rule to apply to metrics.
@@ -726,7 +727,8 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		SetRuleSetOptions(ruleSetOpts).
 		SetKVStore(o.RulesKVStore).
 		SetNamespaceTag([]byte(namespaceTag)).
-		SetRequireNamespaceWatchOnInit(cfg.Matcher.RequireNamespaceWatchOnInit)
+		SetRequireNamespaceWatchOnInit(cfg.Matcher.RequireNamespaceWatchOnInit).
+		SetInterruptCh(o.InterruptCh)
 
 	// NB(r): If rules are being explicitly set in config then we are
 	// going to use an in memory KV store for rules and explicitly set them up.

--- a/src/dbnode/environment/config.go
+++ b/src/dbnode/environment/config.go
@@ -194,6 +194,7 @@ func (c ConfigureResults) SyncCluster() (ConfigureResult, error) {
 
 // ConfigurationParameters are options used to create new ConfigureResults
 type ConfigurationParameters struct {
+	InterruptCh            <-chan error
 	InstrumentOpts         instrument.Options
 	HashingSeed            uint32
 	HostID                 string
@@ -313,7 +314,9 @@ func (c Configuration) configureDynamic(cfgParams ConfigurationParameters) (Conf
 		topoOpts := topology.NewDynamicOptions().
 			SetConfigServiceClient(configSvcClient).
 			SetServiceID(serviceID).
-			SetQueryOptions(services.NewQueryOptions().SetIncludeUnhealthy(true)).
+			SetQueryOptions(services.NewQueryOptions().
+				SetIncludeUnhealthy(true).
+				SetInterruptCh(cfgParams.InterruptCh)).
 			SetInstrumentOptions(cfgParams.InstrumentOpts).
 			SetHashGen(sharding.NewHashGenWithSeed(cfgParams.HashingSeed))
 		topoInit := topology.NewDynamicInitializer(topoOpts)

--- a/src/integration/resources/inprocess/coordinator.go
+++ b/src/integration/resources/inprocess/coordinator.go
@@ -44,6 +44,7 @@ import (
 	"github.com/m3db/m3/src/query/generated/proto/prompb"
 	"github.com/m3db/m3/src/query/server"
 	xconfig "github.com/m3db/m3/src/x/config"
+	xos "github.com/m3db/m3/src/x/os"
 )
 
 const (
@@ -257,7 +258,7 @@ func (c *coordinator) Close() error {
 
 	// TODO: confirm this works correctly when using an embedded coordinator
 	select {
-	case c.interruptCh <- errors.New("in-process coordinator being shut down"):
+	case c.interruptCh <- xos.NewInterruptError("in-process coordinator being shut down"):
 	case <-time.After(interruptTimeout):
 		return errors.New("timeout sending interrupt. closing without graceful shutdown")
 	}

--- a/src/integration/resources/inprocess/dbnode.go
+++ b/src/integration/resources/inprocess/dbnode.go
@@ -40,6 +40,7 @@ import (
 	nettest "github.com/m3db/m3/src/integration/resources/net"
 	"github.com/m3db/m3/src/query/generated/proto/admin"
 	xconfig "github.com/m3db/m3/src/x/config"
+	xos "github.com/m3db/m3/src/x/os"
 )
 
 // TODO(nate): make configurable
@@ -272,7 +273,7 @@ func (d *dbNode) Close() error {
 
 	for i := 0; i < d.cfg.Components(); i++ {
 		select {
-		case d.interruptCh <- errors.New("in-process node being shut down"):
+		case d.interruptCh <- xos.NewInterruptError("in-process node being shut down"):
 		case <-time.After(interruptTimeout):
 			return errors.New("timeout sending interrupt. closing without graceful shutdown")
 		}

--- a/src/integration/resources/inprocess/dbnode_test.go
+++ b/src/integration/resources/inprocess/dbnode_test.go
@@ -38,6 +38,13 @@ import (
 	"github.com/m3db/m3/src/x/serialize"
 )
 
+func TestNewDBNodeNoSetup(t *testing.T) {
+	dbnode, err := NewDBNodeFromYAML(defaultDBNodeConfig, DBNodeOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, dbnode.Close())
+}
+
 func TestNewDBNode(t *testing.T) {
 	_, closer := setupNode(t)
 	closer()

--- a/src/metrics/matcher/options.go
+++ b/src/metrics/matcher/options.go
@@ -141,6 +141,12 @@ type Options interface {
 
 	// RequireNamespaceWatchOnInit returns the flag to ensure matcher is initialized with a loaded namespace watch.
 	RequireNamespaceWatchOnInit() bool
+
+	// InterruptCh returns the interrupt channel.
+	InterruptCh() <-chan error
+
+	// SetInterruptCh sets the interrupt channel.
+	SetInterruptCh(value <-chan error) Options
 }
 
 type options struct {
@@ -158,6 +164,7 @@ type options struct {
 	onNamespaceRemovedFn        OnNamespaceRemovedFn
 	onRuleSetUpdatedFn          OnRuleSetUpdatedFn
 	requireNamespaceWatchOnInit bool
+	interruptCh                 <-chan error
 }
 
 // NewOptions creates a new set of options.
@@ -316,6 +323,15 @@ func (o *options) SetRequireNamespaceWatchOnInit(value bool) Options {
 // RequireNamespaceWatchOnInit returns the flag to ensure matcher is initialized with a loaded namespace watch.
 func (o *options) RequireNamespaceWatchOnInit() bool {
 	return o.requireNamespaceWatchOnInit
+}
+
+func (o *options) SetInterruptCh(ch <-chan error) Options {
+	o.interruptCh = ch
+	return o
+}
+
+func (o *options) InterruptCh() <-chan error {
+	return o.interruptCh
 }
 
 func defaultRuleSetKeyFn(namespace []byte) string {

--- a/src/x/os/interrupt.go
+++ b/src/x/os/interrupt.go
@@ -36,6 +36,20 @@ type InterruptOptions struct {
 	InterruptCh <-chan error
 }
 
+// InterruptError is an error representing an interrupt.
+type InterruptError struct {
+	interrupt string
+}
+
+// NewInterruptError creates a new InterruptError.
+func NewInterruptError(interrupt string) error {
+	return &InterruptError{interrupt: interrupt}
+}
+
+func (i *InterruptError) Error() string {
+	return i.interrupt
+}
+
 // WaitForInterrupt will wait for an interrupt to occur and return when done.
 func WaitForInterrupt(logger *zap.Logger, opts InterruptOptions) {
 	// Handle interrupts.
@@ -56,7 +70,7 @@ func WaitForInterrupt(logger *zap.Logger, opts InterruptOptions) {
 func NewInterruptChannel(numListeners int) <-chan error {
 	interruptCh := make(chan error, numListeners)
 	go func() {
-		err := fmt.Errorf("%v", <-interrupt())
+		err := NewInterruptError(fmt.Sprintf("%v", <-interrupt()))
 		for i := 0; i < numListeners; i++ {
 			interruptCh <- err
 		}

--- a/src/x/watch/options.go
+++ b/src/x/watch/options.go
@@ -67,6 +67,12 @@ type Options interface {
 
 	// SetKey sets the key for the watch.
 	SetKey(key string) Options
+
+	// InterruptCh returns the interrupt channel.
+	InterruptCh() <-chan error
+
+	// SetInterruptCh sets the interrupt channel.
+	SetInterruptCh(value <-chan error) Options
 }
 
 type options struct {
@@ -76,6 +82,7 @@ type options struct {
 	getUpdateFn      GetUpdateFn
 	processFn        ProcessFn
 	key              string
+	interruptCh      <-chan error
 }
 
 // NewOptions creates a new set of options.
@@ -144,4 +151,13 @@ func (o *options) SetKey(key string) Options {
 	opts := *o
 	opts.key = key
 	return &opts
+}
+
+func (o *options) InterruptCh() <-chan error {
+	return o.interruptCh
+}
+
+func (o *options) SetInterruptCh(ch <-chan error) Options {
+	o.interruptCh = ch
+	return o
 }

--- a/src/x/watch/value_test.go
+++ b/src/x/watch/value_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/x/instrument"
+	xos "github.com/m3db/m3/src/x/os"
 
 	"github.com/stretchr/testify/require"
 )
@@ -91,6 +92,21 @@ func TestValueWatchSuccess(t *testing.T) {
 
 	rv.Unwatch()
 	require.Equal(t, valueNotWatching, rv.status)
+}
+
+func TestValueWatchInterrupt(t *testing.T) {
+	interruptCh := make(chan error, 1)
+	interruptCh <- xos.NewInterruptError("interrupt!")
+
+	opts := testValueOptions().
+		SetInterruptCh(interruptCh).
+		SetNewUpdatableFn(testUpdatableFn(NewWatchable()))
+
+	val := NewValue(opts).(*value)
+	err := val.Watch()
+
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "interrupt!")
 }
 
 func TestValueUnwatchNotWatching(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Operations that block the main thread without any way to interrupt them to
shutdown the server can slow down integration tests. This PR fixes two instances:
one in the coordinator and one in the DB node. See the individual commits for
more detail.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
