### PR TITLE
[coordinator] Use runServer in all tests in query_test.go

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/async_downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/async_downsampler.go
@@ -62,16 +62,15 @@ func NewAsyncDownsampler(
 	}
 
 	go func() {
+		asyncDownsampler.Lock()
+		defer asyncDownsampler.Unlock()
 		if asyncDownsampler.done != nil {
 			defer func() {
 				asyncDownsampler.done <- struct{}{}
 			}()
 		}
-
 		downsampler, err := fn()
 
-		asyncDownsampler.Lock()
-		defer asyncDownsampler.Unlock()
 		if err != nil {
 			asyncDownsampler.err = fmt.Errorf(errNewDownsamplerFailFmt, err)
 			return

--- a/src/cmd/services/m3coordinator/downsample/async_downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/async_downsampler.go
@@ -64,6 +64,7 @@ func NewAsyncDownsampler(
 	go func() {
 		asyncDownsampler.Lock()
 		defer asyncDownsampler.Unlock()
+
 		if asyncDownsampler.done != nil {
 			defer func() {
 				asyncDownsampler.done <- struct{}{}

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -537,10 +537,10 @@ func runServer(t *testing.T, opts runServerOpts) (string, closeFn) {
 			DownsamplerReadyCh: opts.downsamplerReadyCh,
 			M3MsgListenerCh:    opts.m3msgListenerCh,
 		})
+		doneCh <- struct{}{}
 		if opts.runResultCh != nil {
 			opts.runResultCh <- r
 		}
-		doneCh <- struct{}{}
 	}()
 
 	if opts.downsamplerReadyCh != nil {

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -175,12 +175,7 @@ func TestWriteH1(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
-	configFile, closeFn := newTestFile(t, "config.yaml", configYAML)
-	defer closeFn()
-
-	var cfg config.Configuration
-	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
-	require.NoError(t, err)
+	cfg := configFromYAML(t, configYAML)
 
 	testWrite(t, cfg, ctrl)
 }
@@ -189,12 +184,7 @@ func TestWriteH2C(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
-	configFile, closer := newTestFile(t, "config.yaml", configYAML)
-	defer closer()
-
-	var cfg config.Configuration
-	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
-	require.NoError(t, err)
+	cfg := configFromYAML(t, configYAML)
 
 	cfg.HTTP.EnableH2C = true
 
@@ -205,12 +195,7 @@ func TestIngestH1(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
-	configFile, closer := newTestFile(t, "config.yaml", configYAML)
-	defer closer()
-
-	var cfg config.Configuration
-	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
-	require.NoError(t, err)
+	cfg := configFromYAML(t, configYAML)
 
 	testIngest(t, cfg, ctrl)
 }
@@ -219,12 +204,7 @@ func TestIngestH2C(t *testing.T) {
 	ctrl := gomock.NewController(xtest.Reporter{T: t})
 	defer ctrl.Finish()
 
-	configFile, closer := newTestFile(t, "config.yaml", configYAML)
-	defer closer()
-
-	var cfg config.Configuration
-	err := xconfig.LoadFile(&cfg, configFile.Name(), xconfig.Options{})
-	require.NoError(t, err)
+	cfg := configFromYAML(t, configYAML)
 
 	cfg.HTTP.EnableH2C = true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Small refactor to query_test.go to use runServer helper to remove some duplicated test code. I have started using MemStore instead of mocked one. It seems it might have revealed race condition in asyncDownsampler constructor that I fixed by moving lock.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
None
```
