### PR TITLE
[dbnode,query] Ensure only single listener for interrupt channel

### DIFF
--- a/src/cluster/kv/util/runtime/options.go
+++ b/src/cluster/kv/util/runtime/options.go
@@ -63,11 +63,11 @@ type Options interface {
 	// ProcessFn returns the process function.
 	ProcessFn() ProcessFn
 
-	// InterruptCh returns the interrupt channel.
-	InterruptCh() <-chan error
+	// InterruptedCh returns the interrupted channel.
+	InterruptedCh() <-chan struct{}
 
-	// SetInterruptCh sets the interrupt channel.
-	SetInterruptCh(value <-chan error) Options
+	// SetInterruptedCh sets the interrupted channel.
+	SetInterruptedCh(value <-chan struct{}) Options
 }
 
 type options struct {
@@ -76,7 +76,7 @@ type options struct {
 	kvStore          kv.Store
 	unmarshalFn      UnmarshalFn
 	processFn        ProcessFn
-	interruptCh      <-chan error
+	interruptedCh    <-chan struct{}
 }
 
 // NewOptions creates a new set of options.
@@ -137,11 +137,11 @@ func (o *options) ProcessFn() ProcessFn {
 	return o.processFn
 }
 
-func (o *options) SetInterruptCh(ch <-chan error) Options {
-	o.interruptCh = ch
+func (o *options) SetInterruptedCh(ch <-chan struct{}) Options {
+	o.interruptedCh = ch
 	return o
 }
 
-func (o *options) InterruptCh() <-chan error {
-	return o.interruptCh
+func (o *options) InterruptedCh() <-chan struct{} {
+	return o.interruptedCh
 }

--- a/src/cluster/kv/util/runtime/value.go
+++ b/src/cluster/kv/util/runtime/value.go
@@ -83,7 +83,7 @@ func (v *value) initValue() {
 		SetGetUpdateFn(v.getUpdateFn).
 		SetProcessFn(v.updateFn).
 		SetKey(v.key).
-		SetInterruptCh(v.opts.InterruptCh())
+		SetInterruptedCh(v.opts.InterruptedCh())
 	v.Value = watch.NewValue(valueOpts)
 }
 

--- a/src/cluster/services/options.go
+++ b/src/cluster/services/options.go
@@ -252,17 +252,17 @@ func NewQueryOptions() QueryOptions { return new(queryOptions) }
 
 type queryOptions struct {
 	includeUnhealthy bool
-	interruptCh      <-chan error
+	interruptedCh    <-chan struct{}
 }
 
 func (qo *queryOptions) IncludeUnhealthy() bool                  { return qo.includeUnhealthy }
 func (qo *queryOptions) SetIncludeUnhealthy(h bool) QueryOptions { qo.includeUnhealthy = h; return qo }
 
-func (qo *queryOptions) InterruptCh() <-chan error {
-	return qo.interruptCh
+func (qo *queryOptions) InterruptedCh() <-chan struct{} {
+	return qo.interruptedCh
 }
 
-func (qo *queryOptions) SetInterruptCh(ch <-chan error) QueryOptions {
-	qo.interruptCh = ch
+func (qo *queryOptions) SetInterruptedCh(ch <-chan struct{}) QueryOptions {
+	qo.interruptedCh = ch
 	return qo
 }

--- a/src/cluster/services/services_mock.go
+++ b/src/cluster/services/services_mock.go
@@ -1271,18 +1271,18 @@ func (mr *MockQueryOptionsMockRecorder) IncludeUnhealthy() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncludeUnhealthy", reflect.TypeOf((*MockQueryOptions)(nil).IncludeUnhealthy))
 }
 
-// InterruptCh mocks base method.
-func (m *MockQueryOptions) InterruptCh() <-chan error {
+// InterruptedCh mocks base method.
+func (m *MockQueryOptions) InterruptedCh() <-chan struct{} {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InterruptCh")
-	ret0, _ := ret[0].(<-chan error)
+	ret := m.ctrl.Call(m, "InterruptedCh")
+	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
-// InterruptCh indicates an expected call of InterruptCh.
-func (mr *MockQueryOptionsMockRecorder) InterruptCh() *gomock.Call {
+// InterruptedCh indicates an expected call of InterruptedCh.
+func (mr *MockQueryOptionsMockRecorder) InterruptedCh() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InterruptCh", reflect.TypeOf((*MockQueryOptions)(nil).InterruptCh))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InterruptedCh", reflect.TypeOf((*MockQueryOptions)(nil).InterruptedCh))
 }
 
 // SetIncludeUnhealthy mocks base method.
@@ -1299,18 +1299,18 @@ func (mr *MockQueryOptionsMockRecorder) SetIncludeUnhealthy(h interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIncludeUnhealthy", reflect.TypeOf((*MockQueryOptions)(nil).SetIncludeUnhealthy), h)
 }
 
-// SetInterruptCh mocks base method.
-func (m *MockQueryOptions) SetInterruptCh(value <-chan error) QueryOptions {
+// SetInterruptedCh mocks base method.
+func (m *MockQueryOptions) SetInterruptedCh(value <-chan struct{}) QueryOptions {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetInterruptCh", value)
+	ret := m.ctrl.Call(m, "SetInterruptedCh", value)
 	ret0, _ := ret[0].(QueryOptions)
 	return ret0
 }
 
-// SetInterruptCh indicates an expected call of SetInterruptCh.
-func (mr *MockQueryOptionsMockRecorder) SetInterruptCh(value interface{}) *gomock.Call {
+// SetInterruptedCh indicates an expected call of SetInterruptedCh.
+func (mr *MockQueryOptionsMockRecorder) SetInterruptedCh(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInterruptCh", reflect.TypeOf((*MockQueryOptions)(nil).SetInterruptCh), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInterruptedCh", reflect.TypeOf((*MockQueryOptions)(nil).SetInterruptedCh), value)
 }
 
 // MockMetadata is a mock of Metadata interface.

--- a/src/cluster/services/types.go
+++ b/src/cluster/services/types.go
@@ -288,11 +288,11 @@ type QueryOptions interface {
 	// SetIncludeUnhealthy sets the value of IncludeUnhealthy.
 	SetIncludeUnhealthy(h bool) QueryOptions
 
-	// InterruptCh returns the interrupt channel.
-	InterruptCh() <-chan error
+	// InterruptedCh returns the interrupted channel.
+	InterruptedCh() <-chan struct{}
 
-	// SetInterruptCh sets the interrupt channel.
-	SetInterruptCh(value <-chan error) QueryOptions
+	// SetInterruptedCh sets the interrupted channel.
+	SetInterruptedCh(value <-chan struct{}) QueryOptions
 }
 
 // Metadata contains the metadata for a service.

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -131,7 +131,7 @@ type DownsamplerOptions struct {
 	TagOptions                 models.TagOptions
 	MetricsAppenderPoolOptions pool.ObjectPoolOptions
 	RWOptions                  xio.Options
-	InterruptCh                <-chan error
+	InterruptedCh              <-chan struct{}
 }
 
 // AutoMappingRule is a mapping rule to apply to metrics.
@@ -728,7 +728,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		SetKVStore(o.RulesKVStore).
 		SetNamespaceTag([]byte(namespaceTag)).
 		SetRequireNamespaceWatchOnInit(cfg.Matcher.RequireNamespaceWatchOnInit).
-		SetInterruptCh(o.InterruptCh)
+		SetInterruptedCh(o.InterruptedCh)
 
 	// NB(r): If rules are being explicitly set in config then we are
 	// going to use an in memory KV store for rules and explicitly set them up.

--- a/src/dbnode/environment/config.go
+++ b/src/dbnode/environment/config.go
@@ -194,7 +194,7 @@ func (c ConfigureResults) SyncCluster() (ConfigureResult, error) {
 
 // ConfigurationParameters are options used to create new ConfigureResults
 type ConfigurationParameters struct {
-	InterruptCh            <-chan error
+	InterruptedCh          <-chan struct{}
 	InstrumentOpts         instrument.Options
 	HashingSeed            uint32
 	HostID                 string
@@ -316,7 +316,7 @@ func (c Configuration) configureDynamic(cfgParams ConfigurationParameters) (Conf
 			SetServiceID(serviceID).
 			SetQueryOptions(services.NewQueryOptions().
 				SetIncludeUnhealthy(true).
-				SetInterruptCh(cfgParams.InterruptCh)).
+				SetInterruptedCh(cfgParams.InterruptedCh)).
 			SetInstrumentOptions(cfgParams.InstrumentOpts).
 			SetHashGen(sharding.NewHashGenWithSeed(cfgParams.HashingSeed))
 		topoInit := topology.NewDynamicInitializer(topoOpts)

--- a/src/metrics/matcher/namespaces.go
+++ b/src/metrics/matcher/namespaces.go
@@ -144,7 +144,7 @@ func NewNamespaces(key string, opts Options) Namespaces {
 		SetKVStore(n.store).
 		SetUnmarshalFn(n.toNamespaces).
 		SetProcessFn(n.process).
-		SetInterruptCh(opts.InterruptCh())
+		SetInterruptedCh(opts.InterruptedCh())
 	n.Value = runtime.NewValue(key, valueOpts)
 	return n
 }

--- a/src/metrics/matcher/namespaces_test.go
+++ b/src/metrics/matcher/namespaces_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/m3db/m3/src/metrics/generated/proto/rulepb"
 	"github.com/m3db/m3/src/metrics/matcher/cache"
 	"github.com/m3db/m3/src/metrics/rules"
-	xos "github.com/m3db/m3/src/x/os"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
@@ -128,14 +127,14 @@ func TestNamespacesWatchRulesetHardErr(t *testing.T) {
 }
 
 func TestNamespacesOpenWithInterrupt(t *testing.T) {
-	interruptCh := make(chan error, 1)
-	interruptCh <- xos.NewInterruptError("interrupt!")
+	interruptedCh := make(chan struct{}, 1)
+	interruptedCh <- struct{}{}
 
-	_, _, nss, _ := testNamespacesWithInterruptCh(interruptCh)
+	_, _, nss, _ := testNamespacesWithInterruptedCh(interruptedCh)
 	err := nss.Open()
 
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "interrupt!")
+	require.Equal(t, err.Error(), "interrupted")
 }
 
 func TestToNamespacesNilValue(t *testing.T) {
@@ -289,7 +288,7 @@ func TestNamespacesProcess(t *testing.T) {
 	}
 }
 
-func testNamespacesWithInterruptCh(interruptCh chan error) (kv.TxnStore, cache.Cache, *namespaces, Options) {
+func testNamespacesWithInterruptedCh(interruptedCh chan struct{}) (kv.TxnStore, cache.Cache, *namespaces, Options) {
 	store := mem.NewStore()
 	cache := newMemCache()
 	opts := NewOptions().
@@ -306,13 +305,13 @@ func testNamespacesWithInterruptCh(interruptCh chan error) (kv.TxnStore, cache.C
 		SetOnRuleSetUpdatedFn(func(namespace []byte, ruleSet RuleSet) {
 			cache.Register(namespace, ruleSet)
 		}).
-		SetInterruptCh(interruptCh)
+		SetInterruptedCh(interruptedCh)
 
 	return store, cache, NewNamespaces(testNamespacesKey, opts).(*namespaces), opts
 }
 
 func testNamespaces() (kv.TxnStore, cache.Cache, *namespaces, Options) {
-	return testNamespacesWithInterruptCh(nil)
+	return testNamespacesWithInterruptedCh(nil)
 }
 
 type memResults struct {

--- a/src/metrics/matcher/options.go
+++ b/src/metrics/matcher/options.go
@@ -142,11 +142,11 @@ type Options interface {
 	// RequireNamespaceWatchOnInit returns the flag to ensure matcher is initialized with a loaded namespace watch.
 	RequireNamespaceWatchOnInit() bool
 
-	// InterruptCh returns the interrupt channel.
-	InterruptCh() <-chan error
+	// InterruptedCh returns the interrupted channel.
+	InterruptedCh() <-chan struct{}
 
-	// SetInterruptCh sets the interrupt channel.
-	SetInterruptCh(value <-chan error) Options
+	// SetInterruptedCh sets the interrupted channel.
+	SetInterruptedCh(value <-chan struct{}) Options
 }
 
 type options struct {
@@ -164,7 +164,7 @@ type options struct {
 	onNamespaceRemovedFn        OnNamespaceRemovedFn
 	onRuleSetUpdatedFn          OnRuleSetUpdatedFn
 	requireNamespaceWatchOnInit bool
-	interruptCh                 <-chan error
+	interruptedCh               <-chan struct{}
 }
 
 // NewOptions creates a new set of options.
@@ -325,13 +325,13 @@ func (o *options) RequireNamespaceWatchOnInit() bool {
 	return o.requireNamespaceWatchOnInit
 }
 
-func (o *options) SetInterruptCh(ch <-chan error) Options {
-	o.interruptCh = ch
+func (o *options) SetInterruptedCh(ch <-chan struct{}) Options {
+	o.interruptedCh = ch
 	return o
 }
 
-func (o *options) InterruptCh() <-chan error {
-	return o.interruptCh
+func (o *options) InterruptedCh() <-chan struct{} {
+	return o.interruptedCh
 }
 
 func defaultRuleSetKeyFn(namespace []byte) string {

--- a/src/x/os/interrupt.go
+++ b/src/x/os/interrupt.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"go.uber.org/zap"
@@ -34,11 +35,29 @@ type InterruptOptions struct {
 	// InterruptChannel is an existing interrupt channel, if none
 	// specified one will be created.
 	InterruptCh <-chan error
+
+	// InterruptedChannel is a channel that will be closed once an
+	// interrupt has been seen. Use this to pass to goroutines who
+	// want to be notified about interruptions that you don't want
+	// consuming from the main interrupt channel.
+	InterruptedCh chan struct{}
 }
 
 // InterruptError is an error representing an interrupt.
 type InterruptError struct {
 	interrupt string
+}
+
+// ErrInterrupted is an error indicating that the interrupted channel was closed,
+// meaning an interrupt was received on the main interrupt channel.
+var ErrInterrupted = NewInterruptError("interrupted")
+
+// NewInterruptOptions creates InterruptOptions with sane defaults.
+func NewInterruptOptions() InterruptOptions {
+	return InterruptOptions{
+		InterruptCh:   NewInterruptChannel(1),
+		InterruptedCh: make(chan struct{}),
+	}
 }
 
 // NewInterruptError creates a new InterruptError.
@@ -48,6 +67,35 @@ func NewInterruptError(interrupt string) error {
 
 func (i *InterruptError) Error() string {
 	return i.interrupt
+}
+
+// WatchForInterrupt watches for interrupts in a non-blocking fashion and closes
+// the interrupted channel when an interrupt is found. Use this method to
+// watch for interrupts while the caller continues to execute (e.g. during
+// server startup). To ensure child goroutines get properly closed, pass them
+// the interrupted channel. If the interrupted channel is closed, then the
+// goroutine knows to stop its work. This method returns a function that
+// can be used to stop the watch.
+func WatchForInterrupt(logger *zap.Logger, opts InterruptOptions) func() {
+	interruptCh := opts.InterruptCh
+	closed := make(chan struct{})
+	go func() {
+		select {
+		case err := <-interruptCh:
+			logger.Warn("interrupt", zap.Error(err))
+			close(opts.InterruptedCh)
+		case <-closed:
+			logger.Info("interrupt watch stopped")
+			return
+		}
+	}()
+
+	var doOnce sync.Once
+	return func() {
+		doOnce.Do(func() {
+			close(closed)
+		})
+	}
 }
 
 // WaitForInterrupt will wait for an interrupt to occur and return when done.
@@ -63,6 +111,10 @@ func WaitForInterrupt(logger *zap.Logger, opts InterruptOptions) {
 	}
 
 	logger.Warn("interrupt", zap.Error(<-interruptCh))
+
+	if opts.InterruptedCh != nil {
+		close(opts.InterruptedCh)
+	}
 }
 
 // NewInterruptChannel will return an interrupt channel useful with multiple

--- a/src/x/os/interrupt_test.go
+++ b/src/x/os/interrupt_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestWatchForInterrupt(t *testing.T) {
+	interruptCh := make(chan error, 1)
+	interruptCh <- NewInterruptError("interrupt time")
+
+	opts := NewInterruptOptions()
+	opts.InterruptCh = interruptCh
+
+	_ = WatchForInterrupt(zap.NewNop(), opts)
+
+	select {
+	case <-opts.InterruptedCh:
+	case <-time.After(5 * time.Second):
+		t.Fail()
+	}
+}
+
+func TestWatchForInterruptCloseTwice(t *testing.T) {
+	opts := NewInterruptOptions()
+	closer := WatchForInterrupt(zap.NewNop(), opts)
+
+	require.NotPanics(t, func() {
+		closer()
+		closer()
+	})
+}

--- a/src/x/watch/options.go
+++ b/src/x/watch/options.go
@@ -68,11 +68,11 @@ type Options interface {
 	// SetKey sets the key for the watch.
 	SetKey(key string) Options
 
-	// InterruptCh returns the interrupt channel.
-	InterruptCh() <-chan error
+	// InterruptedCh returns the interrupted channel.
+	InterruptedCh() <-chan struct{}
 
-	// SetInterruptCh sets the interrupt channel.
-	SetInterruptCh(value <-chan error) Options
+	// SetInterruptedCh sets the interrupted channel.
+	SetInterruptedCh(value <-chan struct{}) Options
 }
 
 type options struct {
@@ -82,7 +82,7 @@ type options struct {
 	getUpdateFn      GetUpdateFn
 	processFn        ProcessFn
 	key              string
-	interruptCh      <-chan error
+	interruptedCh    <-chan struct{}
 }
 
 // NewOptions creates a new set of options.
@@ -153,11 +153,11 @@ func (o *options) SetKey(key string) Options {
 	return &opts
 }
 
-func (o *options) InterruptCh() <-chan error {
-	return o.interruptCh
+func (o *options) InterruptedCh() <-chan struct{} {
+	return o.interruptedCh
 }
 
-func (o *options) SetInterruptCh(ch <-chan error) Options {
-	o.interruptCh = ch
+func (o *options) SetInterruptedCh(ch <-chan struct{}) Options {
+	o.interruptedCh = ch
 	return o
 }

--- a/src/x/watch/value_test.go
+++ b/src/x/watch/value_test.go
@@ -27,8 +27,6 @@ import (
 	"time"
 
 	"github.com/m3db/m3/src/x/instrument"
-	xos "github.com/m3db/m3/src/x/os"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,18 +93,18 @@ func TestValueWatchSuccess(t *testing.T) {
 }
 
 func TestValueWatchInterrupt(t *testing.T) {
-	interruptCh := make(chan error, 1)
-	interruptCh <- xos.NewInterruptError("interrupt!")
+	interruptedCh := make(chan struct{})
+	close(interruptedCh)
 
 	opts := testValueOptions().
-		SetInterruptCh(interruptCh).
+		SetInterruptedCh(interruptedCh).
 		SetNewUpdatableFn(testUpdatableFn(NewWatchable()))
 
 	val := NewValue(opts).(*value)
 	err := val.Watch()
 
 	require.Error(t, err)
-	require.Equal(t, err.Error(), "interrupt!")
+	require.Equal(t, err.Error(), "interrupted")
 }
 
 func TestValueUnwatchNotWatching(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Passing the interrupt channel to multiple goroutines could
cause a race where the main thread ends up missing the interrupt
that triggers a server shutdown. This commit ensures that only
a single goroutine is listening for the interrupt at a given
time and all other interested parties can check the interrupted
channel. The interrupted channel will be closed as soon as
an interrupt is received. Since closed channels return immediately,
this allows any interested goroutine to know if it should terminate
by simply checking the interrupted channel.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
