### PR TITLE
[aggregator] - fix bug where expired datapoints can be included in aggregations

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -266,7 +266,9 @@ func (e *CounterElem) Consume(
 			// this, though, means that if a next dp comes much later (past buffer past) then there
 			// will be a previous dp that should not actually be included in aggregations since it is
 			// expired.
-			e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+			if e.resendEnabled {
+				e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+			}
 
 			// scan back to find the preceding datapoint to timeNanos
 			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -220,6 +220,10 @@ func (e *CounterElem) Consume(
 	}
 	e.toConsume = e.toConsume[:0]
 
+	// Anything prior to this time is before the buffer past and so should be considered expired
+	// and not to be included in this aggregation.
+	bufferPastMinNanos := targetNanos - e.bufferForPastTimedMetricFn(resolution).Nanoseconds()
+
 	// Evaluate and GC expired items.
 	valuesForConsideration := e.values
 	e.values = e.values[:0]
@@ -232,8 +236,7 @@ func (e *CounterElem) Consume(
 		if e.resendEnabled {
 			// If resend is enabled, we only expire if the value is now outside the buffer past. It is safe to expire
 			// since any metrics intended for this value are rejected for being too late.
-			expiredNanos := targetNanos - e.bufferForPastTimedMetricFn(resolution).Nanoseconds()
-			expired = value.startAtNanos < expiredNanos
+			expired = value.startAtNanos < bufferPastMinNanos
 		}
 
 		// Modify the by value copy with whether it needs time flush and accumulate.
@@ -254,6 +257,9 @@ func (e *CounterElem) Consume(
 		prevTimeNanos xtime.UnixNano
 	)
 	// Process the aggregations that are ready for consumption.
+	if len(e.toConsume) > 0 {
+		e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+	}
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -256,15 +256,19 @@ func (e *CounterElem) Consume(
 		cascadeDirty  bool
 		prevTimeNanos xtime.UnixNano
 	)
-	// Process the aggregations that are ready for consumption.
-	if len(e.toConsume) > 0 {
-		e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
-	}
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))
 		// seed the previous timestamp if this is first consumed value.
 		if prevTimeNanos == 0 {
+			// when a datapoint is considered expired, the datapoint previous to it is cleared
+			// while the current is left so that the next datapoint has a previous dp to reference.
+			// this, though, means that if a next dp comes much later (past buffer past) then there
+			// will be a previous dp that should not actually be included in aggregations since it is
+			// expired.
+			e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+
+			// scan back to find the preceding datapoint to timeNanos
 			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)
 		}
 

--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -194,6 +194,15 @@ func (v valuesByTime) previousTimestamp(t xtime.UnixNano) xtime.UnixNano {
 	return previous
 }
 
+// Clears entries that are less than the provided min time.
+func (v valuesByTime) removeOlderThan(min xtime.UnixNano) {
+	for ts := range v {
+		if ts.Before(min) {
+			delete(v, ts)
+		}
+	}
+}
+
 type elemMetrics struct {
 	updatedValues tally.Counter
 }

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -252,6 +252,7 @@ func TestCounterElemAddUnion(t *testing.T) {
 func TestCounterElemAddValue(t *testing.T) {
 	e, err := NewCounterElem(testCounterElemData, newTestOptions())
 	require.NoError(t, err)
+	e.resendEnabled = true
 
 	isEarlierThanFn := isStandardMetricEarlierThan
 	timestampNanosFn := standardMetricTimestampNanos

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -220,6 +220,10 @@ func (e *GaugeElem) Consume(
 	}
 	e.toConsume = e.toConsume[:0]
 
+	// Anything prior to this time is before the buffer past and so should be considered expired
+	// and not to be included in this aggregation.
+	bufferPastMinNanos := targetNanos - e.bufferForPastTimedMetricFn(resolution).Nanoseconds()
+
 	// Evaluate and GC expired items.
 	valuesForConsideration := e.values
 	e.values = e.values[:0]
@@ -232,8 +236,7 @@ func (e *GaugeElem) Consume(
 		if e.resendEnabled {
 			// If resend is enabled, we only expire if the value is now outside the buffer past. It is safe to expire
 			// since any metrics intended for this value are rejected for being too late.
-			expiredNanos := targetNanos - e.bufferForPastTimedMetricFn(resolution).Nanoseconds()
-			expired = value.startAtNanos < expiredNanos
+			expired = value.startAtNanos < bufferPastMinNanos
 		}
 
 		// Modify the by value copy with whether it needs time flush and accumulate.
@@ -254,6 +257,9 @@ func (e *GaugeElem) Consume(
 		prevTimeNanos xtime.UnixNano
 	)
 	// Process the aggregations that are ready for consumption.
+	if len(e.toConsume) > 0 {
+		e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+	}
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -266,7 +266,9 @@ func (e *GaugeElem) Consume(
 			// this, though, means that if a next dp comes much later (past buffer past) then there
 			// will be a previous dp that should not actually be included in aggregations since it is
 			// expired.
-			e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+			if e.resendEnabled {
+				e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+			}
 
 			// scan back to find the preceding datapoint to timeNanos
 			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -320,15 +320,19 @@ func (e *GenericElem) Consume(
 		cascadeDirty  bool
 		prevTimeNanos xtime.UnixNano
 	)
-	// Process the aggregations that are ready for consumption.
-	if len(e.toConsume) > 0 {
-		e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
-	}
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))
 		// seed the previous timestamp if this is first consumed value.
 		if prevTimeNanos == 0 {
+			// when a datapoint is considered expired, the datapoint previous to it is cleared
+			// while the current is left so that the next datapoint has a previous dp to reference.
+			// this, though, means that if a next dp comes much later (past buffer past) then there
+			// will be a previous dp that should not actually be included in aggregations since it is
+			// expired.
+			e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+
+			// scan back to find the preceding datapoint to timeNanos
 			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)
 		}
 

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -330,7 +330,9 @@ func (e *GenericElem) Consume(
 			// this, though, means that if a next dp comes much later (past buffer past) then there
 			// will be a previous dp that should not actually be included in aggregations since it is
 			// expired.
-			e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+			if e.resendEnabled {
+				e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+			}
 
 			// scan back to find the preceding datapoint to timeNanos
 			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -256,15 +256,19 @@ func (e *TimerElem) Consume(
 		cascadeDirty  bool
 		prevTimeNanos xtime.UnixNano
 	)
-	// Process the aggregations that are ready for consumption.
-	if len(e.toConsume) > 0 {
-		e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
-	}
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))
 		// seed the previous timestamp if this is first consumed value.
 		if prevTimeNanos == 0 {
+			// when a datapoint is considered expired, the datapoint previous to it is cleared
+			// while the current is left so that the next datapoint has a previous dp to reference.
+			// this, though, means that if a next dp comes much later (past buffer past) then there
+			// will be a previous dp that should not actually be included in aggregations since it is
+			// expired.
+			e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+
+			// scan back to find the preceding datapoint to timeNanos
 			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)
 		}
 

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -220,6 +220,10 @@ func (e *TimerElem) Consume(
 	}
 	e.toConsume = e.toConsume[:0]
 
+	// Anything prior to this time is before the buffer past and so should be considered expired
+	// and not to be included in this aggregation.
+	bufferPastMinNanos := targetNanos - e.bufferForPastTimedMetricFn(resolution).Nanoseconds()
+
 	// Evaluate and GC expired items.
 	valuesForConsideration := e.values
 	e.values = e.values[:0]
@@ -232,8 +236,7 @@ func (e *TimerElem) Consume(
 		if e.resendEnabled {
 			// If resend is enabled, we only expire if the value is now outside the buffer past. It is safe to expire
 			// since any metrics intended for this value are rejected for being too late.
-			expiredNanos := targetNanos - e.bufferForPastTimedMetricFn(resolution).Nanoseconds()
-			expired = value.startAtNanos < expiredNanos
+			expired = value.startAtNanos < bufferPastMinNanos
 		}
 
 		// Modify the by value copy with whether it needs time flush and accumulate.
@@ -254,6 +257,9 @@ func (e *TimerElem) Consume(
 		prevTimeNanos xtime.UnixNano
 	)
 	// Process the aggregations that are ready for consumption.
+	if len(e.toConsume) > 0 {
+		e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+	}
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -266,7 +266,9 @@ func (e *TimerElem) Consume(
 			// this, though, means that if a next dp comes much later (past buffer past) then there
 			// will be a previous dp that should not actually be included in aggregations since it is
 			// expired.
-			e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+			if e.resendEnabled {
+				e.consumedValues.removeOlderThan(xtime.UnixNano(bufferPastMinNanos))
+			}
 
 			// scan back to find the preceding datapoint to timeNanos
 			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)

--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -102,6 +102,7 @@ import (
 	"github.com/uber/tchannel-go"
 	"go.etcd.io/etcd/embed"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -292,7 +293,10 @@ func Run(runOpts RunOptions) {
 		if serviceName == "" {
 			serviceName = defaultServiceName
 		}
-		tracer, traceCloser, err = cfg.Tracing.NewTracer(serviceName, scope.SubScope("jaeger"), logger)
+		tracer, traceCloser, err = cfg.Tracing.NewTracer(serviceName,
+			scope.SubScope("jaeger"),
+			// Sample logs from tracing SDK since they can be noisy.
+			zap.New(zapcore.NewSamplerWithOptions(logger.Core(), time.Second*30, 1, 0)))
 		if err != nil {
 			tracer = opentracing.NoopTracer{}
 			logger.Warn("could not initialize tracing; using no-op tracer instead",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Datapoints outside the buffer past window are marked as expired and should not be included in aggregations. However, this was not the behavior due to a bug where the GC of expired values only clears the datapoint preceding the latest expired datapoint, and the aggregations did not account for this.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
