### PR TITLE
Revert "Sample tracer logs (#3774)"

### DIFF
--- a/src/dbnode/server/server.go
+++ b/src/dbnode/server/server.go
@@ -102,7 +102,6 @@ import (
 	"github.com/uber/tchannel-go"
 	"go.etcd.io/etcd/embed"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -293,10 +292,7 @@ func Run(runOpts RunOptions) {
 		if serviceName == "" {
 			serviceName = defaultServiceName
 		}
-		tracer, traceCloser, err = cfg.Tracing.NewTracer(serviceName,
-			scope.SubScope("jaeger"),
-			// Sample logs from tracing SDK since they can be noisy.
-			zap.New(zapcore.NewSamplerWithOptions(logger.Core(), time.Second*30, 1, 0)))
+		tracer, traceCloser, err = cfg.Tracing.NewTracer(serviceName, scope.SubScope("jaeger"), logger)
 		if err != nil {
 			tracer = opentracing.NoopTracer{}
 			logger.Warn("could not initialize tracing; using no-op tracer instead",


### PR DESCRIPTION
This reverts commit b8d9b0f52cd262e280647024bc6355cc0b98f1ad.

**What this PR does / why we need it**:
This change was causing division by 0 panics because of 0 value passed for a `thereafter` argument:
```
zap.New(zapcore.NewSamplerWithOptions(logger.Core(), time.Second*30, 1, 0)))
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
