### PR TITLE
[coordinator] Make <500 endpoint errors as invalid params error

### DIFF
--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -237,18 +237,41 @@ tagOptions:
 
 	promReq := test.GeneratePromWriteRequest()
 	promReqBody := test.GeneratePromWriteRequestBody(t, promReq)
-	req, err := http.NewRequestWithContext(
-		context.TODO(),
-		http.MethodPost,
-		fmt.Sprintf("http://%s%s", addr, remote.PromWriteURL),
-		promReqBody,
-	)
-	require.NoError(t, err)
+	requestURL := fmt.Sprintf("http://%s%s", addr, remote.PromWriteURL)
 
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-	assert.NotNil(t, externalFakePromServer.GetLastWriteRequest())
+	t.Run("write request", func(t *testing.T) {
+		defer externalFakePromServer.Reset()
+		req, err := http.NewRequestWithContext(
+			context.TODO(),
+			http.MethodPost,
+			requestURL,
+			promReqBody,
+		)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.NotNil(t, externalFakePromServer.GetLastWriteRequest())
+	})
+
+	t.Run("bad request propagates", func(t *testing.T) {
+		defer externalFakePromServer.Reset()
+		externalFakePromServer.SetError("badRequest", http.StatusBadRequest)
+		req, err := http.NewRequestWithContext(
+			context.TODO(),
+			http.MethodPost,
+			requestURL,
+			promReqBody,
+		)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, 400, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
+		assert.NotNil(t, externalFakePromServer.GetLastWriteRequest())
+	})
 }
 
 func TestGRPCBackend(t *testing.T) {

--- a/src/query/storage/promremote/storage.go
+++ b/src/query/storage/promremote/storage.go
@@ -164,8 +164,14 @@ func (p *promStorage) writeSingle(
 			p.logger.Error("error reading body", zap.Error(err))
 			response = errorReadingBody
 		}
-		return fmt.Errorf("expected status code 2XX: actual=%v, address=%v, resp=%s",
-			resp.StatusCode, address, response)
+		genericError := fmt.Errorf(
+			"expected status code 2XX: actual=%v, address=%v, resp=%s",
+			resp.StatusCode, address, response,
+		)
+		if resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return xerrors.NewInvalidParamsError(genericError)
+		}
+		return genericError
 	}
 	metrics.ReportSuccess(methodDuration)
 	return nil

--- a/src/query/storage/promremote/storage_test.go
+++ b/src/query/storage/promremote/storage_test.go
@@ -250,7 +250,7 @@ func TestWriteBasedOnRetention(t *testing.T) {
 		assert.NotNil(t, promLongRetention2.GetLastWriteRequest())
 	})
 
-	t.Run("wrap non 5xx errors into invalid params", func(t *testing.T) {
+	t.Run("wrap non 5xx errors as invalid params error", func(t *testing.T) {
 		reset()
 		promLongRetention.SetError("test err", http.StatusForbidden)
 		err := sendWrite(storagemetadata.Attributes{
@@ -261,7 +261,7 @@ func TestWriteBasedOnRetention(t *testing.T) {
 		assert.True(t, xerrors.IsInvalidParams(err))
 	})
 
-	t.Run("429 should not be mapped to invalid params", func(t *testing.T) {
+	t.Run("429 should not be wrapped as invalid params", func(t *testing.T) {
 		reset()
 		promLongRetention.SetError("test err", http.StatusTooManyRequests)
 		err := sendWrite(storagemetadata.Attributes{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**: 

map <500 response codes to 400.


**Special notes for your reviewer**:

Makes sure 4xx errors are wrapped in InvalidParamsError that eventually gets mapped to 400 HTTP status code.
This is important because prometheus [scraper retries 5xx errors](https://github.com/prometheus/prometheus/blob/fac1b573349ac4d35c011a891e2bb58f560f9d84/storage/remote/client.go#L241). Before this change any errors returned from endpoint would have been mapped to 500.


Storage layer abstracts away HTTP so it's not possible to just respond with same status codes as in response from the endpoint. However it seems enough to map to 400 or 500 based on Prometheus scraper implementation.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
None
```
