### PR TITLE
[query] Remove Graphite find results that are duplicate if includes both expandable and leaf path values

### DIFF
--- a/scripts/docker-integration-tests/carbon/m3coordinator.yml
+++ b/scripts/docker-integration-tests/carbon/m3coordinator.yml
@@ -12,6 +12,7 @@ clusters:
                 - dbnode01:2379
 
 carbon:
+  findResultsIncludeBothExpandableAndLeaf: true
   ingester:
     listenAddress: "0.0.0.0:7204"
     rewrite:

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -491,6 +491,10 @@ type CarbonConfiguration struct {
 	// CompileEscapeAllNotOnlyQuotes will escape all characters when using a backslash
 	// in a quoted string rather than just reserving for escaping quotes.
 	CompileEscapeAllNotOnlyQuotes bool `yaml:"compileEscapeAllNotOnlyQuotes"`
+	// FindResultsIncludeBothExpandableAndLeaf will include both an expandable
+	// node and a leaf node if there is a duplicate path node that is both an
+	// expandable node and a leaf node.
+	FindResultsIncludeBothExpandableAndLeaf bool `yaml:"findResultsIncludeBothExpandableAndLeaf"`
 }
 
 // MiddlewareConfiguration is middleware-specific configuration.

--- a/src/query/api/v1/handler/graphite/find.go
+++ b/src/query/api/v1/handler/graphite/find.go
@@ -200,10 +200,10 @@ func (h *grahiteFindHandler) ServeHTTP(
 	}
 
 	// TODO: Support multiple result types
-	jsonOpts := findResultsJSONOptions{
+	resultOpts := findResultsOptions{
 		includeBothExpandableAndLeaf: h.graphiteStorageOpts.FindResultsIncludeBothExpandableAndLeaf,
 	}
-	if err := findResultsJSON(w, prefix, seenMap, jsonOpts); err != nil {
+	if err := findResultsJSON(w, prefix, seenMap, resultOpts); err != nil {
 		logger.Error("unable to render find results", zap.Error(err))
 	}
 }

--- a/src/query/api/v1/handler/graphite/find_parser.go
+++ b/src/query/api/v1/handler/graphite/find_parser.go
@@ -170,7 +170,7 @@ func parseFindParamsToQueries(r *http.Request) (
 	return terminatedQuery, childQuery, query, nil
 }
 
-type findResultsJSONOptions struct {
+type findResultsOptions struct {
 	includeBothExpandableAndLeaf bool
 }
 
@@ -178,7 +178,7 @@ func findResultsJSON(
 	w io.Writer,
 	prefix string,
 	tags map[string]nodeDescriptor,
-	opts findResultsJSONOptions,
+	opts findResultsOptions,
 ) error {
 	jw := json.NewWriter(w)
 	jw.BeginArray()
@@ -196,7 +196,7 @@ func writeFindNodeResultJSON(
 	prefix string,
 	value string,
 	descriptor nodeDescriptor,
-	opts findResultsJSONOptions,
+	opts findResultsOptions,
 ) {
 	id := fmt.Sprintf("%s%s", prefix, value)
 

--- a/src/query/api/v1/handler/graphite/find_parser.go
+++ b/src/query/api/v1/handler/graphite/find_parser.go
@@ -199,9 +199,6 @@ func writeFindNodeResultJSON(
 	opts findResultsJSONOptions,
 ) {
 	id := fmt.Sprintf("%s%s", prefix, value)
-	if descriptor.hasChildren {
-		writeFindResultJSON(jw, id, value, true)
-	}
 
 	// Include the leaf node only if no leaf was specified or
 	// if config optionally sets that both should come back.
@@ -212,6 +209,10 @@ func writeFindNodeResultJSON(
 			opts.includeBothExpandableAndLeaf)
 	if includeLeafNode {
 		writeFindResultJSON(jw, id, value, false)
+	}
+
+	if descriptor.hasChildren {
+		writeFindResultJSON(jw, id, value, true)
 	}
 }
 

--- a/src/query/api/v1/handler/graphite/find_test.go
+++ b/src/query/api/v1/handler/graphite/find_test.go
@@ -402,19 +402,19 @@ func testFind(t *testing.T, opts testFindOptions) {
 
 		var testVarations []testVariation
 		for _, limitTest := range testCaseLimitTests {
-			// Test case with default JSON options.
-			testVarations = append(testVarations, testVariation{
-				limitTest:                    limitTest,
-				includeBothExpandableAndLeaf: false,
-				expectedResults:              test.expectedResultsWithoutExpandableAndLeafDuplicates,
-			})
-
-			// Test case test for overloaded JSON options.
-			testVarations = append(testVarations, testVariation{
-				limitTest:                    limitTest,
-				includeBothExpandableAndLeaf: true,
-				expectedResults:              test.expectedResultsWithExpandableAndLeafDuplicates,
-			})
+			testVarations = append(testVarations,
+				// Test case with default find result options.
+				testVariation{
+					limitTest:                    limitTest,
+					includeBothExpandableAndLeaf: false,
+					expectedResults:              test.expectedResultsWithoutExpandableAndLeafDuplicates,
+				},
+				// Test case test for overloaded find result options.
+				testVariation{
+					limitTest:                    limitTest,
+					includeBothExpandableAndLeaf: true,
+					expectedResults:              test.expectedResultsWithExpandableAndLeafDuplicates,
+				})
 		}
 
 		for _, variation := range testVarations {

--- a/src/query/graphite/storage/m3_wrapper.go
+++ b/src/query/graphite/storage/m3_wrapper.go
@@ -70,6 +70,7 @@ type M3WrappedStorageOptions struct {
 	RenderPartialEnd                           bool
 	RenderSeriesAllNaNs                        bool
 	CompileEscapeAllNotOnlyQuotes              bool
+	FindResultsIncludeBothExpandableAndLeaf    bool
 }
 
 type seriesMetadata struct {

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -586,21 +586,22 @@ func Run(runOpts RunOptions) RunResult {
 		graphiteStorageOpts            graphite.M3WrappedStorageOptions
 	)
 	if cfg.Carbon != nil {
-		graphiteStorageOpts.AggregateNamespacesAllData =
-			cfg.Carbon.AggregateNamespacesAllData
-		graphiteStorageOpts.ShiftTimeStart = cfg.Carbon.ShiftTimeStart
-		graphiteStorageOpts.ShiftTimeEnd = cfg.Carbon.ShiftTimeEnd
-		graphiteStorageOpts.ShiftStepsStart = cfg.Carbon.ShiftStepsStart
-		graphiteStorageOpts.ShiftStepsEnd = cfg.Carbon.ShiftStepsEnd
-		graphiteStorageOpts.ShiftStepsStartWhenAtResolutionBoundary = cfg.Carbon.ShiftStepsStartWhenAtResolutionBoundary
-		graphiteStorageOpts.ShiftStepsEndWhenAtResolutionBoundary = cfg.Carbon.ShiftStepsEndWhenAtResolutionBoundary
-		graphiteStorageOpts.ShiftStepsEndWhenStartAtResolutionBoundary = cfg.Carbon.ShiftStepsEndWhenStartAtResolutionBoundary
-		graphiteStorageOpts.ShiftStepsStartWhenEndAtResolutionBoundary = cfg.Carbon.ShiftStepsStartWhenEndAtResolutionBoundary
-		graphiteStorageOpts.RenderPartialStart = cfg.Carbon.RenderPartialStart
-		graphiteStorageOpts.RenderPartialEnd = cfg.Carbon.RenderPartialEnd
-		graphiteStorageOpts.RenderSeriesAllNaNs = cfg.Carbon.RenderSeriesAllNaNs
-		graphiteStorageOpts.CompileEscapeAllNotOnlyQuotes = cfg.Carbon.CompileEscapeAllNotOnlyQuotes
-
+		graphiteStorageOpts = graphite.M3WrappedStorageOptions{
+			AggregateNamespacesAllData:                 cfg.Carbon.AggregateNamespacesAllData,
+			ShiftTimeStart:                             cfg.Carbon.ShiftTimeStart,
+			ShiftTimeEnd:                               cfg.Carbon.ShiftTimeEnd,
+			ShiftStepsStart:                            cfg.Carbon.ShiftStepsStart,
+			ShiftStepsEnd:                              cfg.Carbon.ShiftStepsEnd,
+			ShiftStepsStartWhenAtResolutionBoundary:    cfg.Carbon.ShiftStepsStartWhenAtResolutionBoundary,
+			ShiftStepsEndWhenAtResolutionBoundary:      cfg.Carbon.ShiftStepsEndWhenAtResolutionBoundary,
+			ShiftStepsEndWhenStartAtResolutionBoundary: cfg.Carbon.ShiftStepsEndWhenStartAtResolutionBoundary,
+			ShiftStepsStartWhenEndAtResolutionBoundary: cfg.Carbon.ShiftStepsStartWhenEndAtResolutionBoundary,
+			RenderPartialStart:                         cfg.Carbon.RenderPartialStart,
+			RenderPartialEnd:                           cfg.Carbon.RenderPartialEnd,
+			RenderSeriesAllNaNs:                        cfg.Carbon.RenderSeriesAllNaNs,
+			CompileEscapeAllNotOnlyQuotes:              cfg.Carbon.CompileEscapeAllNotOnlyQuotes,
+			FindResultsIncludeBothExpandableAndLeaf:    cfg.Carbon.FindResultsIncludeBothExpandableAndLeaf,
+		}
 		if limits := cfg.Carbon.LimitsFind; limits != nil {
 			fetchOptsBuilderLimitsOpts := limits.PerQuery.AsFetchOptionsBuilderLimitsOptions()
 			graphiteFindFetchOptsBuilder, err = handleroptions.NewFetchOptionsBuilder(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This more closely matches behavior of other Graphite implementations which only returns the value just once if both an expandable and leaf path value exists for the find endpoint.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
