### PR TITLE
Change TimedForResendEnabled to be a set of regexes against rollup IDs

### DIFF
--- a/src/aggregator/aggregator/aggregator.go
+++ b/src/aggregator/aggregator/aggregator.go
@@ -137,7 +137,7 @@ func NewAggregator(opts Options) Aggregator {
 	timerOpts := iOpts.TimerOptions()
 	logger := iOpts.Logger()
 
-	timedForResendEnabledRollupRegexes := make([]*regexp.Regexp, len(opts.TimedForResendEnabledRollupRegexes()))
+	timedForResendEnabledRollupRegexes := make([]*regexp.Regexp, 0, len(opts.TimedForResendEnabledRollupRegexes()))
 	for _, r := range opts.TimedForResendEnabledRollupRegexes() {
 		compiled, err := regexp.Compile(r)
 		if err != nil {

--- a/src/aggregator/aggregator/aggregator.go
+++ b/src/aggregator/aggregator/aggregator.go
@@ -113,7 +113,7 @@ type aggregator struct {
 	passthroughWriter                  writer.Writer
 	adminClient                        client.AdminClient
 	resignTimeout                      time.Duration
-	timedForResendEnabledRollupRegexes []*regexp.Regexp
+	timedForResendEnabledRollupRegexps []*regexp.Regexp
 
 	shardSetID         uint32
 	shardSetOpen       bool
@@ -151,7 +151,7 @@ func NewAggregator(opts Options) Aggregator {
 		passthroughWriter:                  opts.PassthroughWriter(),
 		adminClient:                        opts.AdminClient(),
 		resignTimeout:                      opts.ResignTimeout(),
-		timedForResendEnabledRollupRegexes: compileRegexps(logger, opts.TimedForResendEnabledRollupRegexes()),
+		timedForResendEnabledRollupRegexps: compileRegexps(logger, opts.TimedForResendEnabledRollupRegexps()),
 		doneCh:                             make(chan struct{}),
 		sleepFn:                            time.Sleep,
 		metrics:                            newAggregatorMetrics(scope, timerOpts, opts.MaxAllowedForwardingDelayFn()),
@@ -160,7 +160,7 @@ func NewAggregator(opts Options) Aggregator {
 }
 
 func compileRegexps(logger *zap.Logger, regexps []string) []*regexp.Regexp {
-	timedForResendEnabledRollupRegexes := make([]*regexp.Regexp, 0, len(regexps))
+	timedForResendEnabledRollupRegexps := make([]*regexp.Regexp, 0, len(regexps))
 	for _, r := range regexps {
 		compiled, err := regexp.Compile(r)
 		if err != nil {
@@ -169,9 +169,9 @@ func compileRegexps(logger *zap.Logger, regexps []string) []*regexp.Regexp {
 				zap.String("regexp", r))
 			continue
 		}
-		timedForResendEnabledRollupRegexes = append(timedForResendEnabledRollupRegexes, compiled)
+		timedForResendEnabledRollupRegexps = append(timedForResendEnabledRollupRegexps, compiled)
 	}
-	return timedForResendEnabledRollupRegexes
+	return timedForResendEnabledRollupRegexps
 }
 
 func (agg *aggregator) Open() error {
@@ -369,7 +369,7 @@ func (agg *aggregator) timedForResendEnabledOnPipeline(p metadata.PipelineMetada
 	if !p.ResendEnabled {
 		return false
 	}
-	if len(agg.timedForResendEnabledRollupRegexes) == 0 {
+	if len(agg.timedForResendEnabledRollupRegexps) == 0 {
 		return false
 	}
 	for _, op := range p.Pipeline.Operations {
@@ -377,7 +377,7 @@ func (agg *aggregator) timedForResendEnabledOnPipeline(p metadata.PipelineMetada
 			continue
 		}
 
-		for _, r := range agg.timedForResendEnabledRollupRegexes {
+		for _, r := range agg.timedForResendEnabledRollupRegexps {
 			if r.Match(op.Rollup.ID) {
 				return true
 			}

--- a/src/aggregator/aggregator/aggregator_test.go
+++ b/src/aggregator/aggregator/aggregator_test.go
@@ -50,13 +50,13 @@ import (
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
-	"go.uber.org/zap"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 )
 
 const (
@@ -426,7 +426,7 @@ func TestAggregatorAddUntimedToTimed(t *testing.T) {
 	logger := zap.NewNop()
 
 	agg, _ := testAggregator(t, ctrl)
-	agg.timedForResendEnabledRollupRegexes = compileRegexps(logger, []string{".*"})
+	agg.timedForResendEnabledRollupRegexps = compileRegexps(logger, []string{".*"})
 	metas := metadata.StagedMetadatas{testStagedMetadatas[0]}
 	// add another pipeline
 	metas[0].Pipelines = append(metas[0].Pipelines, metadata.PipelineMetadata{
@@ -473,7 +473,7 @@ func TestAggregatorAddUntimedToTimedDisabled(t *testing.T) {
 	defer ctrl.Finish()
 
 	agg, _ := testAggregator(t, ctrl)
-	agg.timedForResendEnabledRollupRegexes = nil
+	agg.timedForResendEnabledRollupRegexps = nil
 	metas := metadata.StagedMetadatas{testStagedMetadatas[0]}
 	// add another pipeline
 	metas[0].Pipelines = append(metas[0].Pipelines, metadata.PipelineMetadata{
@@ -1394,13 +1394,13 @@ func TestAggregatorAddForwardedMetrics(t *testing.T) {
 
 func TestPartitionResendEnabled(t *testing.T) {
 	aggAllMatches := NewAggregator(NewOptions(clock.NewOptions()).
-		SetTimedForResendEnabledRollupRegexes([]string{".*"})).(*aggregator)
+		SetTimedForResendEnabledRollupRegexps([]string{".*"})).(*aggregator)
 	aggEmpty := NewAggregator(NewOptions(clock.NewOptions()).
-		SetTimedForResendEnabledRollupRegexes([]string{})).(*aggregator)
+		SetTimedForResendEnabledRollupRegexps([]string{})).(*aggregator)
 	aggNoMatches := NewAggregator(NewOptions(clock.NewOptions()).
-		SetTimedForResendEnabledRollupRegexes([]string{".*123|456.*"})).(*aggregator)
+		SetTimedForResendEnabledRollupRegexps([]string{".*123|456.*"})).(*aggregator)
 	aggSomeMatches := NewAggregator(NewOptions(clock.NewOptions()).
-		SetTimedForResendEnabledRollupRegexes([]string{"1", "(2|3)"})).(*aggregator)
+		SetTimedForResendEnabledRollupRegexps([]string{"1", "(2|3)"})).(*aggregator)
 
 	aggs := []struct {
 		agg  *aggregator

--- a/src/aggregator/aggregator/aggregator_test.go
+++ b/src/aggregator/aggregator/aggregator_test.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 	"sort"
 	"testing"
 	"time"
@@ -47,6 +46,7 @@ import (
 	"github.com/m3db/m3/src/metrics/pipeline/applied"
 	"github.com/m3db/m3/src/metrics/policy"
 	"github.com/m3db/m3/src/metrics/transformation"
+	"github.com/m3db/m3/src/x/clock"
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/instrument"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -1391,25 +1391,14 @@ func TestAggregatorAddForwardedMetrics(t *testing.T) {
 }
 
 func TestPartitionResendEnabled(t *testing.T) {
-	aggAllMatches := &aggregator{
-		timedForResendEnabledRollupRegexes: []*regexp.Regexp{
-			regexp.MustCompile(".*"),
-		},
-	}
-	aggEmpty := &aggregator{
-		timedForResendEnabledRollupRegexes: []*regexp.Regexp{},
-	}
-	aggNoMatches := &aggregator{
-		timedForResendEnabledRollupRegexes: []*regexp.Regexp{
-			regexp.MustCompile(".*123|456.*"),
-		},
-	}
-	aggSomeMatches := &aggregator{
-		timedForResendEnabledRollupRegexes: []*regexp.Regexp{
-			regexp.MustCompile(".*1.*"),
-			regexp.MustCompile(".*(2|3).*"),
-		},
-	}
+	aggAllMatches := NewAggregator(NewOptions(clock.NewOptions()).
+		SetTimedForResendEnabledRollupRegexes([]string{".*"})).(*aggregator)
+	aggEmpty := NewAggregator(NewOptions(clock.NewOptions()).
+		SetTimedForResendEnabledRollupRegexes([]string{})).(*aggregator)
+	aggNoMatches := NewAggregator(NewOptions(clock.NewOptions()).
+		SetTimedForResendEnabledRollupRegexes([]string{".*123|456.*"})).(*aggregator)
+	aggSomeMatches := NewAggregator(NewOptions(clock.NewOptions()).
+		SetTimedForResendEnabledRollupRegexes([]string{"1", "(2|3)"})).(*aggregator)
 
 	aggs := []struct {
 		agg  *aggregator

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -348,58 +348,59 @@ type Options interface {
 	// are ignored for incoming writes.
 	SetWritesIgnoreCutoffCutover(value bool) Options
 
-	// TimedForResendEnabled is a feature flag that changes AddUntimed calls to AddTimed calls if the pipeline has
-	// resends enabled. This allows gracefully migrating from untimed to timed aggregated metrics.
-	TimedForResendEnabled() bool
+	// TimedForResendEnabledRollupRegexes is a set of regexes which define the rollup IDs to be migrated
+	// AddUntimed calls to AddTimed calls if the pipeline has resends enabled. This allows gracefully
+	// migrating from untimed to timed aggregated metrics on a per-rule basis.
+	TimedForResendEnabledRollupRegexes() []string
 
-	// SetTimedForResendEnabled sets TimedForResendEnabled.
-	SetTimedForResendEnabled(value bool) Options
+	// SetTimedForResendEnabledRollupRegexes sets TimedForResendEnabledRollupRegexes.
+	SetTimedForResendEnabledRollupRegexes([]string) Options
 }
 
 type options struct {
 	// Base options.
-	aggTypesOptions                  aggregation.TypesOptions
-	metricPrefix                     []byte
-	counterPrefix                    []byte
-	timerPrefix                      []byte
-	gaugePrefix                      []byte
-	timeLock                         *sync.RWMutex
-	clockOpts                        clock.Options
-	instrumentOpts                   instrument.Options
-	streamOpts                       cm.Options
-	adminClient                      client.AdminClient
-	runtimeOptsManager               runtime.OptionsManager
-	placementManager                 PlacementManager
-	shardFn                          sharding.ShardFn
-	bufferDurationBeforeShardCutover time.Duration
-	bufferDurationAfterShardCutoff   time.Duration
-	flushManager                     FlushManager
-	flushHandler                     handler.Handler
-	passthroughWriter                writer.Writer
-	entryTTL                         time.Duration
-	entryCheckInterval               time.Duration
-	entryCheckBatchPercent           float64
-	maxTimerBatchSizePerWrite        int
-	defaultStoragePolicies           []policy.StoragePolicy
-	flushTimesManager                FlushTimesManager
-	electionManager                  ElectionManager
-	resignTimeout                    time.Duration
-	maxAllowedForwardingDelayFn      MaxAllowedForwardingDelayFn
-	bufferForPastTimedMetric         time.Duration
-	bufferForPastTimedMetricFn       BufferForPastTimedMetricFn
-	bufferForFutureTimedMetric       time.Duration
-	maxNumCachedSourceSets           int
-	discardNaNAggregatedValues       bool
-	entryPool                        EntryPool
-	counterElemPool                  CounterElemPool
-	timerElemPool                    TimerElemPool
-	gaugeElemPool                    GaugeElemPool
-	verboseErrors                    bool
-	addToReset                       bool
-	timedMetricsFlushOffsetEnabled   bool
-	featureFlagBundlesParsed         []FeatureFlagBundleParsed
-	writesIgnoreCutoffCutover        bool
-	timedForResendEnabled            bool
+	aggTypesOptions                    aggregation.TypesOptions
+	metricPrefix                       []byte
+	counterPrefix                      []byte
+	timerPrefix                        []byte
+	gaugePrefix                        []byte
+	timeLock                           *sync.RWMutex
+	clockOpts                          clock.Options
+	instrumentOpts                     instrument.Options
+	streamOpts                         cm.Options
+	adminClient                        client.AdminClient
+	runtimeOptsManager                 runtime.OptionsManager
+	placementManager                   PlacementManager
+	shardFn                            sharding.ShardFn
+	bufferDurationBeforeShardCutover   time.Duration
+	bufferDurationAfterShardCutoff     time.Duration
+	flushManager                       FlushManager
+	flushHandler                       handler.Handler
+	passthroughWriter                  writer.Writer
+	entryTTL                           time.Duration
+	entryCheckInterval                 time.Duration
+	entryCheckBatchPercent             float64
+	maxTimerBatchSizePerWrite          int
+	defaultStoragePolicies             []policy.StoragePolicy
+	flushTimesManager                  FlushTimesManager
+	electionManager                    ElectionManager
+	resignTimeout                      time.Duration
+	maxAllowedForwardingDelayFn        MaxAllowedForwardingDelayFn
+	bufferForPastTimedMetric           time.Duration
+	bufferForPastTimedMetricFn         BufferForPastTimedMetricFn
+	bufferForFutureTimedMetric         time.Duration
+	maxNumCachedSourceSets             int
+	discardNaNAggregatedValues         bool
+	entryPool                          EntryPool
+	counterElemPool                    CounterElemPool
+	timerElemPool                      TimerElemPool
+	gaugeElemPool                      GaugeElemPool
+	verboseErrors                      bool
+	addToReset                         bool
+	timedMetricsFlushOffsetEnabled     bool
+	featureFlagBundlesParsed           []FeatureFlagBundleParsed
+	writesIgnoreCutoffCutover          bool
+	timedForResendEnabledRollupRegexes []string
 
 	// Derived options.
 	fullCounterPrefix []byte
@@ -938,14 +939,14 @@ func (o *options) SetWritesIgnoreCutoffCutover(value bool) Options {
 	return &opts
 }
 
-func (o *options) TimedForResendEnabled() bool {
-	return o.timedForResendEnabled
+func (o *options) TimedForResendEnabledRollupRegexes() []string {
+	return o.timedForResendEnabledRollupRegexes
 }
 
-// SetTimedForResendEnabled sets TimedForResendEnabled.
-func (o *options) SetTimedForResendEnabled(value bool) Options {
+// SetTimedForResendEnabledRollupRegexes sets TimedForResendEnabledRollupRegexes.
+func (o *options) SetTimedForResendEnabledRollupRegexes(value []string) Options {
 	opts := *o
-	opts.timedForResendEnabled = value
+	opts.timedForResendEnabledRollupRegexes = value
 	return &opts
 }
 

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -348,13 +348,13 @@ type Options interface {
 	// are ignored for incoming writes.
 	SetWritesIgnoreCutoffCutover(value bool) Options
 
-	// TimedForResendEnabledRollupRegexes is a set of regexes which define the rollup IDs to be migrated
+	// TimedForResendEnabledRollupRegexps is a set of regexes which define the rollup IDs to be migrated
 	// AddUntimed calls to AddTimed calls if the pipeline has resends enabled. This allows gracefully
 	// migrating from untimed to timed aggregated metrics on a per-rule basis.
-	TimedForResendEnabledRollupRegexes() []string
+	TimedForResendEnabledRollupRegexps() []string
 
-	// SetTimedForResendEnabledRollupRegexes sets TimedForResendEnabledRollupRegexes.
-	SetTimedForResendEnabledRollupRegexes([]string) Options
+	// SetTimedForResendEnabledRollupRegexps sets TimedForResendEnabledRollupRegexps.
+	SetTimedForResendEnabledRollupRegexps([]string) Options
 }
 
 type options struct {
@@ -400,7 +400,7 @@ type options struct {
 	timedMetricsFlushOffsetEnabled     bool
 	featureFlagBundlesParsed           []FeatureFlagBundleParsed
 	writesIgnoreCutoffCutover          bool
-	timedForResendEnabledRollupRegexes []string
+	timedForResendEnabledRollupRegexps []string
 
 	// Derived options.
 	fullCounterPrefix []byte
@@ -939,14 +939,14 @@ func (o *options) SetWritesIgnoreCutoffCutover(value bool) Options {
 	return &opts
 }
 
-func (o *options) TimedForResendEnabledRollupRegexes() []string {
-	return o.timedForResendEnabledRollupRegexes
+func (o *options) TimedForResendEnabledRollupRegexps() []string {
+	return o.timedForResendEnabledRollupRegexps
 }
 
-// SetTimedForResendEnabledRollupRegexes sets TimedForResendEnabledRollupRegexes.
-func (o *options) SetTimedForResendEnabledRollupRegexes(value []string) Options {
+// SetTimedForResendEnabledRollupRegexps sets TimedForResendEnabledRollupRegexps.
+func (o *options) SetTimedForResendEnabledRollupRegexps(value []string) Options {
 	opts := *o
-	opts.timedForResendEnabledRollupRegexes = value
+	opts.timedForResendEnabledRollupRegexps = value
 	return &opts
 }
 

--- a/src/aggregator/integration/setup.go
+++ b/src/aggregator/integration/setup.go
@@ -117,7 +117,7 @@ func newTestServerSetup(t *testing.T, opts testServerOptions) *testServerSetup {
 	// Creating the aggregator options.
 	clockOpts := opts.ClockOptions()
 	aggregatorOpts := aggregator.NewOptions(clockOpts).
-		SetTimedForResendEnabled(true).
+		SetTimedForResendEnabledRollupRegexes([]string{".*"}).
 		SetInstrumentOptions(opts.InstrumentOptions()).
 		SetAggregationTypesOptions(opts.AggregationTypesOptions()).
 		SetEntryCheckInterval(opts.EntryCheckInterval()).

--- a/src/aggregator/integration/setup.go
+++ b/src/aggregator/integration/setup.go
@@ -117,7 +117,7 @@ func newTestServerSetup(t *testing.T, opts testServerOptions) *testServerSetup {
 	// Creating the aggregator options.
 	clockOpts := opts.ClockOptions()
 	aggregatorOpts := aggregator.NewOptions(clockOpts).
-		SetTimedForResendEnabledRollupRegexes([]string{".*"}).
+		SetTimedForResendEnabledRollupRegexps([]string{".*"}).
 		SetInstrumentOptions(opts.InstrumentOptions()).
 		SetAggregationTypesOptions(opts.AggregationTypesOptions()).
 		SetEntryCheckInterval(opts.EntryCheckInterval()).

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -184,10 +184,10 @@ type AggregatorConfiguration struct {
 	// Must be in sync with m3msg WriterConfiguration.IgnoreCutoffCutover.
 	WritesIgnoreCutoffCutover bool `yaml:"writesIgnoreCutoffCutover"`
 
-	// TimedForResendEnabledRollupRegexes is a feature flag that gracefully transitions AddUntimed to AddTimed
-	// for pipelines that support resending aggregate values. The regexes are matched against the rollup IDs
+	// TimedForResendEnabledRollupRegexps is a feature flag that gracefully transitions AddUntimed to AddTimed
+	// for pipelines that support resending aggregate values. The regexps are matched against the rollup IDs
 	// to allow for incremental transition of existing rules to this new behavior.
-	TimedForResendEnabledRollupRegexes []string `yaml:"timedForResendEnabledRollupRegexes"`
+	TimedForResendEnabledRollupRegexps []string `yaml:"timedForResendEnabledRollupRegexps"`
 }
 
 // InstanceIDType is the instance ID type that defines how the
@@ -498,7 +498,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 
 	opts = opts.
 		SetWritesIgnoreCutoffCutover(c.WritesIgnoreCutoffCutover).
-		SetTimedForResendEnabledRollupRegexes(c.TimedForResendEnabledRollupRegexes)
+		SetTimedForResendEnabledRollupRegexps(c.TimedForResendEnabledRollupRegexps)
 
 	return opts, nil
 }

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -184,9 +184,10 @@ type AggregatorConfiguration struct {
 	// Must be in sync with m3msg WriterConfiguration.IgnoreCutoffCutover.
 	WritesIgnoreCutoffCutover bool `yaml:"writesIgnoreCutoffCutover"`
 
-	// TimedForResendEnabled is a feature flag that gracefully transitions AddUntimed to AddTimed for pipelines
-	// that support resending aggregate values.
-	TimedForResendEnabled bool `yaml:"timedForResendEnabled"`
+	// TimedForResendEnabledRollupRegexes is a feature flag that gracefully transitions AddUntimed to AddTimed
+	// for pipelines that support resending aggregate values. The regexes are matched against the rollup IDs
+	// to allow for incremental transition of existing rules to this new behavior.
+	TimedForResendEnabledRollupRegexes []string `yaml:"timedForResendEnabledRollupRegexes"`
 }
 
 // InstanceIDType is the instance ID type that defines how the
@@ -497,7 +498,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 
 	opts = opts.
 		SetWritesIgnoreCutoffCutover(c.WritesIgnoreCutoffCutover).
-		SetTimedForResendEnabled(c.TimedForResendEnabled)
+		SetTimedForResendEnabledRollupRegexes(c.TimedForResendEnabledRollupRegexes)
 
 	return opts, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Replace the `TimedForResendEnabled` feature flag with a set of regexes to allow for incrementally transitioning rollup rules over to using Timed instead of Untimed (as opposed to all or nothing via the original `bool`).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
