### PR TITLE
[tests] Add -y flag when downloading netcat

### DIFF
--- a/scripts/docker-integration-tests/run.sh
+++ b/scripts/docker-integration-tests/run.sh
@@ -26,7 +26,7 @@ if ! command -v nc && [[ "$BUILDKITE" == "true" ]]; then
 	echo "installing netcat"
 	NCDIR="$(mktemp -d)"
 
-	yumdownloader --destdir "$NCDIR" --resolve nc
+	yumdownloader -y --destdir "$NCDIR" --resolve nc
 	(
 		cd "$NCDIR"
 		RPM=$(find . -maxdepth 1 -name '*.rpm' | tail -n1)


### PR DESCRIPTION
We've been seeing integration test occasionally timeout when trying to install `netcat` because they're importing a new GPG key from Google:

```text
+ yumdownloader --destdir /tmp/tmp.oUFvI69mwM --resolve nc
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
amzn2-core                                               | 3.7 kB     00:00
google-cloud-sdk/signature                               |  844 B     00:00
Retrieving key from https://packages.cloud.google.com/yum/doc/yum-key.gpg
Importing GPG key 0x307EA071:
 Userid     : "Rapture Automatic Signing Key (cloud-rapture-signing-key-2021-03-01-08_01_09.pub)"
 Fingerprint: 7f92 e05b 3109 3bef 5a3c 2d38 feea 9169 307e a071
 From       : https://packages.cloud.google.com/yum/doc/yum-key.gpg
Is this ok [y/N]: # 
```

This commit adds a `-y` flag to allow `yumdownloader` to import the new key.
