### PR TITLE
Allow specifying read consistency for Cluster.Query

### DIFF
--- a/src/dbnode/client/client.go
+++ b/src/dbnode/client/client.go
@@ -53,8 +53,8 @@ func newClient(opts Options, asyncOpts ...Options) (*client, error) {
 	return &client{opts: opts, asyncOpts: asyncOpts, newSessionFn: newReplicatedSession}, nil
 }
 
-func (c *client) newSession() (AdminSession, error) {
-	session, err := c.newSessionFn(c.opts, c.asyncOpts)
+func (c *client) newSession(opts Options) (AdminSession, error) {
+	session, err := c.newSessionFn(opts, c.asyncOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (c *client) defaultSession() (AdminSession, error) {
 	}
 	c.Unlock()
 
-	session, err := c.newSession()
+	session, err := c.newSession(c.opts)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,11 @@ func (c *client) Options() Options {
 }
 
 func (c *client) NewSession() (Session, error) {
-	return c.newSession()
+	return c.newSession(c.opts)
+}
+
+func (c *client) NewSessionWithOpts(opts Options) (Session, error) {
+	return c.newSession(opts)
 }
 
 func (c *client) DefaultSession() (Session, error) {
@@ -103,7 +107,7 @@ func (c *client) DefaultSession() (Session, error) {
 }
 
 func (c *client) NewAdminSession() (AdminSession, error) {
-	return c.newSession()
+	return c.newSession(c.opts)
 }
 
 func (c *client) DefaultAdminSession() (AdminSession, error) {

--- a/src/dbnode/client/client.go
+++ b/src/dbnode/client/client.go
@@ -98,7 +98,7 @@ func (c *client) NewSession() (Session, error) {
 	return c.newSession(c.opts)
 }
 
-func (c *client) NewSessionWithOpts(opts Options) (Session, error) {
+func (c *client) NewSessionWithOptions(opts Options) (Session, error) {
 	return c.newSession(opts)
 }
 

--- a/src/dbnode/client/client_mock.go
+++ b/src/dbnode/client/client_mock.go
@@ -119,19 +119,19 @@ func (mr *MockClientMockRecorder) NewSession() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockClient)(nil).NewSession))
 }
 
-// NewSessionWithOpts mocks base method.
-func (m *MockClient) NewSessionWithOpts(opts Options) (Session, error) {
+// NewSessionWithOptions mocks base method.
+func (m *MockClient) NewSessionWithOptions(opts Options) (Session, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewSessionWithOpts", opts)
+	ret := m.ctrl.Call(m, "NewSessionWithOptions", opts)
 	ret0, _ := ret[0].(Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// NewSessionWithOpts indicates an expected call of NewSessionWithOpts.
-func (mr *MockClientMockRecorder) NewSessionWithOpts(opts interface{}) *gomock.Call {
+// NewSessionWithOptions indicates an expected call of NewSessionWithOptions.
+func (mr *MockClientMockRecorder) NewSessionWithOptions(opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSessionWithOpts", reflect.TypeOf((*MockClient)(nil).NewSessionWithOpts), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSessionWithOptions", reflect.TypeOf((*MockClient)(nil).NewSessionWithOptions), opts)
 }
 
 // Options mocks base method.
@@ -633,19 +633,19 @@ func (mr *MockAdminClientMockRecorder) NewSession() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockAdminClient)(nil).NewSession))
 }
 
-// NewSessionWithOpts mocks base method.
-func (m *MockAdminClient) NewSessionWithOpts(opts Options) (Session, error) {
+// NewSessionWithOptions mocks base method.
+func (m *MockAdminClient) NewSessionWithOptions(opts Options) (Session, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewSessionWithOpts", opts)
+	ret := m.ctrl.Call(m, "NewSessionWithOptions", opts)
 	ret0, _ := ret[0].(Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// NewSessionWithOpts indicates an expected call of NewSessionWithOpts.
-func (mr *MockAdminClientMockRecorder) NewSessionWithOpts(opts interface{}) *gomock.Call {
+// NewSessionWithOptions indicates an expected call of NewSessionWithOptions.
+func (mr *MockAdminClientMockRecorder) NewSessionWithOptions(opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSessionWithOpts", reflect.TypeOf((*MockAdminClient)(nil).NewSessionWithOpts), opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSessionWithOptions", reflect.TypeOf((*MockAdminClient)(nil).NewSessionWithOptions), opts)
 }
 
 // Options mocks base method.

--- a/src/dbnode/client/client_mock.go
+++ b/src/dbnode/client/client_mock.go
@@ -119,6 +119,21 @@ func (mr *MockClientMockRecorder) NewSession() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockClient)(nil).NewSession))
 }
 
+// NewSessionWithOpts mocks base method.
+func (m *MockClient) NewSessionWithOpts(opts Options) (Session, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewSessionWithOpts", opts)
+	ret0, _ := ret[0].(Session)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewSessionWithOpts indicates an expected call of NewSessionWithOpts.
+func (mr *MockClientMockRecorder) NewSessionWithOpts(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSessionWithOpts", reflect.TypeOf((*MockClient)(nil).NewSessionWithOpts), opts)
+}
+
 // Options mocks base method.
 func (m *MockClient) Options() Options {
 	m.ctrl.T.Helper()
@@ -616,6 +631,21 @@ func (m *MockAdminClient) NewSession() (Session, error) {
 func (mr *MockAdminClientMockRecorder) NewSession() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSession", reflect.TypeOf((*MockAdminClient)(nil).NewSession))
+}
+
+// NewSessionWithOpts mocks base method.
+func (m *MockAdminClient) NewSessionWithOpts(opts Options) (Session, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewSessionWithOpts", opts)
+	ret0, _ := ret[0].(Session)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewSessionWithOpts indicates an expected call of NewSessionWithOpts.
+func (mr *MockAdminClientMockRecorder) NewSessionWithOpts(opts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSessionWithOpts", reflect.TypeOf((*MockAdminClient)(nil).NewSessionWithOpts), opts)
 }
 
 // Options mocks base method.

--- a/src/dbnode/client/fetch_tagged_results_accumulator.go
+++ b/src/dbnode/client/fetch_tagged_results_accumulator.go
@@ -323,13 +323,14 @@ func (accum *fetchTaggedResultAccumulator) sliceResponsesAsSeriesIter(
 	nsID := pools.CheckedBytesWrapper().Get(elem.NameSpace)
 	seriesIter := pools.SeriesIterator().Get()
 	seriesIter.Reset(encoding.SeriesIteratorOptions{
-		ID:                         pools.ID().BinaryID(tsID),
-		Namespace:                  pools.ID().BinaryID(nsID),
-		Tags:                       decoder,
-		StartInclusive:             accum.startTime,
-		EndExclusive:               accum.endTime,
-		Replicas:                   iters,
-		SeriesIteratorConsolidator: opts.SeriesIteratorConsolidator,
+		ID:                            pools.ID().BinaryID(tsID),
+		Namespace:                     pools.ID().BinaryID(nsID),
+		Tags:                          decoder,
+		StartInclusive:                accum.startTime,
+		EndExclusive:                  accum.endTime,
+		Replicas:                      iters,
+		SeriesIteratorConsolidator:    opts.SeriesIteratorConsolidator,
+		IterateEqualTimestampStrategy: opts.IterateEqualTimestampStrategy,
 	})
 
 	return seriesIter

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -56,6 +56,9 @@ type Client interface {
 	// NewSession creates a new session.
 	NewSession() (Session, error)
 
+	// NewSessionWithOpts creates a new session with the provided Options.
+	NewSessionWithOpts(opts Options) (Session, error)
+
 	// DefaultSession creates a default session that gets reused.
 	DefaultSession() (Session, error)
 

--- a/src/dbnode/client/types.go
+++ b/src/dbnode/client/types.go
@@ -56,8 +56,8 @@ type Client interface {
 	// NewSession creates a new session.
 	NewSession() (Session, error)
 
-	// NewSessionWithOpts creates a new session with the provided Options.
-	NewSessionWithOpts(opts Options) (Session, error)
+	// NewSessionWithOptions creates a new session with the provided Options instead of the ones returned by Options.
+	NewSessionWithOptions(opts Options) (Session, error)
 
 	// DefaultSession creates a default session that gets reused.
 	DefaultSession() (Session, error)

--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -469,7 +469,7 @@ struct QueryRequest {
 	8: optional TimeType resultTimeType = TimeType.UNIX_SECONDS
 	9: optional binary source
 	// Additional options for the Cluster service.
-	10: optional ClusterQueryOptions clusterOptions;
+	10: optional ClusterQueryOptions clusterOptions
 }
 
 // ClusterQueryOptions are additional options for a QueryRequest to the Cluster service.

--- a/src/dbnode/generated/thrift/rpc.thrift
+++ b/src/dbnode/generated/thrift/rpc.thrift
@@ -468,6 +468,34 @@ struct QueryRequest {
 	7: optional TimeType rangeType = TimeType.UNIX_SECONDS
 	8: optional TimeType resultTimeType = TimeType.UNIX_SECONDS
 	9: optional binary source
+	// Additional options for the Cluster service.
+	10: optional ClusterQueryOptions clusterOptions;
+}
+
+// ClusterQueryOptions are additional options for a QueryRequest to the Cluster service.
+struct ClusterQueryOptions {
+        // The read consistency level to use for the query.
+        1: optional ReadConsistency readConsistency
+        // The strategy to resolve conflicts for different values for the same timestamp.
+        2: optional EqualTimestampStrategy conflictResolutionStrategy
+}
+
+// Enumeration of read consistency values. Matches ReadConsistencyLevel type in golang.
+enum ReadConsistency {
+	ONE,
+	UNSTRICT_MAJORITY,
+	MAJORITY,
+	UNSTRICT_ALL,
+	ALL
+}
+
+// Enumeration of strategies to resolve read conflicts for equal timestamps. Matches IterateEqualTimestampStrategy in
+// golang.
+enum EqualTimestampStrategy {
+        LAST_PUSHED,
+        HIGHEST_VALUE,
+        LOWEST_VALUE,
+        HIGHEST_FREQUENCY,
 }
 
 struct QueryResult {

--- a/src/dbnode/generated/thrift/rpc/rpc.go
+++ b/src/dbnode/generated/thrift/rpc/rpc.go
@@ -283,6 +283,147 @@ func (p *AggregateQueryType) Value() (driver.Value, error) {
 	return int64(*p), nil
 }
 
+type ReadConsistency int64
+
+const (
+	ReadConsistency_ONE               ReadConsistency = 0
+	ReadConsistency_UNSTRICT_MAJORITY ReadConsistency = 1
+	ReadConsistency_MAJORITY          ReadConsistency = 2
+	ReadConsistency_UNSTRICT_ALL      ReadConsistency = 3
+	ReadConsistency_ALL               ReadConsistency = 4
+)
+
+func (p ReadConsistency) String() string {
+	switch p {
+	case ReadConsistency_ONE:
+		return "ONE"
+	case ReadConsistency_UNSTRICT_MAJORITY:
+		return "UNSTRICT_MAJORITY"
+	case ReadConsistency_MAJORITY:
+		return "MAJORITY"
+	case ReadConsistency_UNSTRICT_ALL:
+		return "UNSTRICT_ALL"
+	case ReadConsistency_ALL:
+		return "ALL"
+	}
+	return "<UNSET>"
+}
+
+func ReadConsistencyFromString(s string) (ReadConsistency, error) {
+	switch s {
+	case "ONE":
+		return ReadConsistency_ONE, nil
+	case "UNSTRICT_MAJORITY":
+		return ReadConsistency_UNSTRICT_MAJORITY, nil
+	case "MAJORITY":
+		return ReadConsistency_MAJORITY, nil
+	case "UNSTRICT_ALL":
+		return ReadConsistency_UNSTRICT_ALL, nil
+	case "ALL":
+		return ReadConsistency_ALL, nil
+	}
+	return ReadConsistency(0), fmt.Errorf("not a valid ReadConsistency string")
+}
+
+func ReadConsistencyPtr(v ReadConsistency) *ReadConsistency { return &v }
+
+func (p ReadConsistency) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *ReadConsistency) UnmarshalText(text []byte) error {
+	q, err := ReadConsistencyFromString(string(text))
+	if err != nil {
+		return err
+	}
+	*p = q
+	return nil
+}
+
+func (p *ReadConsistency) Scan(value interface{}) error {
+	v, ok := value.(int64)
+	if !ok {
+		return errors.New("Scan value is not int64")
+	}
+	*p = ReadConsistency(v)
+	return nil
+}
+
+func (p *ReadConsistency) Value() (driver.Value, error) {
+	if p == nil {
+		return nil, nil
+	}
+	return int64(*p), nil
+}
+
+type EqualTimestampStrategy int64
+
+const (
+	EqualTimestampStrategy_LAST_PUSHED       EqualTimestampStrategy = 0
+	EqualTimestampStrategy_HIGHEST_VALUE     EqualTimestampStrategy = 1
+	EqualTimestampStrategy_LOWEST_VALUE      EqualTimestampStrategy = 2
+	EqualTimestampStrategy_HIGHEST_FREQUENCY EqualTimestampStrategy = 3
+)
+
+func (p EqualTimestampStrategy) String() string {
+	switch p {
+	case EqualTimestampStrategy_LAST_PUSHED:
+		return "LAST_PUSHED"
+	case EqualTimestampStrategy_HIGHEST_VALUE:
+		return "HIGHEST_VALUE"
+	case EqualTimestampStrategy_LOWEST_VALUE:
+		return "LOWEST_VALUE"
+	case EqualTimestampStrategy_HIGHEST_FREQUENCY:
+		return "HIGHEST_FREQUENCY"
+	}
+	return "<UNSET>"
+}
+
+func EqualTimestampStrategyFromString(s string) (EqualTimestampStrategy, error) {
+	switch s {
+	case "LAST_PUSHED":
+		return EqualTimestampStrategy_LAST_PUSHED, nil
+	case "HIGHEST_VALUE":
+		return EqualTimestampStrategy_HIGHEST_VALUE, nil
+	case "LOWEST_VALUE":
+		return EqualTimestampStrategy_LOWEST_VALUE, nil
+	case "HIGHEST_FREQUENCY":
+		return EqualTimestampStrategy_HIGHEST_FREQUENCY, nil
+	}
+	return EqualTimestampStrategy(0), fmt.Errorf("not a valid EqualTimestampStrategy string")
+}
+
+func EqualTimestampStrategyPtr(v EqualTimestampStrategy) *EqualTimestampStrategy { return &v }
+
+func (p EqualTimestampStrategy) MarshalText() ([]byte, error) {
+	return []byte(p.String()), nil
+}
+
+func (p *EqualTimestampStrategy) UnmarshalText(text []byte) error {
+	q, err := EqualTimestampStrategyFromString(string(text))
+	if err != nil {
+		return err
+	}
+	*p = q
+	return nil
+}
+
+func (p *EqualTimestampStrategy) Scan(value interface{}) error {
+	v, ok := value.(int64)
+	if !ok {
+		return errors.New("Scan value is not int64")
+	}
+	*p = EqualTimestampStrategy(v)
+	return nil
+}
+
+func (p *EqualTimestampStrategy) Value() (driver.Value, error) {
+	if p == nil {
+		return nil, nil
+	}
+	return int64(*p), nil
+}
+
 // Attributes:
 //  - Type
 //  - Message
@@ -11846,16 +11987,18 @@ func (p *AggregateQueryResultTagValueElement) String() string {
 //  - RangeType
 //  - ResultTimeType
 //  - Source
+//  - ClusterOptions
 type QueryRequest struct {
-	Query          *Query   `thrift:"query,1,required" db:"query" json:"query"`
-	RangeStart     int64    `thrift:"rangeStart,2,required" db:"rangeStart" json:"rangeStart"`
-	RangeEnd       int64    `thrift:"rangeEnd,3,required" db:"rangeEnd" json:"rangeEnd"`
-	NameSpace      string   `thrift:"nameSpace,4,required" db:"nameSpace" json:"nameSpace"`
-	Limit          *int64   `thrift:"limit,5" db:"limit" json:"limit,omitempty"`
-	NoData         *bool    `thrift:"noData,6" db:"noData" json:"noData,omitempty"`
-	RangeType      TimeType `thrift:"rangeType,7" db:"rangeType" json:"rangeType,omitempty"`
-	ResultTimeType TimeType `thrift:"resultTimeType,8" db:"resultTimeType" json:"resultTimeType,omitempty"`
-	Source         []byte   `thrift:"source,9" db:"source" json:"source,omitempty"`
+	Query          *Query               `thrift:"query,1,required" db:"query" json:"query"`
+	RangeStart     int64                `thrift:"rangeStart,2,required" db:"rangeStart" json:"rangeStart"`
+	RangeEnd       int64                `thrift:"rangeEnd,3,required" db:"rangeEnd" json:"rangeEnd"`
+	NameSpace      string               `thrift:"nameSpace,4,required" db:"nameSpace" json:"nameSpace"`
+	Limit          *int64               `thrift:"limit,5" db:"limit" json:"limit,omitempty"`
+	NoData         *bool                `thrift:"noData,6" db:"noData" json:"noData,omitempty"`
+	RangeType      TimeType             `thrift:"rangeType,7" db:"rangeType" json:"rangeType,omitempty"`
+	ResultTimeType TimeType             `thrift:"resultTimeType,8" db:"resultTimeType" json:"resultTimeType,omitempty"`
+	Source         []byte               `thrift:"source,9" db:"source" json:"source,omitempty"`
+	ClusterOptions *ClusterQueryOptions `thrift:"clusterOptions,10" db:"clusterOptions" json:"clusterOptions,omitempty"`
 }
 
 func NewQueryRequest() *QueryRequest {
@@ -11922,6 +12065,15 @@ var QueryRequest_Source_DEFAULT []byte
 func (p *QueryRequest) GetSource() []byte {
 	return p.Source
 }
+
+var QueryRequest_ClusterOptions_DEFAULT *ClusterQueryOptions
+
+func (p *QueryRequest) GetClusterOptions() *ClusterQueryOptions {
+	if !p.IsSetClusterOptions() {
+		return QueryRequest_ClusterOptions_DEFAULT
+	}
+	return p.ClusterOptions
+}
 func (p *QueryRequest) IsSetQuery() bool {
 	return p.Query != nil
 }
@@ -11944,6 +12096,10 @@ func (p *QueryRequest) IsSetResultTimeType() bool {
 
 func (p *QueryRequest) IsSetSource() bool {
 	return p.Source != nil
+}
+
+func (p *QueryRequest) IsSetClusterOptions() bool {
+	return p.ClusterOptions != nil
 }
 
 func (p *QueryRequest) Read(iprot thrift.TProtocol) error {
@@ -12003,6 +12159,10 @@ func (p *QueryRequest) Read(iprot thrift.TProtocol) error {
 			}
 		case 9:
 			if err := p.ReadField9(iprot); err != nil {
+				return err
+			}
+		case 10:
+			if err := p.ReadField10(iprot); err != nil {
 				return err
 			}
 		default:
@@ -12114,6 +12274,14 @@ func (p *QueryRequest) ReadField9(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *QueryRequest) ReadField10(iprot thrift.TProtocol) error {
+	p.ClusterOptions = &ClusterQueryOptions{}
+	if err := p.ClusterOptions.Read(iprot); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.ClusterOptions), err)
+	}
+	return nil
+}
+
 func (p *QueryRequest) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("QueryRequest"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -12144,6 +12312,9 @@ func (p *QueryRequest) Write(oprot thrift.TProtocol) error {
 			return err
 		}
 		if err := p.writeField9(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField10(oprot); err != nil {
 			return err
 		}
 	}
@@ -12283,11 +12454,178 @@ func (p *QueryRequest) writeField9(oprot thrift.TProtocol) (err error) {
 	return err
 }
 
+func (p *QueryRequest) writeField10(oprot thrift.TProtocol) (err error) {
+	if p.IsSetClusterOptions() {
+		if err := oprot.WriteFieldBegin("clusterOptions", thrift.STRUCT, 10); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 10:clusterOptions: ", p), err)
+		}
+		if err := p.ClusterOptions.Write(oprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.ClusterOptions), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 10:clusterOptions: ", p), err)
+		}
+	}
+	return err
+}
+
 func (p *QueryRequest) String() string {
 	if p == nil {
 		return "<nil>"
 	}
 	return fmt.Sprintf("QueryRequest(%+v)", *p)
+}
+
+// Attributes:
+//  - ReadConsistency
+//  - ConflictResolutionStrategy
+type ClusterQueryOptions struct {
+	ReadConsistency            *ReadConsistency        `thrift:"readConsistency,1" db:"readConsistency" json:"readConsistency,omitempty"`
+	ConflictResolutionStrategy *EqualTimestampStrategy `thrift:"conflictResolutionStrategy,2" db:"conflictResolutionStrategy" json:"conflictResolutionStrategy,omitempty"`
+}
+
+func NewClusterQueryOptions() *ClusterQueryOptions {
+	return &ClusterQueryOptions{}
+}
+
+var ClusterQueryOptions_ReadConsistency_DEFAULT ReadConsistency
+
+func (p *ClusterQueryOptions) GetReadConsistency() ReadConsistency {
+	if !p.IsSetReadConsistency() {
+		return ClusterQueryOptions_ReadConsistency_DEFAULT
+	}
+	return *p.ReadConsistency
+}
+
+var ClusterQueryOptions_ConflictResolutionStrategy_DEFAULT EqualTimestampStrategy
+
+func (p *ClusterQueryOptions) GetConflictResolutionStrategy() EqualTimestampStrategy {
+	if !p.IsSetConflictResolutionStrategy() {
+		return ClusterQueryOptions_ConflictResolutionStrategy_DEFAULT
+	}
+	return *p.ConflictResolutionStrategy
+}
+func (p *ClusterQueryOptions) IsSetReadConsistency() bool {
+	return p.ReadConsistency != nil
+}
+
+func (p *ClusterQueryOptions) IsSetConflictResolutionStrategy() bool {
+	return p.ConflictResolutionStrategy != nil
+}
+
+func (p *ClusterQueryOptions) Read(iprot thrift.TProtocol) error {
+	if _, err := iprot.ReadStructBegin(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err := iprot.ReadFieldBegin()
+		if err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T field %d read error: ", p, fieldId), err)
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if err := p.ReadField1(iprot); err != nil {
+				return err
+			}
+		case 2:
+			if err := p.ReadField2(iprot); err != nil {
+				return err
+			}
+		default:
+			if err := iprot.Skip(fieldTypeId); err != nil {
+				return err
+			}
+		}
+		if err := iprot.ReadFieldEnd(); err != nil {
+			return err
+		}
+	}
+	if err := iprot.ReadStructEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	return nil
+}
+
+func (p *ClusterQueryOptions) ReadField1(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI32(); err != nil {
+		return thrift.PrependError("error reading field 1: ", err)
+	} else {
+		temp := ReadConsistency(v)
+		p.ReadConsistency = &temp
+	}
+	return nil
+}
+
+func (p *ClusterQueryOptions) ReadField2(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI32(); err != nil {
+		return thrift.PrependError("error reading field 2: ", err)
+	} else {
+		temp := EqualTimestampStrategy(v)
+		p.ConflictResolutionStrategy = &temp
+	}
+	return nil
+}
+
+func (p *ClusterQueryOptions) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteStructBegin("ClusterQueryOptions"); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+	}
+	if p != nil {
+		if err := p.writeField1(oprot); err != nil {
+			return err
+		}
+		if err := p.writeField2(oprot); err != nil {
+			return err
+		}
+	}
+	if err := oprot.WriteFieldStop(); err != nil {
+		return thrift.PrependError("write field stop error: ", err)
+	}
+	if err := oprot.WriteStructEnd(); err != nil {
+		return thrift.PrependError("write struct stop error: ", err)
+	}
+	return nil
+}
+
+func (p *ClusterQueryOptions) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetReadConsistency() {
+		if err := oprot.WriteFieldBegin("readConsistency", thrift.I32, 1); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:readConsistency: ", p), err)
+		}
+		if err := oprot.WriteI32(int32(*p.ReadConsistency)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.readConsistency (1) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 1:readConsistency: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *ClusterQueryOptions) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetConflictResolutionStrategy() {
+		if err := oprot.WriteFieldBegin("conflictResolutionStrategy", thrift.I32, 2); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:conflictResolutionStrategy: ", p), err)
+		}
+		if err := oprot.WriteI32(int32(*p.ConflictResolutionStrategy)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.conflictResolutionStrategy (2) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 2:conflictResolutionStrategy: ", p), err)
+		}
+	}
+	return err
+}
+
+func (p *ClusterQueryOptions) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("ClusterQueryOptions(%+v)", *p)
 }
 
 // Attributes:

--- a/src/dbnode/network/server/httpjson/handlers_test.go
+++ b/src/dbnode/network/server/httpjson/handlers_test.go
@@ -52,7 +52,7 @@ var (
 func newTestClient(ctrl *gomock.Controller) *client.MockClient {
 	client := client.NewMockClient(ctrl)
 	client.EXPECT().Options().Return(testClientOptions).AnyTimes()
-	client.EXPECT().DefaultSession().Return(nil, errTestClientSessionError).AnyTimes()
+	client.EXPECT().NewSessionWithOptions(gomock.Any()).Return(nil, errTestClientSessionError).AnyTimes()
 	return client
 }
 

--- a/src/dbnode/network/server/tchannelthrift/cluster/service.go
+++ b/src/dbnode/network/server/tchannelthrift/cluster/service.go
@@ -26,11 +26,13 @@ import (
 	"sync"
 
 	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/dbnode/encoding"
 	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
 	"github.com/m3db/m3/src/dbnode/network/server/tchannelthrift"
 	"github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/convert"
 	tterrors "github.com/m3db/m3/src/dbnode/network/server/tchannelthrift/errors"
 	"github.com/m3db/m3/src/dbnode/storage/index"
+	"github.com/m3db/m3/src/dbnode/topology"
 	"github.com/m3db/m3/src/x/checked"
 	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/ident"
@@ -43,56 +45,73 @@ type service struct {
 	sync.RWMutex
 
 	client client.Client
-	active client.Session
+	active map[sessionOpts]client.Session
 	opts   client.Options
 	idPool ident.Pool
 	health *rpc.HealthResult_
 }
 
+// a composite key to lookup the type of session for the request.
+type sessionOpts struct {
+	readConsistency        topology.ReadConsistencyLevel
+	equalTimestampStrategy encoding.IterateEqualTimestampStrategy
+}
+
 // NewService creates a new cluster TChannel Thrift service
-func NewService(client client.Client) rpc.TChanCluster {
+func NewService(c client.Client) rpc.TChanCluster {
 	s := &service{
-		client: client,
-		opts:   client.Options(),
-		idPool: client.Options().IdentifierPool(),
+		client: c,
+		active: make(map[sessionOpts]client.Session),
+		opts:   c.Options(),
+		idPool: c.Options().IdentifierPool(),
 		health: &rpc.HealthResult_{Ok: true, Status: "up"},
 	}
 	return s
 }
 
 func (s *service) session() (client.Session, error) {
+	return s.sessionForOpts(s.sessionOptsFromClusterQueryOpts(nil))
+}
+
+func (s *service) sessionForOpts(opts sessionOpts) (client.Session, error) {
 	s.RLock()
-	session := s.active
+	session := s.active[opts]
 	s.RUnlock()
 	if session != nil {
 		return session, nil
 	}
 
 	s.Lock()
-	if s.active != nil {
-		session := s.active
+	session = s.active[opts]
+	if session != nil {
 		s.Unlock()
 		return session, nil
 	}
-	session, err := s.client.DefaultSession()
+	clientOpts := s.client.Options()
+	iterOpts := clientOpts.IterationOptions()
+	iterOpts.IterateEqualTimestampStrategy = opts.equalTimestampStrategy
+	clientOpts = clientOpts.
+		SetReadConsistencyLevel(opts.readConsistency).
+		SetIterationOptions(iterOpts)
+	session, err := s.client.NewSessionWithOpts(clientOpts)
 	if err != nil {
 		s.Unlock()
 		return nil, err
 	}
-	s.active = session
+	s.active[opts] = session
 	s.Unlock()
 
 	return session, nil
 }
 
 func (s *service) Close() error {
-	var err error
+	var multiErr xerrors.MultiError
 	s.Lock()
-	if s.active != nil {
-		err = s.active.Close()
+	for _, sess := range s.active {
+		multiErr = multiErr.Add(sess.Close())
 	}
 	s.Unlock()
-	return err
+	return multiErr.FinalError()
 }
 
 func (s *service) Health(ctx thrift.Context) (*rpc.HealthResult_, error) {
@@ -128,7 +147,7 @@ func (s *service) Query(tctx thrift.Context, req *rpc.QueryRequest) (*rpc.QueryR
 		opts.Source = req.Source
 	}
 
-	session, err := s.session()
+	session, err := s.sessionForOpts(s.sessionOptsFromClusterQueryOpts(req.ClusterOptions))
 	if err != nil {
 		return nil, convert.ToRPCError(err)
 	}
@@ -401,4 +420,45 @@ func (s *service) Truncate(tctx thrift.Context, req *rpc.TruncateRequest) (*rpc.
 	res := rpc.NewTruncateResult_()
 	res.NumSeries = truncated
 	return res, nil
+}
+
+func (s *service) sessionOptsFromClusterQueryOpts(clusterOpts *rpc.ClusterQueryOptions) sessionOpts {
+	sessOpts := sessionOpts{
+		readConsistency:        s.opts.ReadConsistencyLevel(),
+		equalTimestampStrategy: s.opts.IterationOptions().IterateEqualTimestampStrategy,
+	}
+	if clusterOpts == nil {
+		return sessOpts
+	}
+	if clusterOpts.ConflictResolutionStrategy != nil {
+		switch *clusterOpts.ConflictResolutionStrategy {
+		case rpc.EqualTimestampStrategy_LAST_PUSHED:
+			sessOpts.equalTimestampStrategy = encoding.IterateLastPushed
+		case rpc.EqualTimestampStrategy_LOWEST_VALUE:
+			sessOpts.equalTimestampStrategy = encoding.IterateLowestValue
+		case rpc.EqualTimestampStrategy_HIGHEST_VALUE:
+			sessOpts.equalTimestampStrategy = encoding.IterateHighestValue
+		case rpc.EqualTimestampStrategy_HIGHEST_FREQUENCY:
+			sessOpts.equalTimestampStrategy = encoding.IterateHighestFrequencyValue
+		default:
+			sessOpts.equalTimestampStrategy = encoding.DefaultIterateEqualTimestampStrategy
+		}
+	}
+	if clusterOpts.ReadConsistency != nil {
+		switch *clusterOpts.ReadConsistency {
+		case rpc.ReadConsistency_ONE:
+			sessOpts.readConsistency = topology.ReadConsistencyLevelOne
+		case rpc.ReadConsistency_UNSTRICT_MAJORITY:
+			sessOpts.readConsistency = topology.ReadConsistencyLevelUnstrictMajority
+		case rpc.ReadConsistency_MAJORITY:
+			sessOpts.readConsistency = topology.ReadConsistencyLevelMajority
+		case rpc.ReadConsistency_UNSTRICT_ALL:
+			sessOpts.readConsistency = topology.ReadConsistencyLevelUnstrictAll
+		case rpc.ReadConsistency_ALL:
+			sessOpts.readConsistency = topology.ReadConsistencyLevelAll
+		default:
+			sessOpts.readConsistency = topology.ReadConsistencyLevelNone
+		}
+	}
+	return sessOpts
 }

--- a/src/dbnode/network/server/tchannelthrift/cluster/service.go
+++ b/src/dbnode/network/server/tchannelthrift/cluster/service.go
@@ -93,7 +93,7 @@ func (s *service) sessionForOpts(opts sessionOpts) (client.Session, error) {
 	clientOpts = clientOpts.
 		SetReadConsistencyLevel(opts.readConsistency).
 		SetIterationOptions(iterOpts)
-	session, err := s.client.NewSessionWithOpts(clientOpts)
+	session, err := s.client.NewSessionWithOptions(clientOpts)
 	if err != nil {
 		s.Unlock()
 		return nil, err

--- a/src/dbnode/network/server/tchannelthrift/cluster/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/cluster/service_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cluster
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/thrift"
+
+	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/dbnode/generated/thrift/rpc"
+	"github.com/m3db/m3/src/dbnode/storage/index"
+	"github.com/m3db/m3/src/dbnode/topology"
+	xtest "github.com/m3db/m3/src/x/test"
+)
+
+func TestSessionOpts(t *testing.T) {
+	clientOpts := client.NewOptions().
+		SetIterationOptions(index.IterationOptions{
+			IterateEqualTimestampStrategy: encoding.IterateLowestValue,
+		}).
+		SetReadConsistencyLevel(topology.ReadConsistencyLevelMajority)
+	rcAll := rpc.ReadConsistency_ALL
+	csHighest := rpc.EqualTimestampStrategy_HIGHEST_VALUE
+	cases := []struct {
+		name     string
+		reqOpts  *rpc.ClusterQueryOptions
+		sessOpts sessionOpts
+	}{
+		{
+			name: "nil opts",
+			sessOpts: sessionOpts{
+				readConsistency:        topology.ReadConsistencyLevelMajority,
+				equalTimestampStrategy: encoding.IterateLowestValue,
+			},
+		},
+		{
+			name:    "not set",
+			reqOpts: &rpc.ClusterQueryOptions{},
+			sessOpts: sessionOpts{
+				readConsistency:        topology.ReadConsistencyLevelMajority,
+				equalTimestampStrategy: encoding.IterateLowestValue,
+			},
+		},
+		{
+			name: "only read consistency",
+			reqOpts: &rpc.ClusterQueryOptions{
+				ReadConsistency: &rcAll,
+			},
+			sessOpts: sessionOpts{
+				readConsistency:        topology.ReadConsistencyLevelAll,
+				equalTimestampStrategy: encoding.IterateLowestValue,
+			},
+		},
+		{
+			name: "only conflict strategy",
+			reqOpts: &rpc.ClusterQueryOptions{
+				ConflictResolutionStrategy: &csHighest,
+			},
+			sessOpts: sessionOpts{
+				readConsistency:        topology.ReadConsistencyLevelMajority,
+				equalTimestampStrategy: encoding.IterateHighestValue,
+			},
+		},
+		{
+			name: "both set",
+			reqOpts: &rpc.ClusterQueryOptions{
+				ReadConsistency:            &rcAll,
+				ConflictResolutionStrategy: &csHighest,
+			},
+			sessOpts: sessionOpts{
+				readConsistency:        topology.ReadConsistencyLevelAll,
+				equalTimestampStrategy: encoding.IterateHighestValue,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := xtest.NewController(t)
+			defer ctrl.Finish()
+
+			c := client.NewMockClient(ctrl)
+			c.EXPECT().Options().Return(clientOpts).AnyTimes()
+			sess := client.NewMockSession(ctrl)
+			iters := encoding.NewMockSeriesIterators(ctrl)
+			sess.EXPECT().FetchTagged(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				iters, client.FetchResponseMetadata{}, nil)
+			iters.EXPECT().Len().Return(0)
+			iters.EXPECT().Iters().Return(nil)
+			iters.EXPECT().Close()
+
+			ctx, cancel := thrift.NewContext(time.Second)
+			defer cancel()
+			req := &rpc.QueryRequest{
+				ClusterOptions: tc.reqOpts,
+			}
+			c.EXPECT().NewSessionWithOpts(tc.sessOpts).Return(sess, nil)
+			s := NewService(c).(*service)
+			res, err := s.Query(ctx, req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+		})
+	}
+}
+
+func (s sessionOpts) Matches(x interface{}) bool {
+	if c, ok := x.(client.Options); ok {
+		return s.equalTimestampStrategy == c.IterationOptions().IterateEqualTimestampStrategy &&
+			s.readConsistency == c.ReadConsistencyLevel()
+	}
+	return false
+}
+
+func (s sessionOpts) String() string {
+	return fmt.Sprintf("%v %v", s.readConsistency, s.equalTimestampStrategy)
+}
+
+var _ gomock.Matcher = &sessionOpts{}

--- a/src/dbnode/network/server/tchannelthrift/cluster/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/cluster/service_test.go
@@ -73,6 +73,7 @@ func TestSessionOpts(t *testing.T) {
 			sessOpts: sessionOpts{
 				readConsistency:        topology.ReadConsistencyLevelAll,
 				equalTimestampStrategy: encoding.IterateLowestValue,
+				consistencyOverride:    true,
 			},
 		},
 		{
@@ -94,6 +95,7 @@ func TestSessionOpts(t *testing.T) {
 			sessOpts: sessionOpts{
 				readConsistency:        topology.ReadConsistencyLevelAll,
 				equalTimestampStrategy: encoding.IterateHighestValue,
+				consistencyOverride:    true,
 			},
 		},
 	}
@@ -130,8 +132,16 @@ func TestSessionOpts(t *testing.T) {
 
 func (s sessionOpts) Matches(x interface{}) bool {
 	if c, ok := x.(client.Options); ok {
-		return s.equalTimestampStrategy == c.IterationOptions().IterateEqualTimestampStrategy &&
-			s.readConsistency == c.ReadConsistencyLevel()
+		if s.equalTimestampStrategy != c.IterationOptions().IterateEqualTimestampStrategy {
+			return false
+		}
+		if s.readConsistency != c.ReadConsistencyLevel() {
+			return false
+		}
+		if s.consistencyOverride && c.RuntimeOptionsManager() != nil {
+			return false
+		}
+		return true
 	}
 	return false
 }

--- a/src/dbnode/network/server/tchannelthrift/cluster/service_test.go
+++ b/src/dbnode/network/server/tchannelthrift/cluster/service_test.go
@@ -119,7 +119,7 @@ func TestSessionOpts(t *testing.T) {
 			req := &rpc.QueryRequest{
 				ClusterOptions: tc.reqOpts,
 			}
-			c.EXPECT().NewSessionWithOpts(tc.sessOpts).Return(sess, nil)
+			c.EXPECT().NewSessionWithOptions(tc.sessOpts).Return(sess, nil)
 			s := NewService(c).(*service)
 			res, err := s.Query(ctx, req)
 			require.NoError(t, err)

--- a/src/dbnode/storage/index/types.go
+++ b/src/dbnode/storage/index/types.go
@@ -118,6 +118,8 @@ type WideQueryOptions struct {
 type IterationOptions struct {
 	// SeriesIteratorConsolidator provides additional series consolidations.
 	SeriesIteratorConsolidator encoding.SeriesIteratorConsolidator
+	// IterateEqualTimestampStrategy provides the conflict resolution strategy for the same timestamp.
+	IterateEqualTimestampStrategy encoding.IterateEqualTimestampStrategy
 }
 
 // AggregationOptions enables users to specify constraints on aggregations.


### PR DESCRIPTION
Additionally you can specify the conflict resolution strategy to use
when there are different values for the same timestamp.

This is helpful for inspecting the raw data in the database and to use a
stricter read consistency to verify the data exists on all replicas.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
