### PR TITLE
[query] Log summary of time series labels upon "literal too long" error

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -75,9 +75,9 @@ const (
 	// maxLiteralIsTooLongLogCount is the number of times the time series labels should be logged
 	// upon "literal is too long" error.
 	maxLiteralIsTooLongLogCount = 10
-	// literalLengthThreshold is the length of the label literal prefix that is logged upon
+	// literalPrefixLength is the length of the label literal prefix that is logged upon
 	// "literal is too long" error.
-	literalLengthThreshold = 100
+	literalPrefixLength = 100
 )
 
 var (
@@ -586,8 +586,8 @@ func (h *PromWriteHandler) maybeLogLabelsWithTooLongLiterals(logger *zap.Logger,
 	}
 
 	logger.Warn("label exceeds literal length limits",
-		zap.String("name", truncateLiteral(label.Name, literalLengthThreshold)),
-		zap.String("value", truncateLiteral(label.Value, literalLengthThreshold)),
+		zap.String("name", truncateLiteral(label.Name, literalPrefixLength)),
+		zap.String("value", truncateLiteral(label.Value, literalPrefixLength)),
 	)
 }
 

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -577,6 +577,8 @@ func (h *PromWriteHandler) maybeLogSeriesWithLongestLabels(logger *zap.Logger, t
 
 	n := atomic.LoadInt32(&h.numLiteralIsTooLong)
 	if n >= maxLiteralIsTooLongLogCount || !atomic.CompareAndSwapInt32(&h.numLiteralIsTooLong, n, n+1) {
+		// If the value changed in-between the load and compare-and-swap calls, assume that some other series
+		// was already logged by another thread and bail out. It's not critical to log each and every case.
 		return
 	}
 

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -127,7 +127,7 @@ type PromWriteHandler struct {
 	metrics                promWriteMetrics
 
 	// Counting the number of times of "literal is too long" error for log sampling purposes.
-	numLiteralIsTooLong int32
+	numLiteralIsTooLong uint32
 }
 
 // NewPromWriteHandler returns a new instance of handler.
@@ -575,7 +575,7 @@ func (h *PromWriteHandler) maybeLogSeriesWithLongestLabels(logger *zap.Logger, t
 		return
 	}
 
-	if atomic.AddInt32(&h.numLiteralIsTooLong, 1) > maxLiteralIsTooLongLogCount {
+	if atomic.AddUint32(&h.numLiteralIsTooLong, 1) > maxLiteralIsTooLongLogCount {
 		return
 	}
 

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -575,10 +575,7 @@ func (h *PromWriteHandler) maybeLogSeriesWithLongestLabels(logger *zap.Logger, t
 		return
 	}
 
-	n := atomic.LoadInt32(&h.numLiteralIsTooLong)
-	if n >= maxLiteralIsTooLongLogCount || !atomic.CompareAndSwapInt32(&h.numLiteralIsTooLong, n, n+1) {
-		// If the value changed in-between the load and compare-and-swap calls, assume that some other series
-		// was already logged by another thread and bail out. It's not critical to log each and every case.
+	if atomic.AddInt32(&h.numLiteralIsTooLong, 1) > maxLiteralIsTooLongLogCount {
 		return
 	}
 

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -585,18 +585,17 @@ func (h *PromWriteHandler) maybeLogLabelsWithTooLongLiterals(logger *zap.Logger,
 		return
 	}
 
-	logger.Warn("label exceeds literal length limits",
-		zap.String("name", truncateLiteral(label.Name, literalPrefixLength)),
-		zap.String("value", truncateLiteral(label.Value, literalPrefixLength)),
-	)
-}
-
-func truncateLiteral(literal []byte, lengthThreshold int) string {
-	if len(literal) <= lengthThreshold {
-		return string(literal)
+	safePrefix := func(b []byte, l int) []byte {
+		if len(b) <= l {
+			return b
+		}
+		return b[:l]
 	}
-	const ellipsis = "..."
-	return string(literal[:lengthThreshold]) + ellipsis
+
+	logger.Warn("label exceeds literal length limits",
+		zap.String("namePrefix", string(safePrefix(label.Name, literalPrefixLength))),
+		zap.String("valuePrefix", string(safePrefix(label.Value, literalPrefixLength))),
+	)
 }
 
 func newPromTSIter(

--- a/src/query/api/v1/handler/prometheus/remote/write_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/write_test.go
@@ -444,10 +444,11 @@ func TestPromWriteLiteralIsTooLongError(t *testing.T) {
 	for i := 0; i < maxLiteralIsTooLongLogCount*2; i++ {
 		promReqBody := test.GeneratePromWriteRequestBody(t, promReq)
 		req := httptest.NewRequest(PromWriteHTTPMethod, PromWriteURL, promReqBody)
-		resp := httptest.NewRecorder()
-		handler.ServeHTTP(resp, req)
-		result := resp.Result()
-		require.Equal(t, http.StatusBadRequest, result.StatusCode)
+		writer := httptest.NewRecorder()
+		handler.ServeHTTP(writer, req)
+		resp := writer.Result()
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.NoError(t, resp.Body.Close())
 	}
 }
 

--- a/src/query/api/v1/handler/prometheus/remote/write_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/write_test.go
@@ -439,8 +439,6 @@ func TestPromWriteLiteralIsTooLongError(t *testing.T) {
 		},
 	}
 
-	// execute write request many times to check that "literal is too long" sampling doesn't error
-	// or deadlock.
 	for i := 0; i < maxLiteralIsTooLongLogCount*2; i++ {
 		promReqBody := test.GeneratePromWriteRequestBody(t, promReq)
 		req := httptest.NewRequest(PromWriteHTTPMethod, PromWriteURL, promReqBody)

--- a/src/query/models/options.go
+++ b/src/query/models/options.go
@@ -33,15 +33,16 @@ const (
 	defaultAllowTagValueEmpty     = false
 	// NB: this matches the default tag literal length in x/serialize.
 	// https://github.com/m3db/m3/blob/0f671c9fd47a09e19b96b584ae17065690db4a04/src/x/serialize/limits.go#L29-L30
-	defaultMaxTagLiteralLength = math.MaxUint16
+	defaultMaxTagLiteralLength uint16 = math.MaxUint16
 )
 
 var (
 	defaultMetricName = []byte(model.MetricNameLabel)
 	defaultBucketName = []byte("le")
 
-	errNoName   = errors.New("metric name is missing or empty")
-	errNoBucket = errors.New("bucket name is missing or empty")
+	errNoName                   = errors.New("metric name is missing or empty")
+	errNoBucket                 = errors.New("bucket name is missing or empty")
+	errNonPositiveLiteralLength = errors.New("max literal length should be positive")
 )
 
 type tagOptions struct {
@@ -75,6 +76,10 @@ func (o *tagOptions) Validate() error {
 
 	if o.bucketName == nil || len(o.bucketName) == 0 {
 		return errNoBucket
+	}
+
+	if o.maxTagLiteralLength == 0 {
+		return errNonPositiveLiteralLength
 	}
 
 	return o.idScheme.Validate()

--- a/src/query/models/options.go
+++ b/src/query/models/options.go
@@ -23,17 +23,16 @@ package models
 import (
 	"bytes"
 	"errors"
-	"math"
 
 	"github.com/prometheus/common/model"
+
+	"github.com/m3db/m3/src/x/serialize"
 )
 
 const (
 	defaultAllowTagNameDuplicates = false
 	defaultAllowTagValueEmpty     = false
-	// NB: this matches the default tag literal length in x/serialize.
-	// https://github.com/m3db/m3/blob/0f671c9fd47a09e19b96b584ae17065690db4a04/src/x/serialize/limits.go#L29-L30
-	defaultMaxTagLiteralLength uint16 = math.MaxUint16
+	defaultMaxTagLiteralLength    = serialize.DefaultMaxTagLiteralLength
 )
 
 var (

--- a/src/query/models/options_test.go
+++ b/src/query/models/options_test.go
@@ -92,4 +92,8 @@ func TestOptionsEquals(t *testing.T) {
 	opts = opts.SetMetricName(n)
 	opts = opts.SetIDSchemeType(IDSchemeType(10))
 	assert.False(t, opts.Equals(other))
+
+	opts = NewTagOptions()
+	opts.SetMaxTagLiteralLength(42)
+	assert.False(t, opts.Equals(other))
 }

--- a/src/query/models/options_test.go
+++ b/src/query/models/options_test.go
@@ -31,18 +31,21 @@ func TestDefaultTagOptions(t *testing.T) {
 	assert.NoError(t, opts.Validate())
 	assert.Equal(t, defaultMetricName, opts.MetricName())
 	assert.Equal(t, TypeQuoted, opts.IDSchemeType())
+	assert.Equal(t, defaultMaxTagLiteralLength, opts.MaxTagLiteralLength())
 }
 
 func TestValidTagOptions(t *testing.T) {
 	opts := NewTagOptions().
 		SetIDSchemeType(TypePrependMeta).
 		SetMetricName([]byte("name")).
-		SetBucketName([]byte("bucket"))
+		SetBucketName([]byte("bucket")).
+		SetMaxTagLiteralLength(42)
 
 	assert.NoError(t, opts.Validate())
 	assert.Equal(t, []byte("name"), opts.MetricName())
 	assert.Equal(t, []byte("bucket"), opts.BucketName())
 	assert.Equal(t, TypePrependMeta, opts.IDSchemeType())
+	assert.Equal(t, uint16(42), opts.MaxTagLiteralLength())
 }
 
 func TestBadNameTagOptions(t *testing.T) {
@@ -73,6 +76,12 @@ func TestBadSchemeTagOptions(t *testing.T) {
 	opts := NewTagOptions().
 		SetIDSchemeType(IDSchemeType(6))
 	assert.EqualError(t, opts.Validate(), msg)
+}
+
+func TestBadMaxLiteralLength(t *testing.T) {
+	opts := NewTagOptions().
+		SetMaxTagLiteralLength(0)
+	assert.EqualError(t, opts.Validate(), errNonPositiveLiteralLength.Error())
 }
 
 func TestOptionsEquals(t *testing.T) {

--- a/src/query/models/options_test.go
+++ b/src/query/models/options_test.go
@@ -93,7 +93,6 @@ func TestOptionsEquals(t *testing.T) {
 	opts = opts.SetIDSchemeType(IDSchemeType(10))
 	assert.False(t, opts.Equals(other))
 
-	opts = NewTagOptions()
-	opts.SetMaxTagLiteralLength(42)
+	opts = NewTagOptions().SetMaxTagLiteralLength(42)
 	assert.False(t, opts.Equals(other))
 }

--- a/src/query/models/tags.go
+++ b/src/query/models/tags.go
@@ -315,16 +315,20 @@ func (t Tags) validate() error {
 		var (
 			allowTagNameDuplicates = t.Opts.AllowTagNameDuplicates()
 			allowTagValueEmpty     = t.Opts.AllowTagValueEmpty()
+			maxTagLiteralLength    = int(t.Opts.MaxTagLiteralLength())
 		)
 		// Sorted alphanumerically otherwise, use bytes.Compare once for
 		// both order and unique test.
 		for i, tag := range t.Tags {
-			if len(tag.Name) == 0 {
+			if nameLen := len(tag.Name); nameLen == 0 {
 				return fmt.Errorf("tag name empty: index=%d", i)
+			} else if nameLen > maxTagLiteralLength {
+				return fmt.Errorf("tag name too long: index=%d, length=%d, maxLength=%d", i, nameLen, maxTagLiteralLength)
 			}
-			if !allowTagValueEmpty && len(tag.Value) == 0 {
-				return fmt.Errorf("tag value empty: index=%d, name=%s",
-					i, t.Tags[i].Name)
+			if valueLen := len(tag.Value); !allowTagValueEmpty && valueLen == 0 {
+				return fmt.Errorf("tag value empty: index=%d, name=%s", i, tag.Name)
+			} else if valueLen > maxTagLiteralLength {
+				return fmt.Errorf("tag value too long: index=%d, length=%d, maxLength=%d", i, valueLen, maxTagLiteralLength)
 			}
 			if i == 0 {
 				continue // Don't check order/unique attributes.

--- a/src/query/models/tags_test.go
+++ b/src/query/models/tags_test.go
@@ -492,6 +492,36 @@ func TestTagsValidateDuplicateQuotedWithAllowTagNameDuplicates(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestTagsValidateTagNameTooLong(t *testing.T) {
+	tags := NewTags(0, NewTagOptions().
+		SetIDSchemeType(TypeQuoted).
+		SetMaxTagLiteralLength(10))
+	tags = tags.AddTag(Tag{
+		Name:  []byte("name_longer_than_10_characters"),
+		Value: []byte("baz"),
+	})
+	err := tags.Validate()
+	require.EqualError(t, err, "tag name too long: index=0, length=30, maxLength=10")
+	require.True(t, xerrors.IsInvalidParams(err))
+}
+
+func TestTagsValidateTagValueTooLong(t *testing.T) {
+	tags := NewTags(0, NewTagOptions().
+		SetIDSchemeType(TypeQuoted).
+		SetMaxTagLiteralLength(10))
+	tags = tags.AddTag(Tag{
+		Name:  []byte("bar"),
+		Value: []byte("baz"),
+	})
+	tags = tags.AddTag(Tag{
+		Name:  []byte("foo"),
+		Value: []byte("value_longer_than_10_characters"),
+	})
+	err := tags.Validate()
+	require.EqualError(t, err, "tag value too long: index=1, length=31, maxLength=10")
+	require.True(t, xerrors.IsInvalidParams(err))
+}
+
 func TestTagsValidateEmptyNameGraphite(t *testing.T) {
 	tags := NewTags(0, NewTagOptions().SetIDSchemeType(TypeGraphite))
 	tags = tags.AddTag(Tag{Name: nil, Value: []byte("bar")})

--- a/src/query/models/types.go
+++ b/src/query/models/types.go
@@ -113,6 +113,12 @@ type TagOptions interface {
 	// AllowTagValueEmpty returns the value to allow empty tag values to appear.
 	AllowTagValueEmpty() bool
 
+	// SetMaxTagLiteralLength sets the maximum length of a tag Name/Value.
+	SetMaxTagLiteralLength(value uint16) TagOptions
+
+	// MaxTagLiteralLength returns the maximum length of a tag Name/Value.
+	MaxTagLiteralLength() uint16
+
 	// Equals determines if two tag options are equivalent.
 	Equals(other TagOptions) bool
 }

--- a/src/x/serialize/encoder.go
+++ b/src/x/serialize/encoder.go
@@ -61,8 +61,9 @@ func init() {
 }
 
 var (
-	errTagEncoderInUse   = errors.New("encoder already in use")
-	errTagLiteralTooLong = xerrors.NewInvalidParamsError(errors.New("literal is too long"))
+	errTagEncoderInUse = errors.New("encoder already in use")
+	// ErrTagLiteralTooLong is an error when tag name or value exceeds configured literal length limit.
+	ErrTagLiteralTooLong = xerrors.NewInvalidParamsError(errors.New("literal is too long"))
 	// ErrEmptyTagNameLiteral is an error when encoded tag name is empty.
 	ErrEmptyTagNameLiteral = xerrors.NewInvalidParamsError(errors.New("tag name cannot be empty"))
 )
@@ -183,7 +184,7 @@ func (e *encoder) encodeID(i ident.ID) error {
 
 	max := int(e.opts.TagSerializationLimits().MaxTagLiteralLength())
 	if len(d) >= max {
-		return errTagLiteralTooLong
+		return ErrTagLiteralTooLong
 	}
 
 	ld := uint16(len(d))

--- a/src/x/serialize/encoder.go
+++ b/src/x/serialize/encoder.go
@@ -61,9 +61,8 @@ func init() {
 }
 
 var (
-	errTagEncoderInUse = errors.New("encoder already in use")
-	// ErrTagLiteralTooLong is an error when tag name or value exceeds configured literal length limit.
-	ErrTagLiteralTooLong = xerrors.NewInvalidParamsError(errors.New("literal is too long"))
+	errTagEncoderInUse   = errors.New("encoder already in use")
+	errTagLiteralTooLong = xerrors.NewInvalidParamsError(errors.New("literal is too long"))
 	// ErrEmptyTagNameLiteral is an error when encoded tag name is empty.
 	ErrEmptyTagNameLiteral = xerrors.NewInvalidParamsError(errors.New("tag name cannot be empty"))
 )
@@ -184,7 +183,7 @@ func (e *encoder) encodeID(i ident.ID) error {
 
 	max := int(e.opts.TagSerializationLimits().MaxTagLiteralLength())
 	if len(d) >= max {
-		return ErrTagLiteralTooLong
+		return errTagLiteralTooLong
 	}
 
 	ld := uint16(len(d))

--- a/src/x/serialize/limits.go
+++ b/src/x/serialize/limits.go
@@ -22,12 +22,12 @@ package serialize
 
 import "math"
 
-var (
+const (
 	// defaultMaxNumberTags is the maximum number of tags that can be encoded.
 	defaultMaxNumberTags uint16 = math.MaxUint16
 
-	// defaultMaxTagLiteralLength is the maximum length of a tag Name/Value.
-	defaultMaxTagLiteralLength uint16 = math.MaxUint16
+	// DefaultMaxTagLiteralLength is the maximum length of a tag Name/Value.
+	DefaultMaxTagLiteralLength uint16 = math.MaxUint16
 )
 
 type limits struct {
@@ -39,7 +39,7 @@ type limits struct {
 func NewTagSerializationLimits() TagSerializationLimits {
 	return &limits{
 		maxNumberTags:       defaultMaxNumberTags,
-		maxTagLiteralLength: defaultMaxTagLiteralLength,
+		maxTagLiteralLength: DefaultMaxTagLiteralLength,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Add logging for time series labels upon "literal is too long" error. It should help figuring out cases where metrics are being dropped because of unexpected values being placed into labels.

Since the labels can be as long as a few thousands of characters, the label names and values are being truncated and the amount of messages are being limited. This is done to avoid flooding the logs.

**Special notes for your reviewer**:

The code feels hacky, though let's sort this out during review.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
