### PR TITLE
Optionally disable m3msg consumer metric scope

### DIFF
--- a/src/msg/producer/config/writer.go
+++ b/src/msg/producer/config/writer.go
@@ -107,6 +107,9 @@ type WriterConfiguration struct {
 	// IgnoreCutoffCutover allows producing writes ignoring cutoff/cutover timestamp.
 	// Must be in sync with AggregatorConfiguration.WritesIgnoreCutoffCutover.
 	IgnoreCutoffCutover bool `yaml:"ignoreCutoffCutover"`
+	// WithoutConsumerScope drops the consumer tag from the metrics. For large m3msg deployments the consumer tag can
+	// add a lot of cardinality to the metrics.
+	WithoutConsumerScope bool `ymal:"withoutConsumerScope"`
 }
 
 // NewOptions creates writer options.
@@ -118,7 +121,8 @@ func (c *WriterConfiguration) NewOptions(
 	opts := writer.NewOptions().
 		SetTopicName(c.TopicName).
 		SetPlacementOptions(c.PlacementOptions.NewOptions()).
-		SetInstrumentOptions(iOpts)
+		SetInstrumentOptions(iOpts).
+		SetWithoutConsumerScope(c.WithoutConsumerScope)
 
 	kvOpts, err := c.TopicServiceOverride.NewOverrideOptions()
 	if err != nil {

--- a/src/msg/producer/config/writer.go
+++ b/src/msg/producer/config/writer.go
@@ -109,7 +109,7 @@ type WriterConfiguration struct {
 	IgnoreCutoffCutover bool `yaml:"ignoreCutoffCutover"`
 	// WithoutConsumerScope drops the consumer tag from the metrics. For large m3msg deployments the consumer tag can
 	// add a lot of cardinality to the metrics.
-	WithoutConsumerScope bool `ymal:"withoutConsumerScope"`
+	WithoutConsumerScope bool `yaml:"withoutConsumerScope"`
 }
 
 // NewOptions creates writer options.

--- a/src/msg/producer/writer/consumer_service_writer.go
+++ b/src/msg/producer/writer/consumer_service_writer.go
@@ -163,6 +163,7 @@ func initShardWriters(
 		m   = newMessageWriterMetrics(
 			opts.InstrumentOptions().MetricsScope(),
 			opts.InstrumentOptions().TimerOptions(),
+			opts.WithoutConsumerScope(),
 		)
 		mPool messagePool
 	)

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -364,7 +364,7 @@ type Options interface {
 	// SetIgnoreCutoffCutover sets a flag controlling whether cutoff/cutover timestamps are ignored.
 	SetIgnoreCutoffCutover(value bool) Options
 
-	// WithoutConsumerScope disables the consumer scope for metrics. For large m3msg deploymentssrc/msg/producer/writer/message_writer.go the consumer
+	// WithoutConsumerScope disables the consumer scope for metrics. For large m3msg deployments the consumer
 	// scope can add a lot of cardinality to the metrics.
 	WithoutConsumerScope() bool
 

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -363,6 +363,13 @@ type Options interface {
 
 	// SetIgnoreCutoffCutover sets a flag controlling whether cutoff/cutover timestamps are ignored.
 	SetIgnoreCutoffCutover(value bool) Options
+
+	// WithoutConsumerScope disables the consumer scope for metrics. For large m3msg deploymentssrc/msg/producer/writer/message_writer.go the consumer
+	// scope can add a lot of cardinality to the metrics.
+	WithoutConsumerScope() bool
+
+	// SetWithoutConsumerScope sets the value for WithoutConsumerScope.
+	SetWithoutConsumerScope(value bool) Options
 }
 
 type writerOptions struct {
@@ -385,6 +392,7 @@ type writerOptions struct {
 	cOpts                             ConnectionOptions
 	iOpts                             instrument.Options
 	ignoreCutoffCutover               bool
+	withoutConsumerScope              bool
 }
 
 // NewOptions creates Options.
@@ -594,5 +602,15 @@ func (opts *writerOptions) IgnoreCutoffCutover() bool {
 func (opts *writerOptions) SetIgnoreCutoffCutover(value bool) Options {
 	o := *opts
 	o.ignoreCutoffCutover = value
+	return &o
+}
+
+func (opts *writerOptions) WithoutConsumerScope() bool {
+	return opts.withoutConsumerScope
+}
+
+func (opts *writerOptions) SetWithoutConsumerScope(value bool) Options {
+	o := *opts
+	o.withoutConsumerScope = value
 	return &o
 }


### PR DESCRIPTION
For large m3msg deployments the number of consumers can add a lot of
cardinality to the metrics. Now users can disable the "consumer" label
via the config option.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
