### PR TITLE
[x/cache] Fix LRU cache mem leak (when used with no loader)

### DIFF
--- a/src/x/cache/lru_cache_prop_test.go
+++ b/src/x/cache/lru_cache_prop_test.go
@@ -37,10 +37,10 @@ import (
 
 func TestLRUPropertyTest(t *testing.T) {
 	testLRUPropFunc := func(input propTestMultiInput) (bool, error) {
-		size := 1000
+		maxSize := 1000
 
 		cacheOpts := &LRUOptions{
-			MaxEntries: size,
+			MaxEntries: maxSize,
 			Now:        time.Now,
 		}
 
@@ -97,6 +97,10 @@ func TestLRUPropertyTest(t *testing.T) {
 		wg.Wait()
 
 		t.Logf("found=%d, not_found=%d\n", found.Load(), notFound.Load())
+
+		if actualSize := len(lru.entries); actualSize > maxSize {
+			return false, fmt.Errorf("cache size %d exceeded MaxSize %d", actualSize, maxSize)
+		}
 
 		return true, nil
 	}

--- a/src/x/cache/lru_cache_test.go
+++ b/src/x/cache/lru_cache_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -634,6 +635,19 @@ func TestLRU_TryGetExpired(t *testing.T) {
 	// and fail with a panic because the ctx is nil.
 	_, ok = lru.TryGet("foo")
 	require.False(t, ok)
+}
+
+func TestLRU_EnforceMaxEntries(t *testing.T) {
+	var (
+		maxEntries = 2
+		lru        = NewLRU(&LRUOptions{MaxEntries: maxEntries, TTL: time.Second, Now: time.Now})
+	)
+
+	for i := 0; i <= maxEntries; i++ {
+		lru.Put(strconv.Itoa(i), "foo")
+	}
+
+	assert.Len(t, lru.entries, maxEntries)
 }
 
 var defaultKeys = []string{


### PR DESCRIPTION
**What this PR does / why we need it**:
A regression in LRU cache was introduced here: https://github.com/m3db/m3/blob/e2c6903cc0a027a129674afbf819ef294feceb07/src/x/cache/lru_cache.go#L356-L366

Cache entries were never being evicted when it was being used with no loader. Because of early return under `getWithNoLoader = true` the code that invokes `reserveCapacity` was unreachable, and this was the only place where eviction would happen.

**Special notes for your reviewer**:
I have added a call to `reserveCapacity` from `Put` (which assumes no loader is in use).
Another possibility would be to fix `tryCache` implementation to reserve the space on cache miss, but then `Put` would happen not under the same lock, creating a race between `Get`s (freeing up space in advance) and `Put`s which would permit exceeding the cache limit (still being eventually consistent). I chose doing eviction from `Put` as this seemed more semantically correct.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
