### PR TITLE
[dbnode] Make termsIterFromSegments.Next tail recursive

### DIFF
--- a/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go
@@ -121,7 +121,7 @@ func (i *termsIterFromSegments) setField(field []byte) error {
 }
 
 func (i *termsIterFromSegments) Next() bool {
-	for true {
+	for {
 		if i.err != nil {
 			return false
 		}

--- a/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go
@@ -179,11 +179,9 @@ func (i *termsIterFromSegments) Next() bool {
 
 		// Continue looping only if everything skipped or term is empty.
 		if !i.currPostingsList.IsEmpty() {
-			break
+			return true
 		}
 	}
-
-	return true
 }
 
 func (i *termsIterFromSegments) Current() ([]byte, postings.List) {

--- a/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go
@@ -177,6 +177,7 @@ func (i *termsIterFromSegments) Next() bool {
 			}
 		}
 
+		// Continue looping only if everything skipped or term is empty.
 		if !i.currPostingsList.IsEmpty() {
 			break
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This addresses the recently introduced TODO:
https://github.com/m3db/m3/blob/5d6001047d66693f46f7a141ef81415a49c00b34/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go#L179-L183
by converting `termsIterFromSegments.Next()` to a tail recursive form (in order to prevent stack overflow).

**Special notes for your reviewer**:
I believe this will fix the following stackoverflow panic:
```
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xcb36d7c3b8 stack=[0xcb36d7c000, 0xcb56d7c000]
fatal error: stack overflow

runtime stack:
runtime.throw(0x21a54d7, 0xe)
        /usr/local/go/src/runtime/panic.go:1117 +0x72
runtime.newstack()
        /usr/local/go/src/runtime/stack.go:1069 +0x7ed
runtime.morestack()
        /usr/local/go/src/runtime/asm_amd64.s:458 +0x8f

goroutine 3365534080 [running]:
github.com/m3dbx/vellum.(*FSTIterator).next(0xc149792000, 0xffffffffffffffff, 0x0, 0x0)
        /myPath/vendor/github.com/m3dbx/vellum/fst_iterator.go:222 +0xa7b fp=0xcb36d7c3c8 sp=0xcb36d7c3c0 
pc=0xe6d11b
github.com/m3dbx/vellum.(*FSTIterator).Next(...)
        /myPath/vendor/github.com/m3dbx/vellum/fst_iterator.go:219
github.com/m3db/m3/src/m3ninx/index/segment/fst.(*fstTermsIter).Next(0xc257f86000, 0x0)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/fst/fst_terms_iterator.go:103 +0x29d fp
=0xcb36d7c460 sp=0xcb36d7c3c8 pc=0xe8d4bd
github.com/m3db/m3/src/m3ninx/index/segment/fst.(*fstTermsPostingsIter).Next(0xc4e33ea000, 0x0)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/fst/fst_terms_postings_iterator.go:87 +
0x3e fp=0xcb36d7c4a0 sp=0xcb36d7c460 pc=0xe8de1e
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsKeyIter).Next(0xc13fecca00, 0x0)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:21
5 +0x33 fp=0xcb36d7c4c0 sp=0xcb36d7c4a0 pc=0xee3d33
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*multiKeyIterator).Next(0xc04f02c910, 0x0)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_multi_key_iter.g
o:87 +0x82 fp=0xcb36d7c530 sp=0xcb36d7c4c0 pc=0xede982
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsIterFromSegments).Next(0xc03dccb9e0, 0x1)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:12
8 +0x52 fp=0xcb36d7c878 sp=0xcb36d7c530 pc=0xee2bb2
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsIterFromSegments).Next(0xc03dccb9e0, 0x1)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:182 +0xbf7 fp=0xcb36d7cbc0 sp=0xcb36d7c878 pc=0xee3757
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsIterFromSegments).Next(0xc03dccb9e0, 0x1)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:182 +0xbf7 fp=0xcb36d7cf08 sp=0xcb36d7cbc0 pc=0xee3757
(...)
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsIterFromSegments).Next(0xc03dccb9e0, 0x1)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:182 +0xbf7 fp=0xcb36d8efc8 sp=0xcb36d8ec80 pc=0xee3757
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsIterFromSegments).Next(0xc03dccb9e0, 0x1)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:182 +0xbf7 fp=0xcb36d8f310 sp=0xcb36d8efc8 pc=0xee3757
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsIterFromSegments).Next(0xc03dccb9e0, 0x1)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:182 +0xbf7 fp=0xcb36d8f658 sp=0xcb36d8f310 pc=0xee3757
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsIterFromSegments).Next(0xc03dccb9e0, 0x1)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:182 +0xbf7 fp=0xcb36d8f9a0 sp=0xcb36d8f658 pc=0xee3757
github.com/m3db/m3/src/m3ninx/index/segment/builder.(*termsIterFromSegments).Next(0xc03dccb9e0, 0x1)
        /myPath/vendor/github.com/m3db/m3/src/m3ninx/index/segment/builder/multi_segments_terms_iter.go:182 +0xbf7 fp=0xcb36d8fce8 sp=0xcb36d8f9a0 pc=0xee3757
created by github.com/m3db/m3/src/dbnode/storage/index.(*mutableSegments).backgroundCompactWithPlan
        /myPath/vendor/github.com/m3db/m3/src/dbnode/storage/index/mutable_segments.go:716 +0x991
```

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
