### PR TITLE
WIP [dbnode] Optimize block range scan in queryWithSpan

### DIFF
--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -544,13 +544,31 @@ func (b *block) queryWithSpan(
 		doc := iter.Current()
 		if md, ok := doc.Metadata(); ok && md.OnIndexSeries != nil {
 			var (
-				inBlock      bool
-				currentBlock = opts.StartInclusive.Truncate(b.blockSize)
+				inBlock                bool
+				currentBlock           = opts.StartInclusive
+				endExclusive           = opts.EndExclusive
+				minIndexed, maxIndexed = md.OnIndexSeries.IndexedRange()
 			)
+
+			if maxIndexed == 0 {
+				// Empty range.
+				continue
+			}
+
+			// Narrow down the range of blocks to scan because the client could have
+			// queried for an arbitrary wide range.
+			if currentBlock < minIndexed {
+				currentBlock = minIndexed
+			}
+			if endExclusive > maxIndexed+1 {
+				endExclusive = maxIndexed + 1 // +1 to make it exclusive
+			}
+
+			currentBlock = currentBlock.Truncate(b.blockSize)
 			for !inBlock {
 				inBlock = md.OnIndexSeries.IndexedForBlockStart(currentBlock)
 				currentBlock = currentBlock.Add(b.blockSize)
-				if !currentBlock.Before(opts.EndExclusive) {
+				if !currentBlock.Before(endExclusive) {
 					break
 				}
 			}
@@ -628,7 +646,7 @@ func (b *block) addQueryResults(
 	return batch, size, docsCount, err
 }
 
-// AggIter acquires a read lock on the block to get the set of segments for the returned iterator. However, the
+// AggregateIter acquires a read lock on the block to get the set of segments for the returned iterator. However, the
 // segments are searched and results are processed lazily in the returned iterator. The segments are finalized when
 // the ctx is finalized to ensure the mmaps are not freed until the ctx closes. This allows the returned results to
 // reference data in the mmap without copying.

--- a/src/m3ninx/doc/types.go
+++ b/src/m3ninx/doc/types.go
@@ -124,4 +124,9 @@ type OnIndexSeries interface {
 
 	// IndexedForBlockStart returns true if the blockStart has been indexed.
 	IndexedForBlockStart(blockStart xtime.UnixNano) bool
+
+	// IndexedRange returns minimum and maximum blockStart values covered by index entry.
+	// Note that there may be uncovered gaps within that range.
+	// Returns (0, 0) for an empty range.
+	IndexedRange() (xtime.UnixNano, xtime.UnixNano)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The client could query for an arbitrary wide time range (eg. 1000 years) which would cause an expensive iteration over all of it in the inner most loop. This change narrows down the scanned range of blocks to at most what is actually covered by the index entry.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
