### PR TITLE
[coordinator] Enable running M3 coordinator without Etcd

### DIFF
--- a/src/cluster/kv/mem/store.go
+++ b/src/cluster/kv/mem/store.go
@@ -81,6 +81,12 @@ type store struct {
 	watchables map[string]kv.ValueWatchable
 }
 
+// IsMem lets asserting if given store is an in memory one.
+func IsMem(s kv.Store) bool {
+	_, ok := s.(*store)
+	return ok
+}
+
 func (s *store) Get(key string) (kv.Value, error) {
 	s.RLock()
 	defer s.RUnlock()

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -2842,7 +2842,7 @@ func TestDownsamplerWithOverrideNamespace(t *testing.T) {
 	testDownsamplerAggregation(t, testDownsampler)
 }
 
-func TestSafeguardInProcessDownsampelr(t *testing.T) {
+func TestSafeguardInProcessDownsampler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	store := kv.NewMockStore(ctrl)

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -3580,7 +3580,7 @@ func newTestDownsampler(t *testing.T, opts testDownsamplerOptions) testDownsampl
 		RWOptions:                  xio.NewOptions(),
 		TagOptions:                 models.NewTagOptions(),
 	})
-	if opts.expectConstructError == "" {
+	if opts.expectConstructError != "" {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), opts.expectConstructError)
 		return testDownsampler{}

--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -2845,11 +2845,15 @@ func TestDownsamplerWithOverrideNamespace(t *testing.T) {
 func TestSafeguardInProcessDownsampler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+
 	store := kv.NewMockStore(ctrl)
-	store.EXPECT().SetIfNotExists(gomock.Eq(matcher.NewOptions().NamespacesKey()), gomock.Any()).Return(0, nil).Times(1)
+	store.EXPECT().SetIfNotExists(gomock.Eq(matcher.NewOptions().NamespacesKey()), gomock.Any()).Return(0, nil)
+
+	// explicitly asserting that no more mutations are done for original store.
 	store.EXPECT().Set(gomock.Any(), gomock.Any()).Times(0)
 	store.EXPECT().CheckAndSet(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	store.EXPECT().Delete(gomock.Any()).Times(0)
+
 	_ = newTestDownsampler(t, testDownsamplerOptions{
 		remoteClientMock: nil,
 		kvStore:          store,
@@ -2878,7 +2882,7 @@ func TestDownsamplerNamespacesEtcdInit(t *testing.T) {
 		assert.Len(t, ns.Namespaces, 0)
 	})
 
-	t.Run("do not initialize namespaces when RequireNamespaceWatchOnInit is true", func(t *testing.T) {
+	t.Run("does not initialize namespaces key when RequireNamespaceWatchOnInit is true", func(t *testing.T) {
 		store := mem.NewStore()
 
 		matcherConfig := MatcherConfiguration{RequireNamespaceWatchOnInit: true}

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -988,7 +988,10 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 }
 
 func initStoreNamespaces(store kv.Store, nsKey string) error {
-	_, err := store.CheckAndSet(nsKey, 0, &rulepb.Namespaces{})
+	_, err := store.SetIfNotExists(nsKey, &rulepb.Namespaces{})
+	if errors.Is(err, kv.ErrAlreadyExists) {
+		return nil
+	}
 	return err
 }
 

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -851,16 +851,16 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		}, nil
 	}
 
+	serviceID := services.NewServiceID().
+		SetEnvironment("production").
+		SetName("downsampler").
+		SetZone("embedded")
+
 	localKVStore := kvStore
 	// NB(antanas): to protect against running with real Etcd and overriding existing placements.
 	if !mem.IsMem(localKVStore) {
 		localKVStore = mem.NewStore()
 	}
-
-	serviceID := services.NewServiceID().
-		SetEnvironment("production").
-		SetName("downsampler").
-		SetZone("embedded")
 
 	placementManager, err := o.newAggregatorPlacementManager(serviceID, localKVStore)
 	if err != nil {

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -811,9 +811,13 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	}
 
 	// NB(antanas): matcher registers watcher on namespaces key. Making sure it is set, otherwise watcher times out.
-	err = initStoreNamespaces(kvStore, matcherOpts.NamespacesKey())
-	if err != nil {
-		return agg{}, err
+	// With RequireNamespaceWatchOnInit being true we expect namespaces to be set upfront
+	// so we do not initialize them here at all because it might potentially hide human error.
+	if !cfg.Matcher.RequireNamespaceWatchOnInit {
+		err = initStoreNamespaces(kvStore, matcherOpts.NamespacesKey())
+		if err != nil {
+			return agg{}, err
+		}
 	}
 
 	matcher, err := o.newAggregatorMatcher(matcherOpts, matcherCacheCapacity)

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -805,7 +805,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		matcherCacheCapacity = *v
 	}
 
-	kvStore, err := o.ClusterClient.Txn()
+	kvStore, err := o.ClusterClient.KV()
 	if err != nil {
 		return agg{}, err
 	}
@@ -987,7 +987,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	}, nil
 }
 
-func initStoreNamespaces(store kv.TxnStore, nsKey string) error {
+func initStoreNamespaces(store kv.Store, nsKey string) error {
 	_, err := store.CheckAndSet(nsKey, 0, &rulepb.Namespaces{})
 	return err
 }

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -853,12 +853,11 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		}, nil
 	}
 
-	// NB(antanas): to protect against running with real Etcd and overriding existing placements.
-	if !mem.IsMem(kvStore) {
-		return agg{}, errors.New("running in process downsampler with other store " +
-			"then in memory can yield unexpected side effects")
-	}
 	localKVStore := kvStore
+	// NB(antanas): to protect against running with real Etcd and overriding existing placements.
+	if !mem.IsMem(localKVStore) {
+		localKVStore = mem.NewStore()
+	}
 
 	serviceID := services.NewServiceID().
 		SetEnvironment("production").

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -858,20 +858,21 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		return agg{}, errors.New("running in process downsampler with other store " +
 			"then in memory can yield unexpected side effects")
 	}
+	localKVStore := kvStore
 
 	serviceID := services.NewServiceID().
 		SetEnvironment("production").
 		SetName("downsampler").
 		SetZone("embedded")
 
-	placementManager, err := o.newAggregatorPlacementManager(serviceID, kvStore)
+	placementManager, err := o.newAggregatorPlacementManager(serviceID, localKVStore)
 	if err != nil {
 		return agg{}, err
 	}
 
 	flushTimesManager := aggregator.NewFlushTimesManager(
 		aggregator.NewFlushTimesManagerOptions().
-			SetFlushTimesStore(kvStore))
+			SetFlushTimesStore(localKVStore))
 
 	electionManager, err := o.newAggregatorElectionManager(serviceID,
 		placementManager, flushTimesManager, clockOpts)

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -737,8 +737,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 		kvTxnMemStore := mem.NewStore()
 
 		// Initialize the namespaces
-		err := initStoreNamespaces(kvTxnMemStore, matcherOpts.NamespacesKey())
-		if err != nil {
+		if err := initStoreNamespaces(kvTxnMemStore, matcherOpts.NamespacesKey()); err != nil {
 			return agg{}, err
 		}
 
@@ -814,8 +813,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	// With RequireNamespaceWatchOnInit being true we expect namespaces to be set upfront
 	// so we do not initialize them here at all because it might potentially hide human error.
 	if !matcherOpts.RequireNamespaceWatchOnInit() {
-		err = initStoreNamespaces(kvStore, matcherOpts.NamespacesKey())
-		if err != nil {
+		if err := initStoreNamespaces(kvStore, matcherOpts.NamespacesKey()); err != nil {
 			return agg{}, err
 		}
 	}

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -828,10 +828,12 @@ func newDownsamplerAsync(
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to create cluster management etcd client")
 		}
-	// NB(antanas): M3 Coordinator with in process aggregator can run with in memory cluster client.
 	} else if cfg.RemoteAggregator == nil {
-		instrumentOptions.Logger().Info("no etcd config and no remote aggregator - will run with in memory cluster client.")
+		// NB(antanas): M3 Coordinator with in process aggregator can run with in memory cluster client.
+		instrumentOptions.Logger().Info("no etcd config and no remote aggregator - will run with in memory cluster client")
 		clusterClient = memcluster.New(kv.NewOverrideOptions())
+	} else {
+		return nil, nil, fmt.Errorf("no configured cluster management config, must set this config for remote aggregator")
 	}
 
 	newDownsamplerFn := func() (downsample.Downsampler, error) {
@@ -871,7 +873,7 @@ func newDownsamplerAsync(
 
 func newDownsampler(
 	cfg downsample.Configuration,
-	clusterManagementClient clusterclient.Client,
+	clusterClient clusterclient.Client,
 	storage storage.Appender,
 	clusterNamespacesWatcher m3.ClusterNamespacesWatcher,
 	tagOptions models.TagOptions,
@@ -885,22 +887,17 @@ func newDownsampler(
 	instrumentOpts = instrumentOpts.SetMetricsScope(
 		instrumentOpts.MetricsScope().SubScope("downsampler"))
 
-	if clusterManagementClient == nil {
-		return nil, fmt.Errorf("no configured cluster management config, " +
-			"must set this config for downsampler")
-	}
-
 	var kvStore kv.Store
 	var err error
 
 	if applyCustomRuleStore == nil {
-		kvStore, err = clusterManagementClient.KV()
+		kvStore, err = clusterClient.KV()
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to create KV store from the "+
 				"cluster management config client")
 		}
 	} else {
-		kvStore, err = applyCustomRuleStore(clusterManagementClient, instrumentOpts)
+		kvStore, err = applyCustomRuleStore(clusterClient, instrumentOpts)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to apply custom rule store")
 		}
@@ -923,7 +920,7 @@ func newDownsampler(
 
 	downsampler, err := cfg.NewDownsampler(downsample.DownsamplerOptions{
 		Storage:                    storage,
-		ClusterClient:              clusterManagementClient,
+		ClusterClient:              clusterClient,
 		RulesKVStore:               kvStore,
 		ClusterNamespacesWatcher:   clusterNamespacesWatcher,
 		ClockOptions:               clockOpts,

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -34,6 +34,7 @@ import (
 	clusterclient "github.com/m3db/m3/src/cluster/client"
 	etcdclient "github.com/m3db/m3/src/cluster/client/etcd"
 	"github.com/m3db/m3/src/cluster/kv"
+	memcluster "github.com/m3db/m3/src/cluster/mem"
 	handleroptions3 "github.com/m3db/m3/src/cluster/placementhandler/handleroptions"
 	"github.com/m3db/m3/src/cmd/services/m3aggregator/serve"
 	"github.com/m3db/m3/src/cmd/services/m3coordinator/downsample"
@@ -827,6 +828,10 @@ func newDownsamplerAsync(
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "unable to create cluster management etcd client")
 		}
+	// NB(antanas): M3 Coordinator with in process aggregator can run with in memory cluster client.
+	} else if cfg.RemoteAggregator == nil {
+		instrumentOptions.Logger().Info("no etcd config and no remote aggregator - will run with in memory cluster client.")
+		clusterClient = memcluster.New(kv.NewOverrideOptions())
 	}
 
 	newDownsamplerFn := func() (downsample.Downsampler, error) {

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -228,6 +228,7 @@ backend: prom-remote
 
 tagOptions:
   allowTagNameDuplicates: true
+
 `, externalFakePromServer.WriteAddr()))
 
 	require.Equal(t, config.PromRemoteStorageType, cfg.Backend)
@@ -538,14 +539,17 @@ func runServer(t *testing.T, opts runServerOpts) (string, closeFn) {
 		doneCh          = make(chan struct{})
 		listenerCh      = make(chan net.Listener, 1)
 		clusterClient   = clusterclient.NewMockClient(opts.ctrl)
-		clusterClientCh = make(chan clusterclient.Client, 1)
+		clusterClientCh chan clusterclient.Client
 	)
 
-	store := mem.NewStore()
-	_, err := store.Set("/namespaces", &rulepb.Namespaces{})
-	require.NoError(t, err)
-	clusterClient.EXPECT().KV().Return(store, nil).MaxTimes(1)
-	clusterClientCh <- clusterClient
+	if len(opts.cfg.Clusters) > 0 || opts.cfg.ClusterManagement.Etcd != nil {
+		clusterClientCh = make(chan clusterclient.Client, 1)
+		store := mem.NewStore()
+		_, err := store.Set("/namespaces", &rulepb.Namespaces{})
+		require.NoError(t, err)
+		clusterClient.EXPECT().KV().Return(store, nil).MaxTimes(1)
+		clusterClientCh <- clusterClient
+	}
 
 	go func() {
 		r := Run(RunOptions{

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -227,7 +227,6 @@ backend: prom-remote
 
 tagOptions:
   allowTagNameDuplicates: true
-
 `, externalFakePromServer.WriteAddr()))
 
 	require.Equal(t, config.PromRemoteStorageType, cfg.Backend)

--- a/src/query/server/query_test.go
+++ b/src/query/server/query_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/m3db/m3/src/cmd/services/m3query/config"
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/metrics/generated/proto/metricpb"
-	"github.com/m3db/m3/src/metrics/generated/proto/rulepb"
 	"github.com/m3db/m3/src/metrics/policy"
 	"github.com/m3db/m3/src/msg/generated/proto/msgpb"
 	m3msgproto "github.com/m3db/m3/src/msg/protocol/proto"
@@ -545,9 +544,7 @@ func runServer(t *testing.T, opts runServerOpts) (string, closeFn) {
 	if len(opts.cfg.Clusters) > 0 || opts.cfg.ClusterManagement.Etcd != nil {
 		clusterClientCh = make(chan clusterclient.Client, 1)
 		store := mem.NewStore()
-		_, err := store.Set("/namespaces", &rulepb.Namespaces{})
-		require.NoError(t, err)
-		clusterClient.EXPECT().KV().Return(store, nil).MaxTimes(1)
+		clusterClient.EXPECT().KV().Return(store, nil).MaxTimes(2)
 		clusterClientCh <- clusterClient
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:

This enables running M3 Coordinator with in process M3 Aggregator without external Etcd.
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:

Situation until now:
- When running with M3DB backend embedded Etcd would be provided by DB node.
- Running `noop-etcd` actually makes sense with external Etcd since this is a so called "admin mode"
- Running `gRPC` backend would not setup downsampler and Etcd is not required
- When running `promRemote` Etcd is required since downsampler is initialized. And by default it's an in process one.

With this change it's now possible to run in process aggregator (downsampler) without external Etcd. 

Another fix is to initialize `/namespaces` key if it's not set. Otherwise startup takes 5s more because we are waiting for watcher to timeout.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
None
```
