### PR TITLE
[x/serialize] Fix off-by-one error in encoder

### DIFF
--- a/src/x/serialize/encoder.go
+++ b/src/x/serialize/encoder.go
@@ -182,7 +182,7 @@ func (e *encoder) encodeID(i ident.ID) error {
 	d := i.Bytes()
 
 	max := int(e.opts.TagSerializationLimits().MaxTagLiteralLength())
-	if len(d) >= max {
+	if len(d) > max {
 		return errTagLiteralTooLong
 	}
 

--- a/src/x/serialize/encoder_test.go
+++ b/src/x/serialize/encoder_test.go
@@ -134,7 +134,10 @@ func TestTagEncoderErrorEncoding(t *testing.T) {
 	require.False(t, ok)
 
 	e.Reset()
-	tags = ident.NewTagsIterator(ident.NewTags(ident.StringTag("abc", "defg")))
+	tags = ident.NewTagsIterator(ident.NewTags(
+		ident.StringTag("abc", "defg"),
+		ident.StringTag("x", nstring(int(maxLiteralLen))),
+	))
 	require.NoError(t, e.Encode(tags))
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes off-by-one error in `x/serialize/encoder.go` when checking if tag literal length doesn't exceed the limit.

The decoder side uses correct comparison:
https://github.com/m3db/m3/blob/611166b842b2e4a340539a21134ba6eabe100b38/src/x/serialize/decoder.go#L151-L153

The same is true for tag count checks:
https://github.com/m3db/m3/blob/f514fc4f788751c8eebe21ddfb105c7c6fb37ad9/src/x/serialize/encoder.go#L110-L113
https://github.com/m3db/m3/blob/611166b842b2e4a340539a21134ba6eabe100b38/src/x/serialize/decoder.go#L94-L97

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
