### PR TITLE
[tests] Integration test harness test fixes and speedups

### DIFF
--- a/src/integration/resources/inprocess/coordinator_test.go
+++ b/src/integration/resources/inprocess/coordinator_test.go
@@ -36,6 +36,12 @@ import (
 )
 
 func TestNewCoordinator(t *testing.T) {
+	dbnode, err := NewDBNodeFromYAML(defaultDBNodeConfig, DBNodeOptions{})
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dbnode.Close())
+	}()
+
 	coord, err := NewCoordinatorFromYAML(defaultCoordConfig, CoordinatorOptions{})
 	require.NoError(t, err)
 	require.NoError(t, coord.Close())
@@ -49,6 +55,9 @@ func TestNewCoordinator(t *testing.T) {
 func TestNewEmbeddedCoordinator(t *testing.T) {
 	dbnode, err := NewDBNodeFromYAML(embeddedCoordConfig, DBNodeOptions{})
 	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dbnode.Close())
+	}()
 
 	d, ok := dbnode.(*dbNode)
 	require.True(t, ok)
@@ -56,8 +65,6 @@ func TestNewEmbeddedCoordinator(t *testing.T) {
 
 	_, err = NewEmbeddedCoordinator(d)
 	require.NoError(t, err)
-
-	require.NoError(t, dbnode.Close())
 }
 
 func TestNewEmbeddedCoordinatorNotStarted(t *testing.T) {
@@ -65,8 +72,6 @@ func TestNewEmbeddedCoordinatorNotStarted(t *testing.T) {
 	_, err := NewEmbeddedCoordinator(&dbnode)
 	require.Error(t, err)
 }
-
-// TODO(nate): add more tests exercising other endpoints once dbnode impl is landed
 
 func TestM3msgTopicFunctions(t *testing.T) {
 	dbnode, err := NewDBNodeFromYAML(defaultDBNodeConfig, DBNodeOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Consolidate the DB node harness tests into a single test
function to reduce the startup and teardown time.

Additionally, ensure coordinator tests always have a DB
node since they don't really start up properly without
one (unless you have a separate etcd cluster which we don't
support yet).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
