### PR TITLE
[dbnode] Check if namespace is read-only in namespace::FlushIndex

### DIFF
--- a/src/dbnode/storage/namespace_test.go
+++ b/src/dbnode/storage/namespace_test.go
@@ -638,7 +638,8 @@ func TestNamespaceSkipFlushIfReadOnly(t *testing.T) {
 
 	// Set mocked 'OnColdFlush' so that the test would fail if cold flush would happen.
 	opts := DefaultTestOptions().
-		SetOnColdFlush(NewMockOnColdFlush(ctrl))
+		SetOnColdFlush(NewMockOnColdFlush(ctrl)).
+		SetRuntimeOptionsManager(runtime.NewOptionsManager())
 
 	ns, closer := newTestNamespaceWithOpts(t, nsOpts, opts)
 	defer closer()

--- a/src/dbnode/storage/util.go
+++ b/src/dbnode/storage/util.go
@@ -91,9 +91,7 @@ func DefaultTestOptions() Options {
 		panic(err)
 	}
 
-	return defaultTestOptions.
-		SetIndexClaimsManager(icm).
-		SetRuntimeOptionsManager(runtime.NewNoOpOptionsManager(runtime.NewOptions()))
+	return defaultTestOptions.SetIndexClaimsManager(icm)
 }
 
 // numIntervals returns the number of intervals between [start, end] for a given


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds a check if a namespace is read-only in `namespace::FlushIndex` method.

**Special notes for your reviewer**:

The `FlushIndex()` method seems to be transitively used by `src/dbnode/storage/mediator.go` and nothing else uses it.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
