### PR TITLE
[aggregator] more efficiently reference previously consumed values

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -553,7 +553,7 @@ func (e *CounterElem) processValueWithAggregationLock(
 		if !e.parsedPipeline.HasRollup {
 			toFlush := make([]transformation.Datapoint, 0, 2)
 			toFlush = append(toFlush, transformation.Datapoint{
-				TimeNanos: int64(timeNanos),
+				TimeNanos: timeNanos,
 				Value:     value,
 			})
 			if extraDp.TimeNanos != 0 {

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -34,7 +34,6 @@ import (
 	"github.com/m3db/m3/src/metrics/metric/aggregated"
 	"github.com/m3db/m3/src/metrics/metric/unaggregated"
 	"github.com/m3db/m3/src/metrics/transformation"
-	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/willf/bitset"
 )
@@ -42,23 +41,27 @@ import (
 type lockedCounterAggregation struct {
 	sync.Mutex
 
-	dirty       bool
-	flushed     bool
-	closed      bool
-	sourcesSeen map[uint32]*bitset.BitSet
-	aggregation counterAggregation
-	prevValues  []float64 // the previously emitted values (one per aggregation type).
+	dirty        bool
+	flushed      bool
+	closed       bool
+	sourcesSeen  map[uint32]*bitset.BitSet
+	aggregation  counterAggregation
+	prevValues   []float64 // the previously emitted values (one per aggregation type).
+	prevConsumed []float64
 }
 
 type timedCounter struct {
 	startAtNanos     int64 // start time of an aggregation window
 	lockedAgg        *lockedCounterAggregation
 	onConsumeExpired bool
+
+	previous *timedCounter
 }
 
 func (ta *timedCounter) Release() {
 	ta.startAtNanos = 0
 	ta.lockedAgg = nil
+	ta.previous = nil
 }
 
 // CounterElem is an element storing time-bucketed aggregations.
@@ -70,9 +73,6 @@ type CounterElem struct {
 
 	// internal consume state that does not need to be synchronized.
 	toConsume []timedCounter // small buffer to avoid memory allocations during consumption
-	// map of the previous consumed values for each timestamp in the buffer. needed to support binary transforms that
-	// need the value from the previous timestamp.
-	consumedValues valuesByTime
 }
 
 // NewCounterElem returns a new CounterElem.
@@ -249,29 +249,29 @@ func (e *CounterElem) Consume(
 	canCollect := len(e.values) == 0 && e.tombstoned
 	e.Unlock()
 
-	var (
-		cascadeDirty  bool
-		prevTimeNanos xtime.UnixNano
-	)
+	var cascadeDirty bool
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
-		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))
-		// seed the previous timestamp if this is first consumed value.
-		if prevTimeNanos == 0 {
-			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)
-		}
+		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
+		prevTimeNanos := timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
 
 		e.toConsume[i].lockedAgg.Lock()
+		if e.toConsume[i].previous != nil {
+			e.toConsume[i].previous.lockedAgg.Lock()
+		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
 		// cascade the dirty bit to all succeeding values. there is a check later to not resend a value if it doesn't
 		// change, so it's ok to optimistically mark dirty.
 		if cascadeDirty || e.toConsume[i].lockedAgg.dirty {
 			cascadeDirty = e.processValueWithAggregationLock(
+				// current time + agg
 				timeNanos,
-				prevTimeNanos,
 				e.toConsume[i].lockedAgg,
+				// previous time + agg
+				prevTimeNanos,
+				e.toConsume[i].previous.lockedAgg,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -297,13 +297,20 @@ func (e *CounterElem) Consume(
 			}
 		}
 
-		e.toConsume[i].lockedAgg.Unlock()
-		if expired {
-			e.toConsume[i].Release()
-			// the consumed value of the previous timestamp is no longer needed once this value has expired.
-			delete(e.consumedValues, prevTimeNanos)
+		if e.toConsume[i].previous != nil {
+			e.toConsume[i].previous.lockedAgg.Unlock()
 		}
-		prevTimeNanos = timeNanos
+		e.toConsume[i].lockedAgg.Unlock()
+
+		if expired {
+			// Release the previous datapoint so that on a following consume the current
+			// is available as a previous. If the consume cycle is fully empty (i.e. canCollect)
+			// then we can safely cleanup previous and current here.
+			e.toConsume[i].previous.Release()
+			if canCollect {
+				e.toConsume[i].Release()
+			}
+		}
 	}
 
 	if e.parsedPipeline.HasRollup {
@@ -344,7 +351,6 @@ func (e *CounterElem) Close() {
 
 	// internal consumption state that doesn't need to be synchronized.
 	e.toConsume = e.toConsume[:0]
-	e.consumedValues = nil
 
 	if !e.useDefaultAggregation {
 		aggTypesPool.Put(e.aggTypes)
@@ -406,9 +412,10 @@ func (e *CounterElem) findOrCreate(
 	e.values[idx] = timedCounter{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedCounterAggregation{
-			sourcesSeen: sourcesSeen,
-			aggregation: e.NewAggregation(e.opts, e.aggOpts),
-			prevValues:  make([]float64, len(e.aggTypes)),
+			sourcesSeen:  sourcesSeen,
+			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
+			prevValues:   make([]float64, len(e.aggTypes)),
+			prevConsumed: make([]float64, len(e.aggTypes)),
 		},
 	}
 	agg := e.values[idx].lockedAgg
@@ -447,9 +454,10 @@ func (e *CounterElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 // returns true if a datapoint is emitted.
 func (e *CounterElem) processValueWithAggregationLock(
-	timeNanos xtime.UnixNano,
-	prevTimeNanos xtime.UnixNano,
+	timeNanos int64,
 	lockedAgg *lockedCounterAggregation,
+	prevTimeNanos int64,
+	prevLockedAgg *lockedCounterAggregation,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration) bool {
@@ -477,18 +485,19 @@ func (e *CounterElem) processValueWithAggregationLock(
 				value = res.Value
 
 			case isBinaryOp:
-				prev := transformation.Datapoint{
-					Value: nan,
-				}
-				// lazily construct consumedValues since they are only needed by binary transforms.
-				if e.consumedValues == nil {
-					e.consumedValues = make(valuesByTime)
-				}
-				if _, ok := e.consumedValues[prevTimeNanos]; ok {
-					prev = e.consumedValues[prevTimeNanos][aggTypeIdx]
+				var prev transformation.Datapoint
+				if prevLockedAgg == nil {
+					prev = transformation.Datapoint{
+						Value: nan,
+					}
+				} else {
+					prev = transformation.Datapoint{
+						TimeNanos: prevTimeNanos,
+						Value:     prevLockedAgg.prevConsumed[aggTypeIdx],
+					}
 				}
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
@@ -498,16 +507,13 @@ func (e *CounterElem) processValueWithAggregationLock(
 				// need to keep one value. In the future if we need to support higher-order
 				// derivative transformations, we need to store an array of values here.
 				if !math.IsNaN(curr.Value) {
-					if e.consumedValues[timeNanos] == nil {
-						e.consumedValues[timeNanos] = make([]transformation.Datapoint, len(e.aggTypes))
-					}
-					e.consumedValues[timeNanos][aggTypeIdx] = curr
+					lockedAgg.prevConsumed[aggTypeIdx] = value
 				}
 
 				value = res.Value
 			case isUnaryMultiOp:
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -223,12 +223,22 @@ func (e *CounterElem) Consume(
 	// Evaluate and GC expired items.
 	valuesForConsideration := e.values
 	e.values = e.values[:0]
+	var (
+		previous *timedCounter
+		expired  bool
+	)
 	for _, value := range valuesForConsideration {
 		if !isEarlierThanFn(value.startAtNanos, resolution, targetNanos) {
+			// Keep the previous expired value to reference.
+			if previous != nil && expired {
+				e.values = append(e.values, *previous)
+				previous = nil
+			}
+
 			e.values = append(e.values, value)
 			continue
 		}
-		expired := true
+		expired = true
 		if e.resendEnabled {
 			// If resend is enabled, we only expire if the value is now outside the buffer past. It is safe to expire
 			// since any metrics intended for this value are rejected for being too late.
@@ -239,12 +249,17 @@ func (e *CounterElem) Consume(
 		// Modify the by value copy with whether it needs time flush and accumulate.
 		copiedValue := value
 		copiedValue.onConsumeExpired = expired
+		if previous != nil {
+			copiedValue.previous = previous
+		}
 		e.toConsume = append(e.toConsume, copiedValue)
 
 		if !expired {
 			// Keep item. Expired values are GC'd below after consuming.
 			e.values = append(e.values, value)
 		}
+
+		previous = &copiedValue
 	}
 	canCollect := len(e.values) == 0 && e.tombstoned
 	e.Unlock()
@@ -254,11 +269,19 @@ func (e *CounterElem) Consume(
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
-		prevTimeNanos := timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
+
+		var (
+			prevTimeNanos int64
+			prevLockedAgg *lockedCounterAggregation
+		)
+		if e.toConsume[i].previous != nil {
+			prevTimeNanos = timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
+			prevLockedAgg = e.toConsume[i].previous.lockedAgg
+		}
 
 		e.toConsume[i].lockedAgg.Lock()
-		if e.toConsume[i].previous != nil {
-			e.toConsume[i].previous.lockedAgg.Lock()
+		if prevLockedAgg != nil {
+			prevLockedAgg.Lock()
 		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
@@ -271,7 +294,7 @@ func (e *CounterElem) Consume(
 				e.toConsume[i].lockedAgg,
 				// previous time + agg
 				prevTimeNanos,
-				e.toConsume[i].previous.lockedAgg,
+				prevLockedAgg,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -297,16 +320,18 @@ func (e *CounterElem) Consume(
 			}
 		}
 
-		if e.toConsume[i].previous != nil {
-			e.toConsume[i].previous.lockedAgg.Unlock()
-		}
 		e.toConsume[i].lockedAgg.Unlock()
+		if prevLockedAgg != nil {
+			prevLockedAgg.Unlock()
+		}
 
 		if expired {
 			// Release the previous datapoint so that on a following consume the current
 			// is available as a previous. If the consume cycle is fully empty (i.e. canCollect)
 			// then we can safely cleanup previous and current here.
-			e.toConsume[i].previous.Release()
+			if e.toConsume[i].previous != nil {
+				e.toConsume[i].previous.Release()
+			}
 			if canCollect {
 				e.toConsume[i].Release()
 			}
@@ -501,6 +526,8 @@ func (e *CounterElem) processValueWithAggregationLock(
 					Value:     value,
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
+
+				fmt.Println("CALC", res.Value, curr, prev)
 
 				// NB: we only need to record the value needed for derivative transformations.
 				// We currently only support first-order derivative transformations so we only

--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -43,7 +43,6 @@ import (
 	"github.com/m3db/m3/src/metrics/policy"
 	"github.com/m3db/m3/src/metrics/transformation"
 	"github.com/m3db/m3/src/x/pool"
-	xtime "github.com/m3db/m3/src/x/time"
 )
 
 const (
@@ -178,20 +177,6 @@ type elemBase struct {
 	closed               bool
 	cachedSourceSetsLock sync.Mutex                  // nolint: structcheck
 	cachedSourceSets     []map[uint32]*bitset.BitSet // nolint: structcheck
-}
-
-type valuesByTime map[xtime.UnixNano][]transformation.Datapoint
-
-// Return the latest timestamp in the map that is less than the provided timestamp. Returns 0 if a previous timestamp
-// does not exist.
-func (v valuesByTime) previousTimestamp(t xtime.UnixNano) xtime.UnixNano {
-	var previous xtime.UnixNano
-	for ts := range v {
-		if ts.Before(t) && !ts.Before(previous) {
-			previous = ts
-		}
-	}
-	return previous
 }
 
 type elemMetrics struct {

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -41,21 +41,20 @@ import (
 type lockedGaugeAggregation struct {
 	sync.Mutex
 
-	dirty        bool
-	flushed      bool
-	closed       bool
-	sourcesSeen  map[uint32]*bitset.BitSet
-	aggregation  gaugeAggregation
-	prevValues   []float64 // the previously emitted values (one per aggregation type).
-	prevConsumed []float64
+	dirty       bool
+	flushed     bool
+	closed      bool
+	sourcesSeen map[uint32]*bitset.BitSet
+	aggregation gaugeAggregation
+	prevValues  []float64 // the previously emitted values (one per aggregation type).
 }
 
 type timedGauge struct {
 	startAtNanos     int64 // start time of an aggregation window
 	lockedAgg        *lockedGaugeAggregation
 	onConsumeExpired bool
-
-	previous *timedGauge
+	consumed         []float64
+	previous         *timedGauge
 }
 
 func (ta *timedGauge) Release() {
@@ -268,33 +267,16 @@ func (e *GaugeElem) Consume(
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
-		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
-
-		var (
-			prevTimeNanos int64
-			prevLockedAgg *lockedGaugeAggregation
-		)
-		if e.toConsume[i].previous != nil {
-			prevTimeNanos = timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
-			prevLockedAgg = e.toConsume[i].previous.lockedAgg
-		}
 
 		e.toConsume[i].lockedAgg.Lock()
-		if prevLockedAgg != nil {
-			prevLockedAgg.Lock()
-		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
 		// cascade the dirty bit to all succeeding values. there is a check later to not resend a value if it doesn't
 		// change, so it's ok to optimistically mark dirty.
 		if cascadeDirty || e.toConsume[i].lockedAgg.dirty {
 			cascadeDirty = e.processValueWithAggregationLock(
-				// current time + agg
-				timeNanos,
-				e.toConsume[i].lockedAgg,
-				// previous time + agg
-				prevTimeNanos,
-				prevLockedAgg,
+				e.toConsume[i],
+				timestampNanosFn,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -321,9 +303,6 @@ func (e *GaugeElem) Consume(
 		}
 
 		e.toConsume[i].lockedAgg.Unlock()
-		if prevLockedAgg != nil {
-			prevLockedAgg.Unlock()
-		}
 
 		if expired {
 			// Release the previous datapoint so that on a following consume the current
@@ -437,11 +416,11 @@ func (e *GaugeElem) findOrCreate(
 	e.values[idx] = timedGauge{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedGaugeAggregation{
-			sourcesSeen:  sourcesSeen,
-			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
-			prevValues:   make([]float64, len(e.aggTypes)),
-			prevConsumed: make([]float64, len(e.aggTypes)),
+			sourcesSeen: sourcesSeen,
+			aggregation: e.NewAggregation(e.opts, e.aggOpts),
+			prevValues:  make([]float64, len(e.aggTypes)),
 		},
+		consumed: make([]float64, len(e.aggTypes)),
 	}
 	agg := e.values[idx].lockedAgg
 	e.Unlock()
@@ -479,21 +458,28 @@ func (e *GaugeElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 // returns true if a datapoint is emitted.
 func (e *GaugeElem) processValueWithAggregationLock(
-	timeNanos int64,
-	lockedAgg *lockedGaugeAggregation,
-	prevTimeNanos int64,
-	prevLockedAgg *lockedGaugeAggregation,
+	agg timedGauge,
+	timestampNanosFn timestampNanosFn,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration) bool {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
+		timeNanos        = timestampNanosFn(agg.startAtNanos, resolution)
+		prevTimeNanos    int64
+		prevAgg          *timedGauge
 		emitted          bool
 	)
+
+	if agg.previous != nil {
+		prevTimeNanos = timestampNanosFn(agg.previous.startAtNanos, resolution)
+		prevAgg = agg.previous
+	}
+
 	for aggTypeIdx, aggType := range e.aggTypes {
 		var extraDp transformation.Datapoint
-		value := lockedAgg.aggregation.ValueOf(aggType)
+		value := agg.lockedAgg.aggregation.ValueOf(aggType)
 		for _, transformOp := range transformations {
 			unaryOp, isUnaryOp := transformOp.UnaryTransform()
 			binaryOp, isBinaryOp := transformOp.BinaryTransform()
@@ -501,7 +487,7 @@ func (e *GaugeElem) processValueWithAggregationLock(
 			switch {
 			case isUnaryOp:
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 
@@ -511,14 +497,14 @@ func (e *GaugeElem) processValueWithAggregationLock(
 
 			case isBinaryOp:
 				var prev transformation.Datapoint
-				if prevLockedAgg == nil {
+				if prevAgg == nil {
 					prev = transformation.Datapoint{
 						Value: nan,
 					}
 				} else {
 					prev = transformation.Datapoint{
 						TimeNanos: prevTimeNanos,
-						Value:     prevLockedAgg.prevConsumed[aggTypeIdx],
+						Value:     prevAgg.consumed[aggTypeIdx],
 					}
 				}
 				curr := transformation.Datapoint{
@@ -527,14 +513,12 @@ func (e *GaugeElem) processValueWithAggregationLock(
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
 
-				fmt.Println("CALC", res.Value, curr, prev)
-
 				// NB: we only need to record the value needed for derivative transformations.
 				// We currently only support first-order derivative transformations so we only
 				// need to keep one value. In the future if we need to support higher-order
 				// derivative transformations, we need to store an array of values here.
 				if !math.IsNaN(curr.Value) {
-					lockedAgg.prevConsumed[aggTypeIdx] = value
+					agg.consumed[aggTypeIdx] = value
 				}
 
 				value = res.Value
@@ -556,9 +540,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 
 		// It's ok to send a 0 prevValue on the first forward because it's not used in AddUnique unless it's a
 		// resend (version > 0)
-		prevValue := lockedAgg.prevValues[aggTypeIdx]
-		lockedAgg.prevValues[aggTypeIdx] = value
-		if lockedAgg.flushed {
+		prevValue := agg.lockedAgg.prevValues[aggTypeIdx]
+		agg.lockedAgg.prevValues[aggTypeIdx] = value
+		if agg.lockedAgg.flushed {
 			// no need to resend a value that hasn't changed.
 			if (math.IsNaN(prevValue) && math.IsNaN(value)) || (prevValue == value) {
 				continue
@@ -578,16 +562,16 @@ func (e *GaugeElem) processValueWithAggregationLock(
 			for _, point := range toFlush {
 				switch e.idPrefixSuffixType {
 				case NoPrefixNoSuffix:
-					flushLocalFn(nil, e.id, nil, point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
+					flushLocalFn(nil, e.id, nil, point.TimeNanos, point.Value, agg.lockedAgg.aggregation.Annotation(), e.sp)
 				case WithPrefixWithSuffix:
 					flushLocalFn(e.FullPrefix(e.opts), e.id, e.TypeStringFor(e.aggTypesOpts, aggType),
-						point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
+						point.TimeNanos, point.Value, agg.lockedAgg.aggregation.Annotation(), e.sp)
 				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
-				int64(timeNanos), value, prevValue, lockedAgg.aggregation.Annotation())
+				timeNanos, value, prevValue, agg.lockedAgg.aggregation.Annotation())
 		}
 	}
 	return emitted

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -553,7 +553,7 @@ func (e *GaugeElem) processValueWithAggregationLock(
 		if !e.parsedPipeline.HasRollup {
 			toFlush := make([]transformation.Datapoint, 0, 2)
 			toFlush = append(toFlush, transformation.Datapoint{
-				TimeNanos: int64(timeNanos),
+				TimeNanos: timeNanos,
 				Value:     value,
 			})
 			if extraDp.TimeNanos != 0 {

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -36,7 +36,6 @@ import (
 	"github.com/m3db/m3/src/metrics/metric/aggregated"
 	"github.com/m3db/m3/src/metrics/metric/unaggregated"
 	"github.com/m3db/m3/src/metrics/transformation"
-	xtime "github.com/m3db/m3/src/x/time"
 )
 
 type typeSpecificAggregation interface {
@@ -106,23 +105,27 @@ type typeSpecificElemBase interface {
 type lockedAggregation struct {
 	sync.Mutex
 
-	dirty       bool
-	flushed     bool
-	closed      bool
-	sourcesSeen map[uint32]*bitset.BitSet
-	aggregation typeSpecificAggregation
-	prevValues  []float64 // the previously emitted values (one per aggregation type).
+	dirty        bool
+	flushed      bool
+	closed       bool
+	sourcesSeen  map[uint32]*bitset.BitSet
+	aggregation  typeSpecificAggregation
+	prevValues   []float64 // the previously emitted values (one per aggregation type).
+	prevConsumed []float64
 }
 
 type timedAggregation struct {
 	startAtNanos     int64 // start time of an aggregation window
 	lockedAgg        *lockedAggregation
 	onConsumeExpired bool
+
+	previous *timedAggregation
 }
 
 func (ta *timedAggregation) Release() {
 	ta.startAtNanos = 0
 	ta.lockedAgg = nil
+	ta.previous = nil
 }
 
 // GenericElem is an element storing time-bucketed aggregations.
@@ -134,9 +137,6 @@ type GenericElem struct {
 
 	// internal consume state that does not need to be synchronized.
 	toConsume []timedAggregation // small buffer to avoid memory allocations during consumption
-	// map of the previous consumed values for each timestamp in the buffer. needed to support binary transforms that
-	// need the value from the previous timestamp.
-	consumedValues valuesByTime
 }
 
 // NewGenericElem returns a new GenericElem.
@@ -313,29 +313,29 @@ func (e *GenericElem) Consume(
 	canCollect := len(e.values) == 0 && e.tombstoned
 	e.Unlock()
 
-	var (
-		cascadeDirty  bool
-		prevTimeNanos xtime.UnixNano
-	)
+	var cascadeDirty bool
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
-		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))
-		// seed the previous timestamp if this is first consumed value.
-		if prevTimeNanos == 0 {
-			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)
-		}
+		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
+		prevTimeNanos := timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
 
 		e.toConsume[i].lockedAgg.Lock()
+		if e.toConsume[i].previous != nil {
+			e.toConsume[i].previous.lockedAgg.Lock()
+		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
 		// cascade the dirty bit to all succeeding values. there is a check later to not resend a value if it doesn't
 		// change, so it's ok to optimistically mark dirty.
 		if cascadeDirty || e.toConsume[i].lockedAgg.dirty {
 			cascadeDirty = e.processValueWithAggregationLock(
+				// current time + agg
 				timeNanos,
-				prevTimeNanos,
 				e.toConsume[i].lockedAgg,
+				// previous time + agg
+				prevTimeNanos,
+				e.toConsume[i].previous.lockedAgg,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -361,13 +361,20 @@ func (e *GenericElem) Consume(
 			}
 		}
 
-		e.toConsume[i].lockedAgg.Unlock()
-		if expired {
-			e.toConsume[i].Release()
-			// the consumed value of the previous timestamp is no longer needed once this value has expired.
-			delete(e.consumedValues, prevTimeNanos)
+		if e.toConsume[i].previous != nil {
+			e.toConsume[i].previous.lockedAgg.Unlock()
 		}
-		prevTimeNanos = timeNanos
+		e.toConsume[i].lockedAgg.Unlock()
+
+		if expired {
+			// Release the previous datapoint so that on a following consume the current
+			// is available as a previous. If the consume cycle is fully empty (i.e. canCollect)
+			// then we can safely cleanup previous and current here.
+			e.toConsume[i].previous.Release()
+			if canCollect {
+				e.toConsume[i].Release()
+			}
+		}
 	}
 
 	if e.parsedPipeline.HasRollup {
@@ -408,7 +415,6 @@ func (e *GenericElem) Close() {
 
 	// internal consumption state that doesn't need to be synchronized.
 	e.toConsume = e.toConsume[:0]
-	e.consumedValues = nil
 
 	if !e.useDefaultAggregation {
 		aggTypesPool.Put(e.aggTypes)
@@ -470,9 +476,10 @@ func (e *GenericElem) findOrCreate(
 	e.values[idx] = timedAggregation{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedAggregation{
-			sourcesSeen: sourcesSeen,
-			aggregation: e.NewAggregation(e.opts, e.aggOpts),
-			prevValues:  make([]float64, len(e.aggTypes)),
+			sourcesSeen:  sourcesSeen,
+			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
+			prevValues:   make([]float64, len(e.aggTypes)),
+			prevConsumed: make([]float64, len(e.aggTypes)),
 		},
 	}
 	agg := e.values[idx].lockedAgg
@@ -511,9 +518,10 @@ func (e *GenericElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 // returns true if a datapoint is emitted.
 func (e *GenericElem) processValueWithAggregationLock(
-	timeNanos xtime.UnixNano,
-	prevTimeNanos xtime.UnixNano,
+	timeNanos int64,
 	lockedAgg *lockedAggregation,
+	prevTimeNanos int64,
+	prevLockedAgg *lockedAggregation,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration) bool {
@@ -541,18 +549,19 @@ func (e *GenericElem) processValueWithAggregationLock(
 				value = res.Value
 
 			case isBinaryOp:
-				prev := transformation.Datapoint{
-					Value: nan,
-				}
-				// lazily construct consumedValues since they are only needed by binary transforms.
-				if e.consumedValues == nil {
-					e.consumedValues = make(valuesByTime)
-				}
-				if _, ok := e.consumedValues[prevTimeNanos]; ok {
-					prev = e.consumedValues[prevTimeNanos][aggTypeIdx]
+				var prev transformation.Datapoint
+				if prevLockedAgg == nil {
+					prev = transformation.Datapoint{
+						Value: nan,
+					}
+				} else {
+					prev = transformation.Datapoint{
+						TimeNanos: prevTimeNanos,
+						Value:     prevLockedAgg.prevConsumed[aggTypeIdx],
+					}
 				}
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
@@ -562,16 +571,13 @@ func (e *GenericElem) processValueWithAggregationLock(
 				// need to keep one value. In the future if we need to support higher-order
 				// derivative transformations, we need to store an array of values here.
 				if !math.IsNaN(curr.Value) {
-					if e.consumedValues[timeNanos] == nil {
-						e.consumedValues[timeNanos] = make([]transformation.Datapoint, len(e.aggTypes))
-					}
-					e.consumedValues[timeNanos][aggTypeIdx] = curr
+					lockedAgg.prevConsumed[aggTypeIdx] = value
 				}
 
 				value = res.Value
 			case isUnaryMultiOp:
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -105,21 +105,20 @@ type typeSpecificElemBase interface {
 type lockedAggregation struct {
 	sync.Mutex
 
-	dirty        bool
-	flushed      bool
-	closed       bool
-	sourcesSeen  map[uint32]*bitset.BitSet
-	aggregation  typeSpecificAggregation
-	prevValues   []float64 // the previously emitted values (one per aggregation type).
-	prevConsumed []float64
+	dirty       bool
+	flushed     bool
+	closed      bool
+	sourcesSeen map[uint32]*bitset.BitSet
+	aggregation typeSpecificAggregation
+	prevValues  []float64 // the previously emitted values (one per aggregation type).
 }
 
 type timedAggregation struct {
 	startAtNanos     int64 // start time of an aggregation window
 	lockedAgg        *lockedAggregation
 	onConsumeExpired bool
-
-	previous *timedAggregation
+	consumed         []float64
+	previous         *timedAggregation
 }
 
 func (ta *timedAggregation) Release() {
@@ -332,33 +331,16 @@ func (e *GenericElem) Consume(
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
-		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
-
-		var (
-			prevTimeNanos int64
-			prevLockedAgg *lockedAggregation
-		)
-		if e.toConsume[i].previous != nil {
-			prevTimeNanos = timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
-			prevLockedAgg = e.toConsume[i].previous.lockedAgg
-		}
 
 		e.toConsume[i].lockedAgg.Lock()
-		if prevLockedAgg != nil {
-			prevLockedAgg.Lock()
-		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
 		// cascade the dirty bit to all succeeding values. there is a check later to not resend a value if it doesn't
 		// change, so it's ok to optimistically mark dirty.
 		if cascadeDirty || e.toConsume[i].lockedAgg.dirty {
 			cascadeDirty = e.processValueWithAggregationLock(
-				// current time + agg
-				timeNanos,
-				e.toConsume[i].lockedAgg,
-				// previous time + agg
-				prevTimeNanos,
-				prevLockedAgg,
+				e.toConsume[i],
+				timestampNanosFn,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -385,9 +367,6 @@ func (e *GenericElem) Consume(
 		}
 
 		e.toConsume[i].lockedAgg.Unlock()
-		if prevLockedAgg != nil {
-			prevLockedAgg.Unlock()
-		}
 
 		if expired {
 			// Release the previous datapoint so that on a following consume the current
@@ -501,11 +480,11 @@ func (e *GenericElem) findOrCreate(
 	e.values[idx] = timedAggregation{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedAggregation{
-			sourcesSeen:  sourcesSeen,
-			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
-			prevValues:   make([]float64, len(e.aggTypes)),
-			prevConsumed: make([]float64, len(e.aggTypes)),
+			sourcesSeen: sourcesSeen,
+			aggregation: e.NewAggregation(e.opts, e.aggOpts),
+			prevValues:  make([]float64, len(e.aggTypes)),
 		},
+		consumed: make([]float64, len(e.aggTypes)),
 	}
 	agg := e.values[idx].lockedAgg
 	e.Unlock()
@@ -543,21 +522,28 @@ func (e *GenericElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 // returns true if a datapoint is emitted.
 func (e *GenericElem) processValueWithAggregationLock(
-	timeNanos int64,
-	lockedAgg *lockedAggregation,
-	prevTimeNanos int64,
-	prevLockedAgg *lockedAggregation,
+	agg timedAggregation,
+	timestampNanosFn timestampNanosFn,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration) bool {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
+		timeNanos        = timestampNanosFn(agg.startAtNanos, resolution)
+		prevTimeNanos    int64
+		prevAgg          *timedAggregation
 		emitted          bool
 	)
+
+	if agg.previous != nil {
+		prevTimeNanos = timestampNanosFn(agg.previous.startAtNanos, resolution)
+		prevAgg = agg.previous
+	}
+
 	for aggTypeIdx, aggType := range e.aggTypes {
 		var extraDp transformation.Datapoint
-		value := lockedAgg.aggregation.ValueOf(aggType)
+		value := agg.lockedAgg.aggregation.ValueOf(aggType)
 		for _, transformOp := range transformations {
 			unaryOp, isUnaryOp := transformOp.UnaryTransform()
 			binaryOp, isBinaryOp := transformOp.BinaryTransform()
@@ -565,7 +551,7 @@ func (e *GenericElem) processValueWithAggregationLock(
 			switch {
 			case isUnaryOp:
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 
@@ -575,14 +561,14 @@ func (e *GenericElem) processValueWithAggregationLock(
 
 			case isBinaryOp:
 				var prev transformation.Datapoint
-				if prevLockedAgg == nil {
+				if prevAgg == nil {
 					prev = transformation.Datapoint{
 						Value: nan,
 					}
 				} else {
 					prev = transformation.Datapoint{
 						TimeNanos: prevTimeNanos,
-						Value:     prevLockedAgg.prevConsumed[aggTypeIdx],
+						Value:     prevAgg.consumed[aggTypeIdx],
 					}
 				}
 				curr := transformation.Datapoint{
@@ -591,14 +577,12 @@ func (e *GenericElem) processValueWithAggregationLock(
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
 
-				fmt.Println("CALC", res.Value, curr, prev)
-
 				// NB: we only need to record the value needed for derivative transformations.
 				// We currently only support first-order derivative transformations so we only
 				// need to keep one value. In the future if we need to support higher-order
 				// derivative transformations, we need to store an array of values here.
 				if !math.IsNaN(curr.Value) {
-					lockedAgg.prevConsumed[aggTypeIdx] = value
+					agg.consumed[aggTypeIdx] = value
 				}
 
 				value = res.Value
@@ -620,9 +604,9 @@ func (e *GenericElem) processValueWithAggregationLock(
 
 		// It's ok to send a 0 prevValue on the first forward because it's not used in AddUnique unless it's a
 		// resend (version > 0)
-		prevValue := lockedAgg.prevValues[aggTypeIdx]
-		lockedAgg.prevValues[aggTypeIdx] = value
-		if lockedAgg.flushed {
+		prevValue := agg.lockedAgg.prevValues[aggTypeIdx]
+		agg.lockedAgg.prevValues[aggTypeIdx] = value
+		if agg.lockedAgg.flushed {
 			// no need to resend a value that hasn't changed.
 			if (math.IsNaN(prevValue) && math.IsNaN(value)) || (prevValue == value) {
 				continue
@@ -642,16 +626,16 @@ func (e *GenericElem) processValueWithAggregationLock(
 			for _, point := range toFlush {
 				switch e.idPrefixSuffixType {
 				case NoPrefixNoSuffix:
-					flushLocalFn(nil, e.id, nil, point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
+					flushLocalFn(nil, e.id, nil, point.TimeNanos, point.Value, agg.lockedAgg.aggregation.Annotation(), e.sp)
 				case WithPrefixWithSuffix:
 					flushLocalFn(e.FullPrefix(e.opts), e.id, e.TypeStringFor(e.aggTypesOpts, aggType),
-						point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
+						point.TimeNanos, point.Value, agg.lockedAgg.aggregation.Annotation(), e.sp)
 				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
-				int64(timeNanos), value, prevValue, lockedAgg.aggregation.Annotation())
+				timeNanos, value, prevValue, agg.lockedAgg.aggregation.Annotation())
 		}
 	}
 	return emitted

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -617,7 +617,7 @@ func (e *GenericElem) processValueWithAggregationLock(
 		if !e.parsedPipeline.HasRollup {
 			toFlush := make([]transformation.Datapoint, 0, 2)
 			toFlush = append(toFlush, transformation.Datapoint{
-				TimeNanos: int64(timeNanos),
+				TimeNanos: timeNanos,
 				Value:     value,
 			})
 			if extraDp.TimeNanos != 0 {

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -287,12 +287,22 @@ func (e *GenericElem) Consume(
 	// Evaluate and GC expired items.
 	valuesForConsideration := e.values
 	e.values = e.values[:0]
+	var (
+		previous *timedAggregation
+		expired  bool
+	)
 	for _, value := range valuesForConsideration {
 		if !isEarlierThanFn(value.startAtNanos, resolution, targetNanos) {
+			// Keep the previous expired value to reference.
+			if previous != nil && expired {
+				e.values = append(e.values, *previous)
+				previous = nil
+			}
+
 			e.values = append(e.values, value)
 			continue
 		}
-		expired := true
+		expired = true
 		if e.resendEnabled {
 			// If resend is enabled, we only expire if the value is now outside the buffer past. It is safe to expire
 			// since any metrics intended for this value are rejected for being too late.
@@ -303,12 +313,17 @@ func (e *GenericElem) Consume(
 		// Modify the by value copy with whether it needs time flush and accumulate.
 		copiedValue := value
 		copiedValue.onConsumeExpired = expired
+		if previous != nil {
+			copiedValue.previous = previous
+		}
 		e.toConsume = append(e.toConsume, copiedValue)
 
 		if !expired {
 			// Keep item. Expired values are GC'd below after consuming.
 			e.values = append(e.values, value)
 		}
+
+		previous = &copiedValue
 	}
 	canCollect := len(e.values) == 0 && e.tombstoned
 	e.Unlock()
@@ -318,11 +333,19 @@ func (e *GenericElem) Consume(
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
-		prevTimeNanos := timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
+
+		var (
+			prevTimeNanos int64
+			prevLockedAgg *lockedAggregation
+		)
+		if e.toConsume[i].previous != nil {
+			prevTimeNanos = timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
+			prevLockedAgg = e.toConsume[i].previous.lockedAgg
+		}
 
 		e.toConsume[i].lockedAgg.Lock()
-		if e.toConsume[i].previous != nil {
-			e.toConsume[i].previous.lockedAgg.Lock()
+		if prevLockedAgg != nil {
+			prevLockedAgg.Lock()
 		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
@@ -335,7 +358,7 @@ func (e *GenericElem) Consume(
 				e.toConsume[i].lockedAgg,
 				// previous time + agg
 				prevTimeNanos,
-				e.toConsume[i].previous.lockedAgg,
+				prevLockedAgg,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -361,16 +384,18 @@ func (e *GenericElem) Consume(
 			}
 		}
 
-		if e.toConsume[i].previous != nil {
-			e.toConsume[i].previous.lockedAgg.Unlock()
-		}
 		e.toConsume[i].lockedAgg.Unlock()
+		if prevLockedAgg != nil {
+			prevLockedAgg.Unlock()
+		}
 
 		if expired {
 			// Release the previous datapoint so that on a following consume the current
 			// is available as a previous. If the consume cycle is fully empty (i.e. canCollect)
 			// then we can safely cleanup previous and current here.
-			e.toConsume[i].previous.Release()
+			if e.toConsume[i].previous != nil {
+				e.toConsume[i].previous.Release()
+			}
 			if canCollect {
 				e.toConsume[i].Release()
 			}
@@ -565,6 +590,8 @@ func (e *GenericElem) processValueWithAggregationLock(
 					Value:     value,
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
+
+				fmt.Println("CALC", res.Value, curr, prev)
 
 				// NB: we only need to record the value needed for derivative transformations.
 				// We currently only support first-order derivative transformations so we only

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -34,7 +34,6 @@ import (
 	"github.com/m3db/m3/src/metrics/metric/aggregated"
 	"github.com/m3db/m3/src/metrics/metric/unaggregated"
 	"github.com/m3db/m3/src/metrics/transformation"
-	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/willf/bitset"
 )
@@ -42,23 +41,27 @@ import (
 type lockedTimerAggregation struct {
 	sync.Mutex
 
-	dirty       bool
-	flushed     bool
-	closed      bool
-	sourcesSeen map[uint32]*bitset.BitSet
-	aggregation timerAggregation
-	prevValues  []float64 // the previously emitted values (one per aggregation type).
+	dirty        bool
+	flushed      bool
+	closed       bool
+	sourcesSeen  map[uint32]*bitset.BitSet
+	aggregation  timerAggregation
+	prevValues   []float64 // the previously emitted values (one per aggregation type).
+	prevConsumed []float64
 }
 
 type timedTimer struct {
 	startAtNanos     int64 // start time of an aggregation window
 	lockedAgg        *lockedTimerAggregation
 	onConsumeExpired bool
+
+	previous *timedTimer
 }
 
 func (ta *timedTimer) Release() {
 	ta.startAtNanos = 0
 	ta.lockedAgg = nil
+	ta.previous = nil
 }
 
 // TimerElem is an element storing time-bucketed aggregations.
@@ -70,9 +73,6 @@ type TimerElem struct {
 
 	// internal consume state that does not need to be synchronized.
 	toConsume []timedTimer // small buffer to avoid memory allocations during consumption
-	// map of the previous consumed values for each timestamp in the buffer. needed to support binary transforms that
-	// need the value from the previous timestamp.
-	consumedValues valuesByTime
 }
 
 // NewTimerElem returns a new TimerElem.
@@ -249,29 +249,29 @@ func (e *TimerElem) Consume(
 	canCollect := len(e.values) == 0 && e.tombstoned
 	e.Unlock()
 
-	var (
-		cascadeDirty  bool
-		prevTimeNanos xtime.UnixNano
-	)
+	var cascadeDirty bool
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
-		timeNanos := xtime.UnixNano(timestampNanosFn(e.toConsume[i].startAtNanos, resolution))
-		// seed the previous timestamp if this is first consumed value.
-		if prevTimeNanos == 0 {
-			prevTimeNanos = e.consumedValues.previousTimestamp(timeNanos)
-		}
+		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
+		prevTimeNanos := timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
 
 		e.toConsume[i].lockedAgg.Lock()
+		if e.toConsume[i].previous != nil {
+			e.toConsume[i].previous.lockedAgg.Lock()
+		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
 		// cascade the dirty bit to all succeeding values. there is a check later to not resend a value if it doesn't
 		// change, so it's ok to optimistically mark dirty.
 		if cascadeDirty || e.toConsume[i].lockedAgg.dirty {
 			cascadeDirty = e.processValueWithAggregationLock(
+				// current time + agg
 				timeNanos,
-				prevTimeNanos,
 				e.toConsume[i].lockedAgg,
+				// previous time + agg
+				prevTimeNanos,
+				e.toConsume[i].previous.lockedAgg,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -297,13 +297,20 @@ func (e *TimerElem) Consume(
 			}
 		}
 
-		e.toConsume[i].lockedAgg.Unlock()
-		if expired {
-			e.toConsume[i].Release()
-			// the consumed value of the previous timestamp is no longer needed once this value has expired.
-			delete(e.consumedValues, prevTimeNanos)
+		if e.toConsume[i].previous != nil {
+			e.toConsume[i].previous.lockedAgg.Unlock()
 		}
-		prevTimeNanos = timeNanos
+		e.toConsume[i].lockedAgg.Unlock()
+
+		if expired {
+			// Release the previous datapoint so that on a following consume the current
+			// is available as a previous. If the consume cycle is fully empty (i.e. canCollect)
+			// then we can safely cleanup previous and current here.
+			e.toConsume[i].previous.Release()
+			if canCollect {
+				e.toConsume[i].Release()
+			}
+		}
 	}
 
 	if e.parsedPipeline.HasRollup {
@@ -344,7 +351,6 @@ func (e *TimerElem) Close() {
 
 	// internal consumption state that doesn't need to be synchronized.
 	e.toConsume = e.toConsume[:0]
-	e.consumedValues = nil
 
 	if !e.useDefaultAggregation {
 		aggTypesPool.Put(e.aggTypes)
@@ -406,9 +412,10 @@ func (e *TimerElem) findOrCreate(
 	e.values[idx] = timedTimer{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedTimerAggregation{
-			sourcesSeen: sourcesSeen,
-			aggregation: e.NewAggregation(e.opts, e.aggOpts),
-			prevValues:  make([]float64, len(e.aggTypes)),
+			sourcesSeen:  sourcesSeen,
+			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
+			prevValues:   make([]float64, len(e.aggTypes)),
+			prevConsumed: make([]float64, len(e.aggTypes)),
 		},
 	}
 	agg := e.values[idx].lockedAgg
@@ -447,9 +454,10 @@ func (e *TimerElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 // returns true if a datapoint is emitted.
 func (e *TimerElem) processValueWithAggregationLock(
-	timeNanos xtime.UnixNano,
-	prevTimeNanos xtime.UnixNano,
+	timeNanos int64,
 	lockedAgg *lockedTimerAggregation,
+	prevTimeNanos int64,
+	prevLockedAgg *lockedTimerAggregation,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration) bool {
@@ -477,18 +485,19 @@ func (e *TimerElem) processValueWithAggregationLock(
 				value = res.Value
 
 			case isBinaryOp:
-				prev := transformation.Datapoint{
-					Value: nan,
-				}
-				// lazily construct consumedValues since they are only needed by binary transforms.
-				if e.consumedValues == nil {
-					e.consumedValues = make(valuesByTime)
-				}
-				if _, ok := e.consumedValues[prevTimeNanos]; ok {
-					prev = e.consumedValues[prevTimeNanos][aggTypeIdx]
+				var prev transformation.Datapoint
+				if prevLockedAgg == nil {
+					prev = transformation.Datapoint{
+						Value: nan,
+					}
+				} else {
+					prev = transformation.Datapoint{
+						TimeNanos: prevTimeNanos,
+						Value:     prevLockedAgg.prevConsumed[aggTypeIdx],
+					}
 				}
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
@@ -498,16 +507,13 @@ func (e *TimerElem) processValueWithAggregationLock(
 				// need to keep one value. In the future if we need to support higher-order
 				// derivative transformations, we need to store an array of values here.
 				if !math.IsNaN(curr.Value) {
-					if e.consumedValues[timeNanos] == nil {
-						e.consumedValues[timeNanos] = make([]transformation.Datapoint, len(e.aggTypes))
-					}
-					e.consumedValues[timeNanos][aggTypeIdx] = curr
+					lockedAgg.prevConsumed[aggTypeIdx] = value
 				}
 
 				value = res.Value
 			case isUnaryMultiOp:
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -41,21 +41,20 @@ import (
 type lockedTimerAggregation struct {
 	sync.Mutex
 
-	dirty        bool
-	flushed      bool
-	closed       bool
-	sourcesSeen  map[uint32]*bitset.BitSet
-	aggregation  timerAggregation
-	prevValues   []float64 // the previously emitted values (one per aggregation type).
-	prevConsumed []float64
+	dirty       bool
+	flushed     bool
+	closed      bool
+	sourcesSeen map[uint32]*bitset.BitSet
+	aggregation timerAggregation
+	prevValues  []float64 // the previously emitted values (one per aggregation type).
 }
 
 type timedTimer struct {
 	startAtNanos     int64 // start time of an aggregation window
 	lockedAgg        *lockedTimerAggregation
 	onConsumeExpired bool
-
-	previous *timedTimer
+	consumed         []float64
+	previous         *timedTimer
 }
 
 func (ta *timedTimer) Release() {
@@ -268,33 +267,16 @@ func (e *TimerElem) Consume(
 	// Process the aggregations that are ready for consumption.
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
-		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
-
-		var (
-			prevTimeNanos int64
-			prevLockedAgg *lockedTimerAggregation
-		)
-		if e.toConsume[i].previous != nil {
-			prevTimeNanos = timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
-			prevLockedAgg = e.toConsume[i].previous.lockedAgg
-		}
 
 		e.toConsume[i].lockedAgg.Lock()
-		if prevLockedAgg != nil {
-			prevLockedAgg.Lock()
-		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
 		// cascade the dirty bit to all succeeding values. there is a check later to not resend a value if it doesn't
 		// change, so it's ok to optimistically mark dirty.
 		if cascadeDirty || e.toConsume[i].lockedAgg.dirty {
 			cascadeDirty = e.processValueWithAggregationLock(
-				// current time + agg
-				timeNanos,
-				e.toConsume[i].lockedAgg,
-				// previous time + agg
-				prevTimeNanos,
-				prevLockedAgg,
+				e.toConsume[i],
+				timestampNanosFn,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -321,9 +303,6 @@ func (e *TimerElem) Consume(
 		}
 
 		e.toConsume[i].lockedAgg.Unlock()
-		if prevLockedAgg != nil {
-			prevLockedAgg.Unlock()
-		}
 
 		if expired {
 			// Release the previous datapoint so that on a following consume the current
@@ -437,11 +416,11 @@ func (e *TimerElem) findOrCreate(
 	e.values[idx] = timedTimer{
 		startAtNanos: alignedStart,
 		lockedAgg: &lockedTimerAggregation{
-			sourcesSeen:  sourcesSeen,
-			aggregation:  e.NewAggregation(e.opts, e.aggOpts),
-			prevValues:   make([]float64, len(e.aggTypes)),
-			prevConsumed: make([]float64, len(e.aggTypes)),
+			sourcesSeen: sourcesSeen,
+			aggregation: e.NewAggregation(e.opts, e.aggOpts),
+			prevValues:  make([]float64, len(e.aggTypes)),
 		},
+		consumed: make([]float64, len(e.aggTypes)),
 	}
 	agg := e.values[idx].lockedAgg
 	e.Unlock()
@@ -479,21 +458,28 @@ func (e *TimerElem) indexOfWithLock(alignedStart int64) (int, bool) {
 
 // returns true if a datapoint is emitted.
 func (e *TimerElem) processValueWithAggregationLock(
-	timeNanos int64,
-	lockedAgg *lockedTimerAggregation,
-	prevTimeNanos int64,
-	prevLockedAgg *lockedTimerAggregation,
+	agg timedTimer,
+	timestampNanosFn timestampNanosFn,
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration) bool {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
+		timeNanos        = timestampNanosFn(agg.startAtNanos, resolution)
+		prevTimeNanos    int64
+		prevAgg          *timedTimer
 		emitted          bool
 	)
+
+	if agg.previous != nil {
+		prevTimeNanos = timestampNanosFn(agg.previous.startAtNanos, resolution)
+		prevAgg = agg.previous
+	}
+
 	for aggTypeIdx, aggType := range e.aggTypes {
 		var extraDp transformation.Datapoint
-		value := lockedAgg.aggregation.ValueOf(aggType)
+		value := agg.lockedAgg.aggregation.ValueOf(aggType)
 		for _, transformOp := range transformations {
 			unaryOp, isUnaryOp := transformOp.UnaryTransform()
 			binaryOp, isBinaryOp := transformOp.BinaryTransform()
@@ -501,7 +487,7 @@ func (e *TimerElem) processValueWithAggregationLock(
 			switch {
 			case isUnaryOp:
 				curr := transformation.Datapoint{
-					TimeNanos: int64(timeNanos),
+					TimeNanos: timeNanos,
 					Value:     value,
 				}
 
@@ -511,14 +497,14 @@ func (e *TimerElem) processValueWithAggregationLock(
 
 			case isBinaryOp:
 				var prev transformation.Datapoint
-				if prevLockedAgg == nil {
+				if prevAgg == nil {
 					prev = transformation.Datapoint{
 						Value: nan,
 					}
 				} else {
 					prev = transformation.Datapoint{
 						TimeNanos: prevTimeNanos,
-						Value:     prevLockedAgg.prevConsumed[aggTypeIdx],
+						Value:     prevAgg.consumed[aggTypeIdx],
 					}
 				}
 				curr := transformation.Datapoint{
@@ -527,14 +513,12 @@ func (e *TimerElem) processValueWithAggregationLock(
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
 
-				fmt.Println("CALC", res.Value, curr, prev)
-
 				// NB: we only need to record the value needed for derivative transformations.
 				// We currently only support first-order derivative transformations so we only
 				// need to keep one value. In the future if we need to support higher-order
 				// derivative transformations, we need to store an array of values here.
 				if !math.IsNaN(curr.Value) {
-					lockedAgg.prevConsumed[aggTypeIdx] = value
+					agg.consumed[aggTypeIdx] = value
 				}
 
 				value = res.Value
@@ -556,9 +540,9 @@ func (e *TimerElem) processValueWithAggregationLock(
 
 		// It's ok to send a 0 prevValue on the first forward because it's not used in AddUnique unless it's a
 		// resend (version > 0)
-		prevValue := lockedAgg.prevValues[aggTypeIdx]
-		lockedAgg.prevValues[aggTypeIdx] = value
-		if lockedAgg.flushed {
+		prevValue := agg.lockedAgg.prevValues[aggTypeIdx]
+		agg.lockedAgg.prevValues[aggTypeIdx] = value
+		if agg.lockedAgg.flushed {
 			// no need to resend a value that hasn't changed.
 			if (math.IsNaN(prevValue) && math.IsNaN(value)) || (prevValue == value) {
 				continue
@@ -578,16 +562,16 @@ func (e *TimerElem) processValueWithAggregationLock(
 			for _, point := range toFlush {
 				switch e.idPrefixSuffixType {
 				case NoPrefixNoSuffix:
-					flushLocalFn(nil, e.id, nil, point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
+					flushLocalFn(nil, e.id, nil, point.TimeNanos, point.Value, agg.lockedAgg.aggregation.Annotation(), e.sp)
 				case WithPrefixWithSuffix:
 					flushLocalFn(e.FullPrefix(e.opts), e.id, e.TypeStringFor(e.aggTypesOpts, aggType),
-						point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
+						point.TimeNanos, point.Value, agg.lockedAgg.aggregation.Annotation(), e.sp)
 				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
-				int64(timeNanos), value, prevValue, lockedAgg.aggregation.Annotation())
+				timeNanos, value, prevValue, agg.lockedAgg.aggregation.Annotation())
 		}
 	}
 	return emitted

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -223,12 +223,22 @@ func (e *TimerElem) Consume(
 	// Evaluate and GC expired items.
 	valuesForConsideration := e.values
 	e.values = e.values[:0]
+	var (
+		previous *timedTimer
+		expired  bool
+	)
 	for _, value := range valuesForConsideration {
 		if !isEarlierThanFn(value.startAtNanos, resolution, targetNanos) {
+			// Keep the previous expired value to reference.
+			if previous != nil && expired {
+				e.values = append(e.values, *previous)
+				previous = nil
+			}
+
 			e.values = append(e.values, value)
 			continue
 		}
-		expired := true
+		expired = true
 		if e.resendEnabled {
 			// If resend is enabled, we only expire if the value is now outside the buffer past. It is safe to expire
 			// since any metrics intended for this value are rejected for being too late.
@@ -239,12 +249,17 @@ func (e *TimerElem) Consume(
 		// Modify the by value copy with whether it needs time flush and accumulate.
 		copiedValue := value
 		copiedValue.onConsumeExpired = expired
+		if previous != nil {
+			copiedValue.previous = previous
+		}
 		e.toConsume = append(e.toConsume, copiedValue)
 
 		if !expired {
 			// Keep item. Expired values are GC'd below after consuming.
 			e.values = append(e.values, value)
 		}
+
+		previous = &copiedValue
 	}
 	canCollect := len(e.values) == 0 && e.tombstoned
 	e.Unlock()
@@ -254,11 +269,19 @@ func (e *TimerElem) Consume(
 	for i := range e.toConsume {
 		expired := e.toConsume[i].onConsumeExpired
 		timeNanos := timestampNanosFn(e.toConsume[i].startAtNanos, resolution)
-		prevTimeNanos := timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
+
+		var (
+			prevTimeNanos int64
+			prevLockedAgg *lockedTimerAggregation
+		)
+		if e.toConsume[i].previous != nil {
+			prevTimeNanos = timestampNanosFn(e.toConsume[i].previous.startAtNanos, resolution)
+			prevLockedAgg = e.toConsume[i].previous.lockedAgg
+		}
 
 		e.toConsume[i].lockedAgg.Lock()
-		if e.toConsume[i].previous != nil {
-			e.toConsume[i].previous.lockedAgg.Lock()
+		if prevLockedAgg != nil {
+			prevLockedAgg.Lock()
 		}
 
 		// if a previous timestamps was dirty, that value might impact a future derivative calculation, so
@@ -271,7 +294,7 @@ func (e *TimerElem) Consume(
 				e.toConsume[i].lockedAgg,
 				// previous time + agg
 				prevTimeNanos,
-				e.toConsume[i].previous.lockedAgg,
+				prevLockedAgg,
 				flushLocalFn,
 				flushForwardedFn,
 				resolution,
@@ -297,16 +320,18 @@ func (e *TimerElem) Consume(
 			}
 		}
 
-		if e.toConsume[i].previous != nil {
-			e.toConsume[i].previous.lockedAgg.Unlock()
-		}
 		e.toConsume[i].lockedAgg.Unlock()
+		if prevLockedAgg != nil {
+			prevLockedAgg.Unlock()
+		}
 
 		if expired {
 			// Release the previous datapoint so that on a following consume the current
 			// is available as a previous. If the consume cycle is fully empty (i.e. canCollect)
 			// then we can safely cleanup previous and current here.
-			e.toConsume[i].previous.Release()
+			if e.toConsume[i].previous != nil {
+				e.toConsume[i].previous.Release()
+			}
 			if canCollect {
 				e.toConsume[i].Release()
 			}
@@ -501,6 +526,8 @@ func (e *TimerElem) processValueWithAggregationLock(
 					Value:     value,
 				}
 				res := binaryOp.Evaluate(prev, curr, transformation.FeatureFlags{})
+
+				fmt.Println("CALC", res.Value, curr, prev)
 
 				// NB: we only need to record the value needed for derivative transformations.
 				// We currently only support first-order derivative transformations so we only

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -553,7 +553,7 @@ func (e *TimerElem) processValueWithAggregationLock(
 		if !e.parsedPipeline.HasRollup {
 			toFlush := make([]transformation.Datapoint, 0, 2)
 			toFlush = append(toFlush, transformation.Datapoint{
-				TimeNanos: int64(timeNanos),
+				TimeNanos: timeNanos,
 				Value:     value,
 			})
 			if extraDp.TimeNanos != 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Improve a CPU inefficiency in the aggregator consume path. 

On any aggregate `Consume(t timestamp)` call, identifying the timestamp directly preceding `t` required a full scan of a map of all data points in that aggregate's buffer past (see `previousTimestamp(...)`). We already have ordered datapoints in memory, and so now use that to identify a preceding datapoint instead of this extraneous map.

![image](https://user-images.githubusercontent.com/9585325/137397336-1ccad005-698e-4a0d-806a-3b66ad8d40f4.png)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
