### PR TITLE
Add ElemOptions to avoid allocs per aggregated element

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -76,7 +76,7 @@ type CounterElem struct {
 }
 
 // NewCounterElem returns a new CounterElem.
-func NewCounterElem(data ElemData, opts Options) (*CounterElem, error) {
+func NewCounterElem(data ElemData, opts ElemOptions) (*CounterElem, error) {
 	e := &CounterElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedCounter, 0, defaultNumAggregations), // in most cases values will have two entries
@@ -88,7 +88,7 @@ func NewCounterElem(data ElemData, opts Options) (*CounterElem, error) {
 }
 
 // MustNewCounterElem returns a new CounterElem and panics if an error occurs.
-func MustNewCounterElem(data ElemData, opts Options) *CounterElem {
+func MustNewCounterElem(data ElemData, opts ElemOptions) *CounterElem {
 	elem, err := NewCounterElem(data, opts)
 	if err != nil {
 		panic(fmt.Errorf("unable to create element: %v", err))

--- a/src/aggregator/aggregator/elem_base_test.go
+++ b/src/aggregator/aggregator/elem_base_test.go
@@ -120,7 +120,7 @@ func TestElemBaseResetSetDataNoRollup(t *testing.T) {
 }
 
 func TestElemBaseForwardedIDWithDefaultPipeline(t *testing.T) {
-	e := newElemBase(newTestOptions())
+	e := newElemBase(NewElemOptions(newTestOptions()))
 	_, ok := e.ForwardedID()
 	require.False(t, ok)
 }
@@ -134,7 +134,7 @@ func TestElemBaseForwardedIDWithCustomPipeline(t *testing.T) {
 }
 
 func TestElemBaseForwardedAggregationKeyWithDefaultPipeline(t *testing.T) {
-	e := newElemBase(newTestOptions())
+	e := newElemBase(NewElemOptions(newTestOptions()))
 	_, ok := e.ForwardedAggregationKey()
 	require.False(t, ok)
 }

--- a/src/aggregator/aggregator/elem_pool_test.go
+++ b/src/aggregator/aggregator/elem_pool_test.go
@@ -31,7 +31,7 @@ import (
 func TestCounterElemPool(t *testing.T) {
 	p := NewCounterElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *CounterElem {
-		return MustNewCounterElem(ElemData{}, newTestOptions())
+		return MustNewCounterElem(ElemData{}, NewElemOptions(newTestOptions()))
 	})
 
 	// Retrieve an element from the pool.
@@ -52,7 +52,7 @@ func TestCounterElemPool(t *testing.T) {
 func TestTimerElemPool(t *testing.T) {
 	p := NewTimerElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *TimerElem {
-		return MustNewTimerElem(ElemData{}, newTestOptions())
+		return MustNewTimerElem(ElemData{}, NewElemOptions(newTestOptions()))
 	})
 
 	// Retrieve an element from the pool.
@@ -73,7 +73,7 @@ func TestTimerElemPool(t *testing.T) {
 func TestGaugeElemPool(t *testing.T) {
 	p := NewGaugeElemPool(pool.NewObjectPoolOptions().SetSize(1))
 	p.Init(func() *GaugeElem {
-		return MustNewGaugeElem(testGaugeElemData, newTestOptions())
+		return MustNewGaugeElem(testGaugeElemData, NewElemOptions(newTestOptions()))
 	})
 
 	// Retrieve an element from the pool.

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -128,7 +128,7 @@ func TestCounterResetSetData(t *testing.T) {
 	opts := newTestOptions()
 	elemData := testCounterElemData
 	elemData.NumForwardedTimes = 1
-	ce, err := NewCounterElem(elemData, opts)
+	ce, err := NewCounterElem(elemData, NewElemOptions(opts))
 	require.NoError(t, err)
 	require.Equal(t, opts.AggregationTypesOptions().DefaultCounterAggregationTypes(), ce.aggTypes)
 	require.True(t, ce.useDefaultAggregation)
@@ -184,7 +184,7 @@ func TestCounterResetSetData(t *testing.T) {
 
 func TestCounterResetSetDataInvalidAggregationType(t *testing.T) {
 	opts := newTestOptions()
-	ce := MustNewCounterElem(testCounterElemData, opts)
+	ce := MustNewCounterElem(testCounterElemData, NewElemOptions(opts))
 	elemData := testCounterElemData
 	elemData.AggTypes = maggregation.Types{maggregation.Last}
 	err := ce.ResetSetData(elemData)
@@ -193,7 +193,7 @@ func TestCounterResetSetDataInvalidAggregationType(t *testing.T) {
 
 func TestCounterResetSetDataNoRollup(t *testing.T) {
 	opts := newTestOptions()
-	ce := MustNewCounterElem(testCounterElemData, opts)
+	ce := MustNewCounterElem(testCounterElemData, NewElemOptions(opts))
 
 	pipelineNoRollup := applied.NewPipeline([]applied.OpUnion{
 		{
@@ -208,7 +208,7 @@ func TestCounterResetSetDataNoRollup(t *testing.T) {
 }
 
 func TestCounterElemAddUnion(t *testing.T) {
-	e, err := NewCounterElem(testCounterElemData, newTestOptions())
+	e, err := NewCounterElem(testCounterElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a counter metric.
@@ -252,7 +252,7 @@ func TestCounterElemAddUnion(t *testing.T) {
 func TestCounterElemAddUnionWithCustomAggregation(t *testing.T) {
 	elemData := testCounterElemData
 	elemData.AggTypes = testAggregationTypesExpensive
-	e, err := NewCounterElem(elemData, newTestOptions())
+	e, err := NewCounterElem(elemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a counter metric.
@@ -290,7 +290,7 @@ func TestCounterElemAddUnionWithCustomAggregation(t *testing.T) {
 }
 
 func TestCounterElemAddUnique(t *testing.T) {
-	e, err := NewCounterElem(testCounterElemData, newTestOptions())
+	e, err := NewCounterElem(testCounterElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a metric.
@@ -366,7 +366,7 @@ func TestCounterElemAddUnique(t *testing.T) {
 func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
 	elemData := testCounterElemData
 	elemData.AggTypes = testAggregationTypesExpensive
-	e, err := NewCounterElem(elemData, newTestOptions())
+	e, err := NewCounterElem(elemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a counter metric.
@@ -687,7 +687,7 @@ func TestCounterElemClose(t *testing.T) {
 }
 
 func TestCounterFindOrCreateNoSourceSet(t *testing.T) {
-	e, err := NewCounterElem(testCounterElemData, newTestOptions())
+	e, err := NewCounterElem(testCounterElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	inputs := []int64{10, 10, 20, 10, 15}
@@ -712,7 +712,7 @@ func TestCounterFindOrCreateNoSourceSet(t *testing.T) {
 }
 
 func TestCounterFindOrCreateWithSourceSet(t *testing.T) {
-	e, err := NewCounterElem(testCounterElemData, newTestOptions())
+	e, err := NewCounterElem(testCounterElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 	e.cachedSourceSets = make([]map[uint32]*bitset.BitSet, 0)
 
@@ -737,7 +737,7 @@ func TestCounterFindOrCreateWithSourceSet(t *testing.T) {
 
 func TestTimerResetSetData(t *testing.T) {
 	opts := newTestOptions()
-	te, err := NewTimerElem(testTimerElemData, opts)
+	te, err := NewTimerElem(testTimerElemData, NewElemOptions(opts))
 	require.NoError(t, err)
 	require.Nil(t, te.quantilesPool)
 	require.NotNil(t, te.quantiles)
@@ -794,7 +794,7 @@ func TestTimerResetSetData(t *testing.T) {
 
 func TestTimerResetSetDataInvalidAggregationType(t *testing.T) {
 	opts := newTestOptions()
-	te := MustNewTimerElem(testTimerElemData, opts)
+	te := MustNewTimerElem(testTimerElemData, NewElemOptions(opts))
 	elemData := testTimerElemData
 	elemData.AggTypes = maggregation.Types{maggregation.Last}
 	err := te.ResetSetData(elemData)
@@ -803,7 +803,7 @@ func TestTimerResetSetDataInvalidAggregationType(t *testing.T) {
 
 func TestTimerResetSetDataNoRollup(t *testing.T) {
 	opts := newTestOptions()
-	te := MustNewTimerElem(testTimerElemData, opts)
+	te := MustNewTimerElem(testTimerElemData, NewElemOptions(opts))
 
 	pipelineNoRollup := applied.NewPipeline([]applied.OpUnion{
 		{
@@ -818,7 +818,7 @@ func TestTimerResetSetDataNoRollup(t *testing.T) {
 }
 
 func TestTimerElemAddUnion(t *testing.T) {
-	e, err := NewTimerElem(testTimerElemData, newTestOptions())
+	e, err := NewTimerElem(testTimerElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a timer metric.
@@ -864,7 +864,7 @@ func TestTimerElemAddUnion(t *testing.T) {
 }
 
 func TestTimerElemAddUnique(t *testing.T) {
-	e, err := NewTimerElem(testTimerElemData, newTestOptions())
+	e, err := NewTimerElem(testTimerElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a metric.
@@ -1206,7 +1206,7 @@ func TestTimerElemClose(t *testing.T) {
 }
 
 func TestTimerFindOrCreateNoSourceSet(t *testing.T) {
-	e, err := NewTimerElem(testTimerElemData, newTestOptions())
+	e, err := NewTimerElem(testTimerElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	inputs := []int64{10, 10, 20, 10, 15}
@@ -1230,7 +1230,7 @@ func TestTimerFindOrCreateNoSourceSet(t *testing.T) {
 }
 
 func TestTimerFindOrCreateWithSourceSet(t *testing.T) {
-	e, err := NewTimerElem(testTimerElemData, newTestOptions())
+	e, err := NewTimerElem(testTimerElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 	e.cachedSourceSets = make([]map[uint32]*bitset.BitSet, 0)
 
@@ -1255,7 +1255,7 @@ func TestTimerFindOrCreateWithSourceSet(t *testing.T) {
 
 func TestGaugeResetSetData(t *testing.T) {
 	opts := newTestOptions()
-	ge, err := NewGaugeElem(testGaugeElemData, opts)
+	ge, err := NewGaugeElem(testGaugeElemData, NewElemOptions(opts))
 	require.NoError(t, err)
 	require.Equal(t, opts.AggregationTypesOptions().DefaultGaugeAggregationTypes(), ge.aggTypes)
 	require.True(t, ge.useDefaultAggregation)
@@ -1307,7 +1307,7 @@ func TestGaugeResetSetData(t *testing.T) {
 }
 
 func TestGaugeElemAddUnion(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeElemData, newTestOptions())
+	e, err := NewGaugeElem(testGaugeElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a gauge metric.
@@ -1345,7 +1345,7 @@ func TestGaugeElemAddUnion(t *testing.T) {
 func TestGaugeElemAddUnionWithCustomAggregation(t *testing.T) {
 	elemData := testGaugeElemData
 	elemData.AggTypes = testAggregationTypesExpensive
-	e, err := NewGaugeElem(elemData, newTestOptions())
+	e, err := NewGaugeElem(elemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a gauge metric.
@@ -1383,7 +1383,7 @@ func TestGaugeElemAddUnionWithCustomAggregation(t *testing.T) {
 }
 
 func TestGaugeElemAddUnique(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeElemData, newTestOptions())
+	e, err := NewGaugeElem(testGaugeElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a metric.
@@ -1477,7 +1477,7 @@ func TestGaugeElemAddUnique(t *testing.T) {
 func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
 	elemData := testGaugeElemData
 	elemData.AggTypes = testAggregationTypesExpensive
-	e, err := NewGaugeElem(elemData, newTestOptions())
+	e, err := NewGaugeElem(elemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	// Add a gauge metric.
@@ -2218,7 +2218,7 @@ func TestGaugeElemClose(t *testing.T) {
 }
 
 func TestGaugeFindOrCreateNoSourceSet(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeElemData, newTestOptions())
+	e, err := NewGaugeElem(testGaugeElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 
 	inputs := []int64{10, 10, 20, 10, 15}
@@ -2242,7 +2242,7 @@ func TestGaugeFindOrCreateNoSourceSet(t *testing.T) {
 }
 
 func TestGaugeFindOrCreateWithSourceSet(t *testing.T) {
-	e, err := NewGaugeElem(testGaugeElemData, newTestOptions())
+	e, err := NewGaugeElem(testGaugeElemData, NewElemOptions(newTestOptions()))
 	require.NoError(t, err)
 	e.cachedSourceSets = make([]map[uint32]*bitset.BitSet, 0)
 
@@ -2365,7 +2365,7 @@ func testCounterElem(
 	elemData := testCounterElemData
 	elemData.AggTypes = aggTypes
 	elemData.Pipeline = pipeline
-	e := MustNewCounterElem(elemData, opts)
+	e := MustNewCounterElem(elemData, NewElemOptions(opts))
 	for i, aligned := range alignedstartAtNanos {
 		counter := &lockedCounterAggregation{
 			aggregation: newCounterAggregation(raggregation.NewCounter(e.aggOpts)),
@@ -2391,7 +2391,7 @@ func testTimerElem(
 	elemData := testTimerElemData
 	elemData.Pipeline = pipeline
 	elemData.AggTypes = aggTypes
-	e := MustNewTimerElem(elemData, opts)
+	e := MustNewTimerElem(elemData, NewElemOptions(opts))
 	for i, aligned := range alignedstartAtNanos {
 		newTimer := raggregation.NewTimer(opts.AggregationTypesOptions().Quantiles(), opts.StreamOptions(), e.aggOpts)
 		timer := &lockedTimerAggregation{
@@ -2435,7 +2435,7 @@ func testGaugeElemWithData(
 	data ElemData,
 	opts Options,
 ) *GaugeElem {
-	e := MustNewGaugeElem(data, opts)
+	e := MustNewGaugeElem(data, NewElemOptions(opts))
 	require.NoError(t, e.ResetSetData(data))
 	for i, aligned := range alignedstartAtNanos {
 		gauge := &lockedGaugeAggregation{

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -76,7 +76,7 @@ type GaugeElem struct {
 }
 
 // NewGaugeElem returns a new GaugeElem.
-func NewGaugeElem(data ElemData, opts Options) (*GaugeElem, error) {
+func NewGaugeElem(data ElemData, opts ElemOptions) (*GaugeElem, error) {
 	e := &GaugeElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedGauge, 0, defaultNumAggregations), // in most cases values will have two entries
@@ -88,7 +88,7 @@ func NewGaugeElem(data ElemData, opts Options) (*GaugeElem, error) {
 }
 
 // MustNewGaugeElem returns a new GaugeElem and panics if an error occurs.
-func MustNewGaugeElem(data ElemData, opts Options) *GaugeElem {
+func MustNewGaugeElem(data ElemData, opts ElemOptions) *GaugeElem {
 	elem, err := NewGaugeElem(data, opts)
 	if err != nil {
 		panic(fmt.Errorf("unable to create element: %v", err))

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -140,7 +140,7 @@ type GenericElem struct {
 }
 
 // NewGenericElem returns a new GenericElem.
-func NewGenericElem(data ElemData, opts Options) (*GenericElem, error) {
+func NewGenericElem(data ElemData, opts ElemOptions) (*GenericElem, error) {
 	e := &GenericElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedAggregation, 0, defaultNumAggregations), // in most cases values will have two entries
@@ -152,7 +152,7 @@ func NewGenericElem(data ElemData, opts Options) (*GenericElem, error) {
 }
 
 // MustNewGenericElem returns a new GenericElem and panics if an error occurs.
-func MustNewGenericElem(data ElemData, opts Options) *GenericElem {
+func MustNewGenericElem(data ElemData, opts ElemOptions) *GenericElem {
 	elem, err := NewGenericElem(data, opts)
 	if err != nil {
 		panic(fmt.Errorf("unable to create element: %v", err))

--- a/src/aggregator/aggregator/list_test.go
+++ b/src/aggregator/aggregator/list_test.go
@@ -51,7 +51,7 @@ func TestBaseMetricListPushBackElemWithDefaultPipeline(t *testing.T) {
 
 	l, err := newBaseMetricList(testShard, time.Second, nil, nil, nil, testOptions(ctrl))
 	require.NoError(t, err)
-	elem, err := NewCounterElem(ElemData{}, l.opts)
+	elem, err := NewCounterElem(ElemData{}, NewElemOptions(l.opts))
 	require.NoError(t, err)
 
 	// Push a counter to the list.
@@ -77,7 +77,7 @@ func TestBaseMetricListPushBackElemWithForwardingPipeline(t *testing.T) {
 
 	l, err := newBaseMetricList(testShard, time.Second, nil, nil, nil, testOptions(ctrl))
 	require.NoError(t, err)
-	elem, err := NewCounterElem(testCounterElemData, l.opts)
+	elem, err := NewCounterElem(testCounterElemData, NewElemOptions(l.opts))
 	require.NoError(t, err)
 
 	// Push a counter to the list.
@@ -330,21 +330,21 @@ func TestStandardMetricListFlushConsumingAndCollectingLocalMetrics(t *testing.T)
 			elem: MustNewCounterElem(ElemData{
 				ID:            testCounterID,
 				StoragePolicy: testStoragePolicy,
-			}, opts),
+			}, NewElemOptions(opts)),
 			metric: testCounter,
 		},
 		{
 			elem: MustNewTimerElem(ElemData{
 				ID:            testBatchTimerID,
 				StoragePolicy: testStoragePolicy,
-			}, opts),
+			}, NewElemOptions(opts)),
 			metric: testBatchTimer,
 		},
 		{
 			elem: MustNewGaugeElem(ElemData{
 				ID:            testGaugeID,
 				StoragePolicy: testStoragePolicy,
-			}, opts),
+			}, NewElemOptions(opts)),
 			metric: testGauge,
 		},
 	}
@@ -594,7 +594,7 @@ func TestTimedMetricListFlushConsumingAndCollectingTimedMetrics(t *testing.T) {
 				ID:                 []byte("testTimedCounter"),
 				StoragePolicy:      testStoragePolicy,
 				IDPrefixSuffixType: NoPrefixNoSuffix,
-			}, opts),
+			}, NewElemOptions(opts)),
 			metric: aggregated.Metric{
 				Type:      metric.CounterType,
 				ID:        []byte("testTimedCounter"),
@@ -607,7 +607,7 @@ func TestTimedMetricListFlushConsumingAndCollectingTimedMetrics(t *testing.T) {
 				ID:                 []byte("testTimedGauge"),
 				StoragePolicy:      testStoragePolicy,
 				IDPrefixSuffixType: NoPrefixNoSuffix,
-			}, opts),
+			}, NewElemOptions(opts)),
 			metric: aggregated.Metric{
 				Type:      metric.GaugeType,
 				ID:        []byte("testTimedGauge"),
@@ -888,7 +888,7 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 				StoragePolicy:      testStoragePolicy,
 				Pipeline:           pipeline,
 				IDPrefixSuffixType: NoPrefixNoSuffix,
-			}, opts),
+			}, NewElemOptions(opts)),
 			metric: aggregated.ForwardedMetric{
 				Type:      metric.CounterType,
 				ID:        []byte("testForwardedCounter"),
@@ -902,7 +902,7 @@ func TestForwardedMetricListFlushConsumingAndCollectingForwardedMetrics(t *testi
 				StoragePolicy:      testStoragePolicy,
 				Pipeline:           pipeline,
 				IDPrefixSuffixType: NoPrefixNoSuffix,
-			}, opts),
+			}, NewElemOptions(opts)),
 			metric: aggregated.ForwardedMetric{
 				Type:      metric.GaugeType,
 				ID:        []byte("testForwardedGauge"),
@@ -1086,7 +1086,7 @@ func TestForwardedMetricListLastStepLocalFlush(t *testing.T) {
 			elem: MustNewCounterElem(ElemData{
 				ID:            []byte("testForwardedCounter"),
 				StoragePolicy: testStoragePolicy,
-			}, opts),
+			}, NewElemOptions(opts)),
 			expectedPrefix: opts.FullCounterPrefix(),
 			metric: aggregated.ForwardedMetric{
 				Type:      metric.CounterType,
@@ -1099,7 +1099,7 @@ func TestForwardedMetricListLastStepLocalFlush(t *testing.T) {
 			elem: MustNewGaugeElem(ElemData{
 				ID:            []byte("testForwardedGauge"),
 				StoragePolicy: testStoragePolicy,
-			}, opts),
+			}, NewElemOptions(opts)),
 			expectedPrefix: opts.FullGaugePrefix(),
 			metric: aggregated.ForwardedMetric{
 				Type:      metric.GaugeType,

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -852,19 +852,20 @@ func (o *options) initPools() {
 		return NewEntryWithMetrics(nil, metrics, defaultRuntimeOpts, o)
 	})
 
+	elemOpts := NewElemOptions(o)
 	o.counterElemPool = NewCounterElemPool(nil)
 	o.counterElemPool.Init(func() *CounterElem {
-		return MustNewCounterElem(ElemData{}, o)
+		return MustNewCounterElem(ElemData{}, elemOpts)
 	})
 
 	o.timerElemPool = NewTimerElemPool(nil)
 	o.timerElemPool.Init(func() *TimerElem {
-		return MustNewTimerElem(ElemData{}, o)
+		return MustNewTimerElem(ElemData{}, elemOpts)
 	})
 
 	o.gaugeElemPool = NewGaugeElemPool(nil)
 	o.gaugeElemPool.Init(func() *GaugeElem {
-		return MustNewGaugeElem(ElemData{}, o)
+		return MustNewGaugeElem(ElemData{}, elemOpts)
 	})
 }
 

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -76,7 +76,7 @@ type TimerElem struct {
 }
 
 // NewTimerElem returns a new TimerElem.
-func NewTimerElem(data ElemData, opts Options) (*TimerElem, error) {
+func NewTimerElem(data ElemData, opts ElemOptions) (*TimerElem, error) {
 	e := &TimerElem{
 		elemBase: newElemBase(opts),
 		values:   make([]timedTimer, 0, defaultNumAggregations), // in most cases values will have two entries
@@ -88,7 +88,7 @@ func NewTimerElem(data ElemData, opts Options) (*TimerElem, error) {
 }
 
 // MustNewTimerElem returns a new TimerElem and panics if an error occurs.
-func MustNewTimerElem(data ElemData, opts Options) *TimerElem {
+func MustNewTimerElem(data ElemData, opts ElemOptions) *TimerElem {
 	elem, err := NewTimerElem(data, opts)
 	if err != nil {
 		panic(fmt.Errorf("unable to create element: %v", err))

--- a/src/aggregator/integration/setup.go
+++ b/src/aggregator/integration/setup.go
@@ -238,20 +238,21 @@ func newTestServerSetup(t *testing.T, opts testServerOptions) *testServerSetup {
 	// Set up elem pools.
 	counterElemPool := aggregator.NewCounterElemPool(nil)
 	aggregatorOpts = aggregatorOpts.SetCounterElemPool(counterElemPool)
+	elemOpts := aggregator.NewElemOptions(aggregatorOpts)
 	counterElemPool.Init(func() *aggregator.CounterElem {
-		return aggregator.MustNewCounterElem(aggregator.ElemData{}, aggregatorOpts)
+		return aggregator.MustNewCounterElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	timerElemPool := aggregator.NewTimerElemPool(nil)
 	aggregatorOpts = aggregatorOpts.SetTimerElemPool(timerElemPool)
 	timerElemPool.Init(func() *aggregator.TimerElem {
-		return aggregator.MustNewTimerElem(aggregator.ElemData{}, aggregatorOpts)
+		return aggregator.MustNewTimerElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	gaugeElemPool := aggregator.NewGaugeElemPool(nil)
 	aggregatorOpts = aggregatorOpts.SetGaugeElemPool(gaugeElemPool)
 	gaugeElemPool.Init(func() *aggregator.GaugeElem {
-		return aggregator.MustNewGaugeElem(aggregator.ElemData{}, aggregatorOpts)
+		return aggregator.MustNewGaugeElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	return &testServerSetup{

--- a/src/cmd/services/m3aggregator/config/aggregator.go
+++ b/src/cmd/services/m3aggregator/config/aggregator.go
@@ -465,8 +465,10 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	counterElemPoolOpts := c.CounterElemPool.NewObjectPoolOptions(iOpts)
 	counterElemPool := aggregator.NewCounterElemPool(counterElemPoolOpts)
 	opts = opts.SetCounterElemPool(counterElemPool)
+	// use a singleton ElemOptions to avoid allocs per elem.
+	elemOpts := aggregator.NewElemOptions(opts)
 	counterElemPool.Init(func() *aggregator.CounterElem {
-		return aggregator.MustNewCounterElem(aggregator.ElemData{}, opts)
+		return aggregator.MustNewCounterElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	// Set timer elem pool.
@@ -475,7 +477,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	timerElemPool := aggregator.NewTimerElemPool(timerElemPoolOpts)
 	opts = opts.SetTimerElemPool(timerElemPool)
 	timerElemPool.Init(func() *aggregator.TimerElem {
-		return aggregator.MustNewTimerElem(aggregator.ElemData{}, opts)
+		return aggregator.MustNewTimerElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	// Set gauge elem pool.
@@ -484,7 +486,7 @@ func (c *AggregatorConfiguration) NewAggregatorOptions(
 	gaugeElemPool := aggregator.NewGaugeElemPool(gaugeElemPoolOpts)
 	opts = opts.SetGaugeElemPool(gaugeElemPool)
 	gaugeElemPool.Init(func() *aggregator.GaugeElem {
-		return aggregator.MustNewGaugeElem(aggregator.ElemData{}, opts)
+		return aggregator.MustNewGaugeElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	// Set entry pool.

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -937,8 +937,10 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	)
 	counterElemPool := aggregator.NewCounterElemPool(counterElemPoolOpts)
 	aggregatorOpts = aggregatorOpts.SetCounterElemPool(counterElemPool)
+	// use a singleton ElemOptions to avoid allocs per elem.
+	elemOpts := aggregator.NewElemOptions(aggregatorOpts)
 	counterElemPool.Init(func() *aggregator.CounterElem {
-		return aggregator.MustNewCounterElem(aggregator.ElemData{}, aggregatorOpts)
+		return aggregator.MustNewCounterElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	// Set timer elem pool.
@@ -948,7 +950,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	timerElemPool := aggregator.NewTimerElemPool(timerElemPoolOpts)
 	aggregatorOpts = aggregatorOpts.SetTimerElemPool(timerElemPool)
 	timerElemPool.Init(func() *aggregator.TimerElem {
-		return aggregator.MustNewTimerElem(aggregator.ElemData{}, aggregatorOpts)
+		return aggregator.MustNewTimerElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	// Set gauge elem pool.
@@ -958,7 +960,7 @@ func (cfg Configuration) newAggregator(o DownsamplerOptions) (agg, error) {
 	gaugeElemPool := aggregator.NewGaugeElemPool(gaugeElemPoolOpts)
 	aggregatorOpts = aggregatorOpts.SetGaugeElemPool(gaugeElemPool)
 	gaugeElemPool.Init(func() *aggregator.GaugeElem {
-		return aggregator.MustNewGaugeElem(aggregator.ElemData{}, aggregatorOpts)
+		return aggregator.MustNewGaugeElem(aggregator.ElemData{}, elemOpts)
 	})
 
 	adminAggClient := newAggregatorLocalAdminClient()


### PR DESCRIPTION
Previously every new aggregator Elem (e.g guage) would do a few
unncessary allocs, especially metrics. This generates unncessary garbage
and get significantly worse if more metrics are added.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
