### PR TITLE
Add list type/resolution to flush lag metrics

### DIFF
--- a/src/aggregator/aggregator/entry.go
+++ b/src/aggregator/aggregator/entry.go
@@ -600,6 +600,7 @@ func (e *Entry) addNewAggregationKeyWithLock(
 		NumForwardedTimes:  key.numForwardedTimes,
 		IDPrefixSuffixType: key.idPrefixSuffixType,
 		ResendEnabled:      resendEnabled,
+		ListType:           listID.listType,
 	}); err != nil {
 		return nil, err
 	}

--- a/src/aggregator/aggregator/leader_flush_mgr.go
+++ b/src/aggregator/aggregator/leader_flush_mgr.go
@@ -48,11 +48,10 @@ func newLeaderFlusherMetrics(scope tally.Scope) leaderFlusherMetrics {
 }
 
 type leaderFlushManagerMetrics struct {
-	queueSize    tally.Gauge
-	flushTimeLag tally.Histogram
-	standard     leaderFlusherMetrics
-	forwarded    leaderFlusherMetrics
-	timed        leaderFlusherMetrics
+	queueSize tally.Gauge
+	standard  leaderFlusherMetrics
+	forwarded leaderFlusherMetrics
+	timed     leaderFlusherMetrics
 }
 
 func newLeaderFlushManagerMetrics(scope tally.Scope) leaderFlushManagerMetrics {
@@ -61,24 +60,6 @@ func newLeaderFlushManagerMetrics(scope tally.Scope) leaderFlushManagerMetrics {
 	timedScope := scope.Tagged(map[string]string{"flusher-type": "timed"})
 	return leaderFlushManagerMetrics{
 		queueSize: scope.Gauge("queue-size"),
-		flushTimeLag: scope.Histogram("flush-time-lag", tally.DurationBuckets{
-			10 * time.Millisecond,
-			500 * time.Millisecond,
-			time.Second,
-			2 * time.Second,
-			5 * time.Second,
-			10 * time.Second,
-			15 * time.Second,
-			20 * time.Second,
-			25 * time.Second,
-			30 * time.Second,
-			35 * time.Second,
-			40 * time.Second,
-			45 * time.Second,
-			60 * time.Second,
-			90 * time.Second,
-			120 * time.Second,
-		}),
 		standard:  newLeaderFlusherMetrics(standardScope),
 		forwarded: newLeaderFlusherMetrics(forwardedScope),
 		timed:     newLeaderFlusherMetrics(timedScope),
@@ -173,10 +154,10 @@ func (mgr *leaderFlushManager) Prepare(buckets []*flushBucket) (flushTask, time.
 	if numFlushTimes > 0 {
 		earliestFlush := mgr.flushTimes.Min()
 		if nowNanos >= earliestFlush.timeNanos {
-			mgr.metrics.flushTimeLag.RecordDuration(time.Duration(nowNanos - earliestFlush.timeNanos))
 			shouldFlush = true
 			waitFor = 0
 			bucketIdx := earliestFlush.bucketIdx
+			buckets[bucketIdx].flushLag.RecordDuration(time.Duration(nowNanos - earliestFlush.timeNanos))
 			// NB(xichen): make a shallow copy of the flushers inside the lock
 			// and use the snapshot for flushing below because the flushers slice
 			// inside the bucket may be modified during task execution when new

--- a/src/aggregator/aggregator/leader_flush_mgr_test.go
+++ b/src/aggregator/aggregator/leader_flush_mgr_test.go
@@ -779,6 +779,7 @@ func testFlushBuckets(ctrl *gomock.Controller) []*flushBucket {
 	forwardedFlusher4.EXPECT().FlushInterval().Return(time.Minute).AnyTimes()
 	forwardedFlusher4.EXPECT().LastFlushedNanos().Return(int64(3600000000000)).AnyTimes()
 
+	flushLag := tally.NewTestScope("", nil).Histogram("flush-lag", nil)
 	return []*flushBucket{
 		// Standard flushing metric lists.
 		{
@@ -786,18 +787,21 @@ func testFlushBuckets(ctrl *gomock.Controller) []*flushBucket {
 			interval: time.Second,
 			offset:   250 * time.Millisecond,
 			flushers: []flushingMetricList{standardFlusher1, standardFlusher2},
+			flushLag: flushLag,
 		},
 		{
 			bucketID: standardMetricListID{resolution: time.Minute}.toMetricListID(),
 			interval: time.Minute,
 			offset:   12 * time.Second,
 			flushers: []flushingMetricList{standardFlusher3},
+			flushLag: flushLag,
 		},
 		{
 			bucketID: standardMetricListID{resolution: time.Hour}.toMetricListID(),
 			interval: time.Hour,
 			offset:   time.Minute,
 			flushers: []flushingMetricList{standardFlusher4},
+			flushLag: flushLag,
 		},
 		// Timed flushing metric lists.
 		{
@@ -805,6 +809,7 @@ func testFlushBuckets(ctrl *gomock.Controller) []*flushBucket {
 			interval: time.Minute,
 			offset:   250 * time.Millisecond,
 			flushers: []flushingMetricList{timedFlusher1},
+			flushLag: flushLag,
 		},
 		// Forwarded flushing metric lists.
 		{
@@ -812,18 +817,21 @@ func testFlushBuckets(ctrl *gomock.Controller) []*flushBucket {
 			interval: time.Second,
 			offset:   100 * time.Millisecond,
 			flushers: []flushingMetricList{forwardedFlusher1, forwardedFlusher2},
+			flushLag: flushLag,
 		},
 		{
 			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 2}.toMetricListID(),
 			interval: time.Minute,
 			offset:   time.Second,
 			flushers: []flushingMetricList{forwardedFlusher3},
+			flushLag: flushLag,
 		},
 		{
 			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 3}.toMetricListID(),
 			interval: time.Minute,
 			offset:   0,
 			flushers: []flushingMetricList{forwardedFlusher4},
+			flushLag: flushLag,
 		},
 	}
 }
@@ -854,36 +862,42 @@ func testFlushBuckets2(ctrl *gomock.Controller) []*flushBucket {
 	forwardedFlusher2.EXPECT().FlushInterval().Return(time.Minute).AnyTimes()
 	forwardedFlusher2.EXPECT().LastFlushedNanos().Return(int64(3658000000000)).AnyTimes()
 
+	flushLag := tally.NewTestScope("", nil).Histogram("flush-lag", nil)
 	return []*flushBucket{
 		{
 			bucketID: standardMetricListID{resolution: time.Second}.toMetricListID(),
 			interval: time.Second,
 			offset:   250 * time.Millisecond,
 			flushers: []flushingMetricList{standardFlusher1},
+			flushLag: flushLag,
 		},
 		{
 			bucketID: standardMetricListID{resolution: time.Hour}.toMetricListID(),
 			interval: time.Hour,
 			offset:   time.Minute,
 			flushers: []flushingMetricList{standardFlusher2},
+			flushLag: flushLag,
 		},
 		{
 			bucketID: timedMetricListID{resolution: time.Second}.toMetricListID(),
 			interval: time.Second,
 			offset:   250 * time.Millisecond,
 			flushers: []flushingMetricList{timedFlusher1},
+			flushLag: flushLag,
 		},
 		{
 			bucketID: forwardedMetricListID{resolution: time.Second, numForwardedTimes: 1}.toMetricListID(),
 			interval: time.Second,
 			offset:   100 * time.Millisecond,
 			flushers: []flushingMetricList{forwardedFlusher1},
+			flushLag: flushLag,
 		},
 		{
 			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 2}.toMetricListID(),
 			interval: time.Minute,
 			offset:   time.Second,
 			flushers: []flushingMetricList{forwardedFlusher2},
+			flushLag: flushLag,
 		},
 	}
 }


### PR DESCRIPTION
This makes it easier to understand what types of metrics are actually
being delayed.

Additionally remove the flush-run-time metric, since it's pretty much a
duplicate of the flush bucket duration metric. It included the
Prepare+Run time, but the run time dominates the time.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
