### PR TITLE
[read_data_files] Do not warn about ts count when using idFilter

### DIFF
--- a/src/cmd/tools/read_data_files/main/main.go
+++ b/src/cmd/tools/read_data_files/main/main.go
@@ -203,7 +203,7 @@ func main() {
 			seriesCount++
 		}
 
-		if seriesCount != reader.Entries() {
+		if seriesCount != reader.Entries() && *idFilter == "" {
 			log.Warnf("actual time series count (%d) did not match info file data (%d)",
 				seriesCount, reader.Entries())
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes `read_data_files`, currently when used with id filter it complains for no good reason:
```
2021-10-26T10:33:26.531Z	WARN	main/main.go:207	actual time series count (1) did not match info file data (2901)
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
