### PR TITLE
[query] Add support for `last_over_time`

### DIFF
--- a/src/query/functions/temporal/aggregation.go
+++ b/src/query/functions/temporal/aggregation.go
@@ -52,6 +52,9 @@ const (
 	// StdVarType calculates the standard variance of all values in the specified interval.
 	StdVarType = "stdvar_over_time"
 
+	// LastType returns the most recent value in the specified interval.
+	LastType = "last_over_time"
+
 	// QuantileType calculates the φ-quantile (0 ≤ φ ≤ 1) of the values in the specified interval.
 	QuantileType = "quantile_over_time"
 )
@@ -67,6 +70,7 @@ var (
 		SumType:    sumOverTime,
 		StdDevType: stddevOverTime,
 		StdVarType: stdvarOverTime,
+		LastType:   lastOverTime,
 	}
 )
 
@@ -218,6 +222,15 @@ func stdvarOverTime(values []float64) float64 {
 	}
 
 	return aux / count
+}
+
+func lastOverTime(values []float64) float64 {
+	length := len(values)
+	if length == 0 {
+		return math.NaN()
+	}
+
+	return values[length-1]
 }
 
 func sumAndCount(values []float64) (float64, float64) {

--- a/src/query/functions/temporal/aggregation_test.go
+++ b/src/query/functions/temporal/aggregation_test.go
@@ -214,6 +214,42 @@ var aggregationTestCases = []testCase{
 		},
 	},
 	{
+		name:   "last_over_time",
+		opType: LastType,
+		vals: [][]float64{
+			{nan, 1, 2, 3, 4, 0, 1, 2, 3, 4},
+			{5, 6, 7, 8, 9, 5, 6, 7, 8, 9},
+		},
+		expected: [][]float64{
+			{nan, 1, 2, 3, 4, 0, 1, 2, 3, 4},
+			{5, 6, 7, 8, 9, 5, 6, 7, 8, 9},
+		},
+	},
+	{
+		name:   "last_over_time leading NaNs",
+		opType: LastType,
+		vals: [][]float64{
+			{nan, 1, nan, 3, nan, nan, 2, nan, nan, nan},
+			{5, nan, nan, nan, nan, nan, nan, 7, nan, nan},
+		},
+		expected: [][]float64{
+			{nan, 1, nan, 3, nan, nan, 2, nan, nan, nan},
+			{5, nan, nan, nan, nan, nan, nan, 7, nan, nan},
+		},
+	},
+	{
+		name:   "last_over_time all NaNs",
+		opType: LastType,
+		vals: [][]float64{
+			{nan, nan, nan, nan, nan, nan, nan, nan, nan, nan},
+			{nan, nan, nan, nan, nan, nan, nan, nan, nan, nan},
+		},
+		expected: [][]float64{
+			{nan, nan, nan, nan, nan, nan, nan, nan, nan, nan},
+			{nan, nan, nan, nan, nan, nan, nan, nan, nan, nan},
+		},
+	},
+	{
 		name:   "quantile_over_time",
 		opType: QuantileType,
 		vals: [][]float64{

--- a/src/query/functions/temporal/base_test.go
+++ b/src/query/functions/temporal/base_test.go
@@ -151,9 +151,17 @@ func testTemporalFunc(t *testing.T, opGen opGenerator, tests []testCase) {
 						Value: []byte("v2"),
 					}})}
 
-				// NB: name should be dropped from series tags, and the name
-				// should be the updated ID.
-				expectedSeriesMetas := []block.SeriesMeta{metaOne, metaTwo}
+				// The last_over_time function acts like offset;
+				// thus, it should keep the metric name.
+				// For all other functions,
+				// name should be dropped from series tags,
+				// and the name should be the updated ID.
+				var expectedSeriesMetas []block.SeriesMeta
+				if tt.opType != LastType {
+					expectedSeriesMetas = []block.SeriesMeta{metaOne, metaTwo}
+				} else {
+					expectedSeriesMetas = seriesMetas
+				}
 				require.Equal(t, expectedSeriesMetas, sink.Metas)
 			})
 		}

--- a/src/query/parser/promql/matchers.go
+++ b/src/query/parser/promql/matchers.go
@@ -261,7 +261,7 @@ func NewFunctionExpr(
 
 	case temporal.AvgType, temporal.CountType, temporal.MinType,
 		temporal.MaxType, temporal.SumType, temporal.StdDevType,
-		temporal.StdVarType:
+		temporal.StdVarType, temporal.LastType:
 		p, err = temporal.NewAggOp(argValues, name)
 		return p, true, err
 

--- a/src/query/parser/promql/parse_test.go
+++ b/src/query/parser/promql/parse_test.go
@@ -469,6 +469,7 @@ var temporalParseTests = []struct {
 	{"sum_over_time(up[5m])", temporal.SumType},
 	{"stddev_over_time(up[5m])", temporal.StdDevType},
 	{"stdvar_over_time(up[5m])", temporal.StdVarType},
+	{"last_over_time(up[5m])", temporal.LastType},
 	{"quantile_over_time(0.2, up[5m])", temporal.QuantileType},
 	{"irate(up[5m])", temporal.IRateType},
 	{"idelta(up[5m])", temporal.IDeltaType},

--- a/src/query/test/compatibility/testdata/functions.test
+++ b/src/query/test/compatibility/testdata/functions.test
@@ -593,26 +593,26 @@ load 10s
 	data{type="some_nan3"} NaN 0 1
 	data{type="only_nan"} NaN NaN NaN
 
-# Failing with keepNaN feature. eval instant at 1m min_over_time(data[1m])
-#	{type="numbers"} 0
-#	{type="some_nan"} 0
-#	{type="some_nan2"} 1
-#	{type="some_nan3"} 0
-#	{type="only_nan"} NaN
+eval instant at 1m min_over_time(data[1m])
+	{type="numbers"} 0
+	{type="some_nan"} 0
+	{type="some_nan2"} 1
+	{type="some_nan3"} 0
+	# Failing with keepNaN feature. {type="only_nan"} NaN
 
-# Failing with keepNaN feature. eval instant at 1m max_over_time(data[1m])
-#	{type="numbers"} 3
-#	{type="some_nan"} 2
-#	{type="some_nan2"} 2
-#	{type="some_nan3"} 1
-#	{type="only_nan"} NaN
+eval instant at 1m max_over_time(data[1m])
+	{type="numbers"} 3
+	{type="some_nan"} 2
+	{type="some_nan2"} 2
+	{type="some_nan3"} 1
+	# Failing with keepNaN feature. {type="only_nan"} NaN
 
-#eval instant at 1m last_over_time(data[1m])
-#	data{type="numbers"} 3
-#	data{type="some_nan"} NaN
-#	data{type="some_nan2"} 1
-#	data{type="some_nan3"} 1
-#	data{type="only_nan"} NaN
+eval instant at 1m last_over_time(data[1m])
+	data{type="numbers"} 3
+	data{type="some_nan2"} 1
+	data{type="some_nan3"} 1
+	# Failing with keepNaN feature. data{type="some_nan"} NaN
+	# Failing with keepNaN feature. data{type="only_nan"} NaN
 
 clear
 


### PR DESCRIPTION
This `<aggregation>_over_time` function was added in
Prometheus v2.26.0 ([changelog](https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md#2260--2021-03-31), [docs](https://prometheus.io/docs/prometheus/latest/querying/functions/#aggregation_over_time)).

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3883.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for `last_over_time`.
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
