### PR TITLE
[aggregator] Add follower flush metrics

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -298,6 +298,7 @@ func (e *CounterElem) Consume(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	onForwardedFlushedFn onForwardingElemFlushedFn,
+	flushType flushType,
 ) bool {
 	resolution := e.sp.Resolution().Window
 	// reverse engineer the allowed lateness.
@@ -358,6 +359,7 @@ func (e *CounterElem) Consume(
 			flushForwardedFn,
 			resolution,
 			latenessAllowed,
+			flushType,
 		)
 		e.toConsume[i].lockedAgg.flushed = true
 		e.toConsume[i].lockedAgg.Unlock()
@@ -575,7 +577,9 @@ func (e *CounterElem) processValueWithAggregationLock(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration,
-	latenessAllowed time.Duration) bool {
+	latenessAllowed time.Duration,
+	flushType flushType,
+) bool {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
@@ -673,13 +677,19 @@ func (e *CounterElem) processValueWithAggregationLock(
 					flushLocalFn(e.FullPrefix(e.opts), e.id, e.TypeStringFor(e.aggTypesOpts, aggType),
 						point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
 				}
+
+				if !lockedAgg.flushed {
+					e.forwardLagMetric(resolution, "local", flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
+				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution).RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
+				e.forwardLagMetric(resolution, "remote", flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timeNanos), value, prevValue, lockedAgg.aggregation.Annotation(), resendEnabled)

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -471,7 +471,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -482,7 +482,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -493,7 +493,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -505,7 +505,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -517,7 +517,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -535,7 +535,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -546,7 +546,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[1], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -557,7 +557,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[2], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -569,7 +569,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -581,7 +581,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -628,7 +628,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -647,7 +647,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 
 	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -679,7 +679,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	// one value to reference in the future as a previous.
 	ts := alignedstartAtNanos[3] + int64(time.Second*20)
 	require.False(t, e.Consume(ts, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -696,7 +696,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -708,7 +708,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1004,7 +1004,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1015,7 +1015,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1026,7 +1026,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1038,7 +1038,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1050,7 +1050,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1072,7 +1072,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1084,7 +1084,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[1], testStoragePolicy, testTimerAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1095,7 +1095,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[2], testStoragePolicy, testTimerAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1107,7 +1107,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1119,7 +1119,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1169,7 +1169,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -1187,7 +1187,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -1215,7 +1215,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -1232,7 +1232,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -1244,7 +1244,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1641,7 +1641,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1652,7 +1652,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1663,7 +1663,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1675,7 +1675,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1687,7 +1687,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1722,7 +1722,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t,
 		expectedLocalMetricsForGauge(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
@@ -1746,7 +1746,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t,
 		expectedLocalMetricsForGaugeWithVal(testAlignedStarts[2], 0.0, testStoragePolicy,
 			maggregation.DefaultTypes),
@@ -1767,7 +1767,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	// the update cascades, resulting in 2 flushed values.
 	exp := expectedLocalMetricsForGaugeWithVal(testAlignedStarts[1], updatedVal, testStoragePolicy,
 		maggregation.DefaultTypes)
@@ -1790,7 +1790,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	pastBufferTime := pastBuffer + testStoragePolicy.Resolution().Window
 	require.False(t, e.Consume(time.Unix(0, testAlignedStarts[1]).Add(pastBufferTime).UnixNano(),
 		isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1801,7 +1801,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(time.Unix(0, testAlignedStarts[2]).Add(pastBufferTime).UnixNano(),
 		isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1819,7 +1819,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1830,7 +1830,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[1], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1841,7 +1841,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[2], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1853,7 +1853,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1865,7 +1865,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1911,7 +1911,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -1929,7 +1929,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -1957,7 +1957,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -1974,7 +1974,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -1986,7 +1986,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -2025,7 +2025,7 @@ func TestGaugeElemResendSumReset(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	exp := expectedLocalMetricsForGaugeWithVal(
 		alignedstartAtNanos[1], 123.0, testStoragePolicy, maggregation.DefaultTypes)
 	exp = append(exp, expectedLocalMetricsForGaugeWithVal(
@@ -2058,7 +2058,7 @@ func TestGaugeElemResendSumReset(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	exp = expectedLocalMetricsForGaugeWithVal(
 		alignedstartAtNanos[1], 122.0, testStoragePolicy, maggregation.DefaultTypes)
 	exp = append(exp, expectedLocalMetricsForGaugeWithVal(
@@ -2125,7 +2125,7 @@ func TestGaugeElemResendBufferForwarding(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -2144,7 +2144,7 @@ func TestGaugeElemResendBufferForwarding(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -2175,7 +2175,7 @@ func TestGaugeElemResendBufferForwarding(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -2213,7 +2213,7 @@ func TestGaugeElemResendBufferForwarding(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn))
+			localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -2260,7 +2260,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -2271,7 +2271,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, (*localRes)[0].timeNanos, alignedstartAtNanos[1])
 	require.Equal(t, (*localRes)[0].value, 123.0)
 	require.Equal(t, (*localRes)[1].timeNanos, alignedstartAtNanos[1]+int64(5*time.Second))
@@ -2286,7 +2286,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, (*localRes)[0].timeNanos, alignedstartAtNanos[2])
 	require.Equal(t, (*localRes)[0].value, 456.0)
 	require.Equal(t, (*localRes)[1].timeNanos, alignedstartAtNanos[2]+int64(5*time.Second))
@@ -2306,8 +2306,8 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, _ = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
-	//verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+	// verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -2319,7 +2319,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn))
+		localFn, forwardFn, onForwardedFlushedFn, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))

--- a/src/aggregator/aggregator/entry.go
+++ b/src/aggregator/aggregator/entry.go
@@ -34,7 +34,6 @@ import (
 	"github.com/m3db/m3/src/metrics/metadata"
 	"github.com/m3db/m3/src/metrics/metric"
 	"github.com/m3db/m3/src/metrics/metric/aggregated"
-	"github.com/m3db/m3/src/metrics/metric/id"
 	metricid "github.com/m3db/m3/src/metrics/metric/id"
 	"github.com/m3db/m3/src/metrics/metric/unaggregated"
 	"github.com/m3db/m3/src/metrics/policy"
@@ -178,9 +177,9 @@ func NewEntryMetrics(scope tally.Scope) *entryMetrics {
 	forwardedEntryScope := scope.Tagged(map[string]string{"entry-type": "forwarded"})
 	return &entryMetrics{
 		resendEnabled: scope.Counter("resend-enabled"),
-		untimed:   newUntimedEntryMetrics(untimedEntryScope),
-		timed:     newTimedEntryMetrics(timedEntryScope),
-		forwarded: newForwardedEntryMetrics(forwardedEntryScope),
+		untimed:       newUntimedEntryMetrics(untimedEntryScope),
+		timed:         newTimedEntryMetrics(timedEntryScope),
+		forwarded:     newForwardedEntryMetrics(forwardedEntryScope),
 	}
 }
 
@@ -640,7 +639,7 @@ func (e *Entry) removeOldAggregations(newAggregations aggregationValues) {
 }
 
 func (e *Entry) updateStagedMetadatasWithLock(
-	metricID id.RawID,
+	metricID metricid.RawID,
 	metricType metric.Type,
 	hasDefaultMetadatas bool,
 	sm metadata.StagedMetadata,

--- a/src/aggregator/aggregator/flush.go
+++ b/src/aggregator/aggregator/flush.go
@@ -72,6 +72,18 @@ const (
 	discardType
 )
 
+// String provides the string representation for the flush type.
+func (f flushType) String() string {
+	switch f {
+	case consumeType:
+		return "consume"
+	case discardType:
+		return "discard"
+	default:
+		return "unknown"
+	}
+}
+
 // A flushLocalMetricFn flushes an aggregated metric datapoint locally by either
 // consuming or discarding it. Processing of the datapoint is completed once it is
 // flushed.

--- a/src/aggregator/aggregator/flush_mgr.go
+++ b/src/aggregator/aggregator/flush_mgr.go
@@ -369,12 +369,13 @@ func (mgr *flushManager) flushManagerWithLock() roleBasedFlushManager {
 // flushBucket contains all the registered flushing metric lists for a given flush interval.
 // NB(xichen): flushBucket is not thread-safe. It is protected by the lock in the flush manager.
 type flushBucket struct {
-	bucketID metricListID
-	interval time.Duration
-	offset   time.Duration
-	flushers []flushingMetricList
-	duration tally.Timer
-	flushLag tally.Histogram
+	bucketID         metricListID
+	interval         time.Duration
+	offset           time.Duration
+	flushers         []flushingMetricList
+	duration         tally.Timer
+	flushLag         tally.Histogram
+	followerFlushLag tally.Histogram
 }
 
 func newBucket(
@@ -382,12 +383,8 @@ func newBucket(
 	interval, offset time.Duration,
 	scope tally.Scope,
 ) *flushBucket {
-	return &flushBucket{
-		bucketID: bucketID,
-		interval: interval,
-		offset:   offset,
-		duration: scope.Timer("duration"),
-		flushLag: scope.Histogram("flush-lag", tally.DurationBuckets{
+	histFn := func(name string) tally.Histogram {
+		return scope.Histogram(name, tally.DurationBuckets{
 			10 * time.Millisecond,
 			500 * time.Millisecond,
 			time.Second,
@@ -404,7 +401,21 @@ func newBucket(
 			60 * time.Second,
 			90 * time.Second,
 			120 * time.Second,
-		}),
+			150 * time.Second,
+			180 * time.Second,
+			210 * time.Second,
+			240 * time.Second,
+			300 * time.Second,
+		})
+	}
+
+	return &flushBucket{
+		bucketID:         bucketID,
+		interval:         interval,
+		offset:           offset,
+		duration:         scope.Timer("duration"),
+		flushLag:         histFn("flush-lag"),
+		followerFlushLag: histFn("follower-flush-lag"),
 	}
 }
 

--- a/src/aggregator/aggregator/flush_mgr_mock.go
+++ b/src/aggregator/aggregator/flush_mgr_mock.go
@@ -284,3 +284,15 @@ func (mr *MockroleBasedFlushManagerMockRecorder) Prepare(buckets interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockroleBasedFlushManager)(nil).Prepare), buckets)
 }
+
+// UpdateFlushTimes mocks base method.
+func (m *MockroleBasedFlushManager) UpdateFlushTimes(buckets []*flushBucket) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateFlushTimes", buckets)
+}
+
+// UpdateFlushTimes indicates an expected call of UpdateFlushTimes.
+func (mr *MockroleBasedFlushManagerMockRecorder) UpdateFlushTimes(buckets interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFlushTimes", reflect.TypeOf((*MockroleBasedFlushManager)(nil).UpdateFlushTimes), buckets)
+}

--- a/src/aggregator/aggregator/flush_mgr_mock.go
+++ b/src/aggregator/aggregator/flush_mgr_mock.go
@@ -284,15 +284,3 @@ func (mr *MockroleBasedFlushManagerMockRecorder) Prepare(buckets interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockroleBasedFlushManager)(nil).Prepare), buckets)
 }
-
-// UpdateFlushTimes mocks base method.
-func (m *MockroleBasedFlushManager) UpdateFlushTimes(buckets []*flushBucket) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateFlushTimes", buckets)
-}
-
-// UpdateFlushTimes indicates an expected call of UpdateFlushTimes.
-func (mr *MockroleBasedFlushManagerMockRecorder) UpdateFlushTimes(buckets interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFlushTimes", reflect.TypeOf((*MockroleBasedFlushManager)(nil).UpdateFlushTimes), buckets)
-}

--- a/src/aggregator/aggregator/follower_flush_mgr_test.go
+++ b/src/aggregator/aggregator/follower_flush_mgr_test.go
@@ -426,8 +426,17 @@ func TestFollowerFlushManagerPrepareFlushTimesUpdated(t *testing.T) {
 	require.Equal(t, time.Duration(0), dur)
 	task := flushTask.(*followerFlushTask)
 	actual := task.flushersByInterval
-	require.Equal(t, expected, actual)
+	requireFlusherGroupEqual(t, expected, actual)
 	require.Equal(t, now, mgr.lastFlushed)
+}
+
+func requireFlusherGroupEqual(t *testing.T, expected, actual []flushersGroup) {
+	// NB: strip off the follower flush lag histogram when comparing to expected.
+	for idx := range actual {
+		actual[idx].followerFlushLag = nil
+	}
+
+	require.Equal(t, expected, actual)
 }
 
 func TestFollowerFlushManagerPrepareMaxBufferSizeExceeded(t *testing.T) {
@@ -535,7 +544,7 @@ func TestFollowerFlushManagerPrepareMaxBufferSizeExceeded(t *testing.T) {
 	require.Equal(t, time.Duration(0), dur)
 	task := flushTask.(*followerFlushTask)
 	actual := task.flushersByInterval
-	require.Equal(t, expected, actual)
+	requireFlusherGroupEqual(t, expected, actual)
 	require.Equal(t, now, mgr.lastFlushed)
 
 	// Advance time by less than the forced flush window size and expect no flush.

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -298,6 +298,7 @@ func (e *GaugeElem) Consume(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	onForwardedFlushedFn onForwardingElemFlushedFn,
+	flushType flushType,
 ) bool {
 	resolution := e.sp.Resolution().Window
 	// reverse engineer the allowed lateness.
@@ -358,6 +359,7 @@ func (e *GaugeElem) Consume(
 			flushForwardedFn,
 			resolution,
 			latenessAllowed,
+			flushType,
 		)
 		e.toConsume[i].lockedAgg.flushed = true
 		e.toConsume[i].lockedAgg.Unlock()
@@ -575,7 +577,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration,
-	latenessAllowed time.Duration) bool {
+	latenessAllowed time.Duration,
+	flushType flushType,
+) bool {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
@@ -673,13 +677,19 @@ func (e *GaugeElem) processValueWithAggregationLock(
 					flushLocalFn(e.FullPrefix(e.opts), e.id, e.TypeStringFor(e.aggTypesOpts, aggType),
 						point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
 				}
+
+				if !lockedAgg.flushed {
+					e.forwardLagMetric(resolution, "local", flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
+				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution).RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
+				e.forwardLagMetric(resolution, "remote", flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timeNanos), value, prevValue, lockedAgg.aggregation.Annotation(), resendEnabled)

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -362,6 +362,7 @@ func (e *GenericElem) Consume(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	onForwardedFlushedFn onForwardingElemFlushedFn,
+	flushType flushType,
 ) bool {
 	resolution := e.sp.Resolution().Window
 	// reverse engineer the allowed lateness.
@@ -422,6 +423,7 @@ func (e *GenericElem) Consume(
 			flushForwardedFn,
 			resolution,
 			latenessAllowed,
+			flushType,
 		)
 		e.toConsume[i].lockedAgg.flushed = true
 		e.toConsume[i].lockedAgg.Unlock()
@@ -639,7 +641,9 @@ func (e *GenericElem) processValueWithAggregationLock(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration,
-	latenessAllowed time.Duration) bool {
+	latenessAllowed time.Duration,
+	flushType flushType,
+) bool {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
@@ -737,13 +741,19 @@ func (e *GenericElem) processValueWithAggregationLock(
 					flushLocalFn(e.FullPrefix(e.opts), e.id, e.TypeStringFor(e.aggTypesOpts, aggType),
 						point.TimeNanos, point.Value, lockedAgg.aggregation.Annotation(), e.sp)
 				}
+
+				if !lockedAgg.flushed {
+					e.forwardLagMetric(resolution, "local", flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
+				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution).RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
+				e.forwardLagMetric(resolution, "remote", flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timeNanos), value, prevValue, lockedAgg.aggregation.Annotation(), resendEnabled)

--- a/src/aggregator/aggregator/leader_flush_mgr_test.go
+++ b/src/aggregator/aggregator/leader_flush_mgr_test.go
@@ -779,59 +779,71 @@ func testFlushBuckets(ctrl *gomock.Controller) []*flushBucket {
 	forwardedFlusher4.EXPECT().FlushInterval().Return(time.Minute).AnyTimes()
 	forwardedFlusher4.EXPECT().LastFlushedNanos().Return(int64(3600000000000)).AnyTimes()
 
-	flushLag := tally.NewTestScope("", nil).Histogram("flush-lag", nil)
+	var (
+		scope            = tally.NewTestScope("", nil)
+		flushLag         = scope.Histogram("flush-lag", nil)
+		followerFlushLag = scope.Histogram("follower-flush-lag", tally.DefaultBuckets)
+	)
+
 	return []*flushBucket{
 		// Standard flushing metric lists.
 		{
-			bucketID: standardMetricListID{resolution: time.Second}.toMetricListID(),
-			interval: time.Second,
-			offset:   250 * time.Millisecond,
-			flushers: []flushingMetricList{standardFlusher1, standardFlusher2},
-			flushLag: flushLag,
+			bucketID:         standardMetricListID{resolution: time.Second}.toMetricListID(),
+			interval:         time.Second,
+			offset:           250 * time.Millisecond,
+			flushers:         []flushingMetricList{standardFlusher1, standardFlusher2},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		{
-			bucketID: standardMetricListID{resolution: time.Minute}.toMetricListID(),
-			interval: time.Minute,
-			offset:   12 * time.Second,
-			flushers: []flushingMetricList{standardFlusher3},
-			flushLag: flushLag,
+			bucketID:         standardMetricListID{resolution: time.Minute}.toMetricListID(),
+			interval:         time.Minute,
+			offset:           12 * time.Second,
+			flushers:         []flushingMetricList{standardFlusher3},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		{
-			bucketID: standardMetricListID{resolution: time.Hour}.toMetricListID(),
-			interval: time.Hour,
-			offset:   time.Minute,
-			flushers: []flushingMetricList{standardFlusher4},
-			flushLag: flushLag,
+			bucketID:         standardMetricListID{resolution: time.Hour}.toMetricListID(),
+			interval:         time.Hour,
+			offset:           time.Minute,
+			flushers:         []flushingMetricList{standardFlusher4},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		// Timed flushing metric lists.
 		{
-			bucketID: timedMetricListID{resolution: time.Minute}.toMetricListID(),
-			interval: time.Minute,
-			offset:   250 * time.Millisecond,
-			flushers: []flushingMetricList{timedFlusher1},
-			flushLag: flushLag,
+			bucketID:         timedMetricListID{resolution: time.Minute}.toMetricListID(),
+			interval:         time.Minute,
+			offset:           250 * time.Millisecond,
+			flushers:         []flushingMetricList{timedFlusher1},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		// Forwarded flushing metric lists.
 		{
-			bucketID: forwardedMetricListID{resolution: time.Second, numForwardedTimes: 1}.toMetricListID(),
-			interval: time.Second,
-			offset:   100 * time.Millisecond,
-			flushers: []flushingMetricList{forwardedFlusher1, forwardedFlusher2},
-			flushLag: flushLag,
+			bucketID:         forwardedMetricListID{resolution: time.Second, numForwardedTimes: 1}.toMetricListID(),
+			interval:         time.Second,
+			offset:           100 * time.Millisecond,
+			flushers:         []flushingMetricList{forwardedFlusher1, forwardedFlusher2},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		{
-			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 2}.toMetricListID(),
-			interval: time.Minute,
-			offset:   time.Second,
-			flushers: []flushingMetricList{forwardedFlusher3},
-			flushLag: flushLag,
+			bucketID:         forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 2}.toMetricListID(),
+			interval:         time.Minute,
+			offset:           time.Second,
+			flushers:         []flushingMetricList{forwardedFlusher3},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		{
-			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 3}.toMetricListID(),
-			interval: time.Minute,
-			offset:   0,
-			flushers: []flushingMetricList{forwardedFlusher4},
-			flushLag: flushLag,
+			bucketID:         forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 3}.toMetricListID(),
+			interval:         time.Minute,
+			offset:           0,
+			flushers:         []flushingMetricList{forwardedFlusher4},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 	}
 }
@@ -862,42 +874,52 @@ func testFlushBuckets2(ctrl *gomock.Controller) []*flushBucket {
 	forwardedFlusher2.EXPECT().FlushInterval().Return(time.Minute).AnyTimes()
 	forwardedFlusher2.EXPECT().LastFlushedNanos().Return(int64(3658000000000)).AnyTimes()
 
-	flushLag := tally.NewTestScope("", nil).Histogram("flush-lag", nil)
+	var (
+		scope            = tally.NewTestScope("", nil)
+		flushLag         = scope.Histogram("flush-lag", nil)
+		followerFlushLag = scope.Histogram("follower-flush-lag", tally.DefaultBuckets)
+	)
+
 	return []*flushBucket{
 		{
-			bucketID: standardMetricListID{resolution: time.Second}.toMetricListID(),
-			interval: time.Second,
-			offset:   250 * time.Millisecond,
-			flushers: []flushingMetricList{standardFlusher1},
-			flushLag: flushLag,
+			bucketID:         standardMetricListID{resolution: time.Second}.toMetricListID(),
+			interval:         time.Second,
+			offset:           250 * time.Millisecond,
+			flushers:         []flushingMetricList{standardFlusher1},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		{
-			bucketID: standardMetricListID{resolution: time.Hour}.toMetricListID(),
-			interval: time.Hour,
-			offset:   time.Minute,
-			flushers: []flushingMetricList{standardFlusher2},
-			flushLag: flushLag,
+			bucketID:         standardMetricListID{resolution: time.Hour}.toMetricListID(),
+			interval:         time.Hour,
+			offset:           time.Minute,
+			flushers:         []flushingMetricList{standardFlusher2},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		{
-			bucketID: timedMetricListID{resolution: time.Second}.toMetricListID(),
-			interval: time.Second,
-			offset:   250 * time.Millisecond,
-			flushers: []flushingMetricList{timedFlusher1},
-			flushLag: flushLag,
+			bucketID:         timedMetricListID{resolution: time.Second}.toMetricListID(),
+			interval:         time.Second,
+			offset:           250 * time.Millisecond,
+			flushers:         []flushingMetricList{timedFlusher1},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		{
-			bucketID: forwardedMetricListID{resolution: time.Second, numForwardedTimes: 1}.toMetricListID(),
-			interval: time.Second,
-			offset:   100 * time.Millisecond,
-			flushers: []flushingMetricList{forwardedFlusher1},
-			flushLag: flushLag,
+			bucketID:         forwardedMetricListID{resolution: time.Second, numForwardedTimes: 1}.toMetricListID(),
+			interval:         time.Second,
+			offset:           100 * time.Millisecond,
+			flushers:         []flushingMetricList{forwardedFlusher1},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 		{
-			bucketID: forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 2}.toMetricListID(),
-			interval: time.Minute,
-			offset:   time.Second,
-			flushers: []flushingMetricList{forwardedFlusher2},
-			flushLag: flushLag,
+			bucketID:         forwardedMetricListID{resolution: time.Minute, numForwardedTimes: 2}.toMetricListID(),
+			interval:         time.Minute,
+			offset:           time.Second,
+			flushers:         []flushingMetricList{forwardedFlusher2},
+			flushLag:         flushLag,
+			followerFlushLag: followerFlushLag,
 		},
 	}
 }

--- a/src/aggregator/aggregator/list.go
+++ b/src/aggregator/aggregator/list.go
@@ -249,9 +249,7 @@ func (l *baseMetricList) Len() int {
 // elements and manage their lifetimes. If this becomes an issue,
 // need to switch to a custom type-specific list implementation.
 func (l *baseMetricList) PushBack(value metricElem) (*list.Element, error) {
-	var (
-		_, hasForwardedID = value.ForwardedID()
-	)
+	_, hasForwardedID := value.ForwardedID()
 	l.Lock()
 	if l.closed {
 		l.Unlock()
@@ -379,6 +377,7 @@ func (l *baseMetricList) flushBefore(beforeNanos int64, flushType flushType) {
 			flushLocalFn,
 			flushForwardedFn,
 			onForwardedFlushedFn,
+			flushType,
 		) {
 			l.toCollect = append(l.toCollect, e)
 		}


### PR DESCRIPTION
Adds follower flush metrics to mirror existing leader flush metrics.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
