### PR TITLE
[tests] Ensure query param is set in InstantQuery and RangeQuery

### DIFF
--- a/src/integration/resources/coordinator_client.go
+++ b/src/integration/resources/coordinator_client.go
@@ -723,7 +723,7 @@ func (c *CoordinatorClient) query(
 
 // InstantQuery runs an instant query with provided headers
 func (c *CoordinatorClient) InstantQuery(req QueryRequest, headers map[string][]string) (model.Vector, error) {
-	queryStr := fmt.Sprintf("%s?%s", route.QueryURL, req.QueryExpr)
+	queryStr := fmt.Sprintf("%s?query=%s", route.QueryURL, req.QueryExpr)
 	if req.Time != nil {
 		queryStr = fmt.Sprintf("%s&time=%d", queryStr, req.Time.Unix())
 	}
@@ -763,7 +763,7 @@ func (c *CoordinatorClient) RangeQuery(req RangeQueryRequest, headers map[string
 		req.Step = 15 * time.Second // default step is 15 seconds.
 	}
 	queryStr := fmt.Sprintf(
-		"%s?%s&start=%d&end=%d&step=%f",
+		"%s?query=%s&start=%d&end=%d&step=%f",
 		route.QueryRangeURL, req.QueryExpr,
 		req.StartTime.Unix(),
 		req.EndTime.Unix(),

--- a/src/integration/resources/inprocess/aggregator_test.go
+++ b/src/integration/resources/inprocess/aggregator_test.go
@@ -295,7 +295,7 @@ func testAggMetrics(t *testing.T, coord resources.Coordinator) {
 
 	// Instant Query
 	require.NoError(t, resources.Retry(func() error {
-		result, err := coord.InstantQuery(resources.QueryRequest{QueryExpr: "query=cpu"}, queryHeaders)
+		result, err := coord.InstantQuery(resources.QueryRequest{QueryExpr: "cpu"}, queryHeaders)
 		if err != nil {
 			return err
 		}
@@ -312,7 +312,7 @@ func testAggMetrics(t *testing.T, coord resources.Coordinator) {
 	require.NoError(t, resources.Retry(func() error {
 		result, err := coord.RangeQuery(
 			resources.RangeQueryRequest{
-				QueryExpr: "query=cpu",
+				QueryExpr: "cpu",
 				StartTime: time.Now().Add(-30 * time.Second),
 				EndTime:   time.Now(),
 				Step:      1 * time.Second,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
