### PR TITLE
[aggregator] Track unjittered forwarding lag

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -682,9 +682,9 @@ func (e *CounterElem) processValueWithAggregationLock(
 				}
 
 				if !lockedAgg.flushed {
-					e.forwardLagMetric(resolution, "local", true, flushType).
-						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
 					e.forwardLagMetric(resolution, "local", false, flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+					e.forwardLagMetric(resolution, "local", true, flushType).
 						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 				}
 			}
@@ -693,9 +693,9 @@ func (e *CounterElem) processValueWithAggregationLock(
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution, "remote", true, flushType).
-					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
 				e.forwardLagMetric(resolution, "remote", false, flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+				e.forwardLagMetric(resolution, "remote", true, flushType).
 					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -298,6 +298,7 @@ func (e *CounterElem) Consume(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	onForwardedFlushedFn onForwardingElemFlushedFn,
+	jitter time.Duration,
 	flushType flushType,
 ) bool {
 	resolution := e.sp.Resolution().Window
@@ -359,6 +360,7 @@ func (e *CounterElem) Consume(
 			flushForwardedFn,
 			resolution,
 			latenessAllowed,
+			jitter,
 			flushType,
 		)
 		e.toConsume[i].lockedAgg.flushed = true
@@ -578,6 +580,7 @@ func (e *CounterElem) processValueWithAggregationLock(
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration,
 	latenessAllowed time.Duration,
+	jitter time.Duration,
 	flushType flushType,
 ) bool {
 	var (
@@ -679,7 +682,9 @@ func (e *CounterElem) processValueWithAggregationLock(
 				}
 
 				if !lockedAgg.flushed {
-					e.forwardLagMetric(resolution, "local", flushType).
+					e.forwardLagMetric(resolution, "local", true, flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+					e.forwardLagMetric(resolution, "local", false, flushType).
 						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 				}
 			}
@@ -688,7 +693,9 @@ func (e *CounterElem) processValueWithAggregationLock(
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution, "remote", flushType).
+				e.forwardLagMetric(resolution, "remote", true, flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+				e.forwardLagMetric(resolution, "remote", false, flushType).
 					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -471,7 +471,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -482,7 +482,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -493,7 +493,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -505,7 +505,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -517,7 +517,7 @@ func TestCounterElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -535,7 +535,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -546,7 +546,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[1], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -557,7 +557,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForCounter(testAlignedStarts[2], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -569,7 +569,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -581,7 +581,7 @@ func TestCounterElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -628,7 +628,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -647,7 +647,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 
 	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -679,7 +679,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	// one value to reference in the future as a previous.
 	ts := alignedstartAtNanos[3] + int64(time.Second*20)
 	require.False(t, e.Consume(ts, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -696,7 +696,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -708,7 +708,7 @@ func TestCounterElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1004,7 +1004,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1015,7 +1015,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1026,7 +1026,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1038,7 +1038,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1050,7 +1050,7 @@ func TestTimerElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1072,7 +1072,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1084,7 +1084,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[1], testStoragePolicy, testTimerAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1095,7 +1095,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForTimer(testAlignedStarts[2], testStoragePolicy, testTimerAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1107,7 +1107,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1119,7 +1119,7 @@ func TestTimerElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1169,7 +1169,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -1187,7 +1187,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -1215,7 +1215,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -1232,7 +1232,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -1244,7 +1244,7 @@ func TestTimerElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1641,7 +1641,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1652,7 +1652,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1663,7 +1663,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[2], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1675,7 +1675,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1687,7 +1687,7 @@ func TestGaugeElemConsumeDefaultAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1722,7 +1722,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t,
 		expectedLocalMetricsForGauge(testAlignedStarts[1], testStoragePolicy, maggregation.DefaultTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
@@ -1746,7 +1746,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t,
 		expectedLocalMetricsForGaugeWithVal(testAlignedStarts[2], 0.0, testStoragePolicy,
 			maggregation.DefaultTypes),
@@ -1767,7 +1767,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	// the update cascades, resulting in 2 flushed values.
 	exp := expectedLocalMetricsForGaugeWithVal(testAlignedStarts[1], updatedVal, testStoragePolicy,
 		maggregation.DefaultTypes)
@@ -1790,7 +1790,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	pastBufferTime := pastBuffer + testStoragePolicy.Resolution().Window
 	require.False(t, e.Consume(time.Unix(0, testAlignedStarts[1]).Add(pastBufferTime).UnixNano(),
 		isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1801,7 +1801,7 @@ func TestGaugeElemConsumeResendBuffer(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(time.Unix(0, testAlignedStarts[2]).Add(pastBufferTime).UnixNano(),
 		isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1819,7 +1819,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1830,7 +1830,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[1], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1841,7 +1841,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, expectedLocalMetricsForGauge(testAlignedStarts[2], testStoragePolicy, testAggregationTypes), *localRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1853,7 +1853,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1865,7 +1865,7 @@ func TestGaugeElemConsumeCustomAggregationDefaultPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(testAlignedStarts[2], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -1911,7 +1911,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -1929,7 +1929,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -1957,7 +1957,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -1974,7 +1974,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -1986,7 +1986,7 @@ func TestGaugeElemConsumeCustomAggregationCustomPipeline(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
@@ -2025,7 +2025,7 @@ func TestGaugeElemResendSumReset(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	exp := expectedLocalMetricsForGaugeWithVal(
 		alignedstartAtNanos[1], 123.0, testStoragePolicy, maggregation.DefaultTypes)
 	exp = append(exp, expectedLocalMetricsForGaugeWithVal(
@@ -2058,7 +2058,7 @@ func TestGaugeElemResendSumReset(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(testAlignedStarts[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	exp = expectedLocalMetricsForGaugeWithVal(
 		alignedstartAtNanos[1], 122.0, testStoragePolicy, maggregation.DefaultTypes)
 	exp = append(exp, expectedLocalMetricsForGaugeWithVal(
@@ -2125,7 +2125,7 @@ func TestGaugeElemResendBufferForwarding(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -2144,7 +2144,7 @@ func TestGaugeElemResendBufferForwarding(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -2175,7 +2175,7 @@ func TestGaugeElemResendBufferForwarding(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -2213,7 +2213,7 @@ func TestGaugeElemResendBufferForwarding(t *testing.T) {
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t,
 		e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-			localFn, forwardFn, onForwardedFlushedFn, consumeType))
+			localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	verifyForwardedMetrics(t, expectedForwardedRes, *forwardRes)
 	verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*localRes))
@@ -2260,7 +2260,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes := testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes := testOnForwardedFlushedFn()
 	require.False(t, e.Consume(0, isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
@@ -2271,7 +2271,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[1], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, (*localRes)[0].timeNanos, alignedstartAtNanos[1])
 	require.Equal(t, (*localRes)[0].value, 123.0)
 	require.Equal(t, (*localRes)[1].timeNanos, alignedstartAtNanos[1]+int64(5*time.Second))
@@ -2286,7 +2286,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, (*localRes)[0].timeNanos, alignedstartAtNanos[2])
 	require.Equal(t, (*localRes)[0].value, 456.0)
 	require.Equal(t, (*localRes)[1].timeNanos, alignedstartAtNanos[2]+int64(5*time.Second))
@@ -2306,7 +2306,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, _ = testOnForwardedFlushedFn()
 	require.True(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	// verifyOnForwardedFlushResult(t, expectedOnFlushedRes, *onForwardedFlushedRes)
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*localRes))
@@ -2319,7 +2319,7 @@ func TestGaugeElemReset(t *testing.T) {
 	forwardFn, forwardRes = testFlushForwardedMetricFn()
 	onForwardedFlushedFn, onForwardedFlushedRes = testOnForwardedFlushedFn()
 	require.False(t, e.Consume(alignedstartAtNanos[3], isEarlierThanFn, timestampNanosFn, standardMetricTargetNanos,
-		localFn, forwardFn, onForwardedFlushedFn, consumeType))
+		localFn, forwardFn, onForwardedFlushedFn, 0, consumeType))
 	require.Equal(t, 0, len(*localRes))
 	require.Equal(t, 0, len(*forwardRes))
 	require.Equal(t, 0, len(*onForwardedFlushedRes))

--- a/src/aggregator/aggregator/flush.go
+++ b/src/aggregator/aggregator/flush.go
@@ -63,6 +63,9 @@ type flushRequest struct {
 
 	// If nonzero, data between [now - bufferAfterCutoff, now) are buffered.
 	BufferAfterCutoff time.Duration
+
+	// Jitter is the jitter for the flush request.
+	Jitter time.Duration
 }
 
 type flushType int

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -682,9 +682,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 				}
 
 				if !lockedAgg.flushed {
-					e.forwardLagMetric(resolution, "local", true, flushType).
-						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
 					e.forwardLagMetric(resolution, "local", false, flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+					e.forwardLagMetric(resolution, "local", true, flushType).
 						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 				}
 			}
@@ -693,9 +693,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution, "remote", true, flushType).
-					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
 				e.forwardLagMetric(resolution, "remote", false, flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+				e.forwardLagMetric(resolution, "remote", true, flushType).
 					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -298,6 +298,7 @@ func (e *GaugeElem) Consume(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	onForwardedFlushedFn onForwardingElemFlushedFn,
+	jitter time.Duration,
 	flushType flushType,
 ) bool {
 	resolution := e.sp.Resolution().Window
@@ -359,6 +360,7 @@ func (e *GaugeElem) Consume(
 			flushForwardedFn,
 			resolution,
 			latenessAllowed,
+			jitter,
 			flushType,
 		)
 		e.toConsume[i].lockedAgg.flushed = true
@@ -578,6 +580,7 @@ func (e *GaugeElem) processValueWithAggregationLock(
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration,
 	latenessAllowed time.Duration,
+	jitter time.Duration,
 	flushType flushType,
 ) bool {
 	var (
@@ -679,7 +682,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 				}
 
 				if !lockedAgg.flushed {
-					e.forwardLagMetric(resolution, "local", flushType).
+					e.forwardLagMetric(resolution, "local", true, flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+					e.forwardLagMetric(resolution, "local", false, flushType).
 						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 				}
 			}
@@ -688,7 +693,9 @@ func (e *GaugeElem) processValueWithAggregationLock(
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution, "remote", flushType).
+				e.forwardLagMetric(resolution, "remote", true, flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+				e.forwardLagMetric(resolution, "remote", false, flushType).
 					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -746,9 +746,9 @@ func (e *GenericElem) processValueWithAggregationLock(
 				}
 
 				if !lockedAgg.flushed {
-					e.forwardLagMetric(resolution, "local", true, flushType).
-						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
 					e.forwardLagMetric(resolution, "local", false, flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+					e.forwardLagMetric(resolution, "local", true, flushType).
 						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 				}
 			}
@@ -757,9 +757,9 @@ func (e *GenericElem) processValueWithAggregationLock(
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution, "remote", true, flushType).
-					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
 				e.forwardLagMetric(resolution, "remote", false, flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+				e.forwardLagMetric(resolution, "remote", true, flushType).
 					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,

--- a/src/aggregator/aggregator/leader_flush_mgr.go
+++ b/src/aggregator/aggregator/leader_flush_mgr.go
@@ -163,6 +163,7 @@ func (mgr *leaderFlushManager) Prepare(buckets []*flushBucket) (flushTask, time.
 			// inside the bucket may be modified during task execution when new
 			// flushers are registered or old flushers are unregistered.
 			mgr.flushTask.duration = buckets[bucketIdx].duration
+			mgr.flushTask.jitter = buckets[bucketIdx].offset
 			mgr.flushTask.flushers = append(mgr.flushTask.flushers[:0], buckets[bucketIdx].flushers...)
 			nextFlushMetadata := flushMetadata{
 				timeNanos: earliestFlush.timeNanos + int64(buckets[bucketIdx].interval),
@@ -470,6 +471,7 @@ func cloneForwardedFlushTimesForResolution(
 type leaderFlushTask struct {
 	mgr      *leaderFlushManager
 	duration tally.Timer
+	jitter   time.Duration
 	flushers []flushingMetricList
 }
 
@@ -484,6 +486,7 @@ func (t *leaderFlushTask) Run() {
 	var (
 		wgWorkers sync.WaitGroup
 		start     = mgr.nowFn()
+		jitter    = t.jitter
 	)
 	for _, flusher := range t.flushers {
 		// By default traffic is cut off from a shard, unless the shard is in the list of
@@ -504,6 +507,7 @@ func (t *leaderFlushTask) Run() {
 			CutoverNanos:      cutoverNanos,
 			CutoffNanos:       cutoffNanos,
 			BufferAfterCutoff: mgr.maxBufferSize,
+			Jitter:            jitter,
 		}
 		flusher := flusher
 		wgWorkers.Add(1)

--- a/src/aggregator/aggregator/list.go
+++ b/src/aggregator/aggregator/list.go
@@ -147,7 +147,7 @@ func newMetricListMetrics(scope tally.Scope) baseMetricListMetrics {
 // of aggregation windows that are eligible for flushing.
 type targetNanosFn func(nowNanos int64) int64
 
-type flushBeforeFn func(beforeNanos int64, flushType flushType)
+type flushBeforeFn func(beforeNanos int64, jitter time.Duration, flushType flushType)
 
 // baseMetricList is a metric list storing aggregations at a given resolution and
 // flushing them periodically.
@@ -302,23 +302,23 @@ func (l *baseMetricList) Flush(req flushRequest) {
 
 	// Metrics before shard cutover are discarded.
 	if targetNanos <= req.CutoverNanos {
-		l.flushBeforeFn(targetNanos, discardType)
+		l.flushBeforeFn(targetNanos, req.Jitter, discardType)
 		l.metrics.flushBeforeCutover.Inc(1)
 		return
 	}
 
 	// Metrics between shard cutover and shard cutoff are consumed.
 	if req.CutoverNanos > 0 {
-		l.flushBeforeFn(req.CutoverNanos, discardType)
+		l.flushBeforeFn(req.CutoverNanos, req.Jitter, discardType)
 	}
 	if targetNanos <= req.CutoffNanos {
-		l.flushBeforeFn(targetNanos, consumeType)
+		l.flushBeforeFn(targetNanos, req.Jitter, consumeType)
 		l.metrics.flushBetweenCutoverCutoff.Inc(1)
 		return
 	}
 
 	// Metrics after now-keepAfterCutoff are retained.
-	l.flushBeforeFn(req.CutoffNanos, consumeType)
+	l.flushBeforeFn(req.CutoffNanos, req.Jitter, consumeType)
 	bufferEndNanos := targetNanos - int64(req.BufferAfterCutoff)
 	if bufferEndNanos <= req.CutoffNanos {
 		l.metrics.flushBetweenCutoffBufferEnd.Inc(1)
@@ -326,18 +326,18 @@ func (l *baseMetricList) Flush(req flushRequest) {
 	}
 
 	// Metrics between cutoff and now-bufferAfterCutoff are discarded.
-	l.flushBeforeFn(bufferEndNanos, discardType)
+	l.flushBeforeFn(bufferEndNanos, req.Jitter, discardType)
 	l.metrics.flushAfterBufferEnd.Inc(1)
 }
 
 func (l *baseMetricList) DiscardBefore(beforeNanos int64) {
-	l.flushBeforeFn(beforeNanos, discardType)
+	l.flushBeforeFn(beforeNanos, 0, discardType)
 	l.metrics.discardBefore.Inc(1)
 }
 
 // flushBefore flushes or discards data before a given time based on the flush type.
 // It is not thread-safe.
-func (l *baseMetricList) flushBefore(beforeNanos int64, flushType flushType) {
+func (l *baseMetricList) flushBefore(beforeNanos int64, jitter time.Duration, flushType flushType) {
 	if l.LastFlushedNanos() >= beforeNanos {
 		l.metrics.flushBeforeStale.Inc(1)
 		return
@@ -377,6 +377,7 @@ func (l *baseMetricList) flushBefore(beforeNanos int64, flushType flushType) {
 			flushLocalFn,
 			flushForwardedFn,
 			onForwardedFlushedFn,
+			jitter,
 			flushType,
 		) {
 			l.toCollect = append(l.toCollect, e)

--- a/src/aggregator/aggregator/list_test.go
+++ b/src/aggregator/aggregator/list_test.go
@@ -124,7 +124,7 @@ func TestBaseMetricListFlushWithRequests(t *testing.T) {
 	opts := testOptions(ctrl).SetClockOptions(clock.NewOptions().SetNowFn(nowFn))
 	l, err := newBaseMetricList(testShard, time.Second, targetNanosFn, isEarlierThanFn, timestampNanosFn, opts)
 	require.NoError(t, err)
-	l.flushBeforeFn = func(beforeNanos int64, flushType flushType) {
+	l.flushBeforeFn = func(beforeNanos int64, jitter time.Duration, flushType flushType) {
 		results = append(results, flushBeforeResult{
 			beforeNanos: beforeNanos,
 			flushType:   flushType,
@@ -237,7 +237,7 @@ func TestBaseMetricListFlushBeforeStale(t *testing.T) {
 	l, err := newBaseMetricList(testShard, 0, targetNanosFn, isEarlierThanFn, timestampNanosFn, opts)
 	require.NoError(t, err)
 	l.lastFlushedNanos = 1234
-	l.flushBefore(1000, discardType)
+	l.flushBefore(1000, 0, discardType)
 	require.Equal(t, int64(1234), l.LastFlushedNanos())
 }
 

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -682,9 +682,9 @@ func (e *TimerElem) processValueWithAggregationLock(
 				}
 
 				if !lockedAgg.flushed {
-					e.forwardLagMetric(resolution, "local", true, flushType).
-						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
 					e.forwardLagMetric(resolution, "local", false, flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+					e.forwardLagMetric(resolution, "local", true, flushType).
 						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 				}
 			}
@@ -693,9 +693,9 @@ func (e *TimerElem) processValueWithAggregationLock(
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution, "remote", true, flushType).
-					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
 				e.forwardLagMetric(resolution, "remote", false, flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+				e.forwardLagMetric(resolution, "remote", true, flushType).
 					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -298,6 +298,7 @@ func (e *TimerElem) Consume(
 	flushLocalFn flushLocalMetricFn,
 	flushForwardedFn flushForwardedMetricFn,
 	onForwardedFlushedFn onForwardingElemFlushedFn,
+	jitter time.Duration,
 	flushType flushType,
 ) bool {
 	resolution := e.sp.Resolution().Window
@@ -359,6 +360,7 @@ func (e *TimerElem) Consume(
 			flushForwardedFn,
 			resolution,
 			latenessAllowed,
+			jitter,
 			flushType,
 		)
 		e.toConsume[i].lockedAgg.flushed = true
@@ -578,6 +580,7 @@ func (e *TimerElem) processValueWithAggregationLock(
 	flushForwardedFn flushForwardedMetricFn,
 	resolution time.Duration,
 	latenessAllowed time.Duration,
+	jitter time.Duration,
 	flushType flushType,
 ) bool {
 	var (
@@ -679,7 +682,9 @@ func (e *TimerElem) processValueWithAggregationLock(
 				}
 
 				if !lockedAgg.flushed {
-					e.forwardLagMetric(resolution, "local", flushType).
+					e.forwardLagMetric(resolution, "local", true, flushType).
+						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+					e.forwardLagMetric(resolution, "local", false, flushType).
 						RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 				}
 			}
@@ -688,7 +693,9 @@ func (e *TimerElem) processValueWithAggregationLock(
 			// only record lag for the initial flush (not resends)
 			if !lockedAgg.flushed {
 				// latenessAllowed is not due to processing delay, so it remove it from lag calc.
-				e.forwardLagMetric(resolution, "remote", flushType).
+				e.forwardLagMetric(resolution, "remote", true, flushType).
+					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed - jitter)))
+				e.forwardLagMetric(resolution, "remote", false, flushType).
 					RecordDuration(time.Since(timeNanos.ToTime().Add(-latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,


### PR DESCRIPTION
Adds another histogram tracking forward lag with the jitter removed
This is useful for seeing raw differences in lag without dealing with the
additional variable of jitter that can make it difficult to tell how updates
to the code affect lag