### PR TITLE
[aggregator] Propagate cancellation through tick

### DIFF
--- a/src/aggregator/aggregator/aggregator.go
+++ b/src/aggregator/aggregator/aggregator.go
@@ -399,7 +399,7 @@ func (agg *aggregator) Close() error {
 		currTime          time.Time
 		logCloseOperation = func(op string) {
 			currTime = time.Now()
-			agg.logger.Info(fmt.Sprintf("closed %s", op),
+			agg.logger.Info(fmt.Sprintf("!!! closed %s", op),
 				zap.String("took", currTime.Sub(lastOpCompleted).String()))
 			lastOpCompleted = currTime
 		}

--- a/src/aggregator/aggregator/aggregator.go
+++ b/src/aggregator/aggregator/aggregator.go
@@ -97,7 +97,6 @@ type Aggregator interface {
 type tickShardFn func(
 	shard *aggregatorShard,
 	perShardTickDuration time.Duration,
-	doneCh chan struct{},
 ) tickResult
 
 // aggregator stores aggregations of different types of metrics (e.g., counter,
@@ -762,9 +761,8 @@ func (agg *aggregator) tick() {
 func (agg *aggregator) tickShard(
 	shard *aggregatorShard,
 	perShardTickDuration time.Duration,
-	doneCh chan struct{},
 ) tickResult {
-	return shard.Tick(perShardTickDuration, doneCh)
+	return shard.Tick(perShardTickDuration, agg.doneCh)
 }
 
 func (agg *aggregator) tickInternal() {
@@ -789,7 +787,7 @@ func (agg *aggregator) tickInternal() {
 			agg.logger.Info("recevied interrupt on tick; aborting")
 			return
 		default:
-			shardTickResult := agg.tickShardFn(shard, perShardTickDuration, agg.doneCh)
+			shardTickResult := agg.tickShardFn(shard, perShardTickDuration)
 			tickResult = tickResult.merge(shardTickResult)
 		}
 	}

--- a/src/aggregator/aggregator/aggregator_test.go
+++ b/src/aggregator/aggregator/aggregator_test.go
@@ -861,7 +861,7 @@ func TestAggregatorTickCancelled(t *testing.T) {
 		doneAfterTicks = 2
 	)
 
-	agg.tickShardFn = func(*aggregatorShard, time.Duration) tickResult {
+	agg.tickShardFn = func(*aggregatorShard, time.Duration, <-chan struct{}) tickResult {
 		numTicked++
 		if doneAfterTicks == 2 {
 			close(tickedCh)

--- a/src/aggregator/aggregator/aggregator_test.go
+++ b/src/aggregator/aggregator/aggregator_test.go
@@ -861,9 +861,7 @@ func TestAggregatorTickCancelled(t *testing.T) {
 		doneAfterTicks = 2
 	)
 
-	agg.tickShardFn = func(
-		*aggregatorShard, time.Duration, chan struct{},
-	) tickResult {
+	agg.tickShardFn = func(*aggregatorShard, time.Duration) tickResult {
 		numTicked++
 		if doneAfterTicks == 2 {
 			close(tickedCh)

--- a/src/aggregator/aggregator/map.go
+++ b/src/aggregator/aggregator/map.go
@@ -218,8 +218,11 @@ func (m *metricMap) AddForwarded(
 	return err
 }
 
-func (m *metricMap) Tick(target time.Duration) tickResult {
-	mapTickRes := m.tick(target)
+func (m *metricMap) Tick(
+	target time.Duration,
+	doneCh chan struct{},
+) tickResult {
+	mapTickRes := m.tick(target, doneCh)
 	listsTickRes := m.metricLists.Tick()
 	mapTickRes.standard.activeElems = listsTickRes.standard
 	mapTickRes.forwarded.activeElems = listsTickRes.forwarded
@@ -320,7 +323,10 @@ func (m *metricMap) lookupEntryWithLock(key entryKey) (*Entry, bool) {
 // tick performs two operations:
 // 1. Delete entries that have expired, and report the number of expired entries.
 // 2. Report number of standard entries and forwarded entries that are active.
-func (m *metricMap) tick(target time.Duration) tickResult {
+func (m *metricMap) tick(
+	target time.Duration,
+	doneCh chan struct{},
+) tickResult {
 	// Determine batch size.
 	m.RLock()
 	numEntries := m.entryList.Len()
@@ -340,8 +346,27 @@ func (m *metricMap) tick(target time.Duration) tickResult {
 		numTimedActive       int
 		numTimedExpired      int
 		entryIdx             int
+
+		done bool
 	)
+
+	// NB: if no doneChan provided, do not interrupt the tick.
+	if doneCh == nil {
+		doneCh = make(chan struct{})
+	}
+
 	m.forEachEntry(func(entry hashedEntry) {
+		if done {
+			return
+		}
+
+		select {
+		case <-doneCh:
+			done = true
+			return
+		default:
+		}
+
 		now := m.nowFn()
 		if entryIdx > 0 && entryIdx%defaultSoftDeadlineCheckEvery == 0 {
 			targetDeadline := start.Add(time.Duration(entryIdx) * perEntrySoftDeadline)

--- a/src/aggregator/aggregator/map.go
+++ b/src/aggregator/aggregator/map.go
@@ -220,7 +220,7 @@ func (m *metricMap) AddForwarded(
 
 func (m *metricMap) Tick(
 	target time.Duration,
-	doneCh chan struct{},
+	doneCh <-chan struct{},
 ) tickResult {
 	mapTickRes := m.tick(target, doneCh)
 	listsTickRes := m.metricLists.Tick()
@@ -325,7 +325,7 @@ func (m *metricMap) lookupEntryWithLock(key entryKey) (*Entry, bool) {
 // 2. Report number of standard entries and forwarded entries that are active.
 func (m *metricMap) tick(
 	target time.Duration,
-	doneCh chan struct{},
+	doneCh <-chan struct{},
 ) tickResult {
 	// Determine batch size.
 	m.RLock()
@@ -349,11 +349,6 @@ func (m *metricMap) tick(
 
 		done bool
 	)
-
-	// NB: if no doneChan provided, do not interrupt the tick.
-	if doneCh == nil {
-		doneCh = make(chan struct{})
-	}
 
 	m.forEachEntry(func(entry hashedEntry) {
 		if done {

--- a/src/aggregator/aggregator/map_test.go
+++ b/src/aggregator/aggregator/map_test.go
@@ -513,7 +513,7 @@ func TestMetricMapDeleteExpired(t *testing.T) {
 	}
 
 	// Delete expired entries.
-	m.tick(opts.EntryCheckInterval())
+	m.tick(opts.EntryCheckInterval(), nil)
 
 	// Assert there should be only half of the entries left.
 	require.Equal(t, numEntries/2, len(m.entries))
@@ -524,4 +524,48 @@ func TestMetricMapDeleteExpired(t *testing.T) {
 		require.Equal(t, k, e.key)
 		require.NotNil(t, e.entry)
 	}
+}
+
+func TestMetricMapTickCancellation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := testOptions(ctrl)
+	m := newMetricMap(testShard, opts)
+
+	numBatchesProcessed := 0
+	tickedCh := make(chan struct{})
+
+	m.sleepFn = func(d time.Duration) {
+		numBatchesProcessed++
+		if numBatchesProcessed == 10 {
+			close(tickedCh)
+		}
+
+		time.Sleep(d)
+	}
+
+	doneCh := make(chan struct{})
+	go func() {
+		<-tickedCh
+		fmt.Println("closing ch")
+		close(doneCh)
+	}()
+
+	// NB: wait/early exit on every defaultSoftDeadlineCheckEvery
+	numEntries := defaultSoftDeadlineCheckEvery * 60
+	for i := 0; i < numEntries; i++ {
+		key := entryKey{
+			metricType: metricType(metric.CounterType),
+			idHash:     hash.Murmur3Hash128([]byte(fmt.Sprintf("%d", i))),
+		}
+
+		m.entries[key] = m.entryList.PushBack(hashedEntry{
+			key:   key,
+			entry: NewEntry(m.metricLists, runtime.NewOptions(), opts),
+		})
+	}
+
+	m.Tick(time.Minute, doneCh)
+	require.Equal(t, 10, numBatchesProcessed)
 }

--- a/src/aggregator/aggregator/map_test.go
+++ b/src/aggregator/aggregator/map_test.go
@@ -548,7 +548,6 @@ func TestMetricMapTickCancellation(t *testing.T) {
 	doneCh := make(chan struct{})
 	go func() {
 		<-tickedCh
-		fmt.Println("closing ch")
 		close(doneCh)
 	}()
 

--- a/src/aggregator/aggregator/shard.go
+++ b/src/aggregator/aggregator/shard.go
@@ -262,7 +262,7 @@ func (s *aggregatorShard) AddForwarded(
 
 func (s *aggregatorShard) Tick(
 	target time.Duration,
-	doneCh chan struct{},
+	doneCh <-chan struct{},
 ) tickResult {
 	return s.metricMap.Tick(target, doneCh)
 }

--- a/src/aggregator/aggregator/shard.go
+++ b/src/aggregator/aggregator/shard.go
@@ -260,8 +260,11 @@ func (s *aggregatorShard) AddForwarded(
 	return nil
 }
 
-func (s *aggregatorShard) Tick(target time.Duration) tickResult {
-	return s.metricMap.Tick(target)
+func (s *aggregatorShard) Tick(
+	target time.Duration,
+	doneCh chan struct{},
+) tickResult {
+	return s.metricMap.Tick(target, doneCh)
 }
 
 func (s *aggregatorShard) Close() {

--- a/src/cmd/services/m3aggregator/serve/serve.go
+++ b/src/cmd/services/m3aggregator/serve/serve.go
@@ -44,8 +44,13 @@ func Serve(
 	defer func() {
 		start := time.Now()
 		log.Info("closing aggregator")
-		aggregator.Close()
-		log.Info("closed aggregator", zap.String("took", time.Since(start).String()))
+		err := aggregator.Close()
+		fields := []zap.Field{zap.String("took", time.Since(start).String())}
+		if err != nil {
+			log.Warn("closed aggregator with error", append(fields, zap.Error(err))...)
+		} else {
+			log.Info("closed aggregator", fields...)
+		}
 	}()
 
 	if m3msgAddr := opts.M3MsgAddr(); m3msgAddr != "" {

--- a/src/cmd/services/m3aggregator/serve/serve.go
+++ b/src/cmd/services/m3aggregator/serve/serve.go
@@ -43,13 +43,13 @@ func Serve(
 	log := iOpts.Logger()
 	defer func() {
 		start := time.Now()
-		log.Info("closing aggregator")
+		log.Info("!! closing aggregator")
 		err := aggregator.Close()
 		fields := []zap.Field{zap.String("took", time.Since(start).String())}
 		if err != nil {
 			log.Warn("closed aggregator with error", append(fields, zap.Error(err))...)
 		} else {
-			log.Info("closed aggregator", fields...)
+			log.Info("!! closed aggregator", fields...)
 		}
 	}()
 
@@ -65,7 +65,7 @@ func Serve(
 
 		defer func() {
 			start := time.Now()
-			log.Info("closing m3msg server")
+			log.Info("!! closing m3msg server")
 			m3msgServer.Close()
 			log.Info("m3msg server closed", zap.String("took", time.Since(start).String()))
 		}()
@@ -82,9 +82,9 @@ func Serve(
 
 		defer func() {
 			start := time.Now()
-			log.Info("closing raw TCPServer")
+			log.Info("!! closing raw TCPServer")
 			rawTCPServer.Close()
-			log.Info("closed raw TCPServer", zap.String("took", time.Since(start).String()))
+			log.Info("!! closed raw TCPServer", zap.String("took", time.Since(start).String()))
 		}()
 
 		log.Info("raw TCP server listening", zap.String("addr", rawTCPAddr))
@@ -100,9 +100,9 @@ func Serve(
 
 		defer func() {
 			start := time.Now()
-			log.Info("closing http server")
+			log.Info("!! closing http server")
 			httpServer.Close()
-			log.Info("closed http server", zap.String("took", time.Since(start).String()))
+			log.Info("!! closed http server", zap.String("took", time.Since(start).String()))
 		}()
 
 		log.Info("http server listening", zap.String("addr", httpAddr))
@@ -110,7 +110,7 @@ func Serve(
 
 	// Wait for exit signal.
 	<-doneCh
-	log.Info("server signalled on doneCh")
+	log.Info("!! server signalled on doneCh")
 
 	return nil
 }


### PR DESCRIPTION
Aggregator's `tickInternal` method can soft-block `aggregator.Close()` for
a long period of time if the doneCh is signalled during a tick; these end up
iterating over internal shard ticks, which can take up to `EntryCheckInterval`,
which defaults to an hour. This is much longer than the graceful close period,
which is 15s by default, so aggregator graceful close almost never completes,
and ends up timing out instead.