### PR TITLE
[dbnode] Optimize `filesetFiles` function

### DIFF
--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -411,38 +411,6 @@ func (a commitlogsByTimeAndIndexAscending) Less(i, j int) bool {
 	return ti.Equal(tj) && ii < ij
 }
 
-// dataFileSetFilesByTimeAndVolumeIndexAscending sorts file sets files by their
-// block start times and volume index in ascending order. If the files do not
-// have block start times or indexes in their names, the result is undefined.
-type dataFileSetFilesByTimeAndVolumeIndexAscending []string
-
-func (a dataFileSetFilesByTimeAndVolumeIndexAscending) Len() int      { return len(a) }
-func (a dataFileSetFilesByTimeAndVolumeIndexAscending) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a dataFileSetFilesByTimeAndVolumeIndexAscending) Less(i, j int) bool {
-	ti, ii, _ := TimeAndVolumeIndexFromDataFileSetFilename(a[i])
-	tj, ij, _ := TimeAndVolumeIndexFromDataFileSetFilename(a[j])
-	if ti.Before(tj) {
-		return true
-	}
-	return ti.Equal(tj) && ii < ij
-}
-
-// fileSetFilesByTimeAndVolumeIndexAscending sorts file sets files by their
-// block start times and volume index in ascending order. If the files do not
-// have block start times or indexes in their names, the result is undefined.
-type fileSetFilesByTimeAndVolumeIndexAscending []string
-
-func (a fileSetFilesByTimeAndVolumeIndexAscending) Len() int      { return len(a) }
-func (a fileSetFilesByTimeAndVolumeIndexAscending) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a fileSetFilesByTimeAndVolumeIndexAscending) Less(i, j int) bool {
-	ti, ii, _ := TimeAndVolumeIndexFromFileSetFilename(a[i])
-	tj, ij, _ := TimeAndVolumeIndexFromFileSetFilename(a[j])
-	if ti.Before(tj) {
-		return true
-	}
-	return ti.Equal(tj) && ii < ij
-}
-
 // Returns the positions of filename delimiters ('-' and '.') and the number of
 // delimeters found, to be used in conjunction with the intComponentAtIndex
 // function to extract filename components. This function is deliberately

--- a/src/dbnode/persist/fs/files.go
+++ b/src/dbnode/persist/fs/files.go
@@ -1232,6 +1232,61 @@ func SortedCommitLogFiles(commitLogsDir string) ([]string, error) {
 }
 
 type toSortableFn func(files []string) sort.Interface
+type toBlockStartAndVolumeIndexFn func(file string) (xtime.UnixNano, int, error)
+type sortedFilesetFiles []filesetFile
+
+func (s sortedFilesetFiles) Len() int {
+	return len(s)
+}
+
+func (s sortedFilesetFiles) Less(i, j int) bool {
+	ti := s[i].blockStart
+	tj := s[j].blockStart
+
+	if ti.Before(tj) {
+		return true
+	}
+
+	ij := s[j].volumeIndex
+	ii := s[i].volumeIndex
+	return ti.Equal(tj) && ii < ij
+}
+
+func (s sortedFilesetFiles) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type filesetFile struct {
+	fileName    string
+	blockStart  xtime.UnixNano
+	volumeIndex int
+}
+
+func findFilesEx(fileDir string, pattern string, fn toBlockStartAndVolumeIndexFn) (sortedFilesetFiles, error) {
+	matched, err := filepath.Glob(path.Join(fileDir, pattern))
+	if err != nil {
+		return nil, err
+	}
+	if len(matched) == 0 {
+		return nil, nil
+	}
+	result := make([]filesetFile, len(matched))
+	for i, file := range matched {
+		blockStart, volume, err := fn(file)
+		if err != nil {
+			return nil, err
+		}
+
+		result[i] = filesetFile{
+			fileName:    file,
+			blockStart:  blockStart,
+			volumeIndex: volume,
+		}
+	}
+
+	sort.Sort(sortedFilesetFiles(result))
+	return result, nil
+}
 
 func findFiles(fileDir string, pattern string, fn toSortableFn) ([]string, error) {
 	matched, err := filepath.Glob(path.Join(fileDir, pattern))
@@ -1278,7 +1333,7 @@ type filesetFilesSelector struct {
 
 func filesetFiles(args filesetFilesSelector) (FileSetFilesSlice, error) {
 	var (
-		byTimeAsc []string
+		byTimeAsc sortedFilesetFiles
 		err       error
 	)
 	switch args.fileSetType {
@@ -1286,14 +1341,10 @@ func filesetFiles(args filesetFilesSelector) (FileSetFilesSlice, error) {
 		switch args.contentType {
 		case persist.FileSetDataContentType:
 			dir := ShardDataDirPath(args.filePathPrefix, args.namespace, args.shard)
-			byTimeAsc, err = findFiles(dir, args.pattern, func(files []string) sort.Interface {
-				return dataFileSetFilesByTimeAndVolumeIndexAscending(files)
-			})
+			byTimeAsc, err = findFilesEx(dir, args.pattern, TimeAndVolumeIndexFromDataFileSetFilename)
 		case persist.FileSetIndexContentType:
 			dir := NamespaceIndexDataDirPath(args.filePathPrefix, args.namespace)
-			byTimeAsc, err = findFiles(dir, args.pattern, func(files []string) sort.Interface {
-				return fileSetFilesByTimeAndVolumeIndexAscending(files)
-			})
+			byTimeAsc, err = findFilesEx(dir, args.pattern, TimeAndVolumeIndexFromFileSetFilename)
 		default:
 			return nil, fmt.Errorf("unknown content type: %d", args.contentType)
 		}
@@ -1307,9 +1358,7 @@ func filesetFiles(args filesetFilesSelector) (FileSetFilesSlice, error) {
 		default:
 			return nil, fmt.Errorf("unknown content type: %d", args.contentType)
 		}
-		byTimeAsc, err = findFiles(dir, args.pattern, func(files []string) sort.Interface {
-			return fileSetFilesByTimeAndVolumeIndexAscending(files)
-		})
+		byTimeAsc, err = findFilesEx(dir, args.pattern, TimeAndVolumeIndexFromFileSetFilename)
 	default:
 		return nil, fmt.Errorf("unknown type: %d", args.fileSetType)
 	}
@@ -1328,51 +1377,27 @@ func filesetFiles(args filesetFilesSelector) (FileSetFilesSlice, error) {
 		filesetFiles      = []FileSetFile{}
 	)
 	for _, file := range byTimeAsc {
-		var (
-			currentFileBlockStart xtime.UnixNano
-			volumeIndex           int
-			err                   error
-		)
-		switch args.fileSetType {
-		case persist.FileSetFlushType:
-			switch args.contentType {
-			case persist.FileSetDataContentType:
-				currentFileBlockStart, volumeIndex, err = TimeAndVolumeIndexFromDataFileSetFilename(file)
-			case persist.FileSetIndexContentType:
-				currentFileBlockStart, volumeIndex, err = TimeAndVolumeIndexFromFileSetFilename(file)
-			default:
-				return nil, fmt.Errorf("unknown content type: %d", args.contentType)
-			}
-		case persist.FileSetSnapshotType:
-			currentFileBlockStart, volumeIndex, err = TimeAndVolumeIndexFromFileSetFilename(file)
-		default:
-			return nil, fmt.Errorf("unknown type: %d", args.fileSetType)
-		}
-		if err != nil {
-			return nil, err
-		}
-
 		if latestBlockStart == 0 {
 			latestFileSetFile = NewFileSetFile(FileSetFileIdentifier{
 				Namespace:   args.namespace,
-				BlockStart:  currentFileBlockStart,
+				BlockStart:  file.blockStart,
 				Shard:       args.shard,
-				VolumeIndex: volumeIndex,
+				VolumeIndex: file.volumeIndex,
 			}, args.filePathPrefix)
-		} else if !currentFileBlockStart.Equal(latestBlockStart) || latestVolumeIndex != volumeIndex {
+		} else if !file.blockStart.Equal(latestBlockStart) || latestVolumeIndex != file.volumeIndex {
 			filesetFiles = append(filesetFiles, latestFileSetFile)
 			latestFileSetFile = NewFileSetFile(FileSetFileIdentifier{
 				Namespace:   args.namespace,
-				BlockStart:  currentFileBlockStart,
+				BlockStart:  file.blockStart,
 				Shard:       args.shard,
-				VolumeIndex: volumeIndex,
+				VolumeIndex: file.volumeIndex,
 			}, args.filePathPrefix)
 		}
 
-		latestBlockStart = currentFileBlockStart
-		latestVolumeIndex = volumeIndex
+		latestBlockStart = file.blockStart
+		latestVolumeIndex = file.volumeIndex
 
-		latestFileSetFile.AbsoluteFilePaths = append(latestFileSetFile.AbsoluteFilePaths, file)
+		latestFileSetFile.AbsoluteFilePaths = append(latestFileSetFile.AbsoluteFilePaths, file.fileName)
 	}
 
 	filesetFiles = append(filesetFiles, latestFileSetFile)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
For namespaces with long retentions huge CPU spikes could emerge during node bootstrap. Looking at the CPU profile, we can see that `filesetFiles` function is not very efficient. 
![image](https://user-images.githubusercontent.com/1712879/140288414-1286c9bb-1730-4cd1-82e2-ecc16429991f.png)
This PR optimizes `filesetFiles` function by reducing the amount of work it needs to do. It now collects `blockStart` and `volumeIndex` fields and later reuse them during sorting and further iterations (without a need to parse them again).

I've written a small benchmark to measure the new implementation (new implementation is ~ 30% faster):
 * 230140 ns/op  - new implementation
 * 324493 ns/op  - old implementation


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
