### PR TITLE
 Keep pointers to next/prev aggregations

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -78,9 +78,9 @@ type CounterElem struct {
 	flushState map[xtime.UnixNano]flushState
 	// sorted start aligned times that have been written to since the last flush
 	dirty []xtime.UnixNano
-	// min time in the values map. allow for iterating through map.
+	// min time in the values map. allows for iterating through map.
 	minStartTime xtime.UnixNano
-	// max time in the values map.
+	// max time in the values map. allows for iterating through map.
 	maxStartTime xtime.UnixNano
 
 	// internal consume state that does not need to be synchronized.

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -52,10 +52,12 @@ type lockedCounterAggregation struct {
 }
 
 type timedCounter struct {
-	startAtNanos  xtime.UnixNano // start time of an aggregation window
+	startAt       xtime.UnixNano // start time of an aggregation window
 	lockedAgg     *lockedCounterAggregation
 	resendEnabled bool
 	inDirtySet    bool
+	prevStart     xtime.UnixNano
+	nextStart     xtime.UnixNano
 }
 
 // close is called when the aggregation has been expired or the element is being closed.
@@ -78,6 +80,8 @@ type CounterElem struct {
 	dirty []xtime.UnixNano
 	// min time in the values map. allow for iterating through map.
 	minStartTime xtime.UnixNano
+	// max time in the values map.
+	maxStartTime xtime.UnixNano
 
 	// internal consume state that does not need to be synchronized.
 	toConsume          []consumeState   // small buffer to avoid memory allocations during consumption
@@ -234,49 +238,51 @@ func (e *CounterElem) expireValuesWithLock(
 	}
 	resolution := e.sp.Resolution().Window
 
-	currStart := e.minStartTime
+	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
-	for isEarlierThanFn(int64(currStart), resolution, targetNanos) {
-		if currV, ok := e.values[currStart]; ok {
-			if currV.resendEnabled {
-				// if resend enabled we want to keep this value until it is outside the buffer past period.
-				if !isEarlierThanFn(int64(currStart), resolution, resendExpire) {
-					break
-				}
-			}
-
-			// close the agg to prevent any more writes.
-			dirty := false
-			currV.lockedAgg.Lock()
-			currV.lockedAgg.closed = true
-			dirty = currV.lockedAgg.dirty
-			currV.lockedAgg.Unlock()
-			if dirty {
-				// a race occurred and a write happened before we could close the aggregation. will expire next time.
+	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
+		if currAgg.resendEnabled {
+			// if resend enabled we want to keep this value until it is outside the buffer past period.
+			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break
 			}
-
-			// if this current value is closed and clean it will no longer be flushed. this means it's safe
-			// to remove the previous value since it will no longer be needed for binary transformations. when the
-			// next value is eligible to be expired, this current value will actually be removed.
-			// if we're currently pointing at the start skip this because there is no previous for the start. this
-			// ensures we always keep at least one value in the map for binary transformations.
-			if prevV, ok := e.values[e.minStartTime]; ok && currStart != e.minStartTime {
-				// can't expire flush state until after the flushing, so we save the time to expire later.
-				e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
-				delete(e.values, e.minStartTime)
-				e.minStartTime = currStart
-
-				// it's safe to access this outside the agg lock since it was closed in a previous iteration.
-				// This is to make sure there aren't too many cached source sets taking up
-				// too much space.
-				if prevV.lockedAgg.sourcesSeen != nil && len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-					e.cachedSourceSets = append(e.cachedSourceSets, prevV.lockedAgg.sourcesSeen)
-				}
-				prevV.close()
-			}
 		}
-		currStart = currStart.Add(resolution)
+
+		// close the agg to prevent any more writes.
+		dirty := false
+		currAgg.lockedAgg.Lock()
+		currAgg.lockedAgg.closed = true
+		dirty = currAgg.lockedAgg.dirty
+		currAgg.lockedAgg.Unlock()
+		if dirty {
+			// a race occurred and a write happened before we could close the aggregation. will expire next time.
+			break
+		}
+
+		// if this current value is closed and clean it will no longer be flushed. this means it's safe
+		// to remove the previous value since it will no longer be needed for binary transformations. when the
+		// next value is eligible to be expired, this current value will actually be removed.
+		// if we're currently pointing at the start skip this because there is no previous for the start. this
+		// ensures we always keep at least one value in the map for binary transformations.
+		if prevAgg, ok := e.prevAggWithLock(currAgg); ok && currAgg.startAt != e.minStartTime {
+			// can't expire flush state until after the flushing, so we save the time to expire later.
+			e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
+			delete(e.values, e.minStartTime)
+			e.minStartTime = currAgg.startAt
+
+			// it's safe to access this outside the agg lock since it was closed in a previous iteration.
+			// This is to make sure there aren't too many cached source sets taking up
+			// too much space.
+			if prevAgg.lockedAgg.sourcesSeen != nil && len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
+				e.cachedSourceSets = append(e.cachedSourceSets, prevAgg.lockedAgg.sourcesSeen)
+			}
+			prevAgg.close()
+		}
+		var ok bool
+		currAgg, ok = e.nextAggWithLock(currAgg)
+		if !ok {
+			break
+		}
 	}
 }
 
@@ -295,40 +301,47 @@ func (e *CounterElem) expireFlushState() {
 	}
 }
 
-// return the timestamp in the values map that is before the provided time. returns false if the provided time is the
-// smallest time or the map is empty.
-func (e *CounterElem) previousStartAlignedWithLock(timestamp xtime.UnixNano) (xtime.UnixNano, bool) {
+// return the previous aggregation before the provided time. returns false if the provided time is the
+// earliest time or the map is empty.
+func (e *CounterElem) prevAggWithLock(agg timedCounter) (timedCounter, bool) {
 	if len(e.values) == 0 {
-		return 0, false
+		return timedCounter{}, false
 	}
+	if agg.prevStart != 0 {
+		prevAgg, ok := e.values[agg.prevStart]
+		return prevAgg, ok
+	}
+
 	resolution := e.sp.Resolution().Window
-	// ensure the input is start aligned and then calculate the previous start time.
-	startAligned := timestamp.Truncate(resolution).Add(-resolution)
-	for !startAligned.Before(e.minStartTime) {
-		_, ok := e.values[startAligned]
+	startTime := agg.startAt.Add(-resolution)
+	for !startTime.Before(e.minStartTime) {
+		agg, ok := e.values[startTime]
 		if ok {
-			return startAligned, true
+			return agg, true
 		}
-		startAligned = startAligned.Add(-resolution)
+		startTime = startTime.Add(-resolution)
 	}
-	return 0, false
+	return timedCounter{}, false
 }
 
 // return the next aggregation after the provided time. returns false if the provided time is the
 // largest time or the map is empty.
-func (e *CounterElem) nextAggWithLock(startAligned xtime.UnixNano, targetNanos int64,
-	isEarlierThanFn isEarlierThanFn) (timedCounter, bool) {
+func (e *CounterElem) nextAggWithLock(agg timedCounter) (timedCounter, bool) {
 	if len(e.values) == 0 {
 		return timedCounter{}, false
 	}
+	if agg.nextStart != 0 {
+		nextAgg, ok := e.values[agg.nextStart]
+		return nextAgg, ok
+	}
 	resolution := e.sp.Resolution().Window
-	ts := startAligned.Add(resolution)
-	for isEarlierThanFn(int64(ts), resolution, targetNanos) {
-		agg, ok := e.values[ts]
+	start := agg.startAt.Add(resolution)
+	for !start.After(e.maxStartTime) {
+		agg, ok := e.values[start]
 		if ok {
 			return agg, true
 		}
-		ts = ts.Add(resolution)
+		start = start.Add(resolution)
 	}
 	return timedCounter{}, false
 }
@@ -392,11 +405,11 @@ func (e *CounterElem) Consume(
 		// current aggregation value. if the nextAgg was already flushed, it used an outdated value for the previous
 		// value (this agg). this can only happen when we allow updating previously flushed data (i.e resendEnabled).
 		if agg.resendEnabled {
-			nextAgg, ok := e.nextAggWithLock(dirtyTime, targetNanos, isEarlierThanFn)
+			nextAgg, ok := e.nextAggWithLock(agg)
 			// only need to add if not already in the dirty set (since it will be added in a subsequent iteration).
 			if ok &&
 				// at the end of the dirty times OR the next dirty time does not match.
-				(i == len(dirtyTimes)-1 || dirtyTimes[i+1] != nextAgg.startAtNanos) {
+				(i == len(dirtyTimes)-1 || dirtyTimes[i+1] != nextAgg.startAt) {
 				// only need to add if it was previously flushed.
 				e.toConsume, _ = e.appendConsumeStateWithLock(nextAgg, e.toConsume, e.isFlushed)
 			}
@@ -460,14 +473,14 @@ func (e *CounterElem) appendConsumeStateWithLock(
 	agg.lockedAgg.Unlock()
 
 	// update with everything else.
-	previousStartAligned, ok := e.previousStartAlignedWithLock(agg.startAtNanos)
+	prevAgg, ok := e.prevAggWithLock(agg)
 	if ok {
-		cState.prevStartTime = previousStartAligned
+		cState.prevStartTime = prevAgg.startAt
 	} else {
 		cState.prevStartTime = 0
 	}
 	cState.resendEnabled = agg.resendEnabled
-	cState.startAt = agg.startAtNanos
+	cState.startAt = agg.startAt
 	toConsume[len(toConsume)-1] = cState
 
 	if includeFilter != nil && !includeFilter(cState) {
@@ -638,7 +651,7 @@ func (e *CounterElem) findOrCreate(
 		}
 	}
 	timedAgg = timedCounter{
-		startAtNanos: alignedStart,
+		startAt: alignedStart,
 		lockedAgg: &lockedCounterAggregation{
 			sourcesSeen: sourcesSeen,
 			aggregation: e.NewAggregation(e.opts, e.aggOpts),
@@ -646,11 +659,41 @@ func (e *CounterElem) findOrCreate(
 		resendEnabled: createOpts.resendEnabled,
 		inDirtySet:    true,
 	}
-	e.values[alignedStart] = timedAgg
-	e.insertDirty(alignedStart)
-	if len(e.values) == 1 || e.minStartTime > alignedStart {
+
+	if len(e.values) == 0 || e.minStartTime > alignedStart {
 		e.minStartTime = alignedStart
 	}
+	prevMaxStart := e.maxStartTime
+	if len(e.values) == 0 || alignedStart > e.maxStartTime {
+		e.maxStartTime = alignedStart
+	}
+
+	if len(e.values) > 0 {
+		if e.maxStartTime == alignedStart {
+			// common case we are adding the latest start time.
+			timedAgg.prevStart = prevMaxStart
+			prevAgg := e.values[prevMaxStart]
+			prevAgg.nextStart = alignedStart
+			e.values[prevMaxStart] = prevAgg
+		} else {
+			// look up
+			prevAgg, ok := e.prevAggWithLock(timedAgg)
+			if ok {
+				timedAgg.prevStart = prevAgg.startAt
+				prevAgg.nextStart = alignedStart
+				e.values[prevAgg.startAt] = prevAgg
+			}
+			nextAgg, ok := e.nextAggWithLock(timedAgg)
+			if ok {
+				timedAgg.nextStart = nextAgg.startAt
+				nextAgg.prevStart = alignedStart
+				e.values[nextAgg.startAt] = nextAgg
+			}
+		}
+	}
+
+	e.values[alignedStart] = timedAgg
+	e.insertDirty(alignedStart)
 	e.Unlock()
 	return timedAgg.lockedAgg, nil
 }

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -287,7 +287,7 @@ func TestCounterElemAddUnionWithCustomAggregation(t *testing.T) {
 	require.NoError(t, e.AddUnion(testTimestamps[2], testCounter, false))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	a, err = e.find(xtime.UnixNano(testAlignedStarts[1]))
 	require.NoError(t, err)
@@ -345,7 +345,7 @@ func TestCounterElemAddUnique(t *testing.T) {
 		metadata.ForwardMetadata{SourceID: source1}))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	a1, err := e.find(xtime.UnixNano(testAlignedStarts[1]))
 	require.NoError(t, err)
@@ -368,7 +368,7 @@ func TestCounterElemAddUnique(t *testing.T) {
 	require.NoError(t, err)
 	v1 = a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, int64(278), v1.aggregation.Sum())
 	require.Equal(t, int64(1), v1.aggregation.Count())
@@ -428,7 +428,7 @@ func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
 	require.NoError(t, err)
 	v1 := a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, int64(20), v1.aggregation.Sum())
 	require.Equal(t, int64(20), v1.aggregation.Max())
@@ -444,7 +444,7 @@ func TestCounterElemAddUniqueWithCustomAggregation(t *testing.T) {
 	require.NoError(t, err)
 	v1 = a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, int64(20), v1.aggregation.Sum())
 	require.Equal(t, int64(1), v1.aggregation.Count())
@@ -901,7 +901,7 @@ func TestTimerElemAddUnion(t *testing.T) {
 	require.NoError(t, err)
 	v1 := a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	timer = v1.aggregation
 	require.Equal(t, int64(5), timer.Count())
@@ -960,7 +960,7 @@ func TestTimerElemAddUnique(t *testing.T) {
 	require.NoError(t, err)
 	v1 := a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, 20.0, v1.aggregation.Sum())
 	require.Equal(t, int64(1), v1.aggregation.Count())
@@ -973,7 +973,7 @@ func TestTimerElemAddUnique(t *testing.T) {
 		metadata.ForwardMetadata{SourceID: 1}))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, 20.0, v1.aggregation.Sum())
 	require.Equal(t, int64(1), v1.aggregation.Count())
@@ -1400,7 +1400,7 @@ func TestGaugeElemAddUnion(t *testing.T) {
 	require.NoError(t, err)
 	v1 := a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, testGauge.GaugeVal, v1.aggregation.Last())
 	require.Equal(t, testGauge.GaugeVal, v1.aggregation.Sum())
@@ -1448,7 +1448,7 @@ func TestGaugeElemAddUnionWithCustomAggregation(t *testing.T) {
 	require.NoError(t, err)
 	v1 := a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, testGauge.GaugeVal, v1.aggregation.Last())
 	require.Equal(t, testGauge.GaugeVal, v1.aggregation.Max())
@@ -1507,7 +1507,7 @@ func TestGaugeElemAddUnique(t *testing.T) {
 	require.NoError(t, err)
 	v1 := a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, 27.8, v1.aggregation.Sum())
 	require.Equal(t, int64(1), v1.aggregation.Count())
@@ -1523,7 +1523,7 @@ func TestGaugeElemAddUnique(t *testing.T) {
 		metadata.ForwardMetadata{SourceID: source1}))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, 27.8, v1.aggregation.Sum())
 	require.Equal(t, int64(1), v1.aggregation.Count())
@@ -1601,7 +1601,7 @@ func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
 	require.NoError(t, err)
 	v1 := a1.lockedAgg
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, 2.0, v1.aggregation.Sum())
 	require.Equal(t, 2.0, v1.aggregation.Max())
@@ -1614,7 +1614,7 @@ func TestGaugeElemAddUniqueWithCustomAggregation(t *testing.T) {
 		metadata.ForwardMetadata{SourceID: source1}))
 	require.Equal(t, 2, len(e.values))
 	for i := 0; i < len(e.values); i++ {
-		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAtNanos)
+		require.Equal(t, xtime.UnixNano(testAlignedStarts[i]), e.values[e.dirty[i]].startAt)
 	}
 	require.Equal(t, 2.0, v1.aggregation.Sum())
 	require.Equal(t, 2.0, v1.aggregation.Max())
@@ -2842,12 +2842,13 @@ func testCounterElem(
 		counter.aggregation.Update(time.Unix(0, aligned), counterVals[i], nil)
 		startAligned := xtime.UnixNano(aligned)
 		e.values[startAligned] = timedCounter{
-			startAtNanos: startAligned,
-			lockedAgg:    counter,
+			startAt:   startAligned,
+			lockedAgg: counter,
 		}
 		e.dirty = append(e.dirty, startAligned)
 	}
 	e.minStartTime = xtime.UnixNano(alignedstartAtNanos[0])
+	e.maxStartTime = xtime.UnixNano(alignedstartAtNanos[len(alignedstartAtNanos)-1])
 	return e
 }
 
@@ -2871,12 +2872,13 @@ func testTimerElem(
 		timer.aggregation.AddBatch(time.Now(), timerBatches[i], nil)
 		startAligned := xtime.UnixNano(aligned)
 		e.values[startAligned] = timedTimer{
-			startAtNanos: startAligned,
-			lockedAgg:    timer,
+			startAt:   startAligned,
+			lockedAgg: timer,
 		}
 		e.dirty = append(e.dirty, startAligned)
 	}
 	e.minStartTime = xtime.UnixNano(alignedstartAtNanos[0])
+	e.maxStartTime = xtime.UnixNano(alignedstartAtNanos[len(alignedstartAtNanos)-1])
 	return e
 }
 
@@ -2920,13 +2922,14 @@ func testGaugeElemWithData(
 		gauge.aggregation.Update(time.Unix(0, aligned-1), gaugeVals[i], nil)
 		startAligned := xtime.UnixNano(aligned)
 		e.values[startAligned] = timedGauge{
-			startAtNanos:  startAligned,
+			startAt:       startAligned,
 			lockedAgg:     gauge,
 			resendEnabled: resendEnabled,
 		}
 		e.dirty = append(e.dirty, startAligned)
 	}
 	e.minStartTime = xtime.UnixNano(alignedstartAtNanos[0])
+	e.maxStartTime = xtime.UnixNano(alignedstartAtNanos[len(alignedstartAtNanos)-1])
 	return e
 }
 

--- a/src/aggregator/aggregator/entry_test.go
+++ b/src/aggregator/aggregator/entry_test.go
@@ -1556,7 +1556,7 @@ func TestEntryAddTimed(t *testing.T) {
 	expectedNanos := xtime.ToUnixNano(time.Unix(0, testTimedMetric.TimeNanos).Truncate(resolution))
 	v, ok := values[expectedNanos]
 	require.True(t, ok)
-	require.Equal(t, expectedNanos, v.startAtNanos)
+	require.Equal(t, expectedNanos, v.startAt)
 	require.Equal(t, int64(1), v.lockedAgg.aggregation.Count())
 	require.Equal(t, int64(1000), v.lockedAgg.aggregation.Sum())
 	require.Equal(t, float64(1000), v.lockedAgg.aggregation.Mean())
@@ -1588,7 +1588,7 @@ func TestEntryAddTimed(t *testing.T) {
 	expectedNanos = expectedNanos.Add(testTimedMetadata.StoragePolicy.Resolution().Window)
 	v, ok = values[expectedNanos]
 	require.True(t, ok)
-	require.Equal(t, expectedNanos, v.startAtNanos)
+	require.Equal(t, expectedNanos, v.startAt)
 	require.Equal(t, int64(1), v.lockedAgg.aggregation.Count())
 	require.Equal(t, int64(1000), v.lockedAgg.aggregation.Sum())
 
@@ -1629,7 +1629,7 @@ func TestEntryAddTimed(t *testing.T) {
 	require.Equal(t, 1, len(values))
 	resolution = metadata.StoragePolicy.Resolution().Window
 	expectedNanos = xtime.UnixNano(metric.TimeNanos).Truncate(resolution)
-	require.Equal(t, expectedNanos, values[0].startAtNanos)
+	require.Equal(t, expectedNanos, values[0].startAt)
 	require.Equal(t, int64(1), values[0].lockedAgg.aggregation.Count())
 	require.Equal(t, int64(1000), values[0].lockedAgg.aggregation.Sum())
 	require.Equal(t, metric.ID, counterElem.ID())
@@ -1814,7 +1814,7 @@ func TestEntryAddForwarded(t *testing.T) {
 	expectedNanos := xtime.UnixNano(testForwardedMetric.TimeNanos).Truncate(resolution)
 	v, ok := values[expectedNanos]
 	require.True(t, ok)
-	require.Equal(t, expectedNanos, v.startAtNanos)
+	require.Equal(t, expectedNanos, v.startAt)
 	require.Equal(t, int64(2), v.lockedAgg.aggregation.Count())
 	require.Equal(t, int64(100000), v.lockedAgg.aggregation.Sum())
 
@@ -1903,7 +1903,7 @@ func TestEntryAddForwarded(t *testing.T) {
 	expectedNanos = xtime.UnixNano(metric.TimeNanos).Truncate(resolution)
 	v, ok = values[expectedNanos]
 	require.True(t, ok)
-	require.Equal(t, expectedNanos, v.startAtNanos)
+	require.Equal(t, expectedNanos, v.startAt)
 	require.Equal(t, int64(2), v.lockedAgg.aggregation.Count())
 	require.Equal(t, int64(100000), v.lockedAgg.aggregation.Sum())
 	require.Equal(t, metric.ID, counterElem.ID())
@@ -2177,7 +2177,7 @@ func testEntryAddUntimed(
 					require.Equal(t, 1, len(aggregations))
 					v, ok := aggregations[alignedStartNanos]
 					require.True(t, ok)
-					require.True(t, alignedStartNanos.Equal(v.startAtNanos))
+					require.True(t, alignedStartNanos.Equal(v.startAt))
 					require.Equal(t, int64(1234), v.lockedAgg.aggregation.Sum())
 				}
 			},
@@ -2195,7 +2195,7 @@ func testEntryAddUntimed(
 					require.Equal(t, 1, len(aggregations))
 					v, ok := aggregations[xtime.ToUnixNano(alignedStart)]
 					require.True(t, ok)
-					require.True(t, alignedStartNanos.Equal(v.startAtNanos))
+					require.True(t, alignedStartNanos.Equal(v.startAt))
 					require.Equal(t, 18.0, v.lockedAgg.aggregation.Sum())
 				}
 			},
@@ -2213,7 +2213,7 @@ func testEntryAddUntimed(
 					require.Equal(t, 1, len(aggregations))
 					v, ok := aggregations[xtime.ToUnixNano(alignedStart)]
 					require.True(t, ok)
-					require.True(t, alignedStartNanos.Equal(v.startAtNanos))
+					require.True(t, alignedStartNanos.Equal(v.startAt))
 					require.Equal(t, 123.456, v.lockedAgg.aggregation.Last())
 				}
 			},

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -78,9 +78,9 @@ type GaugeElem struct {
 	flushState map[xtime.UnixNano]flushState
 	// sorted start aligned times that have been written to since the last flush
 	dirty []xtime.UnixNano
-	// min time in the values map. allow for iterating through map.
+	// min time in the values map. allows for iterating through map.
 	minStartTime xtime.UnixNano
-	// max time in the values map.
+	// max time in the values map. allows for iterating through map.
 	maxStartTime xtime.UnixNano
 
 	// internal consume state that does not need to be synchronized.

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -52,10 +52,12 @@ type lockedGaugeAggregation struct {
 }
 
 type timedGauge struct {
-	startAtNanos  xtime.UnixNano // start time of an aggregation window
+	startAt       xtime.UnixNano // start time of an aggregation window
 	lockedAgg     *lockedGaugeAggregation
 	resendEnabled bool
 	inDirtySet    bool
+	prevStart     xtime.UnixNano
+	nextStart     xtime.UnixNano
 }
 
 // close is called when the aggregation has been expired or the element is being closed.
@@ -78,6 +80,8 @@ type GaugeElem struct {
 	dirty []xtime.UnixNano
 	// min time in the values map. allow for iterating through map.
 	minStartTime xtime.UnixNano
+	// max time in the values map.
+	maxStartTime xtime.UnixNano
 
 	// internal consume state that does not need to be synchronized.
 	toConsume          []consumeState   // small buffer to avoid memory allocations during consumption
@@ -234,49 +238,51 @@ func (e *GaugeElem) expireValuesWithLock(
 	}
 	resolution := e.sp.Resolution().Window
 
-	currStart := e.minStartTime
+	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
-	for isEarlierThanFn(int64(currStart), resolution, targetNanos) {
-		if currV, ok := e.values[currStart]; ok {
-			if currV.resendEnabled {
-				// if resend enabled we want to keep this value until it is outside the buffer past period.
-				if !isEarlierThanFn(int64(currStart), resolution, resendExpire) {
-					break
-				}
-			}
-
-			// close the agg to prevent any more writes.
-			dirty := false
-			currV.lockedAgg.Lock()
-			currV.lockedAgg.closed = true
-			dirty = currV.lockedAgg.dirty
-			currV.lockedAgg.Unlock()
-			if dirty {
-				// a race occurred and a write happened before we could close the aggregation. will expire next time.
+	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
+		if currAgg.resendEnabled {
+			// if resend enabled we want to keep this value until it is outside the buffer past period.
+			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break
 			}
-
-			// if this current value is closed and clean it will no longer be flushed. this means it's safe
-			// to remove the previous value since it will no longer be needed for binary transformations. when the
-			// next value is eligible to be expired, this current value will actually be removed.
-			// if we're currently pointing at the start skip this because there is no previous for the start. this
-			// ensures we always keep at least one value in the map for binary transformations.
-			if prevV, ok := e.values[e.minStartTime]; ok && currStart != e.minStartTime {
-				// can't expire flush state until after the flushing, so we save the time to expire later.
-				e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
-				delete(e.values, e.minStartTime)
-				e.minStartTime = currStart
-
-				// it's safe to access this outside the agg lock since it was closed in a previous iteration.
-				// This is to make sure there aren't too many cached source sets taking up
-				// too much space.
-				if prevV.lockedAgg.sourcesSeen != nil && len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-					e.cachedSourceSets = append(e.cachedSourceSets, prevV.lockedAgg.sourcesSeen)
-				}
-				prevV.close()
-			}
 		}
-		currStart = currStart.Add(resolution)
+
+		// close the agg to prevent any more writes.
+		dirty := false
+		currAgg.lockedAgg.Lock()
+		currAgg.lockedAgg.closed = true
+		dirty = currAgg.lockedAgg.dirty
+		currAgg.lockedAgg.Unlock()
+		if dirty {
+			// a race occurred and a write happened before we could close the aggregation. will expire next time.
+			break
+		}
+
+		// if this current value is closed and clean it will no longer be flushed. this means it's safe
+		// to remove the previous value since it will no longer be needed for binary transformations. when the
+		// next value is eligible to be expired, this current value will actually be removed.
+		// if we're currently pointing at the start skip this because there is no previous for the start. this
+		// ensures we always keep at least one value in the map for binary transformations.
+		if prevAgg, ok := e.prevAggWithLock(currAgg); ok && currAgg.startAt != e.minStartTime {
+			// can't expire flush state until after the flushing, so we save the time to expire later.
+			e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
+			delete(e.values, e.minStartTime)
+			e.minStartTime = currAgg.startAt
+
+			// it's safe to access this outside the agg lock since it was closed in a previous iteration.
+			// This is to make sure there aren't too many cached source sets taking up
+			// too much space.
+			if prevAgg.lockedAgg.sourcesSeen != nil && len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
+				e.cachedSourceSets = append(e.cachedSourceSets, prevAgg.lockedAgg.sourcesSeen)
+			}
+			prevAgg.close()
+		}
+		var ok bool
+		currAgg, ok = e.nextAggWithLock(currAgg)
+		if !ok {
+			break
+		}
 	}
 }
 
@@ -295,40 +301,47 @@ func (e *GaugeElem) expireFlushState() {
 	}
 }
 
-// return the timestamp in the values map that is before the provided time. returns false if the provided time is the
-// smallest time or the map is empty.
-func (e *GaugeElem) previousStartAlignedWithLock(timestamp xtime.UnixNano) (xtime.UnixNano, bool) {
+// return the previous aggregation before the provided time. returns false if the provided time is the
+// earliest time or the map is empty.
+func (e *GaugeElem) prevAggWithLock(agg timedGauge) (timedGauge, bool) {
 	if len(e.values) == 0 {
-		return 0, false
+		return timedGauge{}, false
 	}
+	if agg.prevStart != 0 {
+		prevAgg, ok := e.values[agg.prevStart]
+		return prevAgg, ok
+	}
+
 	resolution := e.sp.Resolution().Window
-	// ensure the input is start aligned and then calculate the previous start time.
-	startAligned := timestamp.Truncate(resolution).Add(-resolution)
-	for !startAligned.Before(e.minStartTime) {
-		_, ok := e.values[startAligned]
+	startTime := agg.startAt.Add(-resolution)
+	for !startTime.Before(e.minStartTime) {
+		agg, ok := e.values[startTime]
 		if ok {
-			return startAligned, true
+			return agg, true
 		}
-		startAligned = startAligned.Add(-resolution)
+		startTime = startTime.Add(-resolution)
 	}
-	return 0, false
+	return timedGauge{}, false
 }
 
 // return the next aggregation after the provided time. returns false if the provided time is the
 // largest time or the map is empty.
-func (e *GaugeElem) nextAggWithLock(startAligned xtime.UnixNano, targetNanos int64,
-	isEarlierThanFn isEarlierThanFn) (timedGauge, bool) {
+func (e *GaugeElem) nextAggWithLock(agg timedGauge) (timedGauge, bool) {
 	if len(e.values) == 0 {
 		return timedGauge{}, false
 	}
+	if agg.nextStart != 0 {
+		nextAgg, ok := e.values[agg.nextStart]
+		return nextAgg, ok
+	}
 	resolution := e.sp.Resolution().Window
-	ts := startAligned.Add(resolution)
-	for isEarlierThanFn(int64(ts), resolution, targetNanos) {
-		agg, ok := e.values[ts]
+	start := agg.startAt.Add(resolution)
+	for !start.After(e.maxStartTime) {
+		agg, ok := e.values[start]
 		if ok {
 			return agg, true
 		}
-		ts = ts.Add(resolution)
+		start = start.Add(resolution)
 	}
 	return timedGauge{}, false
 }
@@ -392,11 +405,11 @@ func (e *GaugeElem) Consume(
 		// current aggregation value. if the nextAgg was already flushed, it used an outdated value for the previous
 		// value (this agg). this can only happen when we allow updating previously flushed data (i.e resendEnabled).
 		if agg.resendEnabled {
-			nextAgg, ok := e.nextAggWithLock(dirtyTime, targetNanos, isEarlierThanFn)
+			nextAgg, ok := e.nextAggWithLock(agg)
 			// only need to add if not already in the dirty set (since it will be added in a subsequent iteration).
 			if ok &&
 				// at the end of the dirty times OR the next dirty time does not match.
-				(i == len(dirtyTimes)-1 || dirtyTimes[i+1] != nextAgg.startAtNanos) {
+				(i == len(dirtyTimes)-1 || dirtyTimes[i+1] != nextAgg.startAt) {
 				// only need to add if it was previously flushed.
 				e.toConsume, _ = e.appendConsumeStateWithLock(nextAgg, e.toConsume, e.isFlushed)
 			}
@@ -460,14 +473,14 @@ func (e *GaugeElem) appendConsumeStateWithLock(
 	agg.lockedAgg.Unlock()
 
 	// update with everything else.
-	previousStartAligned, ok := e.previousStartAlignedWithLock(agg.startAtNanos)
+	prevAgg, ok := e.prevAggWithLock(agg)
 	if ok {
-		cState.prevStartTime = previousStartAligned
+		cState.prevStartTime = prevAgg.startAt
 	} else {
 		cState.prevStartTime = 0
 	}
 	cState.resendEnabled = agg.resendEnabled
-	cState.startAt = agg.startAtNanos
+	cState.startAt = agg.startAt
 	toConsume[len(toConsume)-1] = cState
 
 	if includeFilter != nil && !includeFilter(cState) {
@@ -638,7 +651,7 @@ func (e *GaugeElem) findOrCreate(
 		}
 	}
 	timedAgg = timedGauge{
-		startAtNanos: alignedStart,
+		startAt: alignedStart,
 		lockedAgg: &lockedGaugeAggregation{
 			sourcesSeen: sourcesSeen,
 			aggregation: e.NewAggregation(e.opts, e.aggOpts),
@@ -646,11 +659,41 @@ func (e *GaugeElem) findOrCreate(
 		resendEnabled: createOpts.resendEnabled,
 		inDirtySet:    true,
 	}
-	e.values[alignedStart] = timedAgg
-	e.insertDirty(alignedStart)
-	if len(e.values) == 1 || e.minStartTime > alignedStart {
+
+	if len(e.values) == 0 || e.minStartTime > alignedStart {
 		e.minStartTime = alignedStart
 	}
+	prevMaxStart := e.maxStartTime
+	if len(e.values) == 0 || alignedStart > e.maxStartTime {
+		e.maxStartTime = alignedStart
+	}
+
+	if len(e.values) > 0 {
+		if e.maxStartTime == alignedStart {
+			// common case we are adding the latest start time.
+			timedAgg.prevStart = prevMaxStart
+			prevAgg := e.values[prevMaxStart]
+			prevAgg.nextStart = alignedStart
+			e.values[prevMaxStart] = prevAgg
+		} else {
+			// look up
+			prevAgg, ok := e.prevAggWithLock(timedAgg)
+			if ok {
+				timedAgg.prevStart = prevAgg.startAt
+				prevAgg.nextStart = alignedStart
+				e.values[prevAgg.startAt] = prevAgg
+			}
+			nextAgg, ok := e.nextAggWithLock(timedAgg)
+			if ok {
+				timedAgg.nextStart = nextAgg.startAt
+				nextAgg.prevStart = alignedStart
+				e.values[nextAgg.startAt] = nextAgg
+			}
+		}
+	}
+
+	e.values[alignedStart] = timedAgg
+	e.insertDirty(alignedStart)
 	e.Unlock()
 	return timedAgg.lockedAgg, nil
 }

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -115,10 +115,12 @@ type lockedAggregation struct {
 }
 
 type timedAggregation struct {
-	startAtNanos  xtime.UnixNano // start time of an aggregation window
+	startAt       xtime.UnixNano // start time of an aggregation window
 	lockedAgg     *lockedAggregation
 	resendEnabled bool
 	inDirtySet    bool
+	prevStart     xtime.UnixNano
+	nextStart     xtime.UnixNano
 }
 
 // close is called when the aggregation has been expired or the element is being closed.
@@ -139,8 +141,10 @@ type GenericElem struct {
 	flushState map[xtime.UnixNano]flushState
 	// sorted start aligned times that have been written to since the last flush
 	dirty []xtime.UnixNano
-	// min time in the values map. allow for iterating through map.
+	// min time in the values map. allows for iterating through map.
 	minStartTime xtime.UnixNano
+	// max time in the values map. allows for iterating through map.
+	maxStartTime xtime.UnixNano
 
 	// internal consume state that does not need to be synchronized.
 	toConsume          []consumeState   // small buffer to avoid memory allocations during consumption
@@ -297,49 +301,51 @@ func (e *GenericElem) expireValuesWithLock(
 	}
 	resolution := e.sp.Resolution().Window
 
-	currStart := e.minStartTime
+	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
-	for isEarlierThanFn(int64(currStart), resolution, targetNanos) {
-		if currV, ok := e.values[currStart]; ok {
-			if currV.resendEnabled {
-				// if resend enabled we want to keep this value until it is outside the buffer past period.
-				if !isEarlierThanFn(int64(currStart), resolution, resendExpire) {
-					break
-				}
-			}
-
-			// close the agg to prevent any more writes.
-			dirty := false
-			currV.lockedAgg.Lock()
-			currV.lockedAgg.closed = true
-			dirty = currV.lockedAgg.dirty
-			currV.lockedAgg.Unlock()
-			if dirty {
-				// a race occurred and a write happened before we could close the aggregation. will expire next time.
+	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
+		if currAgg.resendEnabled {
+			// if resend enabled we want to keep this value until it is outside the buffer past period.
+			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break
 			}
-
-			// if this current value is closed and clean it will no longer be flushed. this means it's safe
-			// to remove the previous value since it will no longer be needed for binary transformations. when the
-			// next value is eligible to be expired, this current value will actually be removed.
-			// if we're currently pointing at the start skip this because there is no previous for the start. this
-			// ensures we always keep at least one value in the map for binary transformations.
-			if prevV, ok := e.values[e.minStartTime]; ok && currStart != e.minStartTime {
-				// can't expire flush state until after the flushing, so we save the time to expire later.
-				e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
-				delete(e.values, e.minStartTime)
-				e.minStartTime = currStart
-
-				// it's safe to access this outside the agg lock since it was closed in a previous iteration.
-				// This is to make sure there aren't too many cached source sets taking up
-				// too much space.
-				if prevV.lockedAgg.sourcesSeen != nil && len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-					e.cachedSourceSets = append(e.cachedSourceSets, prevV.lockedAgg.sourcesSeen)
-				}
-				prevV.close()
-			}
 		}
-		currStart = currStart.Add(resolution)
+
+		// close the agg to prevent any more writes.
+		dirty := false
+		currAgg.lockedAgg.Lock()
+		currAgg.lockedAgg.closed = true
+		dirty = currAgg.lockedAgg.dirty
+		currAgg.lockedAgg.Unlock()
+		if dirty {
+			// a race occurred and a write happened before we could close the aggregation. will expire next time.
+			break
+		}
+
+		// if this current value is closed and clean it will no longer be flushed. this means it's safe
+		// to remove the previous value since it will no longer be needed for binary transformations. when the
+		// next value is eligible to be expired, this current value will actually be removed.
+		// if we're currently pointing at the start skip this because there is no previous for the start. this
+		// ensures we always keep at least one value in the map for binary transformations.
+		if prevAgg, ok := e.prevAggWithLock(currAgg); ok && currAgg.startAt != e.minStartTime {
+			// can't expire flush state until after the flushing, so we save the time to expire later.
+			e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
+			delete(e.values, e.minStartTime)
+			e.minStartTime = currAgg.startAt
+
+			// it's safe to access this outside the agg lock since it was closed in a previous iteration.
+			// This is to make sure there aren't too many cached source sets taking up
+			// too much space.
+			if prevAgg.lockedAgg.sourcesSeen != nil && len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
+				e.cachedSourceSets = append(e.cachedSourceSets, prevAgg.lockedAgg.sourcesSeen)
+			}
+			prevAgg.close()
+		}
+		var ok bool
+		currAgg, ok = e.nextAggWithLock(currAgg)
+		if !ok {
+			break
+		}
 	}
 }
 
@@ -358,40 +364,47 @@ func (e *GenericElem) expireFlushState() {
 	}
 }
 
-// return the timestamp in the values map that is before the provided time. returns false if the provided time is the
-// smallest time or the map is empty.
-func (e *GenericElem) previousStartAlignedWithLock(timestamp xtime.UnixNano) (xtime.UnixNano, bool) {
+// return the previous aggregation before the provided time. returns false if the provided time is the
+// earliest time or the map is empty.
+func (e *GenericElem) prevAggWithLock(agg timedAggregation) (timedAggregation, bool) {
 	if len(e.values) == 0 {
-		return 0, false
+		return timedAggregation{}, false
 	}
+	if agg.prevStart != 0 {
+		prevAgg, ok := e.values[agg.prevStart]
+		return prevAgg, ok
+	}
+
 	resolution := e.sp.Resolution().Window
-	// ensure the input is start aligned and then calculate the previous start time.
-	startAligned := timestamp.Truncate(resolution).Add(-resolution)
-	for !startAligned.Before(e.minStartTime) {
-		_, ok := e.values[startAligned]
+	startTime := agg.startAt.Add(-resolution)
+	for !startTime.Before(e.minStartTime) {
+		agg, ok := e.values[startTime]
 		if ok {
-			return startAligned, true
+			return agg, true
 		}
-		startAligned = startAligned.Add(-resolution)
+		startTime = startTime.Add(-resolution)
 	}
-	return 0, false
+	return timedAggregation{}, false
 }
 
 // return the next aggregation after the provided time. returns false if the provided time is the
 // largest time or the map is empty.
-func (e *GenericElem) nextAggWithLock(startAligned xtime.UnixNano, targetNanos int64,
-	isEarlierThanFn isEarlierThanFn) (timedAggregation, bool) {
+func (e *GenericElem) nextAggWithLock(agg timedAggregation) (timedAggregation, bool) {
 	if len(e.values) == 0 {
 		return timedAggregation{}, false
 	}
+	if agg.nextStart != 0 {
+		nextAgg, ok := e.values[agg.nextStart]
+		return nextAgg, ok
+	}
 	resolution := e.sp.Resolution().Window
-	ts := startAligned.Add(resolution)
-	for isEarlierThanFn(int64(ts), resolution, targetNanos) {
-		agg, ok := e.values[ts]
+	start := agg.startAt.Add(resolution)
+	for !start.After(e.maxStartTime) {
+		agg, ok := e.values[start]
 		if ok {
 			return agg, true
 		}
-		ts = ts.Add(resolution)
+		start = start.Add(resolution)
 	}
 	return timedAggregation{}, false
 }
@@ -455,11 +468,11 @@ func (e *GenericElem) Consume(
 		// current aggregation value. if the nextAgg was already flushed, it used an outdated value for the previous
 		// value (this agg). this can only happen when we allow updating previously flushed data (i.e resendEnabled).
 		if agg.resendEnabled {
-			nextAgg, ok := e.nextAggWithLock(dirtyTime, targetNanos, isEarlierThanFn)
+			nextAgg, ok := e.nextAggWithLock(agg)
 			// only need to add if not already in the dirty set (since it will be added in a subsequent iteration).
 			if ok &&
 				// at the end of the dirty times OR the next dirty time does not match.
-				(i == len(dirtyTimes)-1 || dirtyTimes[i+1] != nextAgg.startAtNanos) {
+				(i == len(dirtyTimes)-1 || dirtyTimes[i+1] != nextAgg.startAt) {
 				// only need to add if it was previously flushed.
 				e.toConsume, _ = e.appendConsumeStateWithLock(nextAgg, e.toConsume, e.isFlushed)
 			}
@@ -523,14 +536,14 @@ func (e *GenericElem) appendConsumeStateWithLock(
 	agg.lockedAgg.Unlock()
 
 	// update with everything else.
-	previousStartAligned, ok := e.previousStartAlignedWithLock(agg.startAtNanos)
+	prevAgg, ok := e.prevAggWithLock(agg)
 	if ok {
-		cState.prevStartTime = previousStartAligned
+		cState.prevStartTime = prevAgg.startAt
 	} else {
 		cState.prevStartTime = 0
 	}
 	cState.resendEnabled = agg.resendEnabled
-	cState.startAt = agg.startAtNanos
+	cState.startAt = agg.startAt
 	toConsume[len(toConsume)-1] = cState
 
 	if includeFilter != nil && !includeFilter(cState) {
@@ -701,7 +714,7 @@ func (e *GenericElem) findOrCreate(
 		}
 	}
 	timedAgg = timedAggregation{
-		startAtNanos: alignedStart,
+		startAt: alignedStart,
 		lockedAgg: &lockedAggregation{
 			sourcesSeen: sourcesSeen,
 			aggregation: e.NewAggregation(e.opts, e.aggOpts),
@@ -709,11 +722,41 @@ func (e *GenericElem) findOrCreate(
 		resendEnabled: createOpts.resendEnabled,
 		inDirtySet:    true,
 	}
-	e.values[alignedStart] = timedAgg
-	e.insertDirty(alignedStart)
-	if len(e.values) == 1 || e.minStartTime > alignedStart {
+
+	if len(e.values) == 0 || e.minStartTime > alignedStart {
 		e.minStartTime = alignedStart
 	}
+	prevMaxStart := e.maxStartTime
+	if len(e.values) == 0 || alignedStart > e.maxStartTime {
+		e.maxStartTime = alignedStart
+	}
+
+	if len(e.values) > 0 {
+		if e.maxStartTime == alignedStart {
+			// common case we are adding the latest start time.
+			timedAgg.prevStart = prevMaxStart
+			prevAgg := e.values[prevMaxStart]
+			prevAgg.nextStart = alignedStart
+			e.values[prevMaxStart] = prevAgg
+		} else {
+			// look up
+			prevAgg, ok := e.prevAggWithLock(timedAgg)
+			if ok {
+				timedAgg.prevStart = prevAgg.startAt
+				prevAgg.nextStart = alignedStart
+				e.values[prevAgg.startAt] = prevAgg
+			}
+			nextAgg, ok := e.nextAggWithLock(timedAgg)
+			if ok {
+				timedAgg.nextStart = nextAgg.startAt
+				nextAgg.prevStart = alignedStart
+				e.values[nextAgg.startAt] = nextAgg
+			}
+		}
+	}
+
+	e.values[alignedStart] = timedAgg
+	e.insertDirty(alignedStart)
 	e.Unlock()
 	return timedAgg.lockedAgg, nil
 }

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -78,9 +78,9 @@ type TimerElem struct {
 	flushState map[xtime.UnixNano]flushState
 	// sorted start aligned times that have been written to since the last flush
 	dirty []xtime.UnixNano
-	// min time in the values map. allow for iterating through map.
+	// min time in the values map. allows for iterating through map.
 	minStartTime xtime.UnixNano
-	// max time in the values map.
+	// max time in the values map. allows for iterating through map.
 	maxStartTime xtime.UnixNano
 
 	// internal consume state that does not need to be synchronized.

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -52,10 +52,12 @@ type lockedTimerAggregation struct {
 }
 
 type timedTimer struct {
-	startAtNanos  xtime.UnixNano // start time of an aggregation window
+	startAt       xtime.UnixNano // start time of an aggregation window
 	lockedAgg     *lockedTimerAggregation
 	resendEnabled bool
 	inDirtySet    bool
+	prevStart     xtime.UnixNano
+	nextStart     xtime.UnixNano
 }
 
 // close is called when the aggregation has been expired or the element is being closed.
@@ -78,6 +80,8 @@ type TimerElem struct {
 	dirty []xtime.UnixNano
 	// min time in the values map. allow for iterating through map.
 	minStartTime xtime.UnixNano
+	// max time in the values map.
+	maxStartTime xtime.UnixNano
 
 	// internal consume state that does not need to be synchronized.
 	toConsume          []consumeState   // small buffer to avoid memory allocations during consumption
@@ -234,49 +238,51 @@ func (e *TimerElem) expireValuesWithLock(
 	}
 	resolution := e.sp.Resolution().Window
 
-	currStart := e.minStartTime
+	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
-	for isEarlierThanFn(int64(currStart), resolution, targetNanos) {
-		if currV, ok := e.values[currStart]; ok {
-			if currV.resendEnabled {
-				// if resend enabled we want to keep this value until it is outside the buffer past period.
-				if !isEarlierThanFn(int64(currStart), resolution, resendExpire) {
-					break
-				}
-			}
-
-			// close the agg to prevent any more writes.
-			dirty := false
-			currV.lockedAgg.Lock()
-			currV.lockedAgg.closed = true
-			dirty = currV.lockedAgg.dirty
-			currV.lockedAgg.Unlock()
-			if dirty {
-				// a race occurred and a write happened before we could close the aggregation. will expire next time.
+	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
+		if currAgg.resendEnabled {
+			// if resend enabled we want to keep this value until it is outside the buffer past period.
+			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break
 			}
-
-			// if this current value is closed and clean it will no longer be flushed. this means it's safe
-			// to remove the previous value since it will no longer be needed for binary transformations. when the
-			// next value is eligible to be expired, this current value will actually be removed.
-			// if we're currently pointing at the start skip this because there is no previous for the start. this
-			// ensures we always keep at least one value in the map for binary transformations.
-			if prevV, ok := e.values[e.minStartTime]; ok && currStart != e.minStartTime {
-				// can't expire flush state until after the flushing, so we save the time to expire later.
-				e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
-				delete(e.values, e.minStartTime)
-				e.minStartTime = currStart
-
-				// it's safe to access this outside the agg lock since it was closed in a previous iteration.
-				// This is to make sure there aren't too many cached source sets taking up
-				// too much space.
-				if prevV.lockedAgg.sourcesSeen != nil && len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
-					e.cachedSourceSets = append(e.cachedSourceSets, prevV.lockedAgg.sourcesSeen)
-				}
-				prevV.close()
-			}
 		}
-		currStart = currStart.Add(resolution)
+
+		// close the agg to prevent any more writes.
+		dirty := false
+		currAgg.lockedAgg.Lock()
+		currAgg.lockedAgg.closed = true
+		dirty = currAgg.lockedAgg.dirty
+		currAgg.lockedAgg.Unlock()
+		if dirty {
+			// a race occurred and a write happened before we could close the aggregation. will expire next time.
+			break
+		}
+
+		// if this current value is closed and clean it will no longer be flushed. this means it's safe
+		// to remove the previous value since it will no longer be needed for binary transformations. when the
+		// next value is eligible to be expired, this current value will actually be removed.
+		// if we're currently pointing at the start skip this because there is no previous for the start. this
+		// ensures we always keep at least one value in the map for binary transformations.
+		if prevAgg, ok := e.prevAggWithLock(currAgg); ok && currAgg.startAt != e.minStartTime {
+			// can't expire flush state until after the flushing, so we save the time to expire later.
+			e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
+			delete(e.values, e.minStartTime)
+			e.minStartTime = currAgg.startAt
+
+			// it's safe to access this outside the agg lock since it was closed in a previous iteration.
+			// This is to make sure there aren't too many cached source sets taking up
+			// too much space.
+			if prevAgg.lockedAgg.sourcesSeen != nil && len(e.cachedSourceSets) < e.opts.MaxNumCachedSourceSets() {
+				e.cachedSourceSets = append(e.cachedSourceSets, prevAgg.lockedAgg.sourcesSeen)
+			}
+			prevAgg.close()
+		}
+		var ok bool
+		currAgg, ok = e.nextAggWithLock(currAgg)
+		if !ok {
+			break
+		}
 	}
 }
 
@@ -295,40 +301,47 @@ func (e *TimerElem) expireFlushState() {
 	}
 }
 
-// return the timestamp in the values map that is before the provided time. returns false if the provided time is the
-// smallest time or the map is empty.
-func (e *TimerElem) previousStartAlignedWithLock(timestamp xtime.UnixNano) (xtime.UnixNano, bool) {
+// return the previous aggregation before the provided time. returns false if the provided time is the
+// earliest time or the map is empty.
+func (e *TimerElem) prevAggWithLock(agg timedTimer) (timedTimer, bool) {
 	if len(e.values) == 0 {
-		return 0, false
+		return timedTimer{}, false
 	}
+	if agg.prevStart != 0 {
+		prevAgg, ok := e.values[agg.prevStart]
+		return prevAgg, ok
+	}
+
 	resolution := e.sp.Resolution().Window
-	// ensure the input is start aligned and then calculate the previous start time.
-	startAligned := timestamp.Truncate(resolution).Add(-resolution)
-	for !startAligned.Before(e.minStartTime) {
-		_, ok := e.values[startAligned]
+	startTime := agg.startAt.Add(-resolution)
+	for !startTime.Before(e.minStartTime) {
+		agg, ok := e.values[startTime]
 		if ok {
-			return startAligned, true
+			return agg, true
 		}
-		startAligned = startAligned.Add(-resolution)
+		startTime = startTime.Add(-resolution)
 	}
-	return 0, false
+	return timedTimer{}, false
 }
 
 // return the next aggregation after the provided time. returns false if the provided time is the
 // largest time or the map is empty.
-func (e *TimerElem) nextAggWithLock(startAligned xtime.UnixNano, targetNanos int64,
-	isEarlierThanFn isEarlierThanFn) (timedTimer, bool) {
+func (e *TimerElem) nextAggWithLock(agg timedTimer) (timedTimer, bool) {
 	if len(e.values) == 0 {
 		return timedTimer{}, false
 	}
+	if agg.nextStart != 0 {
+		nextAgg, ok := e.values[agg.nextStart]
+		return nextAgg, ok
+	}
 	resolution := e.sp.Resolution().Window
-	ts := startAligned.Add(resolution)
-	for isEarlierThanFn(int64(ts), resolution, targetNanos) {
-		agg, ok := e.values[ts]
+	start := agg.startAt.Add(resolution)
+	for !start.After(e.maxStartTime) {
+		agg, ok := e.values[start]
 		if ok {
 			return agg, true
 		}
-		ts = ts.Add(resolution)
+		start = start.Add(resolution)
 	}
 	return timedTimer{}, false
 }
@@ -392,11 +405,11 @@ func (e *TimerElem) Consume(
 		// current aggregation value. if the nextAgg was already flushed, it used an outdated value for the previous
 		// value (this agg). this can only happen when we allow updating previously flushed data (i.e resendEnabled).
 		if agg.resendEnabled {
-			nextAgg, ok := e.nextAggWithLock(dirtyTime, targetNanos, isEarlierThanFn)
+			nextAgg, ok := e.nextAggWithLock(agg)
 			// only need to add if not already in the dirty set (since it will be added in a subsequent iteration).
 			if ok &&
 				// at the end of the dirty times OR the next dirty time does not match.
-				(i == len(dirtyTimes)-1 || dirtyTimes[i+1] != nextAgg.startAtNanos) {
+				(i == len(dirtyTimes)-1 || dirtyTimes[i+1] != nextAgg.startAt) {
 				// only need to add if it was previously flushed.
 				e.toConsume, _ = e.appendConsumeStateWithLock(nextAgg, e.toConsume, e.isFlushed)
 			}
@@ -460,14 +473,14 @@ func (e *TimerElem) appendConsumeStateWithLock(
 	agg.lockedAgg.Unlock()
 
 	// update with everything else.
-	previousStartAligned, ok := e.previousStartAlignedWithLock(agg.startAtNanos)
+	prevAgg, ok := e.prevAggWithLock(agg)
 	if ok {
-		cState.prevStartTime = previousStartAligned
+		cState.prevStartTime = prevAgg.startAt
 	} else {
 		cState.prevStartTime = 0
 	}
 	cState.resendEnabled = agg.resendEnabled
-	cState.startAt = agg.startAtNanos
+	cState.startAt = agg.startAt
 	toConsume[len(toConsume)-1] = cState
 
 	if includeFilter != nil && !includeFilter(cState) {
@@ -638,7 +651,7 @@ func (e *TimerElem) findOrCreate(
 		}
 	}
 	timedAgg = timedTimer{
-		startAtNanos: alignedStart,
+		startAt: alignedStart,
 		lockedAgg: &lockedTimerAggregation{
 			sourcesSeen: sourcesSeen,
 			aggregation: e.NewAggregation(e.opts, e.aggOpts),
@@ -646,11 +659,41 @@ func (e *TimerElem) findOrCreate(
 		resendEnabled: createOpts.resendEnabled,
 		inDirtySet:    true,
 	}
-	e.values[alignedStart] = timedAgg
-	e.insertDirty(alignedStart)
-	if len(e.values) == 1 || e.minStartTime > alignedStart {
+
+	if len(e.values) == 0 || e.minStartTime > alignedStart {
 		e.minStartTime = alignedStart
 	}
+	prevMaxStart := e.maxStartTime
+	if len(e.values) == 0 || alignedStart > e.maxStartTime {
+		e.maxStartTime = alignedStart
+	}
+
+	if len(e.values) > 0 {
+		if e.maxStartTime == alignedStart {
+			// common case we are adding the latest start time.
+			timedAgg.prevStart = prevMaxStart
+			prevAgg := e.values[prevMaxStart]
+			prevAgg.nextStart = alignedStart
+			e.values[prevMaxStart] = prevAgg
+		} else {
+			// look up
+			prevAgg, ok := e.prevAggWithLock(timedAgg)
+			if ok {
+				timedAgg.prevStart = prevAgg.startAt
+				prevAgg.nextStart = alignedStart
+				e.values[prevAgg.startAt] = prevAgg
+			}
+			nextAgg, ok := e.nextAggWithLock(timedAgg)
+			if ok {
+				timedAgg.nextStart = nextAgg.startAt
+				nextAgg.prevStart = alignedStart
+				e.values[nextAgg.startAt] = nextAgg
+			}
+		}
+	}
+
+	e.values[alignedStart] = timedAgg
+	e.insertDirty(alignedStart)
 	e.Unlock()
 	return timedAgg.lockedAgg, nil
 }


### PR DESCRIPTION
This should help when having to iterate through the map to expire. There
are worst case scenarios when the map is sparse that burn a lot of CPU
doing a lot of empty lookups. This worst case happen when metrics become
dormant or infrequent, and you have to scan the entire "range" of the
map for no reason.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
