### PR TITLE
[dbnode] Gracefully handle reads including documents with stale index state

### DIFF
--- a/src/dbnode/integration/index_block_orphaned_entry_test.go
+++ b/src/dbnode/integration/index_block_orphaned_entry_test.go
@@ -1,0 +1,207 @@
+// +build integration
+//
+// Copyright (c) 2021  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integration
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/dbnode/namespace"
+	"github.com/m3db/m3/src/dbnode/persist/fs"
+	"github.com/m3db/m3/src/dbnode/storage"
+	"github.com/m3db/m3/src/dbnode/storage/index/compaction"
+	xclock "github.com/m3db/m3/src/x/clock"
+	"github.com/m3db/m3/src/x/ident"
+	xsync "github.com/m3db/m3/src/x/sync"
+	xtime "github.com/m3db/m3/src/x/time"
+)
+
+const (
+	numTestSeries     = 5
+	concurrentWorkers = 25
+	writesPerWorker   = 5
+	blockSize         = 2 * time.Hour
+)
+
+func TestIndexBlockOrphanedEntry(t *testing.T) {
+	setup := generateTestSetup(t)
+	defer setup.Close()
+
+	// Start the server
+	log := setup.StorageOpts().InstrumentOptions().Logger()
+	require.NoError(t, setup.StartServer())
+
+	// Stop the server
+	defer func() {
+		assert.NoError(t, setup.StopServer())
+		log.Debug("server is now down")
+	}()
+
+	client := setup.M3DBClient()
+	session, err := client.DefaultSession()
+	require.NoError(t, err)
+
+	// Write concurrent metrics to generate multiple entries for the same series
+	ids := make([]ident.ID, 0, numTestSeries)
+	for i := 0; i < numTestSeries; i++ {
+		fooID := ident.StringID(fmt.Sprintf("foo.%v", i))
+		ids = append(ids, fooID)
+
+		writeConcurrentMetrics(t, setup, session, fooID)
+	}
+
+	// Write metrics for a different series to push current foreground segment
+	// to the background. After this, all documents for foo.X exist in background segments
+	barID := ident.StringID("bar")
+	writeConcurrentMetrics(t, setup, session, barID)
+
+	// Fast-forward to a block rotation
+	newBlock := xtime.Now().Truncate(blockSize).Add(blockSize)
+	newCurrentTime := newBlock.Add(30 * time.Minute) // Add extra to account for buffer past
+	setup.SetNowFn(newCurrentTime)
+
+	// Wait for flush
+	log.Info("waiting for block rotation to complete")
+	nsID := setup.Namespaces()[0].ID()
+	found := xclock.WaitUntil(func() bool {
+		filesets, err := fs.IndexFileSetsAt(setup.FilePathPrefix(), nsID, newBlock.Add(-blockSize))
+		require.NoError(t, err)
+		return len(filesets) == 1
+	}, 30*time.Second)
+	require.True(t, found)
+
+	// Do post-block rotation writes
+	for _, id := range ids {
+		writeMetric(t, session, nsID, id, newCurrentTime, 999.0)
+	}
+	writeMetric(t, session, nsID, barID, newCurrentTime, 999.0)
+
+	// Foreground segments should be in the background again which means updated index entry
+	// is now behind the orphaned entry so index reads should fail.
+	log.Info("waiting for metrics to be indexed")
+	var (
+		missing string
+		ok      bool
+	)
+	found = xclock.WaitUntil(func() bool {
+		for _, id := range ids {
+			ok, err = isIndexedCheckedWithTime(
+				t, session, nsID, id, genTags(id), newCurrentTime,
+			)
+			if !ok {
+				missing = id.String()
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second)
+	assert.True(t, found, fmt.Sprintf("series %s never indexed\n", missing))
+	assert.NoError(t, err)
+}
+
+func writeConcurrentMetrics(
+	t *testing.T,
+	setup TestSetup,
+	session client.Session,
+	seriesID ident.ID,
+) {
+	var wg sync.WaitGroup
+	nowFn := setup.DB().Options().ClockOptions().NowFn()
+
+	workerPool := xsync.NewWorkerPool(concurrentWorkers)
+	workerPool.Init()
+
+	mdID := setup.Namespaces()[0].ID()
+	for i := 0; i < concurrentWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for j := 0; j < writesPerWorker; j++ {
+				j := j
+				wg.Add(1)
+				workerPool.Go(func() {
+					defer wg.Done()
+					writeMetric(t, session, mdID, seriesID, xtime.ToUnixNano(nowFn()), float64(j))
+				})
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func genTags(seriesID ident.ID) ident.TagsIterator {
+	return ident.NewTagsIterator(ident.NewTags(ident.StringTag("tagName", seriesID.String())))
+}
+
+func writeMetric(
+	t *testing.T,
+	session client.Session,
+	nsID ident.ID,
+	seriesID ident.ID,
+	timestamp xtime.UnixNano,
+	value float64,
+) {
+	err := session.WriteTagged(nsID, seriesID, genTags(seriesID),
+		timestamp, value, xtime.Second, nil)
+	require.NoError(t, err)
+}
+
+func generateTestSetup(t *testing.T) TestSetup {
+	md, err := namespace.NewMetadata(testNamespaces[0],
+		namespace.NewOptions().
+			SetRetentionOptions(DefaultIntegrationTestRetentionOpts).
+			SetIndexOptions(namespace.NewIndexOptions().SetEnabled(true)))
+	require.NoError(t, err)
+
+	testOpts := NewTestOptions(t).
+		SetNamespaces([]namespace.Metadata{md}).
+		SetWriteNewSeriesAsync(true)
+	testSetup, err := NewTestSetup(t, testOpts, nil,
+		func(s storage.Options) storage.Options {
+			s = s.SetCoreFn(func() int {
+				return rand.Intn(4) //nolint:gosec
+			})
+			compactionOpts := s.IndexOptions().ForegroundCompactionPlannerOptions()
+			compactionOpts.Levels = []compaction.Level{
+				{
+					MinSizeInclusive: 0,
+					MaxSizeExclusive: 1,
+				},
+			}
+			return s.SetIndexOptions(
+				s.IndexOptions().
+					SetForegroundCompactionPlannerOptions(compactionOpts))
+		})
+	require.NoError(t, err)
+
+	return testSetup
+}

--- a/src/dbnode/integration/index_helpers.go
+++ b/src/dbnode/integration/index_helpers.go
@@ -291,13 +291,30 @@ func isIndexed(t *testing.T, s client.Session, ns ident.ID, id ident.ID, tags id
 	return result
 }
 
-func isIndexedChecked(t *testing.T, s client.Session, ns ident.ID, id ident.ID, tags ident.TagIterator) (bool, error) {
+func isIndexedChecked(
+	t *testing.T,
+	s client.Session,
+	ns ident.ID,
+	id ident.ID,
+	tags ident.TagIterator,
+) (bool, error) {
+	return isIndexedCheckedWithTime(t, s, ns, id, tags, xtime.Now())
+}
+
+func isIndexedCheckedWithTime(
+	t *testing.T,
+	s client.Session,
+	ns ident.ID,
+	id ident.ID,
+	tags ident.TagIterator,
+	queryTime xtime.UnixNano,
+) (bool, error) {
 	q := newQuery(t, tags)
 	iter, _, err := s.FetchTaggedIDs(ContextWithDefaultTimeout(), ns,
 		index.Query{Query: q},
 		index.QueryOptions{
-			StartInclusive: xtime.Now(),
-			EndExclusive:   xtime.Now(),
+			StartInclusive: queryTime,
+			EndExclusive:   queryTime.Add(time.Nanosecond),
 			SeriesLimit:    10,
 		})
 	if err != nil {

--- a/src/dbnode/storage/entry_blackbox_test.go
+++ b/src/dbnode/storage/entry_blackbox_test.go
@@ -234,16 +234,16 @@ func TestReconciledOnIndexSeries(t *testing.T) {
 	_ = addMockSeries(ctrl, shard, series.ID(), ident.Tags{}, 1)
 
 	// Validate we perform the reconciliation.
-	e, cleanup, reconciled := entry.ReconciledOnIndexSeries()
+	e, closer, reconciled := entry.ReconciledOnIndexSeries()
 	require.True(t, reconciled)
 	require.Equal(t, uint64(1), e.(*Entry).Index)
-	cleanup()
+	closer.Close()
 
 	// Set the entry's insert time emulating being inserted into the shard.
 	// Ensure no reconciliation.
 	entry.SetInsertTime(time.Now())
-	e, cleanup, reconciled = entry.ReconciledOnIndexSeries()
+	e, closer, reconciled = entry.ReconciledOnIndexSeries()
 	require.False(t, reconciled)
 	require.Equal(t, uint64(0), e.(*Entry).Index)
-	cleanup()
+	closer.Close()
 }

--- a/src/dbnode/storage/entry_blackbox_test.go
+++ b/src/dbnode/storage/entry_blackbox_test.go
@@ -171,7 +171,19 @@ func TestEntryIndexedRange(t *testing.T) {
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
-	entry := NewEntry(NewEntryOptions{Series: newMockSeries(ctrl)})
+	opts := DefaultTestOptions()
+	ctx := opts.ContextPool().Get()
+	defer ctx.Close()
+
+	shard := testDatabaseShard(t, opts)
+	defer func() {
+		require.NoError(t, shard.Close())
+	}()
+
+	entry := NewEntry(NewEntryOptions{
+		Shard:  shard,
+		Series: newMockSeries(ctrl),
+	})
 
 	assertRange := func(expectedMin, expectedMax xtime.UnixNano) {
 		min, max := entry.IndexedRange()
@@ -195,4 +207,43 @@ func TestEntryIndexedRange(t *testing.T) {
 
 	entry.OnIndexSuccess(3)
 	assertRange(1, 5)
+}
+
+func TestReconciledOnIndexSeries(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	opts := DefaultTestOptions()
+	ctx := opts.ContextPool().Get()
+	defer ctx.Close()
+
+	shard := testDatabaseShard(t, opts)
+	defer func() {
+		require.NoError(t, shard.Close())
+	}()
+
+	// Create entry with index 0 that's not inserted
+	series := newMockSeries(ctrl)
+	entry := NewEntry(NewEntryOptions{
+		Index:  0,
+		Shard:  shard,
+		Series: series,
+	})
+
+	// Create entry with index 1 that gets inserted into the lookup map
+	_ = addMockSeries(ctrl, shard, series.ID(), ident.Tags{}, 1)
+
+	// Validate we perform the reconciliation.
+	e, cleanup, reconciled := entry.ReconciledOnIndexSeries()
+	require.True(t, reconciled)
+	require.Equal(t, uint64(1), e.(*Entry).Index)
+	cleanup()
+
+	// Set the entry's insert time emulating being inserted into the shard.
+	// Ensure no reconciliation.
+	entry.SetInsertTime(time.Now())
+	e, cleanup, reconciled = entry.ReconciledOnIndexSeries()
+	require.False(t, reconciled)
+	require.Equal(t, uint64(0), e.(*Entry).Index)
+	cleanup()
 }

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -170,7 +170,8 @@ type blockMetrics struct {
 	queryDocsMatched                tally.Histogram
 	aggregateSeriesMatched          tally.Histogram
 	aggregateDocsMatched            tally.Histogram
-	reconciledEntryOnQuery          tally.Counter
+	entryReconciledOnQuery          tally.Counter
+	entryUnreconciledOnQuery        tally.Counter
 }
 
 func newBlockMetrics(s tally.Scope) blockMetrics {
@@ -193,11 +194,12 @@ func newBlockMetrics(s tally.Scope) blockMetrics {
 			"skip_type": "not-immutable",
 		}).Counter(segmentFreeMmap),
 
-		querySeriesMatched:     s.Histogram("query-series-matched", buckets),
-		queryDocsMatched:       s.Histogram("query-docs-matched", buckets),
-		aggregateSeriesMatched: s.Histogram("aggregate-series-matched", buckets),
-		aggregateDocsMatched:   s.Histogram("aggregate-docs-matched", buckets),
-		reconciledEntryOnQuery: s.Counter("reconciled-entry-on-query"),
+		querySeriesMatched:       s.Histogram("query-series-matched", buckets),
+		queryDocsMatched:         s.Histogram("query-docs-matched", buckets),
+		aggregateSeriesMatched:   s.Histogram("aggregate-series-matched", buckets),
+		aggregateDocsMatched:     s.Histogram("aggregate-docs-matched", buckets),
+		entryReconciledOnQuery:   s.Counter("entry-reconciled-on-query"),
+		entryUnreconciledOnQuery: s.Counter("entry-unreconciled-on-query"),
 	}
 }
 
@@ -544,44 +546,8 @@ func (b *block) queryWithSpan(
 
 		// Ensure that the block contains any of the relevant time segments for the query range.
 		doc := iter.Current()
-		if md, ok := doc.Metadata(); ok && md.OnIndexSeries != nil {
-			onIndexSeries, cleanup, reconciled := md.OnIndexSeries.ReconciledOnIndexSeries()
-			if reconciled {
-				b.metrics.reconciledEntryOnQuery.Inc(1)
-			}
-
-			var (
-				inBlock                bool
-				currentBlock           = opts.StartInclusive.Truncate(b.blockSize)
-				endExclusive           = opts.EndExclusive
-				minIndexed, maxIndexed = onIndexSeries.IndexedRange()
-			)
-			if maxIndexed == 0 {
-				// Empty range.
-				cleanup()
-				continue
-			}
-
-			// Narrow down the range of blocks to scan because the client could have
-			// queried for an arbitrary wide range.
-			if currentBlock.Before(minIndexed) {
-				currentBlock = minIndexed
-			}
-			maxIndexedExclusive := maxIndexed.Add(time.Nanosecond)
-			if endExclusive.After(maxIndexedExclusive) {
-				endExclusive = maxIndexedExclusive
-			}
-
-			for !inBlock && currentBlock.Before(endExclusive) {
-				inBlock = onIndexSeries.IndexedForBlockStart(currentBlock)
-				currentBlock = currentBlock.Add(b.blockSize)
-			}
-
-			cleanup()
-
-			if !inBlock {
-				continue
-			}
+		if !b.docWithinQueryRange(doc, opts) {
+			continue
 		}
 
 		batch = append(batch, doc)
@@ -610,6 +576,49 @@ func (b *block) queryWithSpan(
 	iter.AddDocs(docsCount - docsCountBefore)
 
 	return nil
+}
+
+func (b *block) docWithinQueryRange(doc doc.Document, opts QueryOptions) bool {
+	md, ok := doc.Metadata()
+	if !ok || md.OnIndexSeries == nil {
+		return true
+	}
+
+	onIndexSeries, closer, reconciled := md.OnIndexSeries.ReconciledOnIndexSeries()
+	if reconciled {
+		b.metrics.entryReconciledOnQuery.Inc(1)
+	} else {
+		b.metrics.entryUnreconciledOnQuery.Inc(1)
+	}
+	defer closer.Close()
+
+	var (
+		inBlock                bool
+		currentBlock           = opts.StartInclusive.Truncate(b.blockSize)
+		endExclusive           = opts.EndExclusive
+		minIndexed, maxIndexed = onIndexSeries.IndexedRange()
+	)
+	if maxIndexed == 0 {
+		// Empty range.
+		return false
+	}
+
+	// Narrow down the range of blocks to scan because the client could have
+	// queried for an arbitrary wide range.
+	if currentBlock.Before(minIndexed) {
+		currentBlock = minIndexed
+	}
+	maxIndexedExclusive := maxIndexed.Add(time.Nanosecond)
+	if endExclusive.After(maxIndexedExclusive) {
+		endExclusive = maxIndexedExclusive
+	}
+
+	for !inBlock && currentBlock.Before(endExclusive) {
+		inBlock = onIndexSeries.IndexedForBlockStart(currentBlock)
+		currentBlock = currentBlock.Add(b.blockSize)
+	}
+
+	return inBlock
 }
 
 func (b *block) closeAsync(closer io.Closer) {

--- a/src/dbnode/storage/index/block_bench_test.go
+++ b/src/dbnode/storage/index/block_bench_test.go
@@ -134,3 +134,7 @@ func (m mockOnIndexSeries) NeedsIndexGarbageCollected() bool           { return 
 func (m mockOnIndexSeries) IndexedRange() (xtime.UnixNano, xtime.UnixNano) {
 	return 0, 0
 }
+
+func (m mockOnIndexSeries) ReconciledOnIndexSeries() (doc.OnIndexSeries, doc.ReconciledOnIndexSeriesCleanupFn, bool) {
+	return m, func() {}, false
+}

--- a/src/dbnode/storage/index/block_bench_test.go
+++ b/src/dbnode/storage/index/block_bench_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/namespace"
 	"github.com/m3db/m3/src/m3ninx/doc"
+	"github.com/m3db/m3/src/x/resource"
 	xtime "github.com/m3db/m3/src/x/time"
 
 	"github.com/golang/mock/gomock"
@@ -135,6 +136,6 @@ func (m mockOnIndexSeries) IndexedRange() (xtime.UnixNano, xtime.UnixNano) {
 	return 0, 0
 }
 
-func (m mockOnIndexSeries) ReconciledOnIndexSeries() (doc.OnIndexSeries, doc.ReconciledOnIndexSeriesCleanupFn, bool) {
-	return m, func() {}, false
+func (m mockOnIndexSeries) ReconciledOnIndexSeries() (doc.OnIndexSeries, resource.SimpleCloser, bool) {
+	return m, resource.SimpleCloserFn(func() {}), false
 }

--- a/src/dbnode/storage/index/block_test.go
+++ b/src/dbnode/storage/index/block_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/resource"
 	"github.com/m3db/m3/src/x/tallytest"
 	xtime "github.com/m3db/m3/src/x/time"
 
@@ -1500,7 +1501,7 @@ func TestBlockE2EInsertQueryLimit(t *testing.T) {
 	h1 := doc.NewMockOnIndexSeries(ctrl)
 	h1.EXPECT().OnIndexFinalize(blockStart)
 	h1.EXPECT().OnIndexSuccess(blockStart)
-	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, func() {}, false)
+	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, resource.SimpleCloserFn(func() {}), false)
 	h1.EXPECT().IndexedRange().Return(blockStart, blockStart)
 	h1.EXPECT().IndexedForBlockStart(blockStart).Return(true)
 
@@ -1589,14 +1590,14 @@ func TestBlockE2EInsertAddResultsQuery(t *testing.T) {
 	h1 := doc.NewMockOnIndexSeries(ctrl)
 	h1.EXPECT().OnIndexFinalize(blockStart)
 	h1.EXPECT().OnIndexSuccess(blockStart)
-	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, func() {}, false)
+	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, resource.SimpleCloserFn(func() {}), false)
 	h1.EXPECT().IndexedRange().Return(blockStart, blockStart)
 	h1.EXPECT().IndexedForBlockStart(blockStart).Return(true)
 
 	h2 := doc.NewMockOnIndexSeries(ctrl)
 	h2.EXPECT().OnIndexFinalize(blockStart)
 	h2.EXPECT().OnIndexSuccess(blockStart)
-	h2.EXPECT().ReconciledOnIndexSeries().Return(h2, func() {}, false)
+	h2.EXPECT().ReconciledOnIndexSeries().Return(h2, resource.SimpleCloserFn(func() {}), false)
 	h2.EXPECT().IndexedRange().Return(blockStart, blockStart)
 	h2.EXPECT().IndexedForBlockStart(blockStart).Return(true)
 
@@ -1691,7 +1692,7 @@ func TestBlockE2EInsertAddResultsMergeQuery(t *testing.T) {
 	h1 := doc.NewMockOnIndexSeries(ctrl)
 	h1.EXPECT().OnIndexFinalize(blockStart)
 	h1.EXPECT().OnIndexSuccess(blockStart)
-	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, func() {}, false)
+	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, resource.SimpleCloserFn(func() {}), false)
 	h1.EXPECT().IndexedRange().Return(blockStart, blockStart)
 	h1.EXPECT().IndexedForBlockStart(blockStart).Return(true)
 
@@ -1782,7 +1783,7 @@ func TestBlockE2EInsertAddResultsQueryNarrowingBlockRange(t *testing.T) {
 	h1 := doc.NewMockOnIndexSeries(ctrl)
 	h1.EXPECT().OnIndexFinalize(blockStart)
 	h1.EXPECT().OnIndexSuccess(blockStart)
-	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, func() {}, false)
+	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, resource.SimpleCloserFn(func() {}), false)
 	h1.EXPECT().IndexedRange().Return(blockStart, blockStart.Add(2*blockSize))
 	h1.EXPECT().IndexedForBlockStart(blockStart).Return(false)
 	h1.EXPECT().IndexedForBlockStart(blockStart.Add(1 * blockSize)).Return(false)
@@ -1791,7 +1792,7 @@ func TestBlockE2EInsertAddResultsQueryNarrowingBlockRange(t *testing.T) {
 	h2 := doc.NewMockOnIndexSeries(ctrl)
 	h2.EXPECT().OnIndexFinalize(blockStart)
 	h2.EXPECT().OnIndexSuccess(blockStart)
-	h2.EXPECT().ReconciledOnIndexSeries().Return(h2, func() {}, false)
+	h2.EXPECT().ReconciledOnIndexSeries().Return(h2, resource.SimpleCloserFn(func() {}), false)
 	h2.EXPECT().IndexedRange().Return(xtime.UnixNano(0), xtime.UnixNano(0))
 
 	batch := NewWriteBatch(WriteBatchOptions{

--- a/src/dbnode/storage/index/block_test.go
+++ b/src/dbnode/storage/index/block_test.go
@@ -1500,6 +1500,7 @@ func TestBlockE2EInsertQueryLimit(t *testing.T) {
 	h1 := doc.NewMockOnIndexSeries(ctrl)
 	h1.EXPECT().OnIndexFinalize(blockStart)
 	h1.EXPECT().OnIndexSuccess(blockStart)
+	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, func() {}, false)
 	h1.EXPECT().IndexedRange().Return(blockStart, blockStart)
 	h1.EXPECT().IndexedForBlockStart(blockStart).Return(true)
 
@@ -1588,12 +1589,14 @@ func TestBlockE2EInsertAddResultsQuery(t *testing.T) {
 	h1 := doc.NewMockOnIndexSeries(ctrl)
 	h1.EXPECT().OnIndexFinalize(blockStart)
 	h1.EXPECT().OnIndexSuccess(blockStart)
+	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, func() {}, false)
 	h1.EXPECT().IndexedRange().Return(blockStart, blockStart)
 	h1.EXPECT().IndexedForBlockStart(blockStart).Return(true)
 
 	h2 := doc.NewMockOnIndexSeries(ctrl)
 	h2.EXPECT().OnIndexFinalize(blockStart)
 	h2.EXPECT().OnIndexSuccess(blockStart)
+	h2.EXPECT().ReconciledOnIndexSeries().Return(h2, func() {}, false)
 	h2.EXPECT().IndexedRange().Return(blockStart, blockStart)
 	h2.EXPECT().IndexedForBlockStart(blockStart).Return(true)
 
@@ -1688,6 +1691,7 @@ func TestBlockE2EInsertAddResultsMergeQuery(t *testing.T) {
 	h1 := doc.NewMockOnIndexSeries(ctrl)
 	h1.EXPECT().OnIndexFinalize(blockStart)
 	h1.EXPECT().OnIndexSuccess(blockStart)
+	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, func() {}, false)
 	h1.EXPECT().IndexedRange().Return(blockStart, blockStart)
 	h1.EXPECT().IndexedForBlockStart(blockStart).Return(true)
 
@@ -1778,6 +1782,7 @@ func TestBlockE2EInsertAddResultsQueryNarrowingBlockRange(t *testing.T) {
 	h1 := doc.NewMockOnIndexSeries(ctrl)
 	h1.EXPECT().OnIndexFinalize(blockStart)
 	h1.EXPECT().OnIndexSuccess(blockStart)
+	h1.EXPECT().ReconciledOnIndexSeries().Return(h1, func() {}, false)
 	h1.EXPECT().IndexedRange().Return(blockStart, blockStart.Add(2*blockSize))
 	h1.EXPECT().IndexedForBlockStart(blockStart).Return(false)
 	h1.EXPECT().IndexedForBlockStart(blockStart.Add(1 * blockSize)).Return(false)
@@ -1786,6 +1791,7 @@ func TestBlockE2EInsertAddResultsQueryNarrowingBlockRange(t *testing.T) {
 	h2 := doc.NewMockOnIndexSeries(ctrl)
 	h2.EXPECT().OnIndexFinalize(blockStart)
 	h2.EXPECT().OnIndexSuccess(blockStart)
+	h2.EXPECT().ReconciledOnIndexSeries().Return(h2, func() {}, false)
 	h2.EXPECT().IndexedRange().Return(xtime.UnixNano(0), xtime.UnixNano(0))
 
 	batch := NewWriteBatch(WriteBatchOptions{

--- a/src/dbnode/storage/index_query_concurrent_test.go
+++ b/src/dbnode/storage/index_query_concurrent_test.go
@@ -185,6 +185,10 @@ func testNamespaceIndexHighConcurrentQueries(
 				return ts.Equal(st)
 			}).
 			AnyTimes()
+		onIndexSeries.EXPECT().
+			ReconciledOnIndexSeries().
+			Return(onIndexSeries, func() {}, false).
+			AnyTimes()
 
 		batch := index.NewWriteBatch(index.WriteBatchOptions{
 			InitialCapacity: idsPerBlock,

--- a/src/dbnode/storage/index_query_concurrent_test.go
+++ b/src/dbnode/storage/index_query_concurrent_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
+	"github.com/m3db/m3/src/x/resource"
 	xtest "github.com/m3db/m3/src/x/test"
 	xtime "github.com/m3db/m3/src/x/time"
 )
@@ -187,7 +188,7 @@ func testNamespaceIndexHighConcurrentQueries(
 			AnyTimes()
 		onIndexSeries.EXPECT().
 			ReconciledOnIndexSeries().
-			Return(onIndexSeries, func() {}, false).
+			Return(onIndexSeries, resource.SimpleCloserFn(func() {}), false).
 			AnyTimes()
 
 		batch := index.NewWriteBatch(index.WriteBatchOptions{

--- a/src/dbnode/storage/index_queue_forward_write_test.go
+++ b/src/dbnode/storage/index_queue_forward_write_test.go
@@ -126,6 +126,8 @@ func setupForwardIndex(
 	)
 
 	if !expectAggregateQuery {
+		lifecycle.EXPECT().ReconciledOnIndexSeries().Return(lifecycle, func() {}, false).AnyTimes()
+
 		lifecycle.EXPECT().IndexedRange().Return(ts, ts)
 		lifecycle.EXPECT().IndexedForBlockStart(ts).Return(true)
 

--- a/src/dbnode/storage/index_queue_forward_write_test.go
+++ b/src/dbnode/storage/index_queue_forward_write_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/resource"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtest "github.com/m3db/m3/src/x/test"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -126,7 +127,9 @@ func setupForwardIndex(
 	)
 
 	if !expectAggregateQuery {
-		lifecycle.EXPECT().ReconciledOnIndexSeries().Return(lifecycle, func() {}, false).AnyTimes()
+		lifecycle.EXPECT().ReconciledOnIndexSeries().Return(
+			lifecycle, resource.SimpleCloserFn(func() {}), false,
+		).AnyTimes()
 
 		lifecycle.EXPECT().IndexedRange().Return(ts, ts)
 		lifecycle.EXPECT().IndexedForBlockStart(ts).Return(true)

--- a/src/dbnode/storage/index_queue_test.go
+++ b/src/dbnode/storage/index_queue_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/context"
 	"github.com/m3db/m3/src/x/ident"
+	"github.com/m3db/m3/src/x/resource"
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtest "github.com/m3db/m3/src/x/test"
 	xtime "github.com/m3db/m3/src/x/time"
@@ -353,7 +354,9 @@ func setupIndex(t *testing.T,
 	lifecycleFns.EXPECT().IfAlreadyIndexedMarkIndexSuccessAndFinalize(gomock.Any()).Return(false)
 
 	if !expectAggregateQuery {
-		lifecycleFns.EXPECT().ReconciledOnIndexSeries().Return(lifecycleFns, func() {}, false)
+		lifecycleFns.EXPECT().ReconciledOnIndexSeries().Return(
+			lifecycleFns, resource.SimpleCloserFn(func() {}), false,
+		)
 		lifecycleFns.EXPECT().IndexedRange().Return(ts, ts)
 		lifecycleFns.EXPECT().IndexedForBlockStart(ts).Return(true)
 	}

--- a/src/dbnode/storage/index_queue_test.go
+++ b/src/dbnode/storage/index_queue_test.go
@@ -353,6 +353,7 @@ func setupIndex(t *testing.T,
 	lifecycleFns.EXPECT().IfAlreadyIndexedMarkIndexSuccessAndFinalize(gomock.Any()).Return(false)
 
 	if !expectAggregateQuery {
+		lifecycleFns.EXPECT().ReconciledOnIndexSeries().Return(lifecycleFns, func() {}, false)
 		lifecycleFns.EXPECT().IndexedRange().Return(ts, ts)
 		lifecycleFns.EXPECT().IndexedForBlockStart(ts).Return(true)
 	}

--- a/src/m3ninx/doc/doc_mock.go
+++ b/src/m3ninx/doc/doc_mock.go
@@ -413,6 +413,22 @@ func (mr *MockOnIndexSeriesMockRecorder) OnIndexSuccess(blockStart interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnIndexSuccess", reflect.TypeOf((*MockOnIndexSeries)(nil).OnIndexSuccess), blockStart)
 }
 
+// ReconciledOnIndexSeries mocks base method.
+func (m *MockOnIndexSeries) ReconciledOnIndexSeries() (OnIndexSeries, ReconciledOnIndexSeriesCleanupFn, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconciledOnIndexSeries")
+	ret0, _ := ret[0].(OnIndexSeries)
+	ret1, _ := ret[1].(ReconciledOnIndexSeriesCleanupFn)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
+}
+
+// ReconciledOnIndexSeries indicates an expected call of ReconciledOnIndexSeries.
+func (mr *MockOnIndexSeriesMockRecorder) ReconciledOnIndexSeries() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconciledOnIndexSeries", reflect.TypeOf((*MockOnIndexSeries)(nil).ReconciledOnIndexSeries))
+}
+
 // TryMarkIndexGarbageCollected mocks base method.
 func (m *MockOnIndexSeries) TryMarkIndexGarbageCollected() bool {
 	m.ctrl.T.Helper()

--- a/src/m3ninx/doc/doc_mock.go
+++ b/src/m3ninx/doc/doc_mock.go
@@ -27,6 +27,7 @@ package doc
 import (
 	"reflect"
 
+	"github.com/m3db/m3/src/x/resource"
 	"github.com/m3db/m3/src/x/time"
 
 	"github.com/golang/mock/gomock"
@@ -414,11 +415,11 @@ func (mr *MockOnIndexSeriesMockRecorder) OnIndexSuccess(blockStart interface{}) 
 }
 
 // ReconciledOnIndexSeries mocks base method.
-func (m *MockOnIndexSeries) ReconciledOnIndexSeries() (OnIndexSeries, ReconciledOnIndexSeriesCleanupFn, bool) {
+func (m *MockOnIndexSeries) ReconciledOnIndexSeries() (OnIndexSeries, resource.SimpleCloser, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReconciledOnIndexSeries")
 	ret0, _ := ret[0].(OnIndexSeries)
-	ret1, _ := ret[1].(ReconciledOnIndexSeriesCleanupFn)
+	ret1, _ := ret[1].(resource.SimpleCloser)
 	ret2, _ := ret[2].(bool)
 	return ret0, ret1, ret2
 }

--- a/src/m3ninx/doc/types.go
+++ b/src/m3ninx/doc/types.go
@@ -129,4 +129,17 @@ type OnIndexSeries interface {
 	// The range is inclusive. Note that there may be uncovered gaps within the range.
 	// Returns (0, 0) for an empty range.
 	IndexedRange() (xtime.UnixNano, xtime.UnixNano)
+
+	// ReconciledOnIndexSeries attempts to retrieve the most recent index entry from the
+	// shard if the entry this method was called on was never inserted there. If there
+	// is an error during retrieval, simply returns the current entry. Additionally,
+	// returns a cleanup function to run once finished using the reconciled entry and
+	// a boolean value indicating whether the result came from reconciliation or not.
+	// Cleanup function must be called once done with the reconciled entry so that
+	// reader and writer counts are accurately updated.
+	ReconciledOnIndexSeries() (OnIndexSeries, ReconciledOnIndexSeriesCleanupFn, bool)
 }
+
+// ReconciledOnIndexSeriesCleanupFn is a function for performing cleanup when
+// ReconciledOnIndexSeries is called.
+type ReconciledOnIndexSeriesCleanupFn func()

--- a/src/m3ninx/doc/types.go
+++ b/src/m3ninx/doc/types.go
@@ -21,6 +21,7 @@
 package doc
 
 import (
+	"github.com/m3db/m3/src/x/resource"
 	xtime "github.com/m3db/m3/src/x/time"
 )
 
@@ -137,9 +138,5 @@ type OnIndexSeries interface {
 	// a boolean value indicating whether the result came from reconciliation or not.
 	// Cleanup function must be called once done with the reconciled entry so that
 	// reader and writer counts are accurately updated.
-	ReconciledOnIndexSeries() (OnIndexSeries, ReconciledOnIndexSeriesCleanupFn, bool)
+	ReconciledOnIndexSeries() (OnIndexSeries, resource.SimpleCloser, bool)
 }
-
-// ReconciledOnIndexSeriesCleanupFn is a function for performing cleanup when
-// ReconciledOnIndexSeries is called.
-type ReconciledOnIndexSeriesCleanupFn func()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
In db nodes, state is kept for cheap lookups to determine if a series is
indexed for a specific block start. This state exists on the document in the
index and in the shard object. On concurrent writes to the same time series,
it's possible for these two sources to get out of sync. Basically, the
state associated with the document on the index is a different instance
than the one that gets placed in the shard's lookup map. This can
result in issues where we don't accurately track that a series in
indexed for a specific block start as only the entry in the lookup
map will get updated in the future.

To resolve this, we introduce reconciliation methods when querying these
objects. If it's noticed on read that we're querying index state that
never got inserted into the shard lookup map, then we query the shard
for the appropriate entry and use the results on that object.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
