### PR TITLE
[query] Prom converter supporting value decrease tolerance

### DIFF
--- a/src/cmd/services/m3comparator/main/querier.go
+++ b/src/cmd/services/m3comparator/main/querier.go
@@ -135,7 +135,7 @@ type seriesGen struct {
 	res  time.Duration
 }
 
-// FetchCompressed fetches timeseries data based on a query.
+// FetchCompressedResult fetches timeseries data based on a query.
 func (q *querier) FetchCompressedResult(
 	ctx context.Context,
 	query *storage.FetchQuery,

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -380,6 +380,8 @@ func Run(runOpts RunOptions) RunResult {
 	}
 	cfg.LookbackDuration = &lookbackDuration
 
+	promConvertOptions := cfg.PromConvertOptionsOrDefault()
+
 	readWorkerPool, writeWorkerPool, err := pools.BuildWorkerPools(
 		instrumentOptions,
 		cfg.ReadWorkerPool,
@@ -401,7 +403,8 @@ func Run(runOpts RunOptions) RunResult {
 		SetConsolidationFunc(consolidators.TakeLast).
 		SetReadWorkerPool(readWorkerPool).
 		SetWriteWorkerPool(writeWorkerPool).
-		SetSeriesConsolidationMatchOptions(matchOptions)
+		SetSeriesConsolidationMatchOptions(matchOptions).
+		SetPromConvertOptions(promConvertOptions)
 
 	if runOpts.ApplyCustomTSDBOptions != nil {
 		tsdbOpts, err = runOpts.ApplyCustomTSDBOptions(tsdbOpts, instrumentOptions)

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -380,7 +380,7 @@ func Run(runOpts RunOptions) RunResult {
 	}
 	cfg.LookbackDuration = &lookbackDuration
 
-	promConvertOptions := cfg.PromConvertOptionsOrDefault()
+	promConvertOptions := cfg.Query.Prometheus.ConvertOptionsOrDefault()
 
 	readWorkerPool, writeWorkerPool, err := pools.BuildWorkerPools(
 		instrumentOptions,

--- a/src/query/storage/options.go
+++ b/src/query/storage/options.go
@@ -20,7 +20,11 @@
 
 package storage
 
-import "time"
+import (
+	"time"
+
+	xtime "github.com/m3db/m3/src/x/time"
+)
 
 const (
 	defaultResolutionThresholdForCounterNormalization = time.Hour
@@ -28,6 +32,9 @@ const (
 
 type promConvertOptions struct {
 	resolutionThresholdForCounterNormalization time.Duration
+
+	valueDecreaseTolerance      float64
+	valueDecreaseToleranceUntil xtime.UnixNano
 }
 
 // NewPromConvertOptions builds a new PromConvertOptions with default values.
@@ -45,4 +52,24 @@ func (o *promConvertOptions) SetResolutionThresholdForCounterNormalization(value
 
 func (o *promConvertOptions) ResolutionThresholdForCounterNormalization() time.Duration {
 	return o.resolutionThresholdForCounterNormalization
+}
+
+func (o *promConvertOptions) SetValueDecreaseTolerance(value float64) PromConvertOptions {
+	opts := *o
+	opts.valueDecreaseTolerance = value
+	return &opts
+}
+
+func (o *promConvertOptions) ValueDecreaseTolerance() float64 {
+	return o.valueDecreaseTolerance
+}
+
+func (o *promConvertOptions) SetValueDecreaseToleranceUntil(value xtime.UnixNano) PromConvertOptions {
+	opts := *o
+	opts.valueDecreaseToleranceUntil = value
+	return &opts
+}
+
+func (o *promConvertOptions) ValueDecreaseToleranceUntil() xtime.UnixNano {
+	return o.valueDecreaseToleranceUntil
 }

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -50,8 +50,6 @@ const (
 	TypeRemoteDC
 	// TypeMultiDC is for storages that will aggregate multiple datacenters.
 	TypeMultiDC
-	// TypeDebug is for storages that are used for debugging purposes.
-	TypeDebug
 )
 
 // ErrorBehavior describes what this storage type should do on error. This is
@@ -367,4 +365,16 @@ type PromConvertOptions interface {
 	// ResolutionThresholdForCounterNormalization returns resolution
 	// starting from which (inclusive) a normalization of counter values is performed.
 	ResolutionThresholdForCounterNormalization() time.Duration
+
+	// SetValueDecreaseTolerance sets relative tolerance against decoded time series value decrease.
+	SetValueDecreaseTolerance(value float64) PromConvertOptions
+
+	// ValueDecreaseTolerance returns relative tolerance against decoded time series value decrease.
+	ValueDecreaseTolerance() float64
+
+	// SetValueDecreaseToleranceUntil sets the timestamp (exclusive) until which the tolerance applies.
+	SetValueDecreaseToleranceUntil(value xtime.UnixNano) PromConvertOptions
+
+	// ValueDecreaseToleranceUntil the timestamp (exclusive) until which the tolerance applies.
+	ValueDecreaseToleranceUntil() xtime.UnixNano
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows setting relative decrease tolerance up to which value decreases are eliminated while decoding time series data.

**Special notes for your reviewer**:
See #3872.
This is intended to replace https://github.com/m3db/m3/pull/3876 which can only operate within a single time series block.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
