### PR TITLE
[agg] Use timestamp (not start aligned) for expiring forward versions

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -78,8 +78,9 @@ type CounterElem struct {
 	dirty []xtime.UnixNano
 
 	// internal/no need for synchronization: small buffers to avoid memory allocations during consumption
-	toConsume          []consumeState
-	flushStateToExpire []xtime.UnixNano
+	toConsume            []consumeState
+	flushStateToExpire   []xtime.UnixNano
+	forwardTimesToExpire []xtime.UnixNano
 	// end internal state
 
 	// min time in the values map. allows for iterating through map.
@@ -397,7 +398,14 @@ func (e *CounterElem) Consume(
 
 	if e.parsedPipeline.HasRollup {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey, e.flushStateToExpire)
+		e.forwardTimesToExpire = e.forwardTimesToExpire[:0]
+		for _, startTime := range e.flushStateToExpire {
+			// the forward writer uses the timestamp of the aggregation, so need to convert the start aligned time
+			// to a timestamp.
+			e.forwardTimesToExpire = append(e.forwardTimesToExpire,
+				xtime.UnixNano(timestampNanosFn(int64(startTime), resolution)))
+		}
+		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey, e.forwardTimesToExpire)
 	}
 
 	return canCollect

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -141,8 +141,9 @@ type GenericElem struct {
 	dirty []xtime.UnixNano
 
 	// internal/no need for synchronization: small buffers to avoid memory allocations during consumption
-	toConsume          []consumeState
-	flushStateToExpire []xtime.UnixNano
+	toConsume            []consumeState
+	flushStateToExpire   []xtime.UnixNano
+	forwardTimesToExpire []xtime.UnixNano
 	// end internal state
 
 	// min time in the values map. allows for iterating through map.
@@ -460,7 +461,14 @@ func (e *GenericElem) Consume(
 
 	if e.parsedPipeline.HasRollup {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey, e.flushStateToExpire)
+		e.forwardTimesToExpire = e.forwardTimesToExpire[:0]
+		for _, startTime := range e.flushStateToExpire {
+			// the forward writer uses the timestamp of the aggregation, so need to convert the start aligned time
+			// to a timestamp.
+			e.forwardTimesToExpire = append(e.forwardTimesToExpire,
+				xtime.UnixNano(timestampNanosFn(int64(startTime), resolution)))
+		}
+		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey, e.forwardTimesToExpire)
 	}
 
 	return canCollect

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -78,8 +78,9 @@ type TimerElem struct {
 	dirty []xtime.UnixNano
 
 	// internal/no need for synchronization: small buffers to avoid memory allocations during consumption
-	toConsume          []consumeState
-	flushStateToExpire []xtime.UnixNano
+	toConsume            []consumeState
+	flushStateToExpire   []xtime.UnixNano
+	forwardTimesToExpire []xtime.UnixNano
 	// end internal state
 
 	// min time in the values map. allows for iterating through map.
@@ -397,7 +398,14 @@ func (e *TimerElem) Consume(
 
 	if e.parsedPipeline.HasRollup {
 		forwardedAggregationKey, _ := e.ForwardedAggregationKey()
-		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey, e.flushStateToExpire)
+		e.forwardTimesToExpire = e.forwardTimesToExpire[:0]
+		for _, startTime := range e.flushStateToExpire {
+			// the forward writer uses the timestamp of the aggregation, so need to convert the start aligned time
+			// to a timestamp.
+			e.forwardTimesToExpire = append(e.forwardTimesToExpire,
+				xtime.UnixNano(timestampNanosFn(int64(startTime), resolution)))
+		}
+		onForwardedFlushedFn(e.onForwardedAggregationWrittenFn, forwardedAggregationKey, e.forwardTimesToExpire)
 	}
 
 	return canCollect


### PR DESCRIPTION
The forward_writer uses a version map indexed by timestamp, which is not
start aligned. When the flusher passes the set of times to expire, it
needs to convert the start aligned time to a timestamp.

This manifests as a significant memory leak for sparse workloads where
the timestamp of N != start aligned time of N+1. In those cases the
versions are never GCd when they expire out of the buffer.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
