### PR TITLE
[agg] Fix forward lag calculation

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -842,19 +842,22 @@ func (e *CounterElem) processValue(
 
 				if !fState.flushed {
 					e.forwardLagMetric(resolution, "local", false, flushType).
-						RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed - jitter)))
+						RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
 					e.forwardLagMetric(resolution, "local", true, flushType).
-						RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed)))
+						RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
 				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			// only record lag for the initial flush (not resends)
 			if !fState.flushed {
+				// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
+				// counted towards the processing lag.
+				// forward lag = current time - (agg timestamp + lateness allowed + jitter)
 				e.forwardLagMetric(resolution, "remote", false, flushType).
-					RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed - jitter)))
+					RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
 				e.forwardLagMetric(resolution, "remote", true, flushType).
-					RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed)))
+					RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timestamp), value, prevValue, cState.annotation, cState.resendEnabled)

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -842,19 +842,22 @@ func (e *GaugeElem) processValue(
 
 				if !fState.flushed {
 					e.forwardLagMetric(resolution, "local", false, flushType).
-						RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed - jitter)))
+						RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
 					e.forwardLagMetric(resolution, "local", true, flushType).
-						RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed)))
+						RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
 				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			// only record lag for the initial flush (not resends)
 			if !fState.flushed {
+				// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
+				// counted towards the processing lag.
+				// forward lag = current time - (agg timestamp + lateness allowed + jitter)
 				e.forwardLagMetric(resolution, "remote", false, flushType).
-					RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed - jitter)))
+					RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
 				e.forwardLagMetric(resolution, "remote", true, flushType).
-					RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed)))
+					RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timestamp), value, prevValue, cState.annotation, cState.resendEnabled)

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -905,19 +905,22 @@ func (e *GenericElem) processValue(
 
 				if !fState.flushed {
 					e.forwardLagMetric(resolution, "local", false, flushType).
-						RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed - jitter)))
+						RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
 					e.forwardLagMetric(resolution, "local", true, flushType).
-						RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed)))
+						RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
 				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			// only record lag for the initial flush (not resends)
 			if !fState.flushed {
+				// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
+				// counted towards the processing lag.
+				// forward lag = current time - (agg timestamp + lateness allowed + jitter)
 				e.forwardLagMetric(resolution, "remote", false, flushType).
-					RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed - jitter)))
+					RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
 				e.forwardLagMetric(resolution, "remote", true, flushType).
-					RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed)))
+					RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timestamp), value, prevValue, cState.annotation, cState.resendEnabled)

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -842,19 +842,22 @@ func (e *TimerElem) processValue(
 
 				if !fState.flushed {
 					e.forwardLagMetric(resolution, "local", false, flushType).
-						RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed - jitter)))
+						RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
 					e.forwardLagMetric(resolution, "local", true, flushType).
-						RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed)))
+						RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
 				}
 			}
 		} else {
 			forwardedAggregationKey, _ := e.ForwardedAggregationKey()
 			// only record lag for the initial flush (not resends)
 			if !fState.flushed {
+				// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
+				// counted towards the processing lag.
+				// forward lag = current time - (agg timestamp + lateness allowed + jitter)
 				e.forwardLagMetric(resolution, "remote", false, flushType).
-					RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed - jitter)))
+					RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
 				e.forwardLagMetric(resolution, "remote", true, flushType).
-					RecordDuration(time.Since(timestamp.ToTime().Add(-latenessAllowed)))
+					RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
 			}
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timestamp), value, prevValue, cState.annotation, cState.resendEnabled)


### PR DESCRIPTION
When calculating the forwarding lag, we want to add the latenesAllowed
and jitter to the timestamp so it's not counted in the processing lag
number. By subtracting it we were actually adding additional lag that
was incorrect.

forward lag = now - (timestamp + intentional delay)

intentional delay = allowedLateness + jitter

jitter = how long we intentionally delay a flush task so tasks don't run
at the same time.

allowedLateness = how long we intentionally delay a flush task so
allow for late metrics to arrive.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
