### PR TITLE
[pool] Fix ExampleObjectPool output

### DIFF
--- a/src/x/pool/example_test.go
+++ b/src/x/pool/example_test.go
@@ -50,7 +50,6 @@ func ExampleObjectPool() {
 	o := p.Get().(*exampleObject)
 
 	fmt.Printf("Retrieved struct should have default values: %+v", o)
-	// Output: Retrieved struct should have default values: &{a:0 b:0 c:0}
 
 	// Use the exampleObject.
 	_ = o
@@ -58,4 +57,6 @@ func ExampleObjectPool() {
 	// Reset the exampleObject and return it to the pool.
 	o.reset()
 	p.Put(o)
+	
+	// Output: Retrieved struct should have default values: &{a:0 b:0 c:0}
 }


### PR DESCRIPTION
Move the output to the end. If the output comment block is not the last comment block then no checks will be run.

**What this PR does / why we need it**:
Fixes #3763


