### PR TITLE
[agg] Fix race when migrating to resendEnabled and the agg is closed 

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -127,11 +127,6 @@ func (e *CounterElem) ResetSetData(data ElemData) error {
 
 // AddUnion adds a metric value union at a given timestamp.
 func (e *CounterElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion, resendEnabled bool) error {
-	return e.doAddUnion(timestamp, mu, resendEnabled, false)
-}
-
-func (e *CounterElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion, resendEnabled bool, retry bool,
-) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window)
 	lockedAgg, err := e.findOrCreate(alignedStart.UnixNano(), createAggregationOptions{})
 	if err != nil {
@@ -141,11 +136,10 @@ func (e *CounterElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnio
 	if lockedAgg.closed {
 		// Note: this might have created an entry in the dirty set for lockedAgg when calling findOrCreate, even though
 		// it's already closed. The Consume loop will detect this and clean it up.
+		aggResendEnabled := lockedAgg.resendEnabled
 		lockedAgg.mtx.Unlock()
-		if !resendEnabled && !retry {
-			// handle the edge case where the aggregation was already flushed/closed because the current time is right
-			// at the boundary. just roll the untimed metric into the next aggregation.
-			return e.doAddUnion(alignedStart.Add(e.sp.Resolution().Window), mu, false, true)
+		if !aggResendEnabled && resendEnabled {
+			return errClosedBeforeResendEnabledMigration
 		}
 		return errAggregationClosed
 	}
@@ -153,9 +147,6 @@ func (e *CounterElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnio
 	lockedAgg.dirty = true
 	lockedAgg.resendEnabled = resendEnabled
 	lockedAgg.mtx.Unlock()
-	if retry {
-		e.metrics.retriedValues.Inc(1)
-	}
 	return nil
 }
 
@@ -243,8 +234,7 @@ func (e *CounterElem) expireValuesWithLock(
 	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
 	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
-		currFlushState := e.flushState[currAgg.startAt]
-		if currFlushState.latestResendEnabled {
+		if e.flushState[currAgg.startAt].latestResendEnabled {
 			// if resend enabled we want to keep this value until it is outside the buffer past period.
 			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break

--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -47,16 +47,17 @@ type lockedCounterAggregation struct {
 	sourcesSeen map[uint32]*bitset.BitSet
 	mtx         sync.Mutex
 	dirty       bool
-	closed      bool
+	// resendEnabled is allowed to change while an aggregation is open, so it must be behind the lock.
+	resendEnabled bool
+	closed        bool
 }
 
 type timedCounter struct {
-	lockedAgg     *lockedCounterAggregation
-	startAt       xtime.UnixNano // start time of an aggregation window
-	prevStart     xtime.UnixNano
-	nextStart     xtime.UnixNano
-	resendEnabled bool
-	inDirtySet    bool
+	lockedAgg  *lockedCounterAggregation
+	startAt    xtime.UnixNano // start time of an aggregation window
+	prevStart  xtime.UnixNano
+	nextStart  xtime.UnixNano
+	inDirtySet bool
 }
 
 // close is called when the aggregation has been expired or the element is being closed.
@@ -132,9 +133,7 @@ func (e *CounterElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion,
 func (e *CounterElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion, resendEnabled bool, retry bool,
 ) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window)
-	lockedAgg, err := e.findOrCreate(alignedStart.UnixNano(), createAggregationOptions{
-		resendEnabled: resendEnabled,
-	})
+	lockedAgg, err := e.findOrCreate(alignedStart.UnixNano(), createAggregationOptions{})
 	if err != nil {
 		return err
 	}
@@ -152,6 +151,7 @@ func (e *CounterElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnio
 	}
 	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.dirty = true
+	lockedAgg.resendEnabled = resendEnabled
 	lockedAgg.mtx.Unlock()
 	if retry {
 		e.metrics.retriedValues.Inc(1)
@@ -189,7 +189,6 @@ func (e *CounterElem) AddUnique(
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{
 		initSourceSet: true,
-		resendEnabled: metadata.ResendEnabled,
 	})
 	if err != nil {
 		return err
@@ -225,6 +224,7 @@ func (e *CounterElem) AddUnique(
 		}
 	}
 	lockedAgg.dirty = true
+	lockedAgg.resendEnabled = metadata.ResendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
 }
@@ -243,7 +243,8 @@ func (e *CounterElem) expireValuesWithLock(
 	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
 	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
-		if currAgg.resendEnabled {
+		currFlushState := e.flushState[currAgg.startAt]
+		if currFlushState.latestResendEnabled {
 			// if resend enabled we want to keep this value until it is outside the buffer past period.
 			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break
@@ -448,12 +449,13 @@ func (e *CounterElem) dirtyToConsumeWithLock(targetNanos int64,
 		val := e.values[dirtyTime]
 		val.inDirtySet = false
 		e.values[dirtyTime] = val
+		cState := e.toConsume[len(e.toConsume)-1]
 
 		// potentially consume the nextAgg as well in case we need to cascade an update to the nextAgg.
 		// this is necessary for binary transformations that rely on the previous aggregation value for calculating the
 		// current aggregation value. if the nextAgg was already flushed, it used an outdated value for the previous
 		// value (this agg). this can only happen when we allow updating previously flushed data (i.e resendEnabled).
-		if agg.resendEnabled {
+		if cState.resendEnabled {
 			nextAgg, ok := e.nextAggWithLock(agg)
 			// only need to add if not already in the dirty set (since it will be added in a subsequent iteration).
 			if ok &&
@@ -486,6 +488,7 @@ func (e *CounterElem) appendConsumeStateWithLock(
 	// copy the lockedAgg data while holding the lock.
 	agg.lockedAgg.mtx.Lock()
 	cState.dirty = agg.lockedAgg.dirty
+	cState.resendEnabled = agg.lockedAgg.resendEnabled
 	for _, aggType := range e.aggTypes {
 		cState.values = append(cState.values, agg.lockedAgg.aggregation.ValueOf(aggType))
 	}
@@ -501,9 +504,12 @@ func (e *CounterElem) appendConsumeStateWithLock(
 	} else {
 		cState.prevStartTime = 0
 	}
-	cState.resendEnabled = agg.resendEnabled
 	cState.startAt = agg.startAt
 	toConsume[len(toConsume)-1] = cState
+	// update the flush state with the latestResendEnabled since expireValuesWithLock needs it before actual processing.
+	fState := e.flushState[cState.startAt]
+	fState.latestResendEnabled = cState.resendEnabled
+	e.flushState[cState.startAt] = fState
 
 	if includeFilter != nil && !includeFilter(cState) {
 		// since we eagerly appended, we need to remove if it should not be included.
@@ -635,7 +641,7 @@ func (e *CounterElem) findOrCreate(
 		return nil, err
 	}
 	// if the aggregation is found and does not need to be updated, return as is.
-	if found.lockedAgg != nil && found.inDirtySet && found.resendEnabled == createOpts.resendEnabled {
+	if found.lockedAgg != nil && found.inDirtySet {
 		return found.lockedAgg, err
 	}
 
@@ -651,10 +657,8 @@ func (e *CounterElem) findOrCreate(
 		if !timedAgg.inDirtySet {
 			timedAgg.inDirtySet = true
 			e.insertDirty(alignedStart)
+			e.values[alignedStart] = timedAgg
 		}
-		// ensure the resendEnabled state is the latest.
-		timedAgg.resendEnabled = createOpts.resendEnabled
-		e.values[alignedStart] = timedAgg
 		e.Unlock()
 		return timedAgg.lockedAgg, nil
 	}
@@ -678,8 +682,7 @@ func (e *CounterElem) findOrCreate(
 			sourcesSeen: sourcesSeen,
 			aggregation: e.NewAggregation(e.opts, e.aggOpts),
 		},
-		resendEnabled: createOpts.resendEnabled,
-		inDirtySet:    true,
+		inDirtySet: true,
 	}
 
 	if len(e.values) == 0 || e.minStartTime > alignedStart {

--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -81,7 +81,6 @@ type timestampNanosFn func(windowStartNanos int64, resolution time.Duration) int
 type createAggregationOptions struct {
 	// initSourceSet determines whether to initialize the source set.
 	initSourceSet bool
-	resendEnabled bool
 }
 
 // IDPrefixSuffixType configs if the id should be added with prefix or suffix
@@ -206,7 +205,7 @@ type consumeState struct {
 	prevStartTime xtime.UnixNano
 	// the dirty bit copied from the lockedAgg.
 	dirty bool
-	// copied from the timedAggregation
+	// the resendEnabled bit copied from the lockedAgg
 	resendEnabled bool
 }
 
@@ -221,6 +220,10 @@ type flushState struct {
 	emittedValues []float64
 	// true if this aggregation has ever been flushed.
 	flushed bool
+	// true if the aggregation was flushed with resendEnabled. this is copied from the lockedAggregation at the time
+	// of flush. this value can change on a lockedAggregation while it's still open, so this only represents the state
+	// at the time of the last flush.
+	latestResendEnabled bool
 }
 
 var isDirty = func(state consumeState) bool {

--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -64,10 +64,11 @@ const (
 )
 
 var (
-	nan                          = math.NaN()
-	errElemClosed                = errors.New("element is closed")
-	errAggregationClosed         = errors.New("aggregation is closed")
-	errDuplicateForwardingSource = errors.New("duplicate forwarding source")
+	nan                                   = math.NaN()
+	errElemClosed                         = errors.New("element is closed")
+	errAggregationClosed                  = errors.New("aggregation is closed")
+	errClosedBeforeResendEnabledMigration = errors.New("aggregation closed before resendEnabled migration")
+	errDuplicateForwardingSource          = errors.New("duplicate forwarding source")
 )
 
 // isEarlierThanFn determines whether the timestamps of the metrics in a given
@@ -239,7 +240,6 @@ func (f *flushState) close() {
 type elemMetrics struct {
 	scope         tally.Scope
 	updatedValues tally.Counter
-	retriedValues tally.Counter
 	flush         map[flushKey]flushMetrics
 	mtx           sync.RWMutex
 }
@@ -367,7 +367,6 @@ func NewElemOptions(aggregatorOpts Options) ElemOptions {
 		aggregationOpts: raggregation.NewOptions(aggregatorOpts.InstrumentOptions()),
 		elemMetrics: &elemMetrics{
 			updatedValues: scope.Counter("updated-values"),
-			retriedValues: scope.Counter("retried-values"),
 			scope:         scope,
 			flush:         make(map[flushKey]flushMetrics),
 		},

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -2909,9 +2909,10 @@ func TestExpireValues(t *testing.T) {
 
 			// Add test values.
 			for _, v := range test.values {
-				_, err := e.findOrCreate(int64(v), createAggregationOptions{
-					resendEnabled: test.resendEnabled,
-				})
+				_, err := e.findOrCreate(int64(v), createAggregationOptions{})
+				// need to manually seed the flush state since we don't call Consume(), which takes care of setting
+				// the flush state for expireValuesWithLock to use.
+				e.flushState[v] = flushState{latestResendEnabled: test.resendEnabled}
 				require.NoError(t, err)
 			}
 
@@ -3118,17 +3119,17 @@ func testGaugeElemWithData(
 	require.NoError(t, e.ResetSetData(data))
 	for i, aligned := range alignedstartAtNanos {
 		gauge := &lockedGaugeAggregation{
-			aggregation: newGaugeAggregation(raggregation.NewGauge(e.aggOpts)),
-			sourcesSeen: make(map[uint32]*bitset.BitSet),
+			aggregation:   newGaugeAggregation(raggregation.NewGauge(e.aggOpts)),
+			sourcesSeen:   make(map[uint32]*bitset.BitSet),
+			resendEnabled: resendEnabled,
 		}
 		gauge.dirty = true
 		// offset the timestamp by 1 so the gauge value can be updated using the aligned timestamp later.
 		gauge.aggregation.Update(time.Unix(0, aligned-1), gaugeVals[i], nil)
 		startAligned := xtime.UnixNano(aligned)
 		e.values[startAligned] = timedGauge{
-			startAt:       startAligned,
-			lockedAgg:     gauge,
-			resendEnabled: resendEnabled,
+			startAt:   startAligned,
+			lockedAgg: gauge,
 		}
 		e.dirty = append(e.dirty, startAligned)
 	}

--- a/src/aggregator/aggregator/entry.go
+++ b/src/aggregator/aggregator/entry.go
@@ -177,6 +177,7 @@ func newForwardedEntryMetrics(scope tally.Scope) forwardedEntryMetrics {
 
 type entryMetrics struct {
 	resendEnabled tally.Counter
+	retriedValues tally.Counter
 	untimed       untimedEntryMetrics
 	timed         timedEntryMetrics
 	forwarded     forwardedEntryMetrics
@@ -191,6 +192,7 @@ func NewEntryMetrics(scope tally.Scope) *entryMetrics {
 	forwardedEntryScope := scope.Tagged(map[string]string{"entry-type": "forwarded"})
 	return &entryMetrics{
 		resendEnabled: scope.Counter("resend-enabled"),
+		retriedValues: scope.Counter("retried-values"),
 		untimed:       newUntimedEntryMetrics(untimedEntryScope),
 		timed:         newTimedEntryMetrics(timedEntryScope),
 		forwarded:     newForwardedEntryMetrics(forwardedEntryScope),
@@ -707,31 +709,51 @@ func (e *Entry) updateStagedMetadatasWithLock(
 	return nil
 }
 
-func (e *Entry) addUntimedWithLock(timestamp time.Time, mu unaggregated.MetricUnion) error {
+func (e *Entry) addUntimedWithLock(serverTimestamp time.Time, mu unaggregated.MetricUnion) error {
 	var err error
 	for i := range e.aggregations {
-		ts := timestamp
-		resendEnabled := e.aggregations[i].resendEnabled
+		multierr.AppendInto(&err, e.addUntimedValueWithLock(
+			e.aggregations[i], serverTimestamp, mu, e.aggregations[i].resendEnabled, false))
+	}
+	return err
+}
+
+// addUntimedValueWithLock adds the untimed value to the aggregationValue.
+// this method handles all the various cases of switching to use a client timestamp if resendEnabled is set for the
+// rollup rule.
+func (e *Entry) addUntimedValueWithLock(
+	aggValue aggregationValue,
+	serverTimestamp time.Time,
+	mu unaggregated.MetricUnion,
+	resendEnabled bool,
+	retry bool) error {
+	elem := aggValue.elem.Value.(metricElem)
+	resolution := aggValue.key.storagePolicy.Resolution().Window
+	if resendEnabled && mu.ClientTimeNanos > 0 {
 		// Migrate an originally untimed metric (server timestamp) to a "timed" metric (client timestamp) if
 		// resendEnabled is set on the rollup rule. Continuing to use untimed allows for a seamless transition since
 		// the Entry does not change.
-		if mu.ClientTimeNanos == 0 {
-			resendEnabled = false
+		e.metrics.resendEnabled.Inc(1)
+		err := e.checkTimestampForMetric(int64(mu.ClientTimeNanos), e.nowFn().UnixNano(), resolution)
+		if err != nil {
+			return err
 		}
-		if resendEnabled {
-			e.metrics.resendEnabled.Inc(1)
-			ts = mu.ClientTimeNanos.ToTime()
-			if multierr.AppendInto(
-				&err,
-				e.checkTimestampForMetric(
-					int64(mu.ClientTimeNanos),
-					e.nowFn().UnixNano(),
-					e.aggregations[i].key.storagePolicy.Resolution().Window),
-			) {
-				continue
-			}
+		err = elem.AddUnion(mu.ClientTimeNanos.ToTime(), mu, true)
+		if xerrors.Is(err, errClosedBeforeResendEnabledMigration) {
+			// this handles a race where the rule was just migrated to resendEnabled. if the client timestamp is
+			// delayed, most likely the aggregation has already been closed, since it did not previously have
+			// resendEnabled set. continue using the serverTimestamp and this will eventually resolve itself for future
+			// aggregations.
+			e.metrics.retriedValues.Inc(1)
+			return e.addUntimedValueWithLock(aggValue, serverTimestamp, mu, false, false)
 		}
-		multierr.AppendInto(&err, e.aggregations[i].elem.Value.(metricElem).AddUnion(ts, mu, resendEnabled))
+		return err
+	}
+	err := elem.AddUnion(serverTimestamp, mu, false)
+	if xerrors.Is(err, errAggregationClosed) && !retry {
+		// the aggregation just closed and we lost the race. roll the value into the next aggregation.
+		e.metrics.retriedValues.Inc(1)
+		return e.addUntimedValueWithLock(aggValue, serverTimestamp.Add(resolution), mu, false, true)
 	}
 	return err
 }

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -47,16 +47,17 @@ type lockedGaugeAggregation struct {
 	sourcesSeen map[uint32]*bitset.BitSet
 	mtx         sync.Mutex
 	dirty       bool
-	closed      bool
+	// resendEnabled is allowed to change while an aggregation is open, so it must be behind the lock.
+	resendEnabled bool
+	closed        bool
 }
 
 type timedGauge struct {
-	lockedAgg     *lockedGaugeAggregation
-	startAt       xtime.UnixNano // start time of an aggregation window
-	prevStart     xtime.UnixNano
-	nextStart     xtime.UnixNano
-	resendEnabled bool
-	inDirtySet    bool
+	lockedAgg  *lockedGaugeAggregation
+	startAt    xtime.UnixNano // start time of an aggregation window
+	prevStart  xtime.UnixNano
+	nextStart  xtime.UnixNano
+	inDirtySet bool
 }
 
 // close is called when the aggregation has been expired or the element is being closed.
@@ -132,9 +133,7 @@ func (e *GaugeElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion, r
 func (e *GaugeElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion, resendEnabled bool, retry bool,
 ) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window)
-	lockedAgg, err := e.findOrCreate(alignedStart.UnixNano(), createAggregationOptions{
-		resendEnabled: resendEnabled,
-	})
+	lockedAgg, err := e.findOrCreate(alignedStart.UnixNano(), createAggregationOptions{})
 	if err != nil {
 		return err
 	}
@@ -152,6 +151,7 @@ func (e *GaugeElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion,
 	}
 	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.dirty = true
+	lockedAgg.resendEnabled = resendEnabled
 	lockedAgg.mtx.Unlock()
 	if retry {
 		e.metrics.retriedValues.Inc(1)
@@ -189,7 +189,6 @@ func (e *GaugeElem) AddUnique(
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{
 		initSourceSet: true,
-		resendEnabled: metadata.ResendEnabled,
 	})
 	if err != nil {
 		return err
@@ -225,6 +224,7 @@ func (e *GaugeElem) AddUnique(
 		}
 	}
 	lockedAgg.dirty = true
+	lockedAgg.resendEnabled = metadata.ResendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
 }
@@ -243,7 +243,8 @@ func (e *GaugeElem) expireValuesWithLock(
 	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
 	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
-		if currAgg.resendEnabled {
+		currFlushState := e.flushState[currAgg.startAt]
+		if currFlushState.latestResendEnabled {
 			// if resend enabled we want to keep this value until it is outside the buffer past period.
 			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break
@@ -448,12 +449,13 @@ func (e *GaugeElem) dirtyToConsumeWithLock(targetNanos int64,
 		val := e.values[dirtyTime]
 		val.inDirtySet = false
 		e.values[dirtyTime] = val
+		cState := e.toConsume[len(e.toConsume)-1]
 
 		// potentially consume the nextAgg as well in case we need to cascade an update to the nextAgg.
 		// this is necessary for binary transformations that rely on the previous aggregation value for calculating the
 		// current aggregation value. if the nextAgg was already flushed, it used an outdated value for the previous
 		// value (this agg). this can only happen when we allow updating previously flushed data (i.e resendEnabled).
-		if agg.resendEnabled {
+		if cState.resendEnabled {
 			nextAgg, ok := e.nextAggWithLock(agg)
 			// only need to add if not already in the dirty set (since it will be added in a subsequent iteration).
 			if ok &&
@@ -486,6 +488,7 @@ func (e *GaugeElem) appendConsumeStateWithLock(
 	// copy the lockedAgg data while holding the lock.
 	agg.lockedAgg.mtx.Lock()
 	cState.dirty = agg.lockedAgg.dirty
+	cState.resendEnabled = agg.lockedAgg.resendEnabled
 	for _, aggType := range e.aggTypes {
 		cState.values = append(cState.values, agg.lockedAgg.aggregation.ValueOf(aggType))
 	}
@@ -501,9 +504,12 @@ func (e *GaugeElem) appendConsumeStateWithLock(
 	} else {
 		cState.prevStartTime = 0
 	}
-	cState.resendEnabled = agg.resendEnabled
 	cState.startAt = agg.startAt
 	toConsume[len(toConsume)-1] = cState
+	// update the flush state with the latestResendEnabled since expireValuesWithLock needs it before actual processing.
+	fState := e.flushState[cState.startAt]
+	fState.latestResendEnabled = cState.resendEnabled
+	e.flushState[cState.startAt] = fState
 
 	if includeFilter != nil && !includeFilter(cState) {
 		// since we eagerly appended, we need to remove if it should not be included.
@@ -635,7 +641,7 @@ func (e *GaugeElem) findOrCreate(
 		return nil, err
 	}
 	// if the aggregation is found and does not need to be updated, return as is.
-	if found.lockedAgg != nil && found.inDirtySet && found.resendEnabled == createOpts.resendEnabled {
+	if found.lockedAgg != nil && found.inDirtySet {
 		return found.lockedAgg, err
 	}
 
@@ -651,10 +657,8 @@ func (e *GaugeElem) findOrCreate(
 		if !timedAgg.inDirtySet {
 			timedAgg.inDirtySet = true
 			e.insertDirty(alignedStart)
+			e.values[alignedStart] = timedAgg
 		}
-		// ensure the resendEnabled state is the latest.
-		timedAgg.resendEnabled = createOpts.resendEnabled
-		e.values[alignedStart] = timedAgg
 		e.Unlock()
 		return timedAgg.lockedAgg, nil
 	}
@@ -678,8 +682,7 @@ func (e *GaugeElem) findOrCreate(
 			sourcesSeen: sourcesSeen,
 			aggregation: e.NewAggregation(e.opts, e.aggOpts),
 		},
-		resendEnabled: createOpts.resendEnabled,
-		inDirtySet:    true,
+		inDirtySet: true,
 	}
 
 	if len(e.values) == 0 || e.minStartTime > alignedStart {

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -127,11 +127,6 @@ func (e *TimerElem) ResetSetData(data ElemData) error {
 
 // AddUnion adds a metric value union at a given timestamp.
 func (e *TimerElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion, resendEnabled bool) error {
-	return e.doAddUnion(timestamp, mu, resendEnabled, false)
-}
-
-func (e *TimerElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion, resendEnabled bool, retry bool,
-) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window)
 	lockedAgg, err := e.findOrCreate(alignedStart.UnixNano(), createAggregationOptions{})
 	if err != nil {
@@ -141,11 +136,10 @@ func (e *TimerElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion,
 	if lockedAgg.closed {
 		// Note: this might have created an entry in the dirty set for lockedAgg when calling findOrCreate, even though
 		// it's already closed. The Consume loop will detect this and clean it up.
+		aggResendEnabled := lockedAgg.resendEnabled
 		lockedAgg.mtx.Unlock()
-		if !resendEnabled && !retry {
-			// handle the edge case where the aggregation was already flushed/closed because the current time is right
-			// at the boundary. just roll the untimed metric into the next aggregation.
-			return e.doAddUnion(alignedStart.Add(e.sp.Resolution().Window), mu, false, true)
+		if !aggResendEnabled && resendEnabled {
+			return errClosedBeforeResendEnabledMigration
 		}
 		return errAggregationClosed
 	}
@@ -153,9 +147,6 @@ func (e *TimerElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion,
 	lockedAgg.dirty = true
 	lockedAgg.resendEnabled = resendEnabled
 	lockedAgg.mtx.Unlock()
-	if retry {
-		e.metrics.retriedValues.Inc(1)
-	}
 	return nil
 }
 
@@ -243,8 +234,7 @@ func (e *TimerElem) expireValuesWithLock(
 	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
 	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
-		currFlushState := e.flushState[currAgg.startAt]
-		if currFlushState.latestResendEnabled {
+		if e.flushState[currAgg.startAt].latestResendEnabled {
 			// if resend enabled we want to keep this value until it is outside the buffer past period.
 			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -47,16 +47,17 @@ type lockedTimerAggregation struct {
 	sourcesSeen map[uint32]*bitset.BitSet
 	mtx         sync.Mutex
 	dirty       bool
-	closed      bool
+	// resendEnabled is allowed to change while an aggregation is open, so it must be behind the lock.
+	resendEnabled bool
+	closed        bool
 }
 
 type timedTimer struct {
-	lockedAgg     *lockedTimerAggregation
-	startAt       xtime.UnixNano // start time of an aggregation window
-	prevStart     xtime.UnixNano
-	nextStart     xtime.UnixNano
-	resendEnabled bool
-	inDirtySet    bool
+	lockedAgg  *lockedTimerAggregation
+	startAt    xtime.UnixNano // start time of an aggregation window
+	prevStart  xtime.UnixNano
+	nextStart  xtime.UnixNano
+	inDirtySet bool
 }
 
 // close is called when the aggregation has been expired or the element is being closed.
@@ -132,9 +133,7 @@ func (e *TimerElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion, r
 func (e *TimerElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion, resendEnabled bool, retry bool,
 ) error {
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window)
-	lockedAgg, err := e.findOrCreate(alignedStart.UnixNano(), createAggregationOptions{
-		resendEnabled: resendEnabled,
-	})
+	lockedAgg, err := e.findOrCreate(alignedStart.UnixNano(), createAggregationOptions{})
 	if err != nil {
 		return err
 	}
@@ -152,6 +151,7 @@ func (e *TimerElem) doAddUnion(timestamp time.Time, mu unaggregated.MetricUnion,
 	}
 	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.dirty = true
+	lockedAgg.resendEnabled = resendEnabled
 	lockedAgg.mtx.Unlock()
 	if retry {
 		e.metrics.retriedValues.Inc(1)
@@ -189,7 +189,6 @@ func (e *TimerElem) AddUnique(
 	alignedStart := timestamp.Truncate(e.sp.Resolution().Window).UnixNano()
 	lockedAgg, err := e.findOrCreate(alignedStart, createAggregationOptions{
 		initSourceSet: true,
-		resendEnabled: metadata.ResendEnabled,
 	})
 	if err != nil {
 		return err
@@ -225,6 +224,7 @@ func (e *TimerElem) AddUnique(
 		}
 	}
 	lockedAgg.dirty = true
+	lockedAgg.resendEnabled = metadata.ResendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
 }
@@ -243,7 +243,8 @@ func (e *TimerElem) expireValuesWithLock(
 	currAgg := e.values[e.minStartTime]
 	resendExpire := targetNanos - int64(e.bufferForPastTimedMetricFn(resolution))
 	for isEarlierThanFn(int64(currAgg.startAt), resolution, targetNanos) {
-		if currAgg.resendEnabled {
+		currFlushState := e.flushState[currAgg.startAt]
+		if currFlushState.latestResendEnabled {
 			// if resend enabled we want to keep this value until it is outside the buffer past period.
 			if !isEarlierThanFn(int64(currAgg.startAt), resolution, resendExpire) {
 				break
@@ -448,12 +449,13 @@ func (e *TimerElem) dirtyToConsumeWithLock(targetNanos int64,
 		val := e.values[dirtyTime]
 		val.inDirtySet = false
 		e.values[dirtyTime] = val
+		cState := e.toConsume[len(e.toConsume)-1]
 
 		// potentially consume the nextAgg as well in case we need to cascade an update to the nextAgg.
 		// this is necessary for binary transformations that rely on the previous aggregation value for calculating the
 		// current aggregation value. if the nextAgg was already flushed, it used an outdated value for the previous
 		// value (this agg). this can only happen when we allow updating previously flushed data (i.e resendEnabled).
-		if agg.resendEnabled {
+		if cState.resendEnabled {
 			nextAgg, ok := e.nextAggWithLock(agg)
 			// only need to add if not already in the dirty set (since it will be added in a subsequent iteration).
 			if ok &&
@@ -486,6 +488,7 @@ func (e *TimerElem) appendConsumeStateWithLock(
 	// copy the lockedAgg data while holding the lock.
 	agg.lockedAgg.mtx.Lock()
 	cState.dirty = agg.lockedAgg.dirty
+	cState.resendEnabled = agg.lockedAgg.resendEnabled
 	for _, aggType := range e.aggTypes {
 		cState.values = append(cState.values, agg.lockedAgg.aggregation.ValueOf(aggType))
 	}
@@ -501,9 +504,12 @@ func (e *TimerElem) appendConsumeStateWithLock(
 	} else {
 		cState.prevStartTime = 0
 	}
-	cState.resendEnabled = agg.resendEnabled
 	cState.startAt = agg.startAt
 	toConsume[len(toConsume)-1] = cState
+	// update the flush state with the latestResendEnabled since expireValuesWithLock needs it before actual processing.
+	fState := e.flushState[cState.startAt]
+	fState.latestResendEnabled = cState.resendEnabled
+	e.flushState[cState.startAt] = fState
 
 	if includeFilter != nil && !includeFilter(cState) {
 		// since we eagerly appended, we need to remove if it should not be included.
@@ -635,7 +641,7 @@ func (e *TimerElem) findOrCreate(
 		return nil, err
 	}
 	// if the aggregation is found and does not need to be updated, return as is.
-	if found.lockedAgg != nil && found.inDirtySet && found.resendEnabled == createOpts.resendEnabled {
+	if found.lockedAgg != nil && found.inDirtySet {
 		return found.lockedAgg, err
 	}
 
@@ -651,10 +657,8 @@ func (e *TimerElem) findOrCreate(
 		if !timedAgg.inDirtySet {
 			timedAgg.inDirtySet = true
 			e.insertDirty(alignedStart)
+			e.values[alignedStart] = timedAgg
 		}
-		// ensure the resendEnabled state is the latest.
-		timedAgg.resendEnabled = createOpts.resendEnabled
-		e.values[alignedStart] = timedAgg
 		e.Unlock()
 		return timedAgg.lockedAgg, nil
 	}
@@ -678,8 +682,7 @@ func (e *TimerElem) findOrCreate(
 			sourcesSeen: sourcesSeen,
 			aggregation: e.NewAggregation(e.opts, e.aggOpts),
 		},
-		resendEnabled: createOpts.resendEnabled,
-		inDirtySet:    true,
+		inDirtySet: true,
 	}
 
 	if len(e.values) == 0 || e.minStartTime > alignedStart {


### PR DESCRIPTION
This fixes a race when a rollup rule is migrated to resendEnabled, which
triggers using the client timestamp instead of the server timestamp.
However, the client timestamp might be targeting an old aggregation that
is already closed. When this happens, just continue using the
serverTimestamp and target an open aggregation.

This also refactors the existing logic of rolling forward to the next
aggregation when an aggregation is closed. Now that we have multiple
cases, it's easier to handle all of this logic at the higher level.

I kept this as separate commits. The first commit refactors the resendEnabled bit onto the lockedAggregation. This seems safer and easier to reason about, since we have multiple actors reading/writing this bit. Writes update the bit and the flusher reads the bit. This made it easier to reason about checking the state of the bit to detect this race.
