### PR TITLE
[query] Partial revert for Add ability to set encoding options for qu…

### DIFF
--- a/src/cmd/services/m3dbnode/config/config_test.go
+++ b/src/cmd/services/m3dbnode/config/config_test.go
@@ -401,8 +401,6 @@ func TestConfiguration(t *testing.T) {
     backgroundHealthCheckFailThrottleFactor: 0.5
     hashing:
       seed: 42
-    encoding:
-      m3tsz: null
     proto: null
     asyncWriteWorkerPoolSize: null
     asyncWriteMaxConcurrency: null

--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -30,7 +30,6 @@ import (
 	"github.com/m3db/m3/src/cmd/services/m3coordinator/downsample"
 	ingestm3msg "github.com/m3db/m3/src/cmd/services/m3coordinator/ingest/m3msg"
 	"github.com/m3db/m3/src/cmd/services/m3coordinator/server/m3msg"
-	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/metrics/aggregation"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
 	"github.com/m3db/m3/src/query/graphite/graphite"
@@ -155,9 +154,6 @@ type Configuration struct {
 
 	// Backend is the backend store for query service.
 	Backend BackendStorageType `yaml:"backend"`
-
-	// Encoding is the encoding configuration options.
-	Encoding client.EncodingConfiguration `yaml:"encoding"`
 
 	// TagOptions is the tag configuration options.
 	TagOptions TagOptionsConfiguration `yaml:"tagOptions"`

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -393,7 +393,7 @@ func Run(runOpts RunOptions) RunResult {
 	}
 
 	var (
-		encodingOpts    = cfg.Encoding.NewEncodingOptions()
+		encodingOpts    = encoding.NewOptions()
 		m3dbClusters    m3.Clusters
 		m3dbPoolWrapper *pools.PoolWrapper
 	)


### PR DESCRIPTION
…ery service

**What this PR does / why we need it**:
Revert https://github.com/m3db/m3/pull/3877 (partial because there were some adjacent changes in that PR).

**Special notes for your reviewer**:
The functionality was replaced with https://github.com/m3db/m3/pull/3914.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE