### PR TITLE
[msg] Do not Close singleton MessageProcessors when closing connections

### DIFF
--- a/src/aggregator/server/m3msg/server.go
+++ b/src/aggregator/server/m3msg/server.go
@@ -50,7 +50,7 @@ func NewServer(
 			logger:     opts.InstrumentOptions().Logger(),
 		}
 	}
-	handler := consumer.NewMessageHandler(newMessageProcessor, opts.ConsumerOptions())
+	handler := consumer.NewMessageHandler(consumer.NewMessageProcessorPool(newMessageProcessor), opts.ConsumerOptions())
 	return xserver.NewServer(address, handler, opts.ServerOptions()), nil
 }
 

--- a/src/aggregator/server/m3msg/server.go
+++ b/src/aggregator/server/m3msg/server.go
@@ -50,7 +50,7 @@ func NewServer(
 			logger:     opts.InstrumentOptions().Logger(),
 		}
 	}
-	handler := consumer.NewMessageHandler(consumer.NewMessageProcessorPool(newMessageProcessor), opts.ConsumerOptions())
+	handler := consumer.NewMessageHandler(consumer.NewMessageProcessorFactory(newMessageProcessor), opts.ConsumerOptions())
 	return xserver.NewServer(address, handler, opts.ServerOptions()), nil
 }
 

--- a/src/msg/consumer/consumer.go
+++ b/src/msg/consumer/consumer.go
@@ -69,7 +69,7 @@ func (l *listener) Accept() (Consumer, error) {
 		return nil, err
 	}
 
-	return newConsumer(conn, l.msgPool, l.opts, l.m, NewNoOpMessageProcessor), nil
+	return newConsumer(conn, l.msgPool, l.opts, l.m, NewNoOpMessageProcessor()), nil
 }
 
 type metrics struct {
@@ -123,7 +123,7 @@ func newConsumer(
 	mPool *messagePool,
 	opts Options,
 	m metrics,
-	newMessageProcessorFn NewMessageProcessorFn,
+	mp MessageProcessor,
 ) *consumer {
 	var (
 		wOpts = xio.ResettableWriterOptions{
@@ -146,7 +146,7 @@ func newConsumer(
 		closed:           false,
 		doneCh:           make(chan struct{}),
 		m:                m,
-		messageProcessor: newMessageProcessorFn(),
+		messageProcessor: mp,
 	}
 }
 
@@ -262,7 +262,6 @@ func (c *consumer) Close() {
 	close(c.doneCh)
 	c.wg.Wait()
 	c.conn.Close()
-	c.messageProcessor.Close()
 }
 
 type message struct {

--- a/src/msg/consumer/handlers.go
+++ b/src/msg/consumer/handlers.go
@@ -31,7 +31,7 @@ import (
 )
 
 type messageHandler struct {
-	opts   Options
+	opts      Options
 	mPool     *messagePool
 	mpFactory MessageProcessorFactory
 	m         metrics

--- a/src/msg/consumer/handlers_test.go
+++ b/src/msg/consumer/handlers_test.go
@@ -141,7 +141,8 @@ func TestServerMessageDifferentConnections(t *testing.T) {
 		return mp2
 	}
 
-	s := server.NewServer("a", NewMessageHandler(NewMessageProcessorFactory(newMessageProcessor), opts), server.NewOptions())
+	s := server.NewServer("a",
+		NewMessageHandler(NewMessageProcessorFactory(newMessageProcessor), opts), server.NewOptions())
 	require.NoError(t, err)
 	require.NoError(t, s.Serve(l))
 

--- a/src/msg/consumer/handlers_test.go
+++ b/src/msg/consumer/handlers_test.go
@@ -42,7 +42,7 @@ func TestServerWithSingletonMessageProcessor(t *testing.T) {
 	var (
 		data []string
 		wg   sync.WaitGroup
-		mu sync.Mutex
+		mu   sync.Mutex
 	)
 
 	ctrl := gomock.NewController(t)
@@ -90,6 +90,7 @@ func TestServerWithSingletonMessageProcessor(t *testing.T) {
 	var ack msgpb.Ack
 	testDecoder := proto.NewDecoder(conn1, opts.DecoderOptions(), 10)
 	err = testDecoder.Decode(&ack)
+	require.NoError(t, err)
 	testDecoder = proto.NewDecoder(conn2, opts.DecoderOptions(), 10)
 	err = testDecoder.Decode(&ack)
 	require.NoError(t, err)
@@ -140,7 +141,7 @@ func TestServerMessageDifferentConnections(t *testing.T) {
 		return mp2
 	}
 
-	s := server.NewServer("a", NewMessageHandler(NewMessageProcessorPool(newMessageProcessor), opts), server.NewOptions())
+	s := server.NewServer("a", NewMessageHandler(NewMessageProcessorFactory(newMessageProcessor), opts), server.NewOptions())
 	require.NoError(t, err)
 	require.NoError(t, s.Serve(l))
 


### PR DESCRIPTION
This fixes a regression that was introduced in https://github.com/m3db/m3/pull/3918

The shared singleton MessageProcessor was being closed when a Connection
was being closed.

Now a Pool interface is introduced. A MessageProcessor is fetched when a
Connection is created and returned when a Connection is closed. It is up
to the pool impl to decide if it should Close the MessageProcessor on
each return or only when the pool is closed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
