### PR TITLE
[aggregator] Add a bounded min-max resend buffer

### DIFF
--- a/src/aggregator/aggregation/resend/resend_buffer.go
+++ b/src/aggregator/aggregation/resend/resend_buffer.go
@@ -1,0 +1,227 @@
+package resend
+
+import (
+	"math"
+	"time"
+
+	"github.com/m3db/m3/src/x/instrument"
+	"github.com/uber-go/tally"
+)
+
+const resendBufferLimit = time.Minute
+
+// ResendBuffer is a fixed-size buffer.
+type ResendBuffer interface {
+	// Insert inserts a value into the buffer.
+	Insert(val float64)
+	// Value returns the value for the buffer.
+	Value() float64
+	// Update updates a given value, if it appears in the buffer.
+	Update(prevVal float64, newVal float64)
+	// Close closes the buffer.
+	Close()
+}
+
+// ResendMetrics are metrics for resend buffers.
+type ResendMetrics struct {
+	count   tally.Counter
+	inserts tally.Counter
+	updates tally.Counter
+
+	updatesPersisted tally.Histogram
+
+	bufferLimit tally.Gauge
+}
+
+type resendBuffer struct {
+	metrics           *ResendMetrics
+	updatesPersisted  float64
+	isBetterCandidate compareFn
+	isWorseCandidate  compareFn
+	list              []float64
+}
+
+// NewMaxResendBufferMetrics builds resend metrics for the max buffer.
+func NewMaxResendBufferMetrics(size int, iOpts instrument.Options) *ResendMetrics {
+	scope := iOpts.MetricsScope().SubScope("resend").
+		Tagged(map[string]string{"type": "max"})
+	return newResendBufferMetrics(size, scope)
+}
+
+// NewMinResendBufferMetrics builds resend metrics for the min buffer.
+func NewMinResendBufferMetrics(size int, iOpts instrument.Options) *ResendMetrics {
+	scope := iOpts.MetricsScope().SubScope("resend").
+		Tagged(map[string]string{"type": "min"})
+	return newResendBufferMetrics(size, scope)
+}
+
+func newResendBufferMetrics(size int, scope tally.Scope) *ResendMetrics {
+	updateBuckets := make(tally.ValueBuckets, 0, size)
+	for i := 1; i <= size; i++ {
+		// Add the bucket with an epsilon; these will always be reported as an
+		// integer count, so adding an epsilon here will ensure we record into the
+		// correct bucket.
+		updateBuckets = append(updateBuckets, float64(i)+0.00001)
+	}
+
+	m := &ResendMetrics{
+		count:   scope.Counter("count"),
+		inserts: scope.Counter("inserted"),
+		updates: scope.Counter("updated"),
+
+		updatesPersisted: scope.Histogram("persisted]", updateBuckets),
+
+		bufferLimit: scope.Gauge("buffer_limit"),
+	}
+
+	// start reporting loop for resending the buffer limit.
+	timer := time.NewTimer(resendBufferLimit)
+	go func() {
+		bufferLimit := float64(size)
+		for {
+			<-timer.C
+			m.bufferLimit.Update(bufferLimit)
+		}
+	}()
+
+	return m
+}
+
+// NewMaxBuffer returns a ResendBuffer that will keep the `size` max elements.
+func NewMaxBuffer(size int, metrics *ResendMetrics) ResendBuffer {
+	return newResendBuffer(size, max, metrics)
+}
+
+// NewMinBuffer returns a ResendBuffer that will keep the `size` max elements.
+func NewMinBuffer(size int, metrics *ResendMetrics) ResendBuffer {
+	return newResendBuffer(size, min, metrics)
+}
+
+func newResendBuffer(
+	size int,
+	compareFn compareFn,
+	metrics *ResendMetrics,
+) ResendBuffer {
+	metrics.count.Inc(1)
+
+	return &resendBuffer{
+		metrics:   metrics,
+		compareFn: compareFn,
+
+		// TODO: pooling.
+		list: make([]float64, 0, size),
+	}
+}
+
+type compareFn func(a, b float64) bool
+
+func min(a, b float64) bool {
+	if math.IsNaN(a) {
+		return false
+	}
+	if math.IsNaN(b) {
+		return true
+	}
+	return a < b
+}
+
+func max(a, b float64) bool {
+	if math.IsNaN(a) {
+		return false
+	}
+	if math.IsNaN(b) {
+		return true
+	}
+	return a > b
+}
+
+func (b *resendBuffer) Insert(val float64) {
+	b.metrics.inserts.Inc(1)
+
+	// if list not full yet, fill it up.
+	if len(b.list) < cap(b.list) {
+		b.list = append(b.list, val)
+		return
+	}
+
+	min := b.list[0]
+	minIdx := -1
+
+	// if the incoming value compares, update at index 0.
+	if val > min {
+		minIdx = 0
+	}
+
+	for idx, elem := range b.list[1:] {
+		// fmt.Println("Elem", elem, "min", min, "compare", b.compareFn(elem, min))
+		if elem < min {
+			min = elem
+			if val > min {
+				minIdx = idx + 1
+			}
+		}
+	}
+
+	if minIdx == -1 {
+		return
+	}
+
+	b.list[minIdx] = val
+}
+
+func (b *resendBuffer) Value() float64 {
+	if len(b.list) == 0 {
+		return math.NaN()
+	}
+
+	toReturn := b.list[0]
+	for _, val := range b.list[1:] {
+		if b.compareFn(val, toReturn) {
+			toReturn = val
+		}
+	}
+
+	return toReturn
+}
+
+func (b *resendBuffer) Update(prevVal float64, newVal float64) {
+	if len(b.list) == 0 {
+		// we've received a resend before recording any values,
+		// which is an invalid case.
+		return
+	}
+
+	b.metrics.updates.Inc(1)
+
+	minVal := b.list[0]
+	minIdx := 0
+
+	for idx, val := range b.list {
+		if val == prevVal {
+			b.list[idx] = newVal
+			b.updatesPersisted++
+			b.metrics.updatesPersisted.RecordValue(b.updatesPersisted)
+			return
+		}
+
+		if minVal > val {
+			minVal = val
+			minIdx = idx
+		}
+	}
+
+	// The value we're updating to is larger than an existing value in the buffer.
+	// Replace the smallest previuosly seen value with the new value.
+	// this is only possible if the buffer is full; otherwise we are trying
+	// to update a value which SHOULD be in the list, which is an invalid case.
+	if len(b.list) == cap(b.list) && minVal < newVal {
+		b.list[minIdx] = newVal
+		b.updatesPersisted++
+		b.metrics.updatesPersisted.RecordValue(b.updatesPersisted)
+	}
+}
+
+func (b *resendBuffer) Close() {
+	b.list = b.list[:0]
+	// TODO: return buffer to pool.
+}

--- a/src/aggregator/aggregation/resend/resend_buffer_test.go
+++ b/src/aggregator/aggregation/resend/resend_buffer_test.go
@@ -1,0 +1,91 @@
+package resend
+
+import (
+	"math"
+	"testing"
+
+	"github.com/m3db/m3/src/x/instrument"
+	"github.com/m3db/m3/src/x/tallytest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+)
+
+func TestMaxResendBuffer(t *testing.T) {
+	var (
+		numToAdd   = 10
+		bufferSize = 4
+
+		scope      = tally.NewTestScope("", nil)
+		iOpts      = instrument.NewOptions().SetMetricsScope(scope)
+		maxMetrics = NewMaxResendBufferMetrics(bufferSize, iOpts)
+		maxBuffer  = NewMaxBuffer(bufferSize, maxMetrics)
+
+		inserted int64
+		updated  int64
+	)
+
+	b := maxBuffer.(*resendBuffer)
+	assert.True(t, math.IsNaN(maxBuffer.Value()))
+
+	// Insert progressively larger values that should update the max each insert.
+	for i := 0; i < numToAdd; i++ {
+		inserted++
+		floatVal := float64(i)
+		maxBuffer.Insert(floatVal)
+		require.Equal(t, floatVal, maxBuffer.Value())
+	}
+
+	// Insert small values that should not affect the max or change the list.
+	currMax := maxBuffer.Value()
+	currBuffer := append([]float64{}, b.list...)
+	for i := 0; i < numToAdd-bufferSize; i++ {
+		inserted++
+		floatVal := float64(i)
+		maxBuffer.Insert(floatVal)
+		require.Equal(t, currMax, maxBuffer.Value())
+		require.Equal(t, currBuffer, b.list)
+	}
+
+	// Resend small values that should not affect the max or change the list.
+	for i := 0; i < numToAdd-bufferSize; i++ {
+		updated++
+		maxBuffer.Update(float64(i), 0)
+		require.Equal(t, currMax, maxBuffer.Value())
+		require.Equal(t, currBuffer, b.list)
+	}
+
+	// Resend large values that appear in the list that should update the max.
+	for i := numToAdd - bufferSize; i < numToAdd; i++ {
+		updated++
+		updatedVal := float64(10 + i)
+		maxBuffer.Update(float64(i), updatedVal)
+		require.Equal(t, updatedVal, maxBuffer.Value())
+	}
+
+	// Capture current largest value.
+	currMax = maxBuffer.Value()
+
+	// Resend  a large value that should not appear in the list.
+	largeVal := float64(100)
+
+	updated++
+	maxBuffer.Update(0, largeVal)
+	require.Equal(t, largeVal, maxBuffer.Value())
+
+	// Update the previously resent large value with a small value to ensure value
+	// is returned to max before the large value came in.
+	updated++
+	maxBuffer.Update(largeVal, 0)
+	require.Equal(t, currMax, maxBuffer.Value())
+
+	maxTags := map[string]string{"type": "max"}
+	tallytest.
+		AssertCounterValue(t, 1, scope.Snapshot(), "resend.count", maxTags)
+	tallytest.
+		AssertCounterValue(t, inserted, scope.Snapshot(), "resend.inserted", maxTags)
+	tallytest.
+		AssertCounterValue(t, updated, scope.Snapshot(), "resend.updated", maxTags)
+
+	maxBuffer.Close()
+}


### PR DESCRIPTION
This adds a resend buffer with a bounded size, that will enable aggregator
resends of Min and Max aggregations.  This will fill up the top bufferSize
elements, then replace it preferentially with better resend values if available.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
