### PR TITLE
[agg] Calculate forwarding lag using expected processing time

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -50,6 +50,7 @@ type lockedCounterAggregation struct {
 	// resendEnabled is allowed to change while an aggregation is open, so it must be behind the lock.
 	resendEnabled bool
 	closed        bool
+	lastUpdatedAt xtime.UnixNano
 }
 
 type timedCounter struct {
@@ -145,6 +146,7 @@ func (e *CounterElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion,
 	}
 	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.resendEnabled = resendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
@@ -164,6 +166,7 @@ func (e *CounterElem) AddValue(timestamp time.Time, value float64, annotation []
 	}
 	lockedAgg.aggregation.Add(timestamp, value, annotation)
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.mtx.Unlock()
 	return nil
 }
@@ -215,6 +218,7 @@ func (e *CounterElem) AddUnique(
 		}
 	}
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.resendEnabled = metadata.ResendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
@@ -478,6 +482,7 @@ func (e *CounterElem) appendConsumeStateWithLock(
 	// copy the lockedAgg data while holding the lock.
 	agg.lockedAgg.mtx.Lock()
 	cState.dirty = agg.lockedAgg.dirty
+	cState.lastUpdatedAt = agg.lockedAgg.lastUpdatedAt
 	cState.resendEnabled = agg.lockedAgg.resendEnabled
 	for _, aggType := range e.aggTypes {
 		cState.values = append(cState.values, agg.lockedAgg.aggregation.ValueOf(aggType))
@@ -728,6 +733,8 @@ func (e *CounterElem) processValue(
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
 		timestamp        = xtime.UnixNano(timestampNanosFn(int64(cState.startAt), resolution))
 		prevTimestamp    = xtime.UnixNano(timestampNanosFn(int64(cState.prevStartTime), resolution))
+		// expectedProcessingTime should be the next resolution window after the aggregation was updated.
+		expectedProcessingTime = cState.lastUpdatedAt.Truncate(resolution).Add(resolution)
 	)
 	fState := e.flushState[cState.startAt]
 	if cState.dirty && fState.flushed && !cState.resendEnabled {
@@ -845,16 +852,15 @@ func (e *CounterElem) processValue(
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timestamp), value, prevValue, cState.annotation, cState.resendEnabled)
 		}
-		// only record lag for the initial flush (not resends)
-		if !fState.flushed {
-			// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
-			// counted towards the processing lag.
-			// forward lag = current time - (agg timestamp + lateness allowed + jitter)
-			flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
-				RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
-			flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
-				RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
-		}
+		// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
+		// counted towards the processing lag.
+		// forward lag = current time - (agg timestamp + lateness allowed + jitter)
+		// use expectedProcessingTime instead of the aggregation timestamp since the aggregation timestamp could be
+		// in the past for updated aggregations (resendEnabled).
+		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
+			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed + jitter)))
+		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
+			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed)))
 	}
 	fState.flushed = true
 	e.flushState[cState.startAt] = fState

--- a/src/aggregator/aggregator/elem_base.go
+++ b/src/aggregator/aggregator/elem_base.go
@@ -204,6 +204,8 @@ type consumeState struct {
 	// the start aligned timestamp of the previous aggregation. used to lookup the consumedValues of the previous
 	// aggregation for binary transformations.
 	prevStartTime xtime.UnixNano
+	// the lastUpdatedAt time copied from the lockedAgg.
+	lastUpdatedAt xtime.UnixNano
 	// the dirty bit copied from the lockedAgg.
 	dirty bool
 	// the resendEnabled bit copied from the lockedAgg

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -50,6 +50,7 @@ type lockedGaugeAggregation struct {
 	// resendEnabled is allowed to change while an aggregation is open, so it must be behind the lock.
 	resendEnabled bool
 	closed        bool
+	lastUpdatedAt xtime.UnixNano
 }
 
 type timedGauge struct {
@@ -145,6 +146,7 @@ func (e *GaugeElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion, r
 	}
 	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.resendEnabled = resendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
@@ -164,6 +166,7 @@ func (e *GaugeElem) AddValue(timestamp time.Time, value float64, annotation []by
 	}
 	lockedAgg.aggregation.Add(timestamp, value, annotation)
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.mtx.Unlock()
 	return nil
 }
@@ -215,6 +218,7 @@ func (e *GaugeElem) AddUnique(
 		}
 	}
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.resendEnabled = metadata.ResendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
@@ -478,6 +482,7 @@ func (e *GaugeElem) appendConsumeStateWithLock(
 	// copy the lockedAgg data while holding the lock.
 	agg.lockedAgg.mtx.Lock()
 	cState.dirty = agg.lockedAgg.dirty
+	cState.lastUpdatedAt = agg.lockedAgg.lastUpdatedAt
 	cState.resendEnabled = agg.lockedAgg.resendEnabled
 	for _, aggType := range e.aggTypes {
 		cState.values = append(cState.values, agg.lockedAgg.aggregation.ValueOf(aggType))
@@ -728,6 +733,8 @@ func (e *GaugeElem) processValue(
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
 		timestamp        = xtime.UnixNano(timestampNanosFn(int64(cState.startAt), resolution))
 		prevTimestamp    = xtime.UnixNano(timestampNanosFn(int64(cState.prevStartTime), resolution))
+		// expectedProcessingTime should be the next resolution window after the aggregation was updated.
+		expectedProcessingTime = cState.lastUpdatedAt.Truncate(resolution).Add(resolution)
 	)
 	fState := e.flushState[cState.startAt]
 	if cState.dirty && fState.flushed && !cState.resendEnabled {
@@ -845,16 +852,15 @@ func (e *GaugeElem) processValue(
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timestamp), value, prevValue, cState.annotation, cState.resendEnabled)
 		}
-		// only record lag for the initial flush (not resends)
-		if !fState.flushed {
-			// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
-			// counted towards the processing lag.
-			// forward lag = current time - (agg timestamp + lateness allowed + jitter)
-			flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
-				RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
-			flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
-				RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
-		}
+		// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
+		// counted towards the processing lag.
+		// forward lag = current time - (agg timestamp + lateness allowed + jitter)
+		// use expectedProcessingTime instead of the aggregation timestamp since the aggregation timestamp could be
+		// in the past for updated aggregations (resendEnabled).
+		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
+			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed + jitter)))
+		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
+			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed)))
 	}
 	fState.flushed = true
 	e.flushState[cState.startAt] = fState

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -50,6 +50,7 @@ type lockedTimerAggregation struct {
 	// resendEnabled is allowed to change while an aggregation is open, so it must be behind the lock.
 	resendEnabled bool
 	closed        bool
+	lastUpdatedAt xtime.UnixNano
 }
 
 type timedTimer struct {
@@ -145,6 +146,7 @@ func (e *TimerElem) AddUnion(timestamp time.Time, mu unaggregated.MetricUnion, r
 	}
 	lockedAgg.aggregation.AddUnion(timestamp, mu)
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.resendEnabled = resendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
@@ -164,6 +166,7 @@ func (e *TimerElem) AddValue(timestamp time.Time, value float64, annotation []by
 	}
 	lockedAgg.aggregation.Add(timestamp, value, annotation)
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.mtx.Unlock()
 	return nil
 }
@@ -215,6 +218,7 @@ func (e *TimerElem) AddUnique(
 		}
 	}
 	lockedAgg.dirty = true
+	lockedAgg.lastUpdatedAt = xtime.Now()
 	lockedAgg.resendEnabled = metadata.ResendEnabled
 	lockedAgg.mtx.Unlock()
 	return nil
@@ -478,6 +482,7 @@ func (e *TimerElem) appendConsumeStateWithLock(
 	// copy the lockedAgg data while holding the lock.
 	agg.lockedAgg.mtx.Lock()
 	cState.dirty = agg.lockedAgg.dirty
+	cState.lastUpdatedAt = agg.lockedAgg.lastUpdatedAt
 	cState.resendEnabled = agg.lockedAgg.resendEnabled
 	for _, aggType := range e.aggTypes {
 		cState.values = append(cState.values, agg.lockedAgg.aggregation.ValueOf(aggType))
@@ -728,6 +733,8 @@ func (e *TimerElem) processValue(
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
 		timestamp        = xtime.UnixNano(timestampNanosFn(int64(cState.startAt), resolution))
 		prevTimestamp    = xtime.UnixNano(timestampNanosFn(int64(cState.prevStartTime), resolution))
+		// expectedProcessingTime should be the next resolution window after the aggregation was updated.
+		expectedProcessingTime = cState.lastUpdatedAt.Truncate(resolution).Add(resolution)
 	)
 	fState := e.flushState[cState.startAt]
 	if cState.dirty && fState.flushed && !cState.resendEnabled {
@@ -845,16 +852,15 @@ func (e *TimerElem) processValue(
 			flushForwardedFn(e.writeForwardedMetricFn, forwardedAggregationKey,
 				int64(timestamp), value, prevValue, cState.annotation, cState.resendEnabled)
 		}
-		// only record lag for the initial flush (not resends)
-		if !fState.flushed {
-			// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
-			// counted towards the processing lag.
-			// forward lag = current time - (agg timestamp + lateness allowed + jitter)
-			flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
-				RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed + jitter)))
-			flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
-				RecordDuration(time.Since(timestamp.ToTime().Add(latenessAllowed)))
-		}
+		// add latenessAllowed and jitter to the timestamp of the aggregation, since those should not be
+		// counted towards the processing lag.
+		// forward lag = current time - (agg timestamp + lateness allowed + jitter)
+		// use expectedProcessingTime instead of the aggregation timestamp since the aggregation timestamp could be
+		// in the past for updated aggregations (resendEnabled).
+		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
+			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed + jitter)))
+		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
+			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed)))
 	}
 	fState.flushed = true
 	e.flushState[cState.startAt] = fState


### PR DESCRIPTION
Previously the timestamp of the aggregation was used to calculate the
forwaridng lag. This could be misleading for late metrics updating
resendEnabled aggregations, since they are in the past.

Now the lastUpdatedAt time is used. The lastUpdatedAt is used to
calculate the expectedProcessingTime as the next resolution window after
the lastUpdatedAt.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
