### PR TITLE
[coordinator] Add mapping for Open Metrics types

### DIFF
--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -171,7 +171,7 @@ func seriesAttributesForOpenMetricsSource(series prompb.TimeSeries) (ts.SeriesAt
 		handleValueResets bool
 	)
 
-	// nolint: lll https://github.com/OpenObservability/OpenMetrics/blob/2bd6413e040513afa1bfb8f56dd12db8262e18d9/specification/OpenMetrics.md
+	// https://github.com/OpenObservability/OpenMetrics/blob/2bd6413e040/specification/OpenMetrics.md
 	switch series.Type {
 	case prompb.MetricType_UNKNOWN:
 		promMetricType = ts.PromMetricTypeUnknown

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -125,7 +125,8 @@ func seriesAttributesForPrometheusSource(series prompb.TimeSeries) (ts.SeriesAtt
 	case prompb.MetricType_GAUGE_HISTOGRAM:
 		promMetricType = ts.PromMetricTypeGaugeHistogram
 		name := metricNameFromLabels(series.Labels)
-		handleValueResets = bytes.HasSuffix(name, promCountSuffix)
+		handleValueResets = bytes.HasSuffix(name, promCountSuffix) ||
+			bytes.HasSuffix(name, openMetricsGaugeCountSuffix)
 
 	case prompb.MetricType_SUMMARY:
 		promMetricType = ts.PromMetricTypeSummary

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -42,9 +42,18 @@ var (
 	promDefaultBucketName = []byte(model.BucketLabel)     // le
 
 	// The suffix of count metric name in Prometheus histogram/summary metric families.
-	promDefaultCountSuffix = []byte("_count")
+	promCountSuffix = []byte("_count")
 	// The suffix of sum metric name in Prometheus histogram/summary metric families.
-	promDefaultSumSuffix = []byte("_sum")
+	promSumSuffix = []byte("_sum")
+
+	// The suffix of gauge count metric name in Open Metrics GaugeHistogram metric families.
+	openMetricsGaugeCountSuffix = []byte("_gcount")
+	// The suffix of count metric name in Open Metrics Summary metric families.
+	openMetricsCountSuffix = []byte("_count")
+	// The suffix of count metric name in Open Metrics Summary metric families.
+	openMetricsSumSuffix = []byte("_sum")
+	// The suffix of created metric name in Open Metrics Counter/Histogram/Summary metric families.
+	openMetricsCreatedSuffix = []byte("_created")
 )
 
 // PromLabelsToM3Tags converts Prometheus labels to M3 tags
@@ -76,25 +85,29 @@ func PromLabelsToM3Tags(
 // PromTimeSeriesToSeriesAttributes extracts the series info from a prometheus
 // timeseries.
 func PromTimeSeriesToSeriesAttributes(series prompb.TimeSeries) (ts.SeriesAttributes, error) {
+	switch series.Source {
+	case prompb.Source_PROMETHEUS:
+		return seriesAttributesForPrometheusSource(series)
+
+	case prompb.Source_OPEN_METRICS:
+		return seriesAttributesForOpenMetricsSource(series)
+
+	case prompb.Source_GRAPHITE:
+		return seriesAttributesForGraphiteSource(series)
+
+	default:
+		return ts.SeriesAttributes{}, fmt.Errorf("invalid source type %s", series.Source)
+	}
+}
+
+func seriesAttributesForPrometheusSource(series prompb.TimeSeries) (ts.SeriesAttributes, error) {
 	var (
-		sourceType        ts.SourceType
 		m3MetricType      ts.M3MetricType
 		promMetricType    ts.PromMetricType
 		handleValueResets bool
 	)
 
-	switch series.Source {
-	// TODO(linasm): implement internal support for OPEN_METRICS
-	case prompb.Source_PROMETHEUS, prompb.Source_OPEN_METRICS:
-		sourceType = ts.SourceTypePrometheus
-	case prompb.Source_GRAPHITE:
-		sourceType = ts.SourceTypeGraphite
-	default:
-		return ts.SeriesAttributes{}, fmt.Errorf("invalid source type %v", series.Source)
-	}
-
 	switch series.Type {
-
 	case prompb.MetricType_UNKNOWN:
 		promMetricType = ts.PromMetricTypeUnknown
 
@@ -112,13 +125,13 @@ func PromTimeSeriesToSeriesAttributes(series prompb.TimeSeries) (ts.SeriesAttrib
 	case prompb.MetricType_GAUGE_HISTOGRAM:
 		promMetricType = ts.PromMetricTypeGaugeHistogram
 		name := metricNameFromLabels(series.Labels)
-		handleValueResets = bytes.HasSuffix(name, promDefaultCountSuffix)
+		handleValueResets = bytes.HasSuffix(name, promCountSuffix)
 
 	case prompb.MetricType_SUMMARY:
 		promMetricType = ts.PromMetricTypeSummary
 		name := metricNameFromLabels(series.Labels)
-		handleValueResets = bytes.HasSuffix(name, promDefaultCountSuffix) ||
-			bytes.HasSuffix(name, promDefaultSumSuffix)
+		handleValueResets = bytes.HasSuffix(name, promCountSuffix) ||
+			bytes.HasSuffix(name, promSumSuffix)
 
 	case prompb.MetricType_INFO:
 		promMetricType = ts.PromMetricTypeInfo
@@ -127,31 +140,110 @@ func PromTimeSeriesToSeriesAttributes(series prompb.TimeSeries) (ts.SeriesAttrib
 		promMetricType = ts.PromMetricTypeStateSet
 
 	default:
-		return ts.SeriesAttributes{}, fmt.Errorf("invalid Prometheus metric type %v", series.Type)
+		return ts.SeriesAttributes{}, fmt.Errorf("invalid metric type for Prometheus: %s", series.Type)
 	}
 
 	switch series.M3Type {
 	case prompb.M3Type_M3_COUNTER:
 		m3MetricType = ts.M3MetricTypeCounter
-		if promMetricType == ts.PromMetricTypeUnknown && series.Source == prompb.Source_GRAPHITE {
-			promMetricType = ts.PromMetricTypeCounter
-		}
+
 	case prompb.M3Type_M3_GAUGE:
 		m3MetricType = ts.M3MetricTypeGauge
-		if promMetricType == ts.PromMetricTypeUnknown && series.Source == prompb.Source_GRAPHITE {
-			promMetricType = ts.PromMetricTypeGauge
-		}
+
 	case prompb.M3Type_M3_TIMER:
 		m3MetricType = ts.M3MetricTypeTimer
+
 	default:
-		return ts.SeriesAttributes{}, fmt.Errorf("invalid M3 metric type %v", series.M3Type)
+		return ts.SeriesAttributes{}, fmt.Errorf("invalid M3 metric type: %s", series.M3Type)
 	}
 
 	return ts.SeriesAttributes{
+		Source:            ts.SourceTypePrometheus,
 		M3Type:            m3MetricType,
 		PromType:          promMetricType,
-		Source:            sourceType,
 		HandleValueResets: handleValueResets,
+	}, nil
+}
+
+func seriesAttributesForOpenMetricsSource(series prompb.TimeSeries) (ts.SeriesAttributes, error) {
+	var (
+		promMetricType    ts.PromMetricType
+		handleValueResets bool
+	)
+
+	// https://github.com/OpenObservability/OpenMetrics/blob/2bd6413e040513afa1bfb8f56dd12db8262e18d9/specification/OpenMetrics.md
+	switch series.Type {
+	case prompb.MetricType_UNKNOWN:
+		promMetricType = ts.PromMetricTypeUnknown
+
+	case prompb.MetricType_COUNTER:
+		promMetricType = ts.PromMetricTypeCounter
+		name := metricNameFromLabels(series.Labels)
+		handleValueResets = !bytes.HasSuffix(name, openMetricsCreatedSuffix)
+
+	case prompb.MetricType_GAUGE:
+		promMetricType = ts.PromMetricTypeGauge
+
+	case prompb.MetricType_HISTOGRAM:
+		promMetricType = ts.PromMetricTypeHistogram
+		name := metricNameFromLabels(series.Labels)
+		handleValueResets = !bytes.HasSuffix(name, openMetricsCreatedSuffix)
+
+	case prompb.MetricType_GAUGE_HISTOGRAM:
+		promMetricType = ts.PromMetricTypeGaugeHistogram
+		name := metricNameFromLabels(series.Labels)
+		handleValueResets = bytes.HasSuffix(name, openMetricsGaugeCountSuffix)
+
+	case prompb.MetricType_SUMMARY:
+		promMetricType = ts.PromMetricTypeSummary
+		name := metricNameFromLabels(series.Labels)
+		handleValueResets = bytes.HasSuffix(name, openMetricsCountSuffix) ||
+			bytes.HasSuffix(name, openMetricsSumSuffix)
+
+	case prompb.MetricType_INFO:
+		promMetricType = ts.PromMetricTypeInfo
+
+	case prompb.MetricType_STATESET:
+		promMetricType = ts.PromMetricTypeStateSet
+
+	default:
+		return ts.SeriesAttributes{}, fmt.Errorf("invalid metric type for Open Metrics: %s", series.Type)
+	}
+
+	return ts.SeriesAttributes{
+		Source:            ts.SourceTypeOpenMetrics,
+		PromType:          promMetricType,
+		HandleValueResets: handleValueResets,
+	}, nil
+}
+
+func seriesAttributesForGraphiteSource(series prompb.TimeSeries) (ts.SeriesAttributes, error) {
+	var (
+		m3MetricType   ts.M3MetricType
+		promMetricType ts.PromMetricType
+	)
+
+	switch series.M3Type {
+	case prompb.M3Type_M3_COUNTER:
+		m3MetricType = ts.M3MetricTypeCounter
+		promMetricType = ts.PromMetricTypeCounter
+
+	case prompb.M3Type_M3_GAUGE:
+		m3MetricType = ts.M3MetricTypeGauge
+		promMetricType = ts.PromMetricTypeGauge
+
+	case prompb.M3Type_M3_TIMER:
+		m3MetricType = ts.M3MetricTypeTimer
+
+	default:
+		return ts.SeriesAttributes{}, fmt.Errorf("invalid M3 metric type for graphite: %s", series.M3Type)
+	}
+
+	return ts.SeriesAttributes{
+		Source:            ts.SourceTypeGraphite,
+		M3Type:            m3MetricType,
+		PromType:          promMetricType,
+		HandleValueResets: false,
 	}, nil
 }
 

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -171,7 +171,7 @@ func seriesAttributesForOpenMetricsSource(series prompb.TimeSeries) (ts.SeriesAt
 		handleValueResets bool
 	)
 
-	// https://github.com/OpenObservability/OpenMetrics/blob/2bd6413e040513afa1bfb8f56dd12db8262e18d9/specification/OpenMetrics.md
+	// https://github.com/OpenObservability/OpenMetrics/blob/2bd6413e040513afa1bfb8f56dd12db8262e18d9/specification/OpenMetrics.md nolint: lll
 	switch series.Type {
 	case prompb.MetricType_UNKNOWN:
 		promMetricType = ts.PromMetricTypeUnknown

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -171,7 +171,7 @@ func seriesAttributesForOpenMetricsSource(series prompb.TimeSeries) (ts.SeriesAt
 		handleValueResets bool
 	)
 
-	// https://github.com/OpenObservability/OpenMetrics/blob/2bd6413e040513afa1bfb8f56dd12db8262e18d9/specification/OpenMetrics.md nolint: lll
+	// nolint: lll https://github.com/OpenObservability/OpenMetrics/blob/2bd6413e040513afa1bfb8f56dd12db8262e18d9/specification/OpenMetrics.md
 	switch series.Type {
 	case prompb.MetricType_UNKNOWN:
 		promMetricType = ts.PromMetricTypeUnknown

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -313,7 +313,7 @@ func TestPromTimeSeriesToSeriesAttributesPromMetricsTypeFromPrometheus(t *testin
 
 		{prompb.MetricType_GAUGE_HISTOGRAM, "bucket"}: {metricType: ts.PromMetricTypeGaugeHistogram},
 		{prompb.MetricType_GAUGE_HISTOGRAM, "count"}:  {metricType: ts.PromMetricTypeGaugeHistogram, handleValueResets: true},
-		{prompb.MetricType_GAUGE_HISTOGRAM, "gcount"}:  {metricType: ts.PromMetricTypeGaugeHistogram, handleValueResets: true},
+		{prompb.MetricType_GAUGE_HISTOGRAM, "gcount"}: {metricType: ts.PromMetricTypeGaugeHistogram, handleValueResets: true},
 		{prompb.MetricType_GAUGE_HISTOGRAM, "sum"}:    {metricType: ts.PromMetricTypeGaugeHistogram},
 
 		{metricType: prompb.MetricType_SUMMARY}: {metricType: ts.PromMetricTypeSummary},
@@ -354,7 +354,15 @@ func TestPromTimeSeriesToSeriesAttributesPromMetricsTypeFromPrometheus(t *testin
 	require.Error(t, err)
 }
 
-func TestPromTimeSeriesToSeriesAttributesM3Type(t *testing.T) {
+func TestPromTimeSeriesToSeriesAttributesM3TypeFromPrometheus(t *testing.T) {
+	testPromTimeSeriesToSeriesAttributesM3Type(t, prompb.Source_PROMETHEUS)
+}
+
+func TestPromTimeSeriesToSeriesAttributesM3TypeFromOpenMetrics(t *testing.T) {
+	testPromTimeSeriesToSeriesAttributesM3Type(t, prompb.Source_OPEN_METRICS)
+}
+
+func testPromTimeSeriesToSeriesAttributesM3Type(t *testing.T, source prompb.Source) {
 	mapping := map[prompb.M3Type]ts.M3MetricType{
 		prompb.M3Type_M3_GAUGE:   ts.M3MetricTypeGauge,
 		prompb.M3Type_M3_COUNTER: ts.M3MetricTypeCounter,
@@ -363,16 +371,15 @@ func TestPromTimeSeriesToSeriesAttributesM3Type(t *testing.T) {
 
 	for proto, expected := range mapping {
 		attrs, err := PromTimeSeriesToSeriesAttributes(prompb.TimeSeries{
-			Source: prompb.Source_PROMETHEUS,
+			Source: source,
 			M3Type: proto,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, expected, attrs.M3Type)
-		assert.Equal(t, ts.SourceTypePrometheus, attrs.Source)
 	}
 
 	_, err := PromTimeSeriesToSeriesAttributes(prompb.TimeSeries{
-		Source: prompb.Source_PROMETHEUS,
+		Source: source,
 		M3Type: -1,
 	})
 	require.Error(t, err)

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -320,7 +320,7 @@ func TestPromTimeSeriesToSeriesAttributesPromMetricsTypeFromPrometheus(t *testin
 		{prompb.MetricType_SUMMARY, "sum"}:      {metricType: ts.PromMetricTypeSummary, handleValueResets: true},
 	}
 
-	for proto, expected := range mapping {
+	for proto, expected := range mapping { // nolint: dupl
 		var (
 			name     = fmt.Sprintf("Prometheus type: %s, name suffix: '%s'", proto.metricType, proto.nameSuffix)
 			proto    = proto
@@ -402,7 +402,7 @@ func TestPromTimeSeriesToSeriesAttributesMetricsTypeFromOpenMetrics(t *testing.T
 		{prompb.MetricType_SUMMARY, "created"}: {metricType: ts.PromMetricTypeSummary},
 	}
 
-	for proto, expected := range mapping {
+	for proto, expected := range mapping { // nolint: dupl
 		var (
 			name     = fmt.Sprintf("Open Metrics type: %s, name suffix: '%s'", proto.metricType, proto.nameSuffix)
 			proto    = proto

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -397,10 +397,10 @@ func TestPromTimeSeriesToSeriesAttributesMetricsTypeFromOpenMetrics(t *testing.T
 		{prompb.MetricType_GAUGE_HISTOGRAM, "gcount"}: {metricType: ts.PromMetricTypeGaugeHistogram, handleValueResets: true},
 		{prompb.MetricType_GAUGE_HISTOGRAM, "gsum"}:   {metricType: ts.PromMetricTypeGaugeHistogram},
 
-                {prompb.MetricType_SUMMARY}:            {metricType: ts.PromMetricTypeSummary},
-		{prompb.MetricType_SUMMARY, "count"}:   {metricType: ts.PromMetricTypeSummary, handleValueResets: true},
-		{prompb.MetricType_SUMMARY, "sum"}:     {metricType: ts.PromMetricTypeSummary, handleValueResets: true},
-		{prompb.MetricType_SUMMARY, "created"}: {metricType: ts.PromMetricTypeSummary},
+		{metricType: prompb.MetricType_SUMMARY}: {metricType: ts.PromMetricTypeSummary},
+		{prompb.MetricType_SUMMARY, "count"}:    {metricType: ts.PromMetricTypeSummary, handleValueResets: true},
+		{prompb.MetricType_SUMMARY, "sum"}:      {metricType: ts.PromMetricTypeSummary, handleValueResets: true},
+		{prompb.MetricType_SUMMARY, "created"}:  {metricType: ts.PromMetricTypeSummary},
 	}
 
 	for proto, expected := range mapping { // nolint: dupl

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -313,6 +313,7 @@ func TestPromTimeSeriesToSeriesAttributesPromMetricsTypeFromPrometheus(t *testin
 
 		{prompb.MetricType_GAUGE_HISTOGRAM, "bucket"}: {metricType: ts.PromMetricTypeGaugeHistogram},
 		{prompb.MetricType_GAUGE_HISTOGRAM, "count"}:  {metricType: ts.PromMetricTypeGaugeHistogram, handleValueResets: true},
+		{prompb.MetricType_GAUGE_HISTOGRAM, "gcount"}:  {metricType: ts.PromMetricTypeGaugeHistogram, handleValueResets: true},
 		{prompb.MetricType_GAUGE_HISTOGRAM, "sum"}:    {metricType: ts.PromMetricTypeGaugeHistogram},
 
 		{metricType: prompb.MetricType_SUMMARY}: {metricType: ts.PromMetricTypeSummary},

--- a/src/query/storage/converter_test.go
+++ b/src/query/storage/converter_test.go
@@ -397,6 +397,7 @@ func TestPromTimeSeriesToSeriesAttributesMetricsTypeFromOpenMetrics(t *testing.T
 		{prompb.MetricType_GAUGE_HISTOGRAM, "gcount"}: {metricType: ts.PromMetricTypeGaugeHistogram, handleValueResets: true},
 		{prompb.MetricType_GAUGE_HISTOGRAM, "gsum"}:   {metricType: ts.PromMetricTypeGaugeHistogram},
 
+                {prompb.MetricType_SUMMARY}:            {metricType: ts.PromMetricTypeSummary},
 		{prompb.MetricType_SUMMARY, "count"}:   {metricType: ts.PromMetricTypeSummary, handleValueResets: true},
 		{prompb.MetricType_SUMMARY, "sum"}:     {metricType: ts.PromMetricTypeSummary, handleValueResets: true},
 		{prompb.MetricType_SUMMARY, "created"}: {metricType: ts.PromMetricTypeSummary},

--- a/src/query/ts/metadata.go
+++ b/src/query/ts/metadata.go
@@ -74,6 +74,9 @@ const (
 
 	// SourceTypeGraphite is the graphite source type.
 	SourceTypeGraphite
+
+	// SourceTypeOpenMetrics is the Open Metrics source type.
+	SourceTypeOpenMetrics
 )
 
 // SeriesAttributes has attributes about the time series.


### PR DESCRIPTION
**What this PR does / why we need it**:
Open Metrics metric family types are mapped to the same internal enum as Prometheus metric family types, but the logics of what is a cumulative counter depending on a metric name suffix differs.

**Special notes for your reviewer**:
Was trying to follow https://github.com/OpenObservability/OpenMetrics/blob/2bd6413e040513afa1bfb8f56dd12db8262e18d9/specification/OpenMetrics.md#metric-types.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE