### PR TITLE
[instrument] Optionally log build info to stdout

### DIFF
--- a/src/x/instrument/build.go
+++ b/src/x/instrument/build.go
@@ -23,6 +23,7 @@ package instrument
 import (
 	"errors"
 	"log"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -52,6 +53,12 @@ var (
 	// set to a non-empty string, we log the build information at process startup.
 	LogBuildInfoAtStartup string
 
+	// LogBuildInfoToStdout controls whether we log build information to stdout or stderr.
+	// If it is set to a non-empty string then the build info will be logged to stdout,
+	// otherwise it will be logged to stderr (assuming LogBuildInfoAtStartup is also
+	// non-empty).
+	LogBuildInfoToStdout string
+
 	// goVersion is the current runtime version.
 	goVersion = runtime.Version()
 
@@ -68,19 +75,28 @@ var (
 	errBuildTimeNegative = errors.New("reporter build time must be non-negative")
 )
 
-// LogBuildInfo logs the build information to the provided logger.
+// LogBuildInfo logs the build information using the default logger.
 func LogBuildInfo() {
-	log.Printf("Go Runtime version: %s\n", goVersion)
-	log.Printf("Build Version:      %s\n", Version)
-	log.Printf("Build Revision:     %s\n", Revision)
-	log.Printf("Build Branch:       %s\n", Branch)
-	log.Printf("Build Date:         %s\n", BuildDate)
-	log.Printf("Build TimeUnix:     %s\n", BuildTimeUnix)
+	LogBuildInfoWithLogger(log.Default())
+}
+
+// LogBuildInfoWithLogger logs the build information using the provided logger.
+func LogBuildInfoWithLogger(logger *log.Logger) {
+	logger.Printf("Go Runtime version: %s\n", goVersion)
+	logger.Printf("Build Version:      %s\n", Version)
+	logger.Printf("Build Revision:     %s\n", Revision)
+	logger.Printf("Build Branch:       %s\n", Branch)
+	logger.Printf("Build Date:         %s\n", BuildDate)
+	logger.Printf("Build TimeUnix:     %s\n", BuildTimeUnix)
 }
 
 func init() {
 	if LogBuildInfoAtStartup != "" {
-		LogBuildInfo()
+		logger := log.Default()
+		if LogBuildInfoToStdout != "" {
+			logger = log.New(os.Stdout, "", log.LstdFlags)
+		}
+		LogBuildInfoWithLogger(logger)
 	}
 }
 


### PR DESCRIPTION
This commit updates the `instrument` package to be able to log the build info to stdout instead of stderr. GKE logs written to stdout are classified as `INFO` logs in Google Cloud Logging whereas logs written to `stderr` are classified as `ERROR` logs so build info logs are currently classified as `ERROR` logs which doesn't feel appropriate.
