### PR TITLE
[integrations] Add writeRequest API to coordinator client

### DIFF
--- a/src/integration/resources/coordinator_client.go
+++ b/src/integration/resources/coordinator_client.go
@@ -611,10 +611,7 @@ func (c *CoordinatorClient) WritePromWithLabels(
 	samples []prompb.Sample,
 	headers Headers,
 ) error {
-	var (
-		url       = c.makeURL("api/v1/prom/remote/write")
-		reqLabels = []prompb.Label{{Name: []byte(model.MetricNameLabel), Value: []byte(name)}}
-	)
+	reqLabels := []prompb.Label{{Name: []byte(model.MetricNameLabel), Value: []byte(name)}}
 	reqLabels = append(reqLabels, labels...)
 
 	writeRequest := prompb.WriteRequest{
@@ -625,6 +622,12 @@ func (c *CoordinatorClient) WritePromWithLabels(
 			},
 		},
 	}
+
+	return c.WritePromWithRequest(writeRequest, headers)
+}
+
+func (c *CoordinatorClient) WritePromWithRequest(writeRequest prompb.WriteRequest, headers Headers) error {
+	url := c.makeURL("api/v1/prom/remote/write")
 
 	logger := c.logger.With(
 		ZapMethod("writeProm"), zap.String("url", url),

--- a/src/integration/resources/docker/coordinator.go
+++ b/src/integration/resources/docker/coordinator.go
@@ -219,19 +219,6 @@ func (c *coordinator) WriteProm(
 	return c.client.WriteProm(name, tags, samples, headers)
 }
 
-func (c *coordinator) WritePromWithLabels(
-	name string,
-	labels []prompb.Label,
-	samples []prompb.Sample,
-	headers resources.Headers,
-) error {
-	if c.resource.closed {
-		return errClosed
-	}
-
-	return c.client.WritePromWithLabels(name, labels, samples, headers)
-}
-
 func (c *coordinator) WritePromWithRequest(
 	writeRequest prompb.WriteRequest,
 	headers resources.Headers,

--- a/src/integration/resources/docker/coordinator.go
+++ b/src/integration/resources/docker/coordinator.go
@@ -232,6 +232,17 @@ func (c *coordinator) WritePromWithLabels(
 	return c.client.WritePromWithLabels(name, labels, samples, headers)
 }
 
+func (c *coordinator) WritePromWithRequest(
+	writeRequest prompb.WriteRequest,
+	headers resources.Headers,
+) error {
+	if c.resource.closed {
+		return errClosed
+	}
+
+	return c.client.WritePromWithRequest(writeRequest, headers)
+}
+
 func (c *coordinator) ApplyKVUpdate(update string) error {
 	if c.resource.closed {
 		return errClosed

--- a/src/integration/resources/inprocess/coordinator.go
+++ b/src/integration/resources/inprocess/coordinator.go
@@ -420,17 +420,6 @@ func (c *Coordinator) WriteProm(
 	return c.client.WriteProm(name, tags, samples, headers)
 }
 
-// WritePromWithLabels writes a prometheus metric. Allows you to provide the labels for
-// the write directly instead of conveniently converting them from a map.
-func (c *Coordinator) WritePromWithLabels(
-	name string,
-	labels []prompb.Label,
-	samples []prompb.Sample,
-	headers resources.Headers,
-) error {
-	return c.client.WritePromWithLabels(name, labels, samples, headers)
-}
-
 func (c *Coordinator) WritePromWithRequest(writeRequest prompb.WriteRequest, headers resources.Headers) error {
 	return c.client.WritePromWithRequest(writeRequest, headers)
 }

--- a/src/integration/resources/inprocess/coordinator.go
+++ b/src/integration/resources/inprocess/coordinator.go
@@ -420,6 +420,8 @@ func (c *Coordinator) WriteProm(
 	return c.client.WriteProm(name, tags, samples, headers)
 }
 
+// WritePromWithRequest executes a prometheus write request. Allows you to
+// provide the request directly which is useful for batch metric requests.
 func (c *Coordinator) WritePromWithRequest(writeRequest prompb.WriteRequest, headers resources.Headers) error {
 	return c.client.WritePromWithRequest(writeRequest, headers)
 }

--- a/src/integration/resources/inprocess/coordinator.go
+++ b/src/integration/resources/inprocess/coordinator.go
@@ -431,6 +431,10 @@ func (c *Coordinator) WritePromWithLabels(
 	return c.client.WritePromWithLabels(name, labels, samples, headers)
 }
 
+func (c *Coordinator) WritePromWithRequest(writeRequest prompb.WriteRequest, headers resources.Headers) error {
+	return c.client.WritePromWithRequest(writeRequest, headers)
+}
+
 // RunQuery runs the given query with a given verification function.
 func (c *Coordinator) RunQuery(
 	verifier resources.ResponseVerifier,

--- a/src/integration/resources/types.go
+++ b/src/integration/resources/types.go
@@ -63,9 +63,6 @@ type Coordinator interface {
 	WriteCarbon(port int, metric string, v float64, t time.Time) error
 	// WriteProm writes a prometheus metric. Takes tags/labels as a map for convenience.
 	WriteProm(name string, tags map[string]string, samples []prompb.Sample, headers Headers) error
-	// WritePromWithLabels writes a prometheus metric. Allows you to provide the labels for
-	// the write directly instead of conveniently converting them from a map.
-	WritePromWithLabels(name string, labels []prompb.Label, samples []prompb.Sample, headers Headers) error
 	// WritePromWithRequest executes a prometheus write request. Allows you to
 	// provide the request directly which is useful for batch metric requests.
 	WritePromWithRequest(writeRequest prompb.WriteRequest, headers Headers) error

--- a/src/integration/resources/types.go
+++ b/src/integration/resources/types.go
@@ -66,6 +66,9 @@ type Coordinator interface {
 	// WritePromWithLabels writes a prometheus metric. Allows you to provide the labels for
 	// the write directly instead of conveniently converting them from a map.
 	WritePromWithLabels(name string, labels []prompb.Label, samples []prompb.Sample, headers Headers) error
+	// WritePromWithRequest executes a prometheus write request. Allows you to
+	// provide the request directly which is useful for batch metric requests.
+	WritePromWithRequest(writeRequest prompb.WriteRequest, headers Headers) error
 	// RunQuery runs the given query with a given verification function.
 	RunQuery(verifier ResponseVerifier, query string, headers Headers) error
 	// InstantQuery runs an instant query with provided headers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Allows integration tests to construct `prompb.WriteRequests`. This is useful for sending many timeseries in a single request which previously wasn't possible.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
