### PR TITLE
[agg] Fix race closing an aggregation that migrated to resendEnabled

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -248,6 +248,12 @@ func (e *CounterElem) expireValuesWithLock(
 		// close the agg to prevent any more writes.
 		dirty := false
 		currAgg.lockedAgg.mtx.Lock()
+		if currAgg.lockedAgg.resendEnabled != e.flushState[currAgg.startAt].latestResendEnabled {
+			// the aggregation migrated to resendEnabled after the flusher read the resendEnabled state.
+			// keep the aggregation for now and try to expire on the next flush.
+			currAgg.lockedAgg.mtx.Unlock()
+			break
+		}
 		currAgg.lockedAgg.closed = true
 		dirty = currAgg.lockedAgg.dirty
 		currAgg.lockedAgg.mtx.Unlock()

--- a/src/aggregator/aggregator/elem_test.go
+++ b/src/aggregator/aggregator/elem_test.go
@@ -2909,7 +2909,8 @@ func TestExpireValues(t *testing.T) {
 
 			// Add test values.
 			for _, v := range test.values {
-				_, err := e.findOrCreate(int64(v), createAggregationOptions{})
+				a, err := e.findOrCreate(int64(v), createAggregationOptions{})
+				a.resendEnabled = test.resendEnabled
 				// need to manually seed the flush state since we don't call Consume(), which takes care of setting
 				// the flush state for expireValuesWithLock to use.
 				e.flushState[v] = flushState{latestResendEnabled: test.resendEnabled}

--- a/src/aggregator/aggregator/entry_test.go
+++ b/src/aggregator/aggregator/entry_test.go
@@ -1121,6 +1121,62 @@ func TestAddUntimed_ResendEnabledMigrationRace(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestAddUntimed_ResendEnabledMigrationRaceWithFlusher(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	e, _, _ := testEntry(ctrl, testEntryOptions{})
+	metadatas := metadata.StagedMetadatas{
+		{
+			Metadata: metadata.Metadata{
+				Pipelines: []metadata.PipelineMetadata{
+					{
+						AggregationID: aggregation.MustCompressTypes(aggregation.Sum),
+						ResendEnabled: false,
+						StoragePolicies: policy.StoragePolicies{
+							testStoragePolicy,
+						},
+					},
+				},
+			},
+		},
+	}
+	resolution := testStoragePolicy.Resolution().Window
+	mu := testGauge
+
+	// add value with resendEnable=false
+	require.NoError(t, e.addUntimed(mu, metadatas))
+	require.Len(t, e.aggregations, 1)
+	require.False(t, e.aggregations[0].resendEnabled)
+	elem := e.aggregations[0].elem.Value.(*GaugeElem)
+	vals := elem.values
+	require.Len(t, vals, 1)
+	t1 := xtime.ToUnixNano(e.nowFn().Truncate(resolution))
+	_, ok := vals[t1]
+	require.True(t, ok)
+
+	t2 := t1.Add(resolution)
+	// partially consume the aggregation
+	elem.dirtyToConsumeWithLock(int64(t2), resolution, isStandardMetricEarlierThan)
+
+	// add value with resendEnabled=true that targets the aggregation being flushed
+	metadatas[0].Metadata.Pipelines[0].ResendEnabled = true
+	mu.ClientTimeNanos = t1
+	require.NoError(t, e.addUntimed(mu, metadatas))
+
+	// continue consuming the aggregation
+	elem.expireValuesWithLock(int64(t2), isStandardMetricEarlierThan, flushMetrics{})
+
+	// target the aggregation being flushed again...it should still be open since it migrated to resendEnabled before
+	// closing.
+	require.NoError(t, e.addUntimed(mu, metadatas))
+
+	require.Len(t, vals, 1)
+	v, ok := vals[t1]
+	require.True(t, ok)
+	require.False(t, v.lockedAgg.closed)
+}
+
 func TestAddUntimed_ClosedAggregation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/src/aggregator/aggregator/gauge_elem_gen.go
+++ b/src/aggregator/aggregator/gauge_elem_gen.go
@@ -248,6 +248,12 @@ func (e *GaugeElem) expireValuesWithLock(
 		// close the agg to prevent any more writes.
 		dirty := false
 		currAgg.lockedAgg.mtx.Lock()
+		if currAgg.lockedAgg.resendEnabled != e.flushState[currAgg.startAt].latestResendEnabled {
+			// the aggregation migrated to resendEnabled after the flusher read the resendEnabled state.
+			// keep the aggregation for now and try to expire on the next flush.
+			currAgg.lockedAgg.mtx.Unlock()
+			break
+		}
 		currAgg.lockedAgg.closed = true
 		dirty = currAgg.lockedAgg.dirty
 		currAgg.lockedAgg.mtx.Unlock()

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -311,6 +311,12 @@ func (e *GenericElem) expireValuesWithLock(
 		// close the agg to prevent any more writes.
 		dirty := false
 		currAgg.lockedAgg.mtx.Lock()
+		if currAgg.lockedAgg.resendEnabled != e.flushState[currAgg.startAt].latestResendEnabled {
+			// the aggregation migrated to resendEnabled after the flusher read the resendEnabled state.
+			// keep the aggregation for now and try to expire on the next flush.
+			currAgg.lockedAgg.mtx.Unlock()
+			break
+		}
 		currAgg.lockedAgg.closed = true
 		dirty = currAgg.lockedAgg.dirty
 		currAgg.lockedAgg.mtx.Unlock()

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -248,6 +248,12 @@ func (e *TimerElem) expireValuesWithLock(
 		// close the agg to prevent any more writes.
 		dirty := false
 		currAgg.lockedAgg.mtx.Lock()
+		if currAgg.lockedAgg.resendEnabled != e.flushState[currAgg.startAt].latestResendEnabled {
+			// the aggregation migrated to resendEnabled after the flusher read the resendEnabled state.
+			// keep the aggregation for now and try to expire on the next flush.
+			currAgg.lockedAgg.mtx.Unlock()
+			break
+		}
 		currAgg.lockedAgg.closed = true
 		dirty = currAgg.lockedAgg.dirty
 		currAgg.lockedAgg.mtx.Unlock()


### PR DESCRIPTION
This fixes a tricky race condition:

1. Flusher copies resendEnabled=false from the agg
2. Writer migrates agg to resendEnabled=true (agg is not closed yet)
3. Flusher closes the agg because it has stale state
   (resendEnabled=false)
4. Subsequent writes to the agg will fail with aggregationClosed

The fix is to read the resendEnabled state again in step 3 after
re-acquiring the lock in order to close the agg. If the state changed,
don't close the aggregation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
