### PR TITLE
[coordinator] Report written metrics from carbon endpoint

### DIFF
--- a/src/cmd/services/m3coordinator/ingest/carbon/ingest.go
+++ b/src/cmd/services/m3coordinator/ingest/carbon/ingest.go
@@ -397,8 +397,7 @@ func (i *ingester) write(
 
 			// Break because we only want to apply one rule per metric based on which
 			// ever one matches first.
-			err := i.writeWithOptions(ctx, resources, timestamp, value,
-				downsampleAndStoragePolicies)
+			err := i.writeWithOptions(ctx, resources, timestamp, value, downsampleAndStoragePolicies)
 			if err != nil {
 				return false
 			}
@@ -432,7 +431,7 @@ func (i *ingester) writeWithOptions(
 	}
 
 	err = i.downsamplerAndWriter.Write(ctx, tags, resources.datapoints,
-		xtime.Second, nil, opts)
+		xtime.Second, nil, opts, ts.SourceTypeGraphite)
 	if err != nil {
 		i.logger.Error("err writing carbon metric",
 			zap.String("name", string(resources.name)), zap.Error(err))

--- a/src/cmd/services/m3coordinator/ingest/carbon/ingest_test.go
+++ b/src/cmd/services/m3coordinator/ingest/carbon/ingest_test.go
@@ -216,33 +216,34 @@ func TestIngesterHandleConn(t *testing.T) {
 		idx   = 0
 	)
 	mockDownsamplerAndWriter.EXPECT().
-		Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any(), graphiteSource).DoAndReturn(func(
-		_ context.Context,
-		tags models.Tags,
-		dp ts.Datapoints,
-		unit xtime.Unit,
-		annotation []byte,
-		overrides ingest.WriteOptions,
-		_ ts.SourceType,
-	) interface{} {
-		lock.Lock()
-		// Clone tags because they (and their underlying bytes) are pooled.
-		found = append(found, testMetric{
-			tags:      tags.Clone(),
-			timestamp: int(dp[0].Timestamp.Seconds()),
-			value:     dp[0].Value,
-		})
+		Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any(), graphiteSource).
+		DoAndReturn(func(
+			_ context.Context,
+			tags models.Tags,
+			dp ts.Datapoints,
+			unit xtime.Unit,
+			annotation []byte,
+			overrides ingest.WriteOptions,
+			_ ts.SourceType,
+		) interface{} {
+			lock.Lock()
+			// Clone tags because they (and their underlying bytes) are pooled.
+			found = append(found, testMetric{
+				tags:      tags.Clone(),
+				timestamp: int(dp[0].Timestamp.Seconds()),
+				value:     dp[0].Value,
+			})
 
-		// Make 1 in 10 writes fail to test those paths.
-		returnErr := idx%10 == 0
-		idx++
-		lock.Unlock()
+			// Make 1 in 10 writes fail to test those paths.
+			returnErr := idx%10 == 0
+			idx++
+			lock.Unlock()
 
-		if returnErr {
-			return errors.New("some_error")
-		}
-		return nil
-	}).AnyTimes()
+			if returnErr {
+				return errors.New("some_error")
+			}
+			return nil
+		}).AnyTimes()
 
 	session := client.NewMockSession(ctrl)
 	watcher := newTestWatcher(t, session, m3.AggregatedClusterNamespaceDefinition{
@@ -534,35 +535,36 @@ func newMockDownsamplerAndWriter(
 		idx     = 0
 	)
 	mockDownsamplerAndWriter.EXPECT().
-		Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any(), graphiteSource).DoAndReturn(func(
-		_ context.Context,
-		tags models.Tags,
-		dp ts.Datapoints,
-		unit xtime.Unit,
-		annotation []byte,
-		writeOpts ingest.WriteOptions,
-		_ ts.SourceType,
-	) interface{} {
-		lock.Lock()
-		// Clone tags because they (and their underlying bytes) are pooled.
-		*found = append(*found, testMetric{
-			tags:      tags.Clone(),
-			timestamp: int(dp[0].Timestamp.Seconds()),
-			value:     dp[0].Value,
-		})
+		Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any(), graphiteSource).
+		DoAndReturn(func(
+			_ context.Context,
+			tags models.Tags,
+			dp ts.Datapoints,
+			unit xtime.Unit,
+			annotation []byte,
+			writeOpts ingest.WriteOptions,
+			_ ts.SourceType,
+		) interface{} {
+			lock.Lock()
+			// Clone tags because they (and their underlying bytes) are pooled.
+			*found = append(*found, testMetric{
+				tags:      tags.Clone(),
+				timestamp: int(dp[0].Timestamp.Seconds()),
+				value:     dp[0].Value,
+			})
 
-		// Make 1 in 10 writes fail to test those paths.
-		returnErr := idx%10 == 0
-		idx++
-		lock.Unlock()
+			// Make 1 in 10 writes fail to test those paths.
+			returnErr := idx%10 == 0
+			idx++
+			lock.Unlock()
 
-		expectations(writeOpts.DownsampleMappingRules)
+			expectations(writeOpts.DownsampleMappingRules)
 
-		if returnErr {
-			return errors.New("some_error")
-		}
-		return nil
-	}).AnyTimes()
+			if returnErr {
+				return errors.New("some_error")
+			}
+			return nil
+		}).AnyTimes()
 
 	return mockDownsamplerAndWriter, found
 }

--- a/src/cmd/services/m3coordinator/ingest/carbon/ingest_test.go
+++ b/src/cmd/services/m3coordinator/ingest/carbon/ingest_test.go
@@ -60,6 +60,8 @@ const (
 	// Keep this value large enough to catch issues like the ingester
 	// not copying the name.
 	numLinesInTestPacket = 10000
+
+	graphiteSource = ts.SourceTypeGraphite
 )
 
 var (
@@ -214,13 +216,14 @@ func TestIngesterHandleConn(t *testing.T) {
 		idx   = 0
 	)
 	mockDownsamplerAndWriter.EXPECT().
-		Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any()).DoAndReturn(func(
+		Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any(), graphiteSource).DoAndReturn(func(
 		_ context.Context,
 		tags models.Tags,
 		dp ts.Datapoints,
 		unit xtime.Unit,
 		annotation []byte,
 		overrides ingest.WriteOptions,
+		_ ts.SourceType,
 	) interface{} {
 		lock.Lock()
 		// Clone tags because they (and their underlying bytes) are pooled.
@@ -343,7 +346,7 @@ func TestIngesterHonorsMatchers(t *testing.T) {
 				found = []testMetric{}
 			)
 			mockDownsamplerAndWriter.EXPECT().
-				Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any()).
+				Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any(), graphiteSource).
 				DoAndReturn(func(
 					_ context.Context,
 					tags models.Tags,
@@ -351,6 +354,7 @@ func TestIngesterHonorsMatchers(t *testing.T) {
 					unit xtime.Unit,
 					annotation []byte,
 					writeOpts ingest.WriteOptions,
+					_ ts.SourceType,
 				) interface{} {
 					lock.Lock()
 					// Clone tags because they (and their underlying bytes) are pooled.
@@ -530,13 +534,14 @@ func newMockDownsamplerAndWriter(
 		idx     = 0
 	)
 	mockDownsamplerAndWriter.EXPECT().
-		Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any()).DoAndReturn(func(
+		Write(gomock.Any(), gomock.Any(), gomock.Any(), xtime.Second, gomock.Any(), gomock.Any(), graphiteSource).DoAndReturn(func(
 		_ context.Context,
 		tags models.Tags,
 		dp ts.Datapoints,
 		unit xtime.Unit,
 		annotation []byte,
 		writeOpts ingest.WriteOptions,
+		_ ts.SourceType,
 	) interface{} {
 		lock.Lock()
 		// Clone tags because they (and their underlying bytes) are pooled.

--- a/src/cmd/services/m3coordinator/ingest/write_mock.go
+++ b/src/cmd/services/m3coordinator/ingest/write_mock.go
@@ -74,17 +74,17 @@ func (mr *MockDownsamplerAndWriterMockRecorder) Storage() *gomock.Call {
 }
 
 // Write mocks base method.
-func (m *MockDownsamplerAndWriter) Write(arg0 context.Context, arg1 models.Tags, arg2 ts.Datapoints, arg3 time.Unit, arg4 []byte, arg5 WriteOptions) error {
+func (m *MockDownsamplerAndWriter) Write(arg0 context.Context, arg1 models.Tags, arg2 ts.Datapoints, arg3 time.Unit, arg4 []byte, arg5 WriteOptions, arg6 ts.SourceType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Write", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "Write", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockDownsamplerAndWriterMockRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockDownsamplerAndWriterMockRecorder) Write(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockDownsamplerAndWriter)(nil).Write), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockDownsamplerAndWriter)(nil).Write), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // WriteBatch mocks base method.

--- a/src/cmd/services/m3coordinator/ingest/write_test.go
+++ b/src/cmd/services/m3coordinator/ingest/write_test.go
@@ -49,6 +49,8 @@ var (
 	// Created by init().
 	testWorkerPool xsync.PooledWorkerPool
 
+	source = ts.SourceTypePrometheus
+
 	testTags1 = models.NewTags(3, nil).AddTags(
 		[]models.Tag{
 			{
@@ -225,7 +227,7 @@ func TestDownsampleAndWrite(t *testing.T) {
 	expectDefaultStorageWrites(session, testDatapoints1, testAnnotation1)
 
 	err := downAndWrite.Write(
-		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, defaultOverride)
+		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, defaultOverride, source)
 	require.NoError(t, err)
 }
 
@@ -237,7 +239,7 @@ func TestDownsampleAndWriteWithBadTags(t *testing.T) {
 		testDownsamplerAndWriterOptions{})
 
 	err := downAndWrite.Write(
-		context.Background(), testBadTags, testDatapoints1, xtime.Second, testAnnotation1, defaultOverride)
+		context.Background(), testBadTags, testDatapoints1, xtime.Second, testAnnotation1, defaultOverride, source)
 	require.Error(t, err)
 
 	// Make sure we get a validation error for downsample code path
@@ -268,7 +270,7 @@ func TestDownsampleAndWriteWithDownsampleOverridesAndNoMappingRules(t *testing.T
 	expectDefaultStorageWrites(session, testDatapoints1, testAnnotation1)
 
 	err := downAndWrite.Write(context.Background(),
-		testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides)
+		testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides, source)
 	require.NoError(t, err)
 }
 
@@ -306,7 +308,7 @@ func TestDownsampleAndWriteWithDownsampleOverridesAndMappingRules(t *testing.T) 
 	expectDefaultStorageWrites(session, testDatapoints1, testAnnotation1)
 
 	err := downAndWrite.Write(
-		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides)
+		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides, source)
 	require.NoError(t, err)
 }
 
@@ -361,7 +363,7 @@ func TestDownsampleAndWriteWithDownsampleOverridesAndDropMappingRules(t *testing
 	mockMetricsAppender.EXPECT().Finalize()
 
 	err := downAndWrite.Write(
-		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides)
+		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides, source)
 	require.NoError(t, err)
 }
 
@@ -382,7 +384,7 @@ func TestDownsampleAndWriteWithWriteOverridesAndNoStoragePolicies(t *testing.T) 
 	expectDefaultDownsampling(ctrl, testDatapoints1, downsampler, zeroDownsamplerAppenderOpts)
 
 	err := downAndWrite.Write(
-		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides)
+		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides, source)
 	require.NoError(t, err)
 }
 
@@ -429,7 +431,7 @@ func TestDownsampleAndWriteWithWriteOverridesAndStoragePolicies(t *testing.T) {
 	}
 
 	err := downAndWrite.Write(
-		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides)
+		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, overrides, source)
 	require.NoError(t, err)
 }
 
@@ -443,7 +445,7 @@ func TestDownsampleAndWriteNoDownsampler(t *testing.T) {
 	expectDefaultStorageWrites(session, testDatapoints1, testAnnotation1)
 
 	err := downAndWrite.Write(
-		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, defaultOverride)
+		context.Background(), testTags1, testDatapoints1, xtime.Second, testAnnotation1, defaultOverride, source)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds reporting of `coordinator_downsampler_metrics_written{source="graphite"}` from carbon ingest endpoint for a complete picture.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
