### PR TITLE
[agg] Add metric tracking duration between writes

### DIFF
--- a/src/aggregator/aggregator/entry.go
+++ b/src/aggregator/aggregator/entry.go
@@ -181,7 +181,7 @@ type entryMetrics struct {
 	untimed               untimedEntryMetrics
 	timed                 timedEntryMetrics
 	forwarded             forwardedEntryMetrics
-	entryExpiryByCategory map[metricCategory]tally.Histogram
+	durationBetweenWrites map[metricCategory]tally.Histogram
 }
 
 // NewEntryMetrics creates new entry metrics.
@@ -191,12 +191,12 @@ func NewEntryMetrics(scope tally.Scope) *entryMetrics {
 	untimedEntryScope := scope.Tagged(map[string]string{"entry-type": "untimed"})
 	timedEntryScope := scope.Tagged(map[string]string{"entry-type": "timed"})
 	forwardedEntryScope := scope.Tagged(map[string]string{"entry-type": "forwarded"})
-	// NB: add a histogram tracking entry expiries to help tune entry TTL.
-	expiries := make(map[metricCategory]tally.Histogram, len(validMetricCategories))
+	// NB: add a histogram tracking the duration between writes to help tune entry TTL.
+	writeDurations := make(map[metricCategory]tally.Histogram, len(validMetricCategories))
 	for _, category := range validMetricCategories {
-		expiries[category] = scope.
+		writeDurations[category] = scope.
 			Tagged(map[string]string{"metric-category": category.String()}).
-			Histogram("expiry", tally.DurationBuckets{
+			Histogram("duration-between-writes", tally.DurationBuckets{
 				time.Minute,
 				time.Minute * 2,
 				time.Minute * 5,
@@ -215,7 +215,7 @@ func NewEntryMetrics(scope tally.Scope) *entryMetrics {
 		untimed:               newUntimedEntryMetrics(untimedEntryScope),
 		timed:                 newTimedEntryMetrics(timedEntryScope),
 		forwarded:             newForwardedEntryMetrics(forwardedEntryScope),
-		entryExpiryByCategory: expiries,
+		durationBetweenWrites: writeDurations,
 	}
 }
 
@@ -375,18 +375,18 @@ func (e *Entry) ShouldExpire(now time.Time) bool {
 	}
 	e.mtx.RUnlock()
 
-	return e.shouldExpire(xtime.UnixNano(now.UnixNano()), unknownMetricCategory, false)
+	return e.shouldExpire(xtime.UnixNano(now.UnixNano()))
 }
 
 // TryExpire attempts to expire the entry, returning true
 // if the entry is expired, and false otherwise.
-func (e *Entry) TryExpire(now time.Time, metricCategory metricCategory) bool {
+func (e *Entry) TryExpire(now time.Time) bool {
 	e.mtx.Lock()
 	if e.closed {
 		e.mtx.Unlock()
 		return false
 	}
-	if !e.shouldExpire(xtime.UnixNano(now.UnixNano()), metricCategory, true) {
+	if !e.shouldExpire(xtime.UnixNano(now.UnixNano())) {
 		e.mtx.Unlock()
 		return false
 	}
@@ -451,7 +451,7 @@ func (e *Entry) addUntimed(
 	// must have all completed. This is used to ensure we never write metrics
 	// for times that have already been flushed.
 	currTime := e.nowFn()
-	e.lastAccessNanos.Store(currTime.UnixNano())
+	e.setLastAccessed(unknownMetricCategory)
 
 	e.mtx.RLock()
 	if e.closed {
@@ -798,7 +798,7 @@ func (e *Entry) addTimed(
 	// must have all completed. This is used to ensure we never write metrics
 	// for times that have already been flushed.
 	currTime := e.nowFn()
-	e.lastAccessNanos.Store(currTime.UnixNano())
+	e.setLastAccessed(timedMetric)
 
 	e.mtx.RLock()
 	if e.closed {
@@ -1037,7 +1037,7 @@ func (e *Entry) addForwarded(
 	// for times that have already been flushed.
 	currTime := e.nowFn()
 	currTimeNanos := currTime.UnixNano()
-	e.lastAccessNanos.Store(currTimeNanos)
+	e.setLastAccessed(forwardedMetric)
 
 	e.mtx.RLock()
 	if e.closed {
@@ -1179,18 +1179,10 @@ func (e *Entry) addForwardedWithLock(
 	return err
 }
 
-func (e *Entry) shouldExpire(
-	now xtime.UnixNano,
-	metricCategory metricCategory,
-	recordTiming bool,
-) bool {
+func (e *Entry) shouldExpire(now xtime.UnixNano) bool {
 	// Only expire the entry if there are no active writers
 	// and it has reached its ttl since last accessed.
 	age := now.Sub(xtime.UnixNano(e.lastAccessNanos.Load()))
-	if recordTiming {
-		e.metrics.entryExpiryByCategory[metricCategory].RecordDuration(age)
-	}
-
 	return e.numWriters.Load() == 0 && age > e.opts.EntryTTL()
 }
 
@@ -1208,6 +1200,12 @@ func (e *Entry) applyValueRateLimit(numValues int64, m rateLimitEntryMetrics) er
 	m.valueRateLimitExceeded.Inc(1)
 	m.droppedValues.Inc(numValues)
 	return errWriteValueRateLimitExceeded
+}
+
+func (e *Entry) setLastAccessed(category metricCategory) {
+	now := e.nowFn().UnixNano()
+	e.metrics.durationBetweenWrites[category].RecordDuration(time.Duration(now - e.lastAccessNanos.Load()))
+	e.lastAccessNanos.Store(now)
 }
 
 type aggregationValue struct {

--- a/src/aggregator/aggregator/entry_test.go
+++ b/src/aggregator/aggregator/entry_test.go
@@ -2050,12 +2050,11 @@ func TestEntryMaybeExpireWithExpiry(t *testing.T) {
 	}
 
 	// Try expiring this entry and assert it's not expired.
-	require.False(t, e.TryExpire(*now, unknownMetricCategory))
+	require.False(t, e.TryExpire(*now))
 
 	// Try expiring the entry with time in the future and
 	// assert it's expired.
-	require.True(t, e.TryExpire(now.Add(e.opts.EntryTTL()).Add(time.Second),
-		unknownMetricCategory))
+	require.True(t, e.TryExpire(now.Add(e.opts.EntryTTL()).Add(time.Second)))
 
 	// Assert elements have been tombstoned
 	require.Equal(t, 0, len(e.aggregations))

--- a/src/aggregator/aggregator/map.go
+++ b/src/aggregator/aggregator/map.go
@@ -430,7 +430,7 @@ func (m *metricMap) purgeExpired(
 	m.Lock()
 	for i := range entries {
 		key := entries[i].key
-		if entries[i].entry.TryExpire(now, key.metricCategory) {
+		if entries[i].entry.TryExpire(now) {
 			switch key.metricCategory {
 			case untimedMetric:
 				numStandardExpired++


### PR DESCRIPTION
This replaces the previous attempt of recording the distributions of
expirations. The previous attempt would update the distribution on
ticks, which would heavily weight untouched metrics.

Instead we just want the distribution between writes to a metric, only
counting metrics that are actually updated.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
