### PR TITLE
[m3coordinator] Add a model for rollup tag name and value

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/id_pool_types.go
+++ b/src/cmd/services/m3coordinator/downsample/id_pool_types.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 
+	coordmodel "github.com/m3db/m3/src/cmd/services/m3coordinator/model"
 	"github.com/m3db/m3/src/metrics/metric/id"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/pool"
@@ -35,8 +36,8 @@ import (
 
 var (
 	defaultMetricNameTagName = []byte(model.MetricNameLabel)
-	rollupTagName            = []byte("__rollup__")
-	rollupTagValue           = []byte("true")
+	rollupTagName            = []byte(coordmodel.RollupTagName)
+	rollupTagValue           = []byte(coordmodel.RollupTagValue)
 	rollupTag                = ident.Tag{
 		Name:  ident.BytesID(rollupTagName),
 		Value: ident.BytesID(rollupTagValue),

--- a/src/cmd/services/m3coordinator/model/rollup.go
+++ b/src/cmd/services/m3coordinator/model/rollup.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package model contains model definitions for m3 coordinator.
+package model
+
+const (
+	// RollupTagName is the name of a rollup tag.
+	RollupTagName = "__rollup__"
+
+	// RollupTagValue is the value of a rollup tag.
+	RollupTagValue = "true"
+)


### PR DESCRIPTION
Small refactor to allow us to reuse these values later.