### PR TITLE
[M3msg] Add static retry policy for message retry

### DIFF
--- a/src/msg/producer/config/writer.go
+++ b/src/msg/producer/config/writer.go
@@ -21,6 +21,7 @@
 package config
 
 import (
+	"errors"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -105,8 +106,8 @@ type WriterConfiguration struct {
 
 	// StaticMessageRetry configs a static message retry policy.
 	StaticMessageRetry *StaticMessageRetryConfiguration `yaml:"staticMessageRetry"`
-	// MessageRetry configs a argorithmic retry policy.
-	// This takes precedence over the static retry config.
+	// MessageRetry configs a algorithmic retry policy.
+	// Only one of the retry configuration should be used.
 	MessageRetry *retry.Configuration `yaml:"messageRetry"`
 
 	// IgnoreCutoffCutover allows producing writes ignoring cutoff/cutover timestamp.
@@ -166,15 +167,9 @@ func (c *WriterConfiguration) NewOptions(
 	if c.MessagePool != nil {
 		opts = opts.SetMessagePoolOptions(c.MessagePool.NewObjectPoolOptions(iOpts))
 	}
-	if c.StaticMessageRetry != nil {
-		fn, err := writer.StaticRetryNanosFn(c.StaticMessageRetry.Backoff)
-		if err != nil {
-			return nil, err
-		}
-		opts = opts.SetMessageRetryNanosFn(fn)
-	}
-	if c.MessageRetry != nil {
-		opts = opts.SetMessageRetryNanosFn(writer.NextRetryNanosFn(c.MessageRetry.NewOptions(iOpts.MetricsScope())))
+	opts, err = c.setRetryOptions(opts, iOpts)
+	if err != nil {
+		return nil, err
 	}
 	if c.MessageQueueNewWritesScanInterval != nil {
 		opts = opts.SetMessageQueueNewWritesScanInterval(*c.MessageQueueNewWritesScanInterval)
@@ -207,5 +202,27 @@ func (c *WriterConfiguration) NewOptions(
 	opts = opts.SetIgnoreCutoffCutover(c.IgnoreCutoffCutover)
 
 	opts = opts.SetDecoderOptions(opts.DecoderOptions().SetRWOptions(rwOptions))
+	return opts, nil
+}
+
+func (c *WriterConfiguration) setRetryOptions(
+	opts writer.Options,
+	iOpts instrument.Options,
+) (writer.Options, error) {
+	if c.StaticMessageRetry != nil && c.MessageRetry != nil {
+		return nil, errors.New("invalid writer config with both static and algorithmic retry config set")
+	}
+	if c.MessageRetry != nil {
+		return opts.SetMessageRetryNanosFn(
+			writer.NextRetryNanosFn(c.MessageRetry.NewOptions(iOpts.MetricsScope())),
+		), nil
+	}
+	if c.StaticMessageRetry != nil {
+		fn, err := writer.StaticRetryNanosFn(c.StaticMessageRetry.Backoff)
+		if err != nil {
+			return nil, err
+		}
+		return opts.SetMessageRetryNanosFn(fn), nil
+	}
 	return opts, nil
 }

--- a/src/msg/producer/config/writer_test.go
+++ b/src/msg/producer/config/writer_test.go
@@ -24,15 +24,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/kv"
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/x/instrument"
 	xio "github.com/m3db/m3/src/x/io"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
 )
 
 func TestConnectionConfiguration(t *testing.T) {
@@ -113,7 +113,7 @@ decoder:
 	require.Equal(t, time.Second, wOpts.TopicWatchInitTimeout())
 	require.Equal(t, 2*time.Second, wOpts.PlacementWatchInitTimeout())
 	require.Equal(t, 5, wOpts.MessagePoolOptions().Size())
-	require.Equal(t, time.Millisecond, wOpts.MessageRetryOptions().InitialBackoff())
+	require.NotNil(t, wOpts.MessageRetryNanosFn())
 	require.Equal(t, 200*time.Millisecond, wOpts.MessageQueueNewWritesScanInterval())
 	require.Equal(t, 10*time.Second, wOpts.MessageQueueFullScanInterval())
 	require.Equal(t, 1024, wOpts.MessageQueueScanBatchSize())

--- a/src/msg/producer/writer/consumer_writer_test.go
+++ b/src/msg/producer/writer/consumer_writer_test.go
@@ -393,7 +393,13 @@ func testOptions() Options {
 		SetMessagePoolOptions(pool.NewObjectPoolOptions().SetSize(1)).
 		SetMessageQueueNewWritesScanInterval(100 * time.Millisecond).
 		SetMessageQueueFullScanInterval(200 * time.Millisecond).
-		SetMessageRetryNanosFn(NextRetryNanosFn(retry.NewOptions().SetInitialBackoff(100 * time.Millisecond).SetMaxBackoff(500 * time.Millisecond))).
+		SetMessageRetryNanosFn(
+			NextRetryNanosFn(
+				retry.NewOptions().
+					SetInitialBackoff(100 * time.Millisecond).
+					SetMaxBackoff(500 * time.Millisecond),
+			),
+		).
 		SetAckErrorRetryOptions(retry.NewOptions().SetInitialBackoff(200 * time.Millisecond).SetMaxBackoff(time.Second)).
 		SetConnectionOptions(testConnectionOptions())
 }

--- a/src/msg/producer/writer/consumer_writer_test.go
+++ b/src/msg/producer/writer/consumer_writer_test.go
@@ -27,16 +27,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+
 	"github.com/m3db/m3/src/msg/generated/proto/msgpb"
 	"github.com/m3db/m3/src/msg/protocol/proto"
 	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/retry"
 	xtest "github.com/m3db/m3/src/x/test"
-
-	"github.com/fortytw2/leaktest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 )
 
 var (
@@ -393,7 +393,7 @@ func testOptions() Options {
 		SetMessagePoolOptions(pool.NewObjectPoolOptions().SetSize(1)).
 		SetMessageQueueNewWritesScanInterval(100 * time.Millisecond).
 		SetMessageQueueFullScanInterval(200 * time.Millisecond).
-		SetMessageRetryOptions(retry.NewOptions().SetInitialBackoff(100 * time.Millisecond).SetMaxBackoff(500 * time.Millisecond)).
+		SetMessageRetryNanosFn(NextRetryNanosFn(retry.NewOptions().SetInitialBackoff(100 * time.Millisecond).SetMaxBackoff(500 * time.Millisecond))).
 		SetAckErrorRetryOptions(retry.NewOptions().SetInitialBackoff(200 * time.Millisecond).SetMaxBackoff(time.Second)).
 		SetConnectionOptions(testConnectionOptions())
 }

--- a/src/msg/producer/writer/message_writer.go
+++ b/src/msg/producer/writer/message_writer.go
@@ -865,8 +865,8 @@ func StaticRetryNanosFn(backoffDurations []time.Duration) (MessageRetryNanosFn, 
 		retry := writeTimes - 1
 		l := len(backoffInt64s)
 		if retry < l {
-			return int64(backoffInt64s[retry])
+			return backoffInt64s[retry]
 		}
-		return int64(backoffInt64s[l-1])
+		return backoffInt64s[l-1]
 	}, nil
 }

--- a/src/msg/producer/writer/message_writer.go
+++ b/src/msg/producer/writer/message_writer.go
@@ -27,19 +27,23 @@ import (
 	"sync"
 	"time"
 
+	"github.com/uber-go/tally"
+
 	"github.com/m3db/m3/src/msg/producer"
 	"github.com/m3db/m3/src/msg/protocol/proto"
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/retry"
 	"github.com/m3db/m3/src/x/unsafe"
-
-	"github.com/uber-go/tally"
 )
 
+// MessageRetryNanosFn returns the message backoff time for retry in nanoseconds.
+type MessageRetryNanosFn func(writeTimes int) int64
+
 var (
-	errFailAllConsumers = errors.New("could not write to any consumer")
-	errNoWriters        = errors.New("no writers")
+	errInvalidBackoffDuration = errors.New("invalid backoff duration")
+	errFailAllConsumers       = errors.New("could not write to any consumer")
+	errNoWriters              = errors.New("no writers")
 )
 
 const _recordMessageDelayEvery = 4 // keep it a power of two value to keep modulo fast
@@ -211,7 +215,7 @@ type messageWriterImpl struct {
 	replicatedShardID   uint64
 	mPool               messagePool
 	opts                Options
-	nextRetryAfterNanos func(int) int64
+	nextRetryAfterNanos MessageRetryNanosFn
 	encoder             proto.Encoder
 	numConnections      int
 
@@ -249,7 +253,7 @@ func newMessageWriter(
 		replicatedShardID:   replicatedShardID,
 		mPool:               mPool,
 		opts:                opts,
-		nextRetryAfterNanos: nextRetryNanosFn(opts.MessageRetryOptions()),
+		nextRetryAfterNanos: opts.MessageRetryNanosFn(),
 		encoder:             proto.NewEncoder(opts.EncoderOptions()),
 		numConnections:      opts.ConnectionOptions().NumConnections(),
 		msgID:               0,
@@ -812,7 +816,8 @@ func (m *scanBatchMetrics) recordNonzeroCounter(idx metricIdx, c tally.Counter) 
 	}
 }
 
-func nextRetryNanosFn(retryOpts retry.Options) func(int) int64 {
+// NextRetryNanosFn creates a MessageRetryNanosFn based on the retry options.
+func NextRetryNanosFn(retryOpts retry.Options) func(int) int64 {
 	var (
 		jitter              = retryOpts.Jitter()
 		backoffFactor       = retryOpts.BackoffFactor()
@@ -845,4 +850,23 @@ func nextRetryNanosFn(retryOpts retry.Options) func(int) int64 {
 		}
 		return backoff
 	}
+}
+
+// StaticRetryNanosFn creates a MessageRetryNanosFn based on static config.
+func StaticRetryNanosFn(backoffDurations []time.Duration) (MessageRetryNanosFn, error) {
+	if len(backoffDurations) == 0 {
+		return nil, errInvalidBackoffDuration
+	}
+	backoffInt64s := make([]int64, 0, len(backoffDurations))
+	for _, b := range backoffDurations {
+		backoffInt64s = append(backoffInt64s, int64(b))
+	}
+	return func(writeTimes int) int64 {
+		retry := writeTimes - 1
+		l := len(backoffInt64s)
+		if retry < l {
+			return int64(backoffInt64s[retry])
+		}
+		return int64(backoffInt64s[l-1])
+	}, nil
 }

--- a/src/msg/producer/writer/message_writer_test.go
+++ b/src/msg/producer/writer/message_writer_test.go
@@ -26,15 +26,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3/src/msg/producer"
-	"github.com/m3db/m3/src/x/instrument"
-	"github.com/m3db/m3/src/x/retry"
-	xtest "github.com/m3db/m3/src/x/test"
-
 	"github.com/fortytw2/leaktest"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
+
+	"github.com/m3db/m3/src/msg/producer"
+	"github.com/m3db/m3/src/x/instrument"
+	"github.com/m3db/m3/src/x/retry"
+	xtest "github.com/m3db/m3/src/x/test"
 )
 
 func TestMessageWriterRandomIndex(t *testing.T) {
@@ -535,8 +535,8 @@ func TestMessageWriterKeepNewWritesInOrderInFrontOfTheQueue(t *testing.T) {
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
-	opts := testOptions().SetMessageRetryOptions(
-		retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond),
+	opts := testOptions().SetMessageRetryNanosFn(
+		NextRetryNanosFn(retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond)),
 	)
 	w := newMessageWriter(200, testMessagePool(opts), opts, testMessageWriterMetrics()).(*messageWriterImpl)
 
@@ -579,8 +579,8 @@ func TestMessageWriterRetryIterateBatchFullScan(t *testing.T) {
 	defer ctrl.Finish()
 
 	retryBatchSize := 2
-	opts := testOptions().SetMessageQueueScanBatchSize(retryBatchSize).SetMessageRetryOptions(
-		retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond),
+	opts := testOptions().SetMessageQueueScanBatchSize(retryBatchSize).SetMessageRetryNanosFn(
+		NextRetryNanosFn(retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond)),
 	)
 	w := newMessageWriter(200, testMessagePool(opts), opts, testMessageWriterMetrics()).(*messageWriterImpl)
 
@@ -644,8 +644,8 @@ func TestMessageWriterRetryIterateBatchFullScanWithMessageTTL(t *testing.T) {
 	defer ctrl.Finish()
 
 	retryBatchSize := 2
-	opts := testOptions().SetMessageQueueScanBatchSize(retryBatchSize).SetMessageRetryOptions(
-		retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond),
+	opts := testOptions().SetMessageQueueScanBatchSize(retryBatchSize).SetMessageRetryNanosFn(
+		NextRetryNanosFn(retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond)),
 	)
 	w := newMessageWriter(200, testMessagePool(opts), opts, testMessageWriterMetrics()).(*messageWriterImpl)
 
@@ -706,8 +706,8 @@ func TestMessageWriterRetryIterateBatchNotFullScan(t *testing.T) {
 	defer ctrl.Finish()
 
 	retryBatchSize := 100
-	opts := testOptions().SetMessageQueueScanBatchSize(retryBatchSize).SetMessageRetryOptions(
-		retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond),
+	opts := testOptions().SetMessageQueueScanBatchSize(retryBatchSize).SetMessageRetryNanosFn(
+		NextRetryNanosFn(retry.NewOptions().SetInitialBackoff(2 * time.Nanosecond).SetMaxBackoff(5 * time.Nanosecond)),
 	)
 	w := newMessageWriter(200, testMessagePool(opts), opts, testMessageWriterMetrics()).(*messageWriterImpl)
 
@@ -776,8 +776,8 @@ func TestMessageWriterRetryIterateBatchNotFullScan(t *testing.T) {
 
 func TestNextRetryAfterNanos(t *testing.T) {
 	backoffDuration := time.Minute
-	opts := testOptions().SetMessageRetryOptions(
-		retry.NewOptions().SetInitialBackoff(backoffDuration).SetMaxBackoff(2 * backoffDuration).SetJitter(true),
+	opts := testOptions().SetMessageRetryNanosFn(
+		NextRetryNanosFn(retry.NewOptions().SetInitialBackoff(backoffDuration).SetMaxBackoff(2 * backoffDuration).SetJitter(true)),
 	)
 	w := newMessageWriter(200, nil, opts, testMessageWriterMetrics()).(*messageWriterImpl)
 
@@ -796,6 +796,31 @@ func TestNextRetryAfterNanos(t *testing.T) {
 	m.IncWriteTimes()
 	retryAtNanos = w.nextRetryAfterNanos(m.WriteTimes()) + nowNanos
 	require.True(t, retryAtNanos == nowNanos+2*int64(backoffDuration))
+}
+
+func TestStaticRetryAfterNanos(t *testing.T) {
+	fn, err := StaticRetryNanosFn([]time.Duration{time.Minute, 10 * time.Second, 5 * time.Second})
+	require.NoError(t, err)
+
+	opts := testOptions().SetMessageRetryNanosFn(fn)
+	w := newMessageWriter(200, nil, opts, testMessageWriterMetrics()).(*messageWriterImpl)
+
+	m := newMessage()
+	m.IncWriteTimes()
+	retryAtNanos := w.nextRetryAfterNanos(m.WriteTimes())
+	require.Equal(t, int64(time.Minute), retryAtNanos)
+
+	m.IncWriteTimes()
+	retryAtNanos = w.nextRetryAfterNanos(m.WriteTimes())
+	require.Equal(t, int64(10*time.Second), retryAtNanos)
+
+	m.IncWriteTimes()
+	retryAtNanos = w.nextRetryAfterNanos(m.WriteTimes())
+	require.Equal(t, int64(5*time.Second), retryAtNanos)
+
+	m.IncWriteTimes()
+	retryAtNanos = w.nextRetryAfterNanos(m.WriteTimes())
+	require.Equal(t, int64(5*time.Second), retryAtNanos)
 }
 
 func TestExpectedProcessedAt(t *testing.T) {

--- a/src/msg/producer/writer/message_writer_test.go
+++ b/src/msg/producer/writer/message_writer_test.go
@@ -776,9 +776,15 @@ func TestMessageWriterRetryIterateBatchNotFullScan(t *testing.T) {
 
 func TestNextRetryAfterNanos(t *testing.T) {
 	backoffDuration := time.Minute
-	opts := testOptions().SetMessageRetryNanosFn(
-		NextRetryNanosFn(retry.NewOptions().SetInitialBackoff(backoffDuration).SetMaxBackoff(2 * backoffDuration).SetJitter(true)),
-	)
+	opts := testOptions().
+		SetMessageRetryNanosFn(
+			NextRetryNanosFn(
+				retry.NewOptions().
+					SetInitialBackoff(backoffDuration).
+					SetMaxBackoff(2 * backoffDuration).
+					SetJitter(true),
+			),
+		)
 	w := newMessageWriter(200, nil, opts, testMessageWriterMetrics()).(*messageWriterImpl)
 
 	nowNanos := time.Now().UnixNano()

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -290,11 +290,11 @@ type Options interface {
 	// SetMessagePoolOptions sets the options of pool for messages.
 	SetMessagePoolOptions(value pool.ObjectPoolOptions) Options
 
-	// MessageRetryOptions returns the retry options for message retry.
-	MessageRetryOptions() retry.Options
+	// MessageRetryNanosFn returns the MessageRetryNanosFn.
+	MessageRetryNanosFn() MessageRetryNanosFn
 
-	// SetMessageRetryOptions sets the retry options for message retry.
-	SetMessageRetryOptions(value retry.Options) Options
+	// SetMessageRetryNanosFn sets the MessageRetryNanosFn.
+	SetMessageRetryNanosFn(value MessageRetryNanosFn) Options
 
 	// MessageQueueNewWritesScanInterval returns the interval between scanning
 	// message queue for new writes.
@@ -375,6 +375,7 @@ type Options interface {
 }
 
 type writerOptions struct {
+	messageRetryNanosFn               MessageRetryNanosFn
 	topicName                         string
 	topicService                      topic.Service
 	topicWatchInitTimeout             time.Duration
@@ -489,13 +490,13 @@ func (opts *writerOptions) SetMessagePoolOptions(value pool.ObjectPoolOptions) O
 	return &o
 }
 
-func (opts *writerOptions) MessageRetryOptions() retry.Options {
-	return opts.messageRetryOpts
+func (opts *writerOptions) MessageRetryNanosFn() MessageRetryNanosFn {
+	return opts.messageRetryNanosFn
 }
 
-func (opts *writerOptions) SetMessageRetryOptions(value retry.Options) Options {
+func (opts *writerOptions) SetMessageRetryNanosFn(value MessageRetryNanosFn) Options {
 	o := *opts
-	o.messageRetryOpts = value
+	o.messageRetryNanosFn = value
 	return &o
 }
 

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -375,13 +375,13 @@ type Options interface {
 }
 
 type writerOptions struct {
-	messageRetryNanosFn               MessageRetryNanosFn
 	topicName                         string
 	topicService                      topic.Service
 	topicWatchInitTimeout             time.Duration
 	services                          services.Services
 	placementOpts                     placement.Options
 	placementWatchInitTimeout         time.Duration
+	messageRetryNanosFn               MessageRetryNanosFn
 	messagePoolOptions                pool.ObjectPoolOptions
 	messageQueueNewWritesScanInterval time.Duration
 	messageQueueFullScanInterval      time.Duration

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -383,7 +383,6 @@ type writerOptions struct {
 	placementOpts                     placement.Options
 	placementWatchInitTimeout         time.Duration
 	messagePoolOptions                pool.ObjectPoolOptions
-	messageRetryOpts                  retry.Options
 	messageQueueNewWritesScanInterval time.Duration
 	messageQueueFullScanInterval      time.Duration
 	messageQueueScanBatchSize         int
@@ -406,7 +405,7 @@ func NewOptions() Options {
 		topicWatchInitTimeout:             defaultTopicWatchInitTimeout,
 		placementOpts:                     placement.NewOptions(),
 		placementWatchInitTimeout:         defaultPlacementWatchInitTimeout,
-		messageRetryOpts:                  messageRetryOpts,
+		messageRetryNanosFn:               NextRetryNanosFn(messageRetryOpts),
 		messageQueueNewWritesScanInterval: defaultMessageQueueNewWritesScanInterval,
 		messageQueueFullScanInterval:      defaultMessageQueueFullScanInterval,
 		messageQueueScanBatchSize:         defaultMessageQueueScanBatchSize,

--- a/src/msg/producer/writer/options_test.go
+++ b/src/msg/producer/writer/options_test.go
@@ -55,8 +55,7 @@ func TestOptions(t *testing.T) {
 
 	require.Nil(t, opts.SetInstrumentOptions(nil).InstrumentOptions())
 
-	require.NotNil(t, opts.MessageRetryOptions())
-	require.Equal(t, defaultWriterRetryInitialBackoff, opts.MessageRetryOptions().InitialBackoff())
+	require.Equal(t, defaultWriterRetryInitialBackoff, opts.MessageRetryNanosFn())
 }
 
 func TestConnectionOptions(t *testing.T) {

--- a/src/msg/producer/writer/options_test.go
+++ b/src/msg/producer/writer/options_test.go
@@ -55,7 +55,7 @@ func TestOptions(t *testing.T) {
 
 	require.Nil(t, opts.SetInstrumentOptions(nil).InstrumentOptions())
 
-	require.Equal(t, defaultWriterRetryInitialBackoff, opts.MessageRetryNanosFn())
+	require.NotNil(t, opts.MessageRetryNanosFn())
 }
 
 func TestConnectionOptions(t *testing.T) {


### PR DESCRIPTION
In a use case I want to make the message writer retry messages like this:
- 1st retry needs to wait 5 minutes to give the consumer some time for processing.
- 2nd retry needs to happen 10s after the 1st retry.
- 3rd and future retries wait approximately 10s after the last retry.

It is impossible to config the retry options to do so.

This pr adds a static retry policy that allows user to declare backoff duration between each retry clearly. 


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
probably, since we support a new way to config retry policy.
```
