### PR TITLE
[tools] add service type argument to m3ctl placement command

### DIFF
--- a/src/cmd/tools/m3ctl/README.md
+++ b/src/cmd/tools/m3ctl/README.md
@@ -31,15 +31,15 @@ m3ctl apply -f ./database/examples/dbcreate.yaml
 m3ctl get ns
 # delete a namespace
 m3ctl delete ns -id default
-# list placements
-m3ctl get pl
+# list service placements (m3db/m3coordinator/m3aggregator)
+m3ctl get pl <service>
 # point to some remote and list namespaces
 m3ctl -endpoint http://localhost:7201 get ns
 # check the namespaces in a kubernetes cluster
-# first setup a tunnel via kubectl port-forward ... 7201 
+# first setup a tunnel via kubectl port-forward ... 7201
 m3ctl -endpoint http://localhost:7201 get ns
-# list the ids of the placements
-m3ctl -endpoint http://localhost:7201 get pl | jq .placement.instances[].id
+# list the ids of the m3db placements
+m3ctl -endpoint http://localhost:7201 get pl m3db | jq .placement.instances[].id
 ```
 
 Some example yaml files for the "apply" subcommand are provided in the yaml/examples directory.
@@ -72,11 +72,11 @@ instances:
     endpoint: node3:9000
     hostname: node3
     port: 9000
-```    
+```
 
 See the examples directories below.
 
 # References
 
- * [Operational guide](https://docs.m3db.io/operational_guide) 
+ * [Operational guide](https://docs.m3db.io/operational_guide)
  * [API docs](https://www.m3db.io/openapi/)

--- a/src/cmd/tools/m3ctl/main/main.go
+++ b/src/cmd/tools/m3ctl/main/main.go
@@ -87,7 +87,7 @@ func main() {
 	}()
 
 	rootCmd := &cobra.Command{
-		Use: "cobra",
+		Use: "m3ctl",
 	}
 
 	getCmd := &cobra.Command{
@@ -104,7 +104,7 @@ func main() {
 		Use:   "apply",
 		Short: "Apply various yamls to remote endpoint",
 		Long: `This will take specific yamls and send them over to the remote
-endpoint.  See the yaml/examples directory for examples.  Operations such as 
+endpoint.  See the yaml/examples directory for examples. Operations such as
 database creation, database init, adding a node, and replacing a node, are supported.
 `,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -159,13 +159,15 @@ database creation, database init, adding a node, and replacing a node, are suppo
 	}
 
 	getPlacementCmd := &cobra.Command{
-		Use:     "placement",
-		Short:   "Get the placement from the remote endpoint",
-		Aliases: []string{"pl"},
+		Use:       "placement <m3db/m3coordinator/m3aggregator>",
+		Short:     "Get service placement from the remote endpoint",
+		Args:      cobra.ExactValidArgs(1),
+		ValidArgs: []string{"m3db", "m3coordinator", "m3aggregator"},
+		Aliases:   []string{"pl"},
 		Run: func(cmd *cobra.Command, args []string) {
 			logger.Debug("running command", zap.String("command", cmd.Name()))
 
-			resp, err := placements.DoGet(endPoint, headers, logger)
+			resp, err := placements.DoGet(endPoint, args[0], headers, logger)
 			if err != nil {
 				logger.Fatal("get placement failed", zap.Error(err))
 			}
@@ -175,13 +177,15 @@ database creation, database init, adding a node, and replacing a node, are suppo
 	}
 
 	deletePlacementCmd := &cobra.Command{
-		Use:     "placement",
-		Short:   "Delete the placement from the remote endpoint",
-		Aliases: []string{"pl"},
+		Use:       "placement <m3db/m3coordinator/m3aggregator>",
+		Short:     "Delete service placement from the remote endpoint",
+		Args:      cobra.ExactValidArgs(1),
+		ValidArgs: []string{"m3db", "m3coordinator", "m3aggregator"},
+		Aliases:   []string{"pl"},
 		Run: func(cmd *cobra.Command, args []string) {
 			logger.Debug("running command", zap.String("command", cmd.Name()))
 
-			resp, err := placements.DoDelete(endPoint, headers, nodeName, deleteAll, logger)
+			resp, err := placements.DoDelete(endPoint, args[0], headers, nodeName, deleteAll, logger)
 			if err != nil {
 				logger.Fatal("delete placement failed", zap.Error(err))
 			}

--- a/src/cmd/tools/m3ctl/placements/delete.go
+++ b/src/cmd/tools/m3ctl/placements/delete.go
@@ -31,15 +31,17 @@ import (
 // DoDelete does the delete api calls for placements
 func DoDelete(
 	endpoint string,
+	service string,
 	headers map[string]string,
 	nodeName string,
 	deleteEntire bool,
 	logger *zap.Logger,
 ) ([]byte, error) {
+	path := DefaultPath + service + "/placement"
 	if deleteEntire {
-		url := fmt.Sprintf("%s%s", endpoint, DefaultPath)
+		url := fmt.Sprintf("%s%s", endpoint, path)
 		return client.DoDelete(url, headers, logger)
 	}
-	url := fmt.Sprintf("%s%s/%s", endpoint, DefaultPath, nodeName)
+	url := fmt.Sprintf("%s%s/%s", endpoint, path, nodeName)
 	return client.DoDelete(url, headers, logger)
 }

--- a/src/cmd/tools/m3ctl/placements/get.go
+++ b/src/cmd/tools/m3ctl/placements/get.go
@@ -31,9 +31,11 @@ import (
 // DoGet calls the backend api for get placements
 func DoGet(
 	endpoint string,
+	service string,
 	headers map[string]string,
 	logger *zap.Logger,
 ) ([]byte, error) {
-	url := fmt.Sprintf("%s%s", endpoint, DefaultPath)
+	path := DefaultPath + service + "/placement"
+	url := fmt.Sprintf("%s%s", endpoint, path)
 	return client.DoGet(url, headers, logger)
 }

--- a/src/cmd/tools/m3ctl/placements/types.go
+++ b/src/cmd/tools/m3ctl/placements/types.go
@@ -22,5 +22,5 @@ package placements
 
 const (
 	// DefaultPath is the url path for api calls for placements
-	DefaultPath = "/api/v1/services/m3db/placement"
+	DefaultPath = "/api/v1/services/"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the first commit of adding multiple services support for m3ctl. Current change adds `--service` flag to `m3ctl get placement`, `m3ctl delete placement` commands in order to manage placements for different m3 services, like aggregator, coordinator or m3db (default).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
Additional command line flag is added.

**Does this PR require updating code package or user-facing documentation?**:
NONE