### PR TITLE
[query] Result metadata fixes

### DIFF
--- a/src/query/api/v1/handler/prom/read.go
+++ b/src/query/api/v1/handler/prom/read.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
 	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/native"
@@ -123,9 +124,19 @@ func (h *readHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// NB (@shreyas): We put the FetchOptions in context so it can be
 	// retrieved in the queryable object as there is no other way to pass
 	// that through.
-	var resultMetadata block.ResultMetadata
+	//
+	// We also put a function into the context that allows callers to safely
+	// pass back result metadata concurrently so that they can be combined
+	// for later reporting.
+	var resultMetadataMutex sync.Mutex
+	resultMetadata := block.NewResultMetadata()
+	resultMetadataReceiveFn := func(m block.ResultMetadata) {
+		resultMetadataMutex.Lock()
+		defer resultMetadataMutex.Unlock()
+		resultMetadata = resultMetadata.CombineMetadata(m)
+	}
 	ctx = context.WithValue(ctx, prometheus.FetchOptionsContextKey, fetchOptions)
-	ctx = context.WithValue(ctx, prometheus.BlockResultMetadataKey, &resultMetadata)
+	ctx = context.WithValue(ctx, prometheus.BlockResultMetadataFnKey, resultMetadataReceiveFn)
 
 	qry, err := h.opts.newQueryFn(params)
 	if err != nil {

--- a/src/query/api/v1/handler/prometheus/remote/read_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/read_test.go
@@ -204,8 +204,7 @@ func TestPromReadStorageWithFetchError(t *testing.T) {
 	}
 
 	fetchOpts := &storage.FetchOptions{}
-	result := storage.PromResult{Metadata: block.ResultMetadata{
-		Exhaustive: true, LocalOnly: true}}
+	result := storage.NewPromResult([]*prompb.TimeSeries{})
 	engine := executor.NewMockEngine(ctrl)
 	engine.EXPECT().
 		ExecuteProm(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -397,20 +396,17 @@ func TestReadWithOptions(t *testing.T) {
 	now := xtime.Now()
 	promNow := storage.TimeToPromTimestamp(now)
 
-	r := storage.PromResult{
-		PromResult: &prompb.QueryResult{
-			Timeseries: []*prompb.TimeSeries{
-				{
-					Samples: []prompb.Sample{{Value: 1, Timestamp: promNow}},
-					Labels: []prompb.Label{
-						{Name: []byte("a"), Value: []byte("b")},
-						{Name: []byte("remove"), Value: []byte("c")},
-					},
+	r := storage.NewPromResult(
+		[]*prompb.TimeSeries{
+			{
+				Samples: []prompb.Sample{{Value: 1, Timestamp: promNow}},
+				Labels: []prompb.Label{
+					{Name: []byte("a"), Value: []byte("b")},
+					{Name: []byte("remove"), Value: []byte("c")},
 				},
 			},
 		},
-		Metadata: block.NewResultMetadata(),
-	}
+	)
 
 	req := &prompb.ReadRequest{
 		Queries: []*prompb.Query{{StartTimestampMs: 10, EndTimestampMs: 100}},

--- a/src/query/storage/prom_converter.go
+++ b/src/query/storage/prom_converter.go
@@ -147,11 +147,7 @@ func toPromSequentially(
 		}
 	}
 
-	return PromResult{
-		PromResult: &prompb.QueryResult{
-			Timeseries: seriesList,
-		},
-	}, nil
+	return NewPromResult(seriesList), nil
 }
 
 func toPromConcurrently(
@@ -213,11 +209,7 @@ func toPromConcurrently(
 		}
 	}
 
-	return PromResult{
-		PromResult: &prompb.QueryResult{
-			Timeseries: filteredList,
-		},
-	}, nil
+	return NewPromResult(filteredList), nil
 }
 
 func seriesIteratorsToPromResult(
@@ -258,7 +250,9 @@ func SeriesIteratorsToPromResult(
 
 	promResult, err := seriesIteratorsToPromResult(ctx, fetchResult,
 		readWorkerPool, tagOptions, maxResolution, promConvertOptions)
-	promResult.Metadata = fetchResult.Metadata
+	// Merge the fetchResult metadata into any metadata that was already
+	// computed for this promResult.
+	promResult.Metadata = promResult.Metadata.CombineMetadata(fetchResult.Metadata)
 
 	return promResult, err
 }

--- a/src/query/storage/prometheus/context.go
+++ b/src/query/storage/prometheus/context.go
@@ -35,8 +35,8 @@ const (
 	// FetchOptionsContextKey is the context key for fetch options.
 	FetchOptionsContextKey ContextKey = "fetch-options"
 
-	// BlockResultMetadataKey is the context key for block meta result.
-	BlockResultMetadataKey ContextKey = "block-meta-result"
+	// BlockResultMetadataFnKey is the context key for a function to receive block metadata results.
+	BlockResultMetadataFnKey ContextKey = "block-meta-result-fn"
 )
 
 // RemoteReadFlags is a set of flags for storage remote read requests.
@@ -52,9 +52,9 @@ func fetchOptions(ctx context.Context) (*storage.FetchOptions, error) {
 	return nil, errors.New("fetch options not available")
 }
 
-func resultMetadata(ctx context.Context) (*block.ResultMetadata, error) {
-	value := ctx.Value(BlockResultMetadataKey)
-	if v, ok := value.(*block.ResultMetadata); ok {
+func resultMetadataReceiveFn(ctx context.Context) (func(m block.ResultMetadata), error) {
+	value := ctx.Value(BlockResultMetadataFnKey)
+	if v, ok := value.(func(m block.ResultMetadata)); ok {
 		return v, nil
 	}
 	return nil, errors.New("block result metadata not available")

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -355,6 +355,16 @@ type PromResult struct {
 	Metadata block.ResultMetadata
 }
 
+// NewPromResult returns a new, initialized PromResult
+func NewPromResult(timeseries []*prompb.TimeSeries) PromResult {
+	return PromResult{
+		PromResult: &prompb.QueryResult{
+			Timeseries: timeseries,
+		},
+		Metadata: block.NewResultMetadata(),
+	}
+}
+
 // PromConvertOptions are options controlling the conversion of raw series iterators
 // to a Prometheus-compatible result.
 type PromConvertOptions interface {


### PR DESCRIPTION
- Allows concurrent updates to result metadata. This is necessary when a Prometheus query ends up creating multiple concurrent fetch operations.
- Allows Prometheus result code paths to generate their own metadata without it being immediately overwritten by its caller. This will be useful in the future when those code paths actually do generate their own metadata.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
