### PR TITLE
[downsampler] Add LatestRollupRules from ActiveRuleset -> Downsampler

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/async_downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/async_downsampler.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/m3db/m3/src/metrics/rules/view"
 )
 
 const (
@@ -82,6 +84,12 @@ func NewAsyncDownsampler(
 	}()
 
 	return asyncDownsampler
+}
+
+func (d *asyncDownsampler) LatestRollupRules(namespace []byte, timeNanos int64) ([]view.RollupRule, error) {
+	d.RLock()
+	defer d.RUnlock()
+	return d.downsampler.LatestRollupRules(namespace, timeNanos)
 }
 
 func (d *asyncDownsampler) NewMetricsAppender() (MetricsAppender, error) {

--- a/src/cmd/services/m3coordinator/downsample/downsample_mock.go
+++ b/src/cmd/services/m3coordinator/downsample/downsample_mock.go
@@ -27,6 +27,7 @@ package downsample
 import (
 	"reflect"
 
+	"github.com/m3db/m3/src/metrics/rules/view"
 	"github.com/m3db/m3/src/x/time"
 
 	"github.com/golang/mock/gomock"
@@ -67,6 +68,21 @@ func (m *MockDownsampler) Enabled() bool {
 func (mr *MockDownsamplerMockRecorder) Enabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enabled", reflect.TypeOf((*MockDownsampler)(nil).Enabled))
+}
+
+// LatestRollupRules mocks base method.
+func (m *MockDownsampler) LatestRollupRules(arg0 []byte, arg1 int64) ([]view.RollupRule, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestRollupRules", arg0, arg1)
+	ret0, _ := ret[0].([]view.RollupRule)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestRollupRules indicates an expected call of LatestRollupRules.
+func (mr *MockDownsamplerMockRecorder) LatestRollupRules(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestRollupRules", reflect.TypeOf((*MockDownsampler)(nil).LatestRollupRules), arg0, arg1)
 }
 
 // NewMetricsAppender mocks base method.

--- a/src/cmd/services/m3coordinator/downsample/downsampler.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/m3db/m3/src/metrics/generated/proto/metricpb"
+	"github.com/m3db/m3/src/metrics/rules/view"
 	"github.com/m3db/m3/src/query/storage/m3"
 	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 	"github.com/m3db/m3/src/query/ts"
@@ -35,6 +36,9 @@ import (
 
 // Downsampler is a downsampler.
 type Downsampler interface {
+	// LatestRollupRules returns a snapshot of the latest rollup rules for a given namespace
+	// at a given time.
+	LatestRollupRules(namespace []byte, timeNanos int64) ([]view.RollupRule, error)
 	NewMetricsAppender() (MetricsAppender, error)
 	// Enabled indicates whether the downsampler is enabled or not. A
 	// downsampler is enabled if there are aggregated ClusterNamespaces
@@ -147,6 +151,12 @@ func defaultMetricsAppenderOptions(opts DownsamplerOptions, agg agg) metricsAppe
 		untimedRollups: agg.untimedRollups,
 		metrics:        metrics,
 	}
+}
+
+func (d *downsampler) LatestRollupRules(namespace []byte, timeNanos int64) ([]view.RollupRule, error) {
+	d.RLock()
+	defer d.RUnlock()
+	return d.agg.matcher.LatestRollupRules(namespace, timeNanos)
 }
 
 func (d *downsampler) NewMetricsAppender() (MetricsAppender, error) {

--- a/src/cmd/services/m3coordinator/ingest/write.go
+++ b/src/cmd/services/m3coordinator/ingest/write.go
@@ -91,6 +91,8 @@ type DownsamplerAndWriter interface {
 	) BatchError
 
 	Storage() storage.Storage
+
+	Downsampler() downsample.Downsampler
 }
 
 // BatchError allows for access to individual errors.
@@ -582,6 +584,10 @@ func (d *downsamplerAndWriter) writeAggregatedBatch(
 	}
 
 	return multiErr.Add(iter.Error())
+}
+
+func (d *downsamplerAndWriter) Downsampler() downsample.Downsampler {
+	return d.downsampler
 }
 
 func (d *downsamplerAndWriter) Storage() storage.Storage {

--- a/src/cmd/services/m3coordinator/ingest/write_mock.go
+++ b/src/cmd/services/m3coordinator/ingest/write_mock.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/m3db/m3/src/cmd/services/m3coordinator/downsample"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/ts"
@@ -57,6 +58,20 @@ func NewMockDownsamplerAndWriter(ctrl *gomock.Controller) *MockDownsamplerAndWri
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDownsamplerAndWriter) EXPECT() *MockDownsamplerAndWriterMockRecorder {
 	return m.recorder
+}
+
+// Downsampler mocks base method.
+func (m *MockDownsamplerAndWriter) Downsampler() downsample.Downsampler {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Downsampler")
+	ret0, _ := ret[0].(downsample.Downsampler)
+	return ret0
+}
+
+// Downsampler indicates an expected call of Downsampler.
+func (mr *MockDownsamplerAndWriterMockRecorder) Downsampler() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Downsampler", reflect.TypeOf((*MockDownsamplerAndWriter)(nil).Downsampler))
 }
 
 // Storage mocks base method.

--- a/src/metrics/matcher/match.go
+++ b/src/metrics/matcher/match.go
@@ -28,10 +28,15 @@ import (
 	"github.com/m3db/m3/src/metrics/matcher/cache"
 	"github.com/m3db/m3/src/metrics/metric/id"
 	"github.com/m3db/m3/src/metrics/rules"
+	"github.com/m3db/m3/src/metrics/rules/view"
 )
 
 // Matcher matches rules against metric IDs.
 type Matcher interface {
+	// LatestRollupRules returns the latest rollup rules for a given namespace
+	// at a given time.
+	LatestRollupRules(namespace []byte, timeNanos int64) ([]view.RollupRule, error)
+
 	// ForwardMatch matches rules against metric ID for time range [fromNanos, toNanos)
 	// and returns the match result.
 	ForwardMatch(id id.ID, fromNanos, toNanos int64, opts rules.MatchOptions) (rules.MatchResult, error)
@@ -106,6 +111,10 @@ func NewMatcher(cache cache.Cache, opts Options) (Matcher, error) {
 	}, nil
 }
 
+func (m *matcher) LatestRollupRules(namespace []byte, timeNanos int64) ([]view.RollupRule, error) {
+	return m.namespaces.LatestRollupRules(namespace, timeNanos)
+}
+
 func (m *matcher) ForwardMatch(
 	id id.ID,
 	fromNanos, toNanos int64,
@@ -141,6 +150,10 @@ func newMatcherMetrics(scope tally.Scope) matcherMetrics {
 			),
 		),
 	}
+}
+
+func (m *noCacheMatcher) LatestRollupRules(namespace []byte, timeNanos int64) ([]view.RollupRule, error) {
+	return m.namespaces.LatestRollupRules(namespace, timeNanos)
 }
 
 func (m *noCacheMatcher) ForwardMatch(

--- a/src/metrics/matcher/matcher_mock.go
+++ b/src/metrics/matcher/matcher_mock.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/m3db/m3/src/metrics/metric/id"
 	"github.com/m3db/m3/src/metrics/rules"
+	"github.com/m3db/m3/src/metrics/rules/view"
 
 	"github.com/golang/mock/gomock"
 )
@@ -83,4 +84,19 @@ func (m *MockMatcher) ForwardMatch(arg0 id.ID, arg1, arg2 int64, arg3 rules.Matc
 func (mr *MockMatcherMockRecorder) ForwardMatch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForwardMatch", reflect.TypeOf((*MockMatcher)(nil).ForwardMatch), arg0, arg1, arg2, arg3)
+}
+
+// LatestRollupRules mocks base method.
+func (m *MockMatcher) LatestRollupRules(arg0 []byte, arg1 int64) ([]view.RollupRule, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestRollupRules", arg0, arg1)
+	ret0, _ := ret[0].([]view.RollupRule)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestRollupRules indicates an expected call of LatestRollupRules.
+func (mr *MockMatcherMockRecorder) LatestRollupRules(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestRollupRules", reflect.TypeOf((*MockMatcher)(nil).LatestRollupRules), arg0, arg1)
 }

--- a/src/metrics/matcher/ruleset.go
+++ b/src/metrics/matcher/ruleset.go
@@ -28,6 +28,7 @@ import (
 	"github.com/m3db/m3/src/cluster/kv/util/runtime"
 	"github.com/m3db/m3/src/metrics/generated/proto/rulepb"
 	"github.com/m3db/m3/src/metrics/rules"
+	"github.com/m3db/m3/src/metrics/rules/view"
 	"github.com/m3db/m3/src/x/clock"
 	"github.com/m3db/m3/src/x/instrument"
 
@@ -117,6 +118,13 @@ func newRuleSet(
 		SetProcessFn(r.process)
 	r.Value = runtime.NewValue(key, valueOpts)
 	return r
+}
+
+func (r *ruleSet) LatestRollupRules(timeNanos int64) ([]view.RollupRule, error) {
+	r.RLock()
+	rollupRules, err := r.matcher.LatestRollupRules(timeNanos)
+	r.RUnlock()
+	return rollupRules, err
 }
 
 func (r *ruleSet) Namespace() []byte {

--- a/src/metrics/matcher/ruleset_test.go
+++ b/src/metrics/matcher/ruleset_test.go
@@ -212,6 +212,10 @@ type mockMatcher struct {
 	aggTypesOpts                   aggregation.TypesOptions
 }
 
+func (mm *mockMatcher) LatestRollupRules(timeNanos int64) ([]view.RollupRule, error) {
+	return []view.RollupRule{}, nil
+}
+
 func (mm *mockMatcher) ForwardMatch(
 	id []byte,
 	fromNanos, toNanos int64,

--- a/src/metrics/rules/active_ruleset_test.go
+++ b/src/metrics/rules/active_ruleset_test.go
@@ -73,6 +73,28 @@ func TestActiveRuleSetCutoverTimesWithRollupRules(t *testing.T) {
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 }
 
+func TestActiveRuleSetLatestRollupRules(t *testing.T) {
+	rules := testRollupRules(t)
+	as := newActiveRuleSet(
+		0,
+		nil,
+		rules,
+		testTagsFilterOptions(),
+		mockNewID,
+	)
+	timeNanos := int64(95000)
+	rollupView, err := as.LatestRollupRules(timeNanos)
+	require.NoError(t, err)
+	// rr3 is tombstoned, so it should not be returned
+	require.Equal(t, len(rules)-1, len(rollupView))
+	for _, rr := range rollupView {
+		// explicitly check that rollupRule3 is not returned..
+		require.NotEqual(t, rr.Name, "rollupRule3.snapshot3")
+		// ..and that we only get the non-Tombstoned entries.
+		require.False(t, rr.Tombstoned)
+	}
+}
+
 func TestActiveRuleSetCutoverTimesWithMappingRulesAndRollupRules(t *testing.T) {
 	as := newActiveRuleSet(
 		0,


### PR DESCRIPTION
Extend the ActiveRuleset etc interfaces to provide a snapshot of the latest Rollup Rules for a namespace and timeNanos.

This will allow other parts of the code to inspect rollup rules, which can help with query analysis.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
