### PR TITLE
[storage] Additional metadata on aggregated vs unaggregated series, etc.

### DIFF
--- a/src/query/api/v1/handler/graphite/find_test.go
+++ b/src/query/api/v1/handler/graphite/find_test.go
@@ -292,8 +292,9 @@ func testFind(t *testing.T, opts testFindOptions) {
 							{Name: b("__g1__"), Values: bs("bug", "bar", "baz")},
 						},
 						Metadata: block.ResultMetadata{
-							LocalOnly:  true,
-							Exhaustive: lt.ex,
+							LocalOnly:      true,
+							Exhaustive:     lt.ex,
+							MetadataByName: make(map[string]*block.ResultMetricMetadata),
 						},
 					}
 				},
@@ -317,9 +318,10 @@ func testFind(t *testing.T, opts testFindOptions) {
 							{Name: b("__g1__"), Values: bs("baz", "bix", "bug")},
 						},
 						Metadata: block.ResultMetadata{
-							LocalOnly:  false,
-							Exhaustive: true,
-							Warnings:   warnings,
+							LocalOnly:      false,
+							Exhaustive:     true,
+							Warnings:       warnings,
+							MetadataByName: make(map[string]*block.ResultMetricMetadata),
 						},
 					}
 				},
@@ -365,8 +367,9 @@ func testFind(t *testing.T, opts testFindOptions) {
 							{Name: b("__g3__"), Values: bs("baz0", "baz1", "baz2")},
 						},
 						Metadata: block.ResultMetadata{
-							LocalOnly:  true,
-							Exhaustive: true,
+							LocalOnly:      true,
+							Exhaustive:     true,
+							MetadataByName: make(map[string]*block.ResultMetricMetadata),
 						},
 					}
 				},

--- a/src/query/api/v1/handler/prometheus/handleroptions/header_test.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/header_test.go
@@ -77,20 +77,92 @@ func TestAddDBResultResponseHeaders(t *testing.T) {
 	assert.Equal(t, 1, len(recorder.Header()))
 	assert.Equal(t, "{\"waitedIndex\":3,\"waitedSeriesRead\":42}",
 		recorder.Header().Get(headers.WaitedHeader))
+}
 
-	recorder = httptest.NewRecorder()
-	meta = block.NewResultMetadata()
+func TestAddDBResultResponseHeadersFetched(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	meta := block.NewResultMetadata()
 	meta.FetchedSeriesCount = 42
+	meta.FetchedMetadataCount = 142
+	meta.FetchedResponses = 99
+	meta.FetchedBytesEstimate = 1072
 	require.NoError(t, AddDBResultResponseHeaders(recorder, meta, nil))
-	assert.Equal(t, 1, len(recorder.Header()))
+	assert.Equal(t, 4, len(recorder.Header()))
+	assert.Equal(t, "99", recorder.Header().Get(headers.FetchedResponsesHeader))
+	assert.Equal(t, "1072", recorder.Header().Get(headers.FetchedBytesEstimateHeader))
 	assert.Equal(t, "42", recorder.Header().Get(headers.FetchedSeriesCount))
+	assert.Equal(t, "142", recorder.Header().Get(headers.FetchedMetadataCount))
+}
+
+func TestAddDBResultResponseHeadersNamespaces(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	meta := block.NewResultMetadata()
+	meta.Namespaces = []string{}
+	require.NoError(t, AddDBResultResponseHeaders(recorder, meta, nil))
+	assert.Equal(t, 0, len(recorder.Header()))
 
 	recorder = httptest.NewRecorder()
 	meta = block.NewResultMetadata()
-	meta.FetchedMetadataCount = 42
+	meta.Namespaces = []string{"default"}
 	require.NoError(t, AddDBResultResponseHeaders(recorder, meta, nil))
 	assert.Equal(t, 1, len(recorder.Header()))
-	assert.Equal(t, "42", recorder.Header().Get(headers.FetchedMetadataCount))
+	assert.Equal(t, "default", recorder.Header().Get(headers.NamespacesHeader))
+
+	recorder = httptest.NewRecorder()
+	meta = block.NewResultMetadata()
+	meta.Namespaces = []string{"default", "myfavoritens"}
+	require.NoError(t, AddDBResultResponseHeaders(recorder, meta, nil))
+	assert.Equal(t, 1, len(recorder.Header()))
+	assert.Equal(t, "default,myfavoritens", recorder.Header().Get(headers.NamespacesHeader))
+}
+
+func TestAddDBResultResponseHeadersMetadataByName(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	meta := block.NewResultMetadata()
+	meta.MetadataByName = map[string]*block.ResultMetricMetadata{
+		"mymetric": {
+			NoSamples:    1,
+			WithSamples:  2,
+			Aggregated:   3,
+			Unaggregated: 4,
+		},
+	}
+	require.NoError(t, AddDBResultResponseHeaders(recorder, meta, nil))
+	assert.Equal(t, 5, len(recorder.Header()))
+	assert.Equal(t, "1", recorder.Header().Get(headers.FetchedSeriesNoSamplesCount))
+	assert.Equal(t, "2", recorder.Header().Get(headers.FetchedSeriesWithSamplesCount))
+	assert.Equal(t, "3", recorder.Header().Get(headers.FetchedAggregatedSeriesCount))
+	assert.Equal(t, "4", recorder.Header().Get(headers.FetchedUnaggregatedSeriesCount))
+	assert.Equal(t,
+		"{\"mymetric\":{\"NoSamples\":1,\"WithSamples\":2,\"Aggregated\":3,\"Unaggregated\":4}}",
+		recorder.Header().Get(headers.MetricStats))
+
+	recorder = httptest.NewRecorder()
+	meta = block.NewResultMetadata()
+	meta.MetadataByName = map[string]*block.ResultMetricMetadata{
+		"metric_a": {
+			NoSamples:    1,
+			WithSamples:  2,
+			Aggregated:   3,
+			Unaggregated: 4,
+		},
+		"metric_b": {
+			NoSamples:    10,
+			WithSamples:  20,
+			Aggregated:   30,
+			Unaggregated: 40,
+		},
+	}
+	require.NoError(t, AddDBResultResponseHeaders(recorder, meta, nil))
+	assert.Equal(t, 5, len(recorder.Header()))
+	assert.Equal(t, "11", recorder.Header().Get(headers.FetchedSeriesNoSamplesCount))
+	assert.Equal(t, "22", recorder.Header().Get(headers.FetchedSeriesWithSamplesCount))
+	assert.Equal(t, "33", recorder.Header().Get(headers.FetchedAggregatedSeriesCount))
+	assert.Equal(t, "44", recorder.Header().Get(headers.FetchedUnaggregatedSeriesCount))
+	assert.Equal(t,
+		"{\"metric_a\":{\"NoSamples\":1,\"WithSamples\":2,\"Aggregated\":3,\"Unaggregated\":4},"+
+			"\"metric_b\":{\"NoSamples\":10,\"WithSamples\":20,\"Aggregated\":30,\"Unaggregated\":40}}",
+		recorder.Header().Get(headers.MetricStats))
 }
 
 func TestAddReturnedLimitResponseHeaders(t *testing.T) {

--- a/src/query/api/v1/handler/prometheus/remote/read_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/read_test.go
@@ -313,9 +313,10 @@ func TestMultipleRead(t *testing.T) {
 			},
 		},
 		Metadata: block.ResultMetadata{
-			Exhaustive: true,
-			LocalOnly:  true,
-			Warnings:   []block.Warning{{Name: "foo", Message: "bar"}},
+			Exhaustive:     true,
+			LocalOnly:      true,
+			Warnings:       []block.Warning{{Name: "foo", Message: "bar"}},
+			MetadataByName: make(map[string]*block.ResultMetricMetadata),
 		},
 	}
 
@@ -329,9 +330,10 @@ func TestMultipleRead(t *testing.T) {
 			},
 		},
 		Metadata: block.ResultMetadata{
-			Exhaustive: false,
-			LocalOnly:  true,
-			Warnings:   []block.Warning{},
+			Exhaustive:     false,
+			LocalOnly:      true,
+			Warnings:       []block.Warning{},
+			MetadataByName: make(map[string]*block.ResultMetricMetadata),
 		},
 	}
 

--- a/src/query/api/v1/handler/prometheus/remote/tag_values_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values_test.go
@@ -185,8 +185,9 @@ func testTagValuesWithMatch(
 			},
 		},
 		Metadata: block.ResultMetadata{
-			Exhaustive: false,
-			Warnings:   []block.Warning{{Name: "foo", Message: "bar"}},
+			Exhaustive:     false,
+			Warnings:       []block.Warning{{Name: "foo", Message: "bar"}},
+			MetadataByName: make(map[string]*block.ResultMetricMetadata),
 		},
 	}
 

--- a/src/query/block/meta.go
+++ b/src/query/block/meta.go
@@ -55,9 +55,50 @@ func (m Metadata) String() string {
 // Warnings is a slice of warnings.
 type Warnings []Warning
 
+// ResultMetricMetadata describes metadata on a per metric-name basis.
+type ResultMetricMetadata struct {
+	// NoSamples is the total number of series that were fetched to compute
+	// this result but had no samples and were omitted from the Prometheus result.
+	NoSamples int
+	// WithSamples is the total number of series that were fetched to compute
+	// this result and had samples and were included in the Prometheus result.
+	WithSamples int
+	// Aggregated is the total number of aggregated series that were fetched to
+	// compute this result.
+	Aggregated int
+	// Unaggregated is the total number of unaggregated series that were fetched to
+	// compute this result.
+	Unaggregated int
+}
+
+// Merge takes another ResultMetricMetadata and merges it into this one
+func (m *ResultMetricMetadata) Merge(other ResultMetricMetadata) {
+	m.NoSamples += other.NoSamples
+	m.WithSamples += other.WithSamples
+	m.Aggregated += other.Aggregated
+	m.Unaggregated += other.Unaggregated
+}
+
+func mergeMetricMetadataMaps(dst, src map[string]*ResultMetricMetadata) {
+	for name, other := range src {
+		m, ok := dst[name]
+		if !ok {
+			dst[name] = other
+		} else {
+			m.Merge(*other)
+		}
+	}
+}
+
 // ResultMetadata describes metadata common to each type of query results,
 // indicating any additional information about the result.
 type ResultMetadata struct {
+	// Namespaces are the set of namespaces queried.
+	Namespaces []string
+	// FetchedResponses is the number of M3 RPC fetch responses received.
+	FetchedResponses int
+	// FetchedBytesEstimate is the estimated number of bytes fetched.
+	FetchedBytesEstimate int
 	// LocalOnly indicates that this query was executed only on the local store.
 	LocalOnly bool
 	// Exhaustive indicates whether the underlying data set presents a full
@@ -80,13 +121,55 @@ type ResultMetadata struct {
 	// FetchedMetadataCount is the total amount of metadata that was fetched to compute
 	// this result.
 	FetchedMetadataCount int
+	// MetricNames is the set of unique metric tag name values across all series in this result.
+	MetadataByName map[string]*ResultMetricMetadata
+}
+
+// ByName returns the ResultMetricMetadata for a given metric name
+func (m ResultMetadata) ByName(name string) *ResultMetricMetadata {
+	r, ok := m.MetadataByName[name]
+	if ok {
+		return r
+	}
+
+	r = &ResultMetricMetadata{}
+	m.MetadataByName[name] = r
+	return r
+}
+
+// TopMetadataByName returns the top `max` ResultMetricMetadatas by the sum of their
+// contained counters.
+func (m ResultMetadata) TopMetadataByName(max int) map[string]*ResultMetricMetadata {
+	if len(m.MetadataByName) <= max {
+		return m.MetadataByName
+	}
+
+	keys := []string{}
+	for k := range m.MetadataByName {
+		keys = append(keys, k)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		a := m.MetadataByName[keys[i]]
+		b := m.MetadataByName[keys[j]]
+		n := a.Aggregated + a.Unaggregated + a.NoSamples + a.WithSamples
+		m := b.Aggregated + b.Unaggregated + b.NoSamples + b.WithSamples
+		// Sort in descending order
+		return n > m
+	})
+	top := make(map[string]*ResultMetricMetadata)
+	for i := 0; i < max; i++ {
+		k := keys[i]
+		top[k] = m.MetadataByName[k]
+	}
+	return top
 }
 
 // NewResultMetadata creates a new result metadata.
 func NewResultMetadata() ResultMetadata {
 	return ResultMetadata{
-		LocalOnly:  true,
-		Exhaustive: true,
+		LocalOnly:      true,
+		Exhaustive:     true,
+		MetadataByName: make(map[string]*ResultMetricMetadata),
 	}
 }
 
@@ -125,6 +208,18 @@ func combineWarnings(a, b Warnings) Warnings {
 	}
 
 	return nil
+}
+
+func combineMetricMetadata(a, b map[string]*ResultMetricMetadata) map[string]*ResultMetricMetadata {
+	if a == nil && b == nil {
+		return nil
+	}
+
+	merged := make(map[string]*ResultMetricMetadata)
+	mergeMetricMetadataMaps(merged, a)
+	mergeMetricMetadataMaps(merged, b)
+
+	return merged
 }
 
 // Equals determines if two result metadatas are equal.
@@ -171,6 +266,9 @@ func (m ResultMetadata) Equals(n ResultMetadata) bool {
 // CombineMetadata combines two result metadatas.
 func (m ResultMetadata) CombineMetadata(other ResultMetadata) ResultMetadata {
 	return ResultMetadata{
+		Namespaces:           append(m.Namespaces, other.Namespaces...),
+		FetchedResponses:     m.FetchedResponses + other.FetchedResponses,
+		FetchedBytesEstimate: m.FetchedBytesEstimate + other.FetchedBytesEstimate,
 		LocalOnly:            m.LocalOnly && other.LocalOnly,
 		Exhaustive:           m.Exhaustive && other.Exhaustive,
 		Warnings:             combineWarnings(m.Warnings, other.Warnings),
@@ -178,6 +276,7 @@ func (m ResultMetadata) CombineMetadata(other ResultMetadata) ResultMetadata {
 		WaitedIndex:          m.WaitedIndex + other.WaitedIndex,
 		WaitedSeriesRead:     m.WaitedSeriesRead + other.WaitedSeriesRead,
 		FetchedSeriesCount:   m.FetchedSeriesCount + other.FetchedSeriesCount,
+		MetadataByName:       combineMetricMetadata(m.MetadataByName, other.MetadataByName),
 		FetchedMetadataCount: m.FetchedMetadataCount + other.FetchedMetadataCount,
 	}
 }

--- a/src/query/graphite/storage/m3_wrapper_test.go
+++ b/src/query/graphite/storage/m3_wrapper_test.go
@@ -164,7 +164,8 @@ func buildResult(
 	return block.Result{
 		Blocks: []block.Block{bl},
 		Metadata: block.ResultMetadata{
-			Resolutions: resos,
+			Resolutions:    resos,
+			MetadataByName: make(map[string]*block.ResultMetricMetadata),
 		},
 	}
 }

--- a/src/query/remote/server_test.go
+++ b/src/query/remote/server_test.go
@@ -538,9 +538,10 @@ func TestBatchedCompleteTags(t *testing.T) {
 				CompleteNameOnly: nameOnly,
 				CompletedTags:    tags,
 				Metadata: block.ResultMetadata{
-					Exhaustive: false,
-					LocalOnly:  true,
-					Warnings:   []block.Warning{{Name: "foo", Message: "bar"}},
+					Exhaustive:     false,
+					LocalOnly:      true,
+					Warnings:       []block.Warning{{Name: "foo", Message: "bar"}},
+					MetadataByName: make(map[string]*block.ResultMetricMetadata),
 				},
 			}
 

--- a/src/x/headers/headers.go
+++ b/src/x/headers/headers.go
@@ -169,6 +169,38 @@ const (
 	// series that were fetched by the query, before computation.
 	FetchedSeriesCount = M3HeaderPrefix + "Series-Count"
 
+	// FetchedSeriesNoSamplesCount is the header added that tracks the total number of
+	// fetched series that were fetched by the query but had no samples.
+	FetchedSeriesNoSamplesCount = M3HeaderPrefix + "Series-No-Samples-Count"
+
+	// FetchedSeriesWithSamplesCount is the header added that tracks the total number of
+	// fetched series that were fetched by the query and had non-zero samples.
+	FetchedSeriesWithSamplesCount = M3HeaderPrefix + "Series-With-Samples-Count"
+
+	// FetchedAggregatedSeriesCount is the header added that tracks the total number of
+	// aggregated series that were fetched by the query, before computation.
+	FetchedAggregatedSeriesCount = M3HeaderPrefix + "Aggregated-Series-Count"
+
+	// FetchedUnaggregatedSeriesCount is the header added that tracks the total number of
+	// unaggregated series that were fetched by the query, before computation.
+	FetchedUnaggregatedSeriesCount = M3HeaderPrefix + "Unaggregated-Series-Count"
+
+	// MetricStats is the header added that tracks the unique set of metric stats
+	// all series fetched by this query, before computation, by metric name.
+	MetricStats = M3HeaderPrefix + "Metric-Stats"
+
+	// NamespacesHeader is the header added that tracks the unique set of namespaces
+	// read by this query.
+	NamespacesHeader = M3HeaderPrefix + "Namespaces"
+
+	// FetchedResponsesHeader is the header added that tracks the number of M3DB responses
+	// read by this query.
+	FetchedResponsesHeader = M3HeaderPrefix + "Fetched-Responses"
+
+	// FetchedBytesEstimateHeader is the header added that tracks the estimated number
+	// of bytes returned by all fetch responses (counted by FetchedResponsesHeader).
+	FetchedBytesEstimateHeader = M3HeaderPrefix + "Fetched-Bytes-Estimate"
+
 	// FetchedMetadataCount is the header added that tracks the total amount of
 	// metadata that was fetched by the query, before computation.
 	FetchedMetadataCount = M3HeaderPrefix + "Metadata-Count"


### PR DESCRIPTION
Breaks down the M3-Series-Count response header into:
* Unaggregated series count (not rolled up series)
* Aggregated series count(rolled up series)
* Series without samples (omitted from the result)
* Series with samples (included in the result)

It also emits the following for diagnostics:
* The set of namespaces accessed when querying m3
* The estimated byte size of the result set (already calculated, now exposed)
* The number of m3 response batches received (already calculated, now exposed)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
