### PR TITLE
WIP [coordinator] Map Graphite types to annotation.Payload proto

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/write_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/write_test.go
@@ -376,11 +376,11 @@ func TestPromWriteGraphiteMetricsTypes(t *testing.T) {
 
 	executeWriteRequest(t, opts, promReq)
 
-	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_UNKNOWN, false)
-	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_COUNTER, false)
-	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_GAUGE, false)
-	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_GAUGE, false)
-	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_UNKNOWN, false)
+	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_GRAPHITE_TIMER, false)
+	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_GRAPHITE_COUNTER, false)
+	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_GRAPHITE_GAUGE, false)
+	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_GRAPHITE_GAUGE, false)
+	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_GRAPHITE_TIMER, false)
 	verifyIterValueAnnotation(t, capturedIter, annotation.MetricType_UNKNOWN, false)
 
 	require.False(t, capturedIter.Next())

--- a/src/query/storage/converter.go
+++ b/src/query/storage/converter.go
@@ -226,6 +226,8 @@ func seriesAttributesForGraphiteSource(series prompb.TimeSeries) (ts.SeriesAttri
 		promMetricType = ts.PromMetricTypeCounter
 	case prompb.M3Type_M3_GAUGE:
 		promMetricType = ts.PromMetricTypeGauge
+	case prompb.M3Type_M3_TIMER:
+		promMetricType = ts.PromMetricTypeUnknown
 	}
 
 	return ts.SeriesAttributes{


### PR DESCRIPTION
**What this PR does / why we need it**:
Maps internal Graphite metric types (counter/gauge/timer) to the new `annotation.Payload` protobuf enum values introduced in https://github.com/m3db/m3/pull/3987).

**Special notes for your reviewer**:
Depends on https://github.com/m3db/m3/pull/3987.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
