### PR TITLE
[serialize] Add a fast unchecked tag decoder 

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
@@ -62,10 +62,7 @@ func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
 		}), poolOpts)
 	tagDecoderPool.Init()
 
-	metricTagsIteratorPool := serialize.NewMetricTagsIteratorPool(tagDecoderPool, poolOpts)
-	metricTagsIteratorPool.Init()
-
-	appenderPool := newMetricsAppenderPool(poolOpts, metricTagsIteratorPool, defaultMetricNameTagName)
+	appenderPool := newMetricsAppenderPool(poolOpts, serialize.NewTagSerializationLimits(), defaultMetricNameTagName)
 
 	for i := 0; i < count; i++ {
 		matcher := matcher.NewMockMatcher(ctrl)
@@ -157,10 +154,7 @@ func TestSamplesAppenderPoolResetsTagSimple(t *testing.T) {
 		}), poolOpts)
 	tagDecoderPool.Init()
 
-	metricTagsIteratorPool := serialize.NewMetricTagsIteratorPool(tagDecoderPool, poolOpts)
-	metricTagsIteratorPool.Init()
-
-	appenderPool := newMetricsAppenderPool(poolOpts, metricTagsIteratorPool, defaultMetricNameTagName)
+	appenderPool := newMetricsAppenderPool(poolOpts, serialize.NewTagSerializationLimits(), defaultMetricNameTagName)
 
 	appender := appenderPool.Get()
 	appender.AddTag([]byte("foo"), []byte("bar"))

--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -1038,7 +1038,7 @@ func (o DownsamplerOptions) newAggregatorPools() aggPools {
 
 	metricsAppenderPool := newMetricsAppenderPool(
 		o.MetricsAppenderPoolOptions,
-		metricTagsIteratorPool,
+		o.TagDecoderOptions.TagSerializationLimits(),
 		o.NameTagOrDefault())
 
 	return aggPools{

--- a/src/x/serialize/unchecked_decoder.go
+++ b/src/x/serialize/unchecked_decoder.go
@@ -118,10 +118,6 @@ func (d *uncheckedDecoder) decodeTag() error {
 	if err != nil {
 		return err
 	}
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/src/x/serialize/unchecked_decoder.go
+++ b/src/x/serialize/unchecked_decoder.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package serialize
+
+import (
+	"fmt"
+)
+
+// uncheckedDecoder is a fast decoder that skips all safety checks (i.e. ref counts).
+// it is suitable to use this when you are confident the provided bytes to decode are not shared.
+type uncheckedDecoder struct {
+	// immutable state for the lifetime of the decoder
+	maxTags      uint16
+	maxTagLength uint16
+
+	// immutable state for the lifetime of a single use.
+	length int
+
+	// mutable state during a single use.
+	data            []byte
+	remaining       int
+	err             error
+	currentTagName  []byte
+	currentTagValue []byte
+}
+
+func newUncheckedTagDecoder(tagLimits TagSerializationLimits) *uncheckedDecoder {
+	return &uncheckedDecoder{
+		// inline the config values since this call is in the hotpath of the matcher. saved about 1% cpu.
+		maxTags:      tagLimits.MaxNumberTags(),
+		maxTagLength: tagLimits.MaxTagLiteralLength(),
+	}
+}
+
+func (d *uncheckedDecoder) reset(b []byte) {
+	d.data = b
+	var length uint16
+	if len(d.data) == 0 {
+		d.length = 0
+		d.remaining = 0
+	} else {
+		header, err := d.decodeUInt16()
+		if err != nil {
+			d.err = err
+			return
+		}
+
+		if header != HeaderMagicNumber {
+			d.err = ErrIncorrectHeader
+			return
+		}
+
+		length, err = d.decodeUInt16()
+		if err != nil {
+			d.err = err
+			return
+		}
+
+		if limit := d.maxTags; length > limit {
+			d.err = fmt.Errorf("too many tags [ limit = %d, observed = %d ]", limit, length)
+			return
+		}
+	}
+	d.length = int(length)
+	d.remaining = int(length)
+	d.err = nil
+	d.currentTagName = nil
+	d.currentTagValue = nil
+}
+
+func (d *uncheckedDecoder) next() bool {
+	if d.err != nil || d.remaining <= 0 {
+		return false
+	}
+
+	if err := d.decodeTag(); err != nil {
+		d.err = err
+		return false
+	}
+
+	d.remaining--
+	return true
+}
+
+func (d *uncheckedDecoder) current() ([]byte, []byte) {
+	return d.currentTagName, d.currentTagValue
+}
+
+func (d *uncheckedDecoder) decodeTag() error {
+	var err error
+	d.currentTagName, err = d.decodeID()
+	if err != nil {
+		return err
+	}
+	if len(d.currentTagName) == 0 {
+		return ErrEmptyTagNameLiteral
+	}
+
+	d.currentTagValue, err = d.decodeID()
+	if err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *uncheckedDecoder) decodeID() ([]byte, error) {
+	l, err := d.decodeUInt16()
+	if err != nil {
+		return nil, err
+	}
+
+	if limit := d.maxTagLength; l > limit {
+		return nil, fmt.Errorf("tag literal too long [ limit = %d, observed = %d ]", limit, int(l))
+	}
+
+	if len(d.data) < int(l) {
+		return nil, errInvalidByteStreamIDDecoding
+	}
+
+	id := d.data[:l]
+	d.data = d.data[l:]
+
+	return id, nil
+}
+
+func (d *uncheckedDecoder) decodeUInt16() (uint16, error) {
+	if len(d.data) < 2 {
+		return 0, errInvalidByteStreamUintDecoding
+	}
+
+	n := decodeUInt16(d.data)
+	d.data = d.data[2:]
+	return n, nil
+}

--- a/src/x/serialize/unchecked_decoder_test.go
+++ b/src/x/serialize/unchecked_decoder_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package serialize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUncheckedEmptyDecode(t *testing.T) {
+	var b []byte
+	b = append(b, headerMagicBytes...)
+	b = append(b, []byte{0x0, 0x0}...)
+
+	d := newTestUncheckedTagDecoder()
+	d.reset(b)
+	require.False(t, d.next())
+	require.NoError(t, d.err)
+}
+
+func TestUncheckedNilDecode(t *testing.T) {
+	d := newTestUncheckedTagDecoder()
+	d.reset(nil)
+	require.False(t, d.next())
+	require.NoError(t, d.err)
+}
+
+func TestUncheckedEmptyTagNameDecode(t *testing.T) {
+	var b []byte
+	b = append(b, headerMagicBytes...)
+	b = append(b, encodeUInt16(1, make([]byte, 2))...) /* num tags */
+	b = append(b, encodeUInt16(0, make([]byte, 2))...) /* len empty string */
+	b = append(b, encodeUInt16(4, make([]byte, 2))...) /* len defg */
+	b = append(b, []byte("defg")...)
+
+	d := newTestUncheckedTagDecoder()
+	d.reset(b)
+	require.False(t, d.next())
+	require.Error(t, d.err)
+}
+
+func TestUncheckedEmptyTagValueDecode(t *testing.T) {
+	var b []byte
+	b = append(b, headerMagicBytes...)
+	b = append(b, encodeUInt16(1, make([]byte, 2))...) /* num tags */
+	b = append(b, encodeUInt16(1, make([]byte, 2))...) /* len "1" */
+	b = append(b, []byte("a")...)                      /* tag name */
+	b = append(b, encodeUInt16(0, make([]byte, 2))...) /* len tag value */
+
+	d := newTestUncheckedTagDecoder()
+	d.reset(b)
+	assertUncheckedNextTag(t, d, "a", "")
+	require.False(t, d.next())
+	require.NoError(t, d.err)
+}
+
+func TestUncheckedDecodeHeaderMissing(t *testing.T) {
+	var b []byte
+	b = append(b, []byte{0x0, 0x0}...)
+	b = append(b, []byte{0x0, 0x0}...)
+
+	d := newTestUncheckedTagDecoder()
+	d.reset(b)
+	require.False(t, d.next())
+	require.Error(t, d.err)
+}
+
+func TestUncheckedDecodeResetsErrState(t *testing.T) {
+	var b []byte
+	b = append(b, []byte{0x0, 0x0}...)
+	b = append(b, []byte{0x0, 0x0}...)
+
+	d := newTestUncheckedTagDecoder()
+	d.reset(b)
+	require.False(t, d.next())
+	require.Error(t, d.err)
+
+	d.reset(nil)
+	require.NoError(t, d.err)
+}
+
+func TestUncheckedDecodeSimple(t *testing.T) {
+	b := testTagDecoderBytesRaw()
+	d := newTestUncheckedTagDecoder()
+	d.reset(b)
+	require.NoError(t, d.err)
+
+	assertUncheckedNextTag(t, d, "abc", "defg")
+	assertUncheckedNextTag(t, d, "x", "bar")
+
+	require.False(t, d.next())
+	require.NoError(t, d.err)
+}
+
+func TestUncheckedDecodeTooManyTags(t *testing.T) {
+	b := testTagDecoderBytesRaw()
+	d := newUncheckedTagDecoder(NewTagSerializationLimits().SetMaxNumberTags(1))
+	d.reset(b)
+	require.Error(t, d.err)
+}
+
+func TestUncheckedDecodeLiteralTooLong(t *testing.T) {
+	b := testTagDecoderBytesRaw()
+	d := newUncheckedTagDecoder(NewTagSerializationLimits().
+		SetMaxNumberTags(2).
+		SetMaxTagLiteralLength(3))
+	d.reset(b)
+	require.NoError(t, d.err)
+	require.False(t, d.next())
+	require.Error(t, d.err)
+}
+
+func TestUncheckedDecodeMissingTags(t *testing.T) {
+	var b []byte
+	b = append(b, headerMagicBytes...)
+	b = append(b, encodeUInt16(2, make([]byte, 2))...) /* num tags */
+
+	d := newTestUncheckedTagDecoder()
+	d.reset(b)
+	require.NoError(t, d.err)
+
+	require.False(t, d.next())
+	require.Error(t, d.err)
+}
+
+func TestUncheckedDecodeMissingValue(t *testing.T) {
+	var b []byte
+	b = append(b, headerMagicBytes...)
+	b = append(b, encodeUInt16(2, make([]byte, 2))...) /* num tags */
+	b = append(b, encodeUInt16(3, make([]byte, 2))...) /* len abc */
+	b = append(b, []byte("abc")...)
+
+	b = append(b, encodeUInt16(4, make([]byte, 2))...) /* len defg */
+	b = append(b, []byte("defg")...)
+
+	b = append(b, encodeUInt16(1, make([]byte, 2))...) /* len x */
+	b = append(b, []byte("x")...)
+
+	d := newTestUncheckedTagDecoder()
+	d.reset(b)
+	require.NoError(t, d.err)
+
+	assertUncheckedNextTag(t, d, "abc", "defg")
+	require.False(t, d.next())
+	require.Error(t, d.err)
+}
+
+// assert the next tag in the iteration. ensures the decoder and faster decoder match.
+func assertUncheckedNextTag(t *testing.T, d *uncheckedDecoder, name, value string) {
+	require.True(t, d.next())
+	curName, curValue := d.current()
+	require.Equal(t, name, string(curName))
+	require.Equal(t, value, string(curValue))
+}
+
+func newTestUncheckedTagDecoder() *uncheckedDecoder {
+	return newUncheckedTagDecoder(NewTagSerializationLimits())
+}

--- a/src/x/serialize/unchecked_metric_tags_iterator.go
+++ b/src/x/serialize/unchecked_metric_tags_iterator.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package serialize
+
+type uncheckedMetricTagsIter struct {
+	data    []byte
+	decoder *uncheckedDecoder
+}
+
+// NewUncheckedMetricTagsIterator creates a MetricTagsIterator that removes all safety checks (i.e ref counts).
+// It is suitable to use this when you are confident the provided bytes to iterate are not shared.
+func NewUncheckedMetricTagsIterator(tagLimits TagSerializationLimits) MetricTagsIterator {
+	return &uncheckedMetricTagsIter{
+		decoder: newUncheckedTagDecoder(tagLimits),
+	}
+}
+
+func (it *uncheckedMetricTagsIter) Reset(sortedTagPairs []byte) {
+	it.data = sortedTagPairs
+	it.decoder.reset(sortedTagPairs)
+}
+
+func (it *uncheckedMetricTagsIter) Bytes() []byte {
+	return it.data
+}
+
+func (it *uncheckedMetricTagsIter) NumTags() int {
+	return it.decoder.length
+}
+
+func (it *uncheckedMetricTagsIter) TagValue(tagName []byte) ([]byte, bool) {
+	// use the fast decoder (i.e no pools) since this lookup is outside the current iteration.
+	// decoding errors are dropped and the tag is reported as missing.
+	value, found, _ := TagValueFromEncodedTagsFast(it.data, tagName)
+	return value, found
+}
+
+func (it *uncheckedMetricTagsIter) Next() bool {
+	return it.decoder.next()
+}
+
+func (it *uncheckedMetricTagsIter) Current() ([]byte, []byte) {
+	return it.decoder.current()
+}
+
+func (it *uncheckedMetricTagsIter) Err() error {
+	return it.decoder.err
+}
+
+func (it *uncheckedMetricTagsIter) Close() {
+	panic("should not close")
+}


### PR DESCRIPTION
This adds an unchecked tag decoder/iterator which removes all safety
checks (i.e ref checking) to improve the performance. It is safe to use
this when the underlying bytes are not shared and are safe to reuse.

A good example of this is the downsampler, that is single threaded and
has to match a metric id against many rules. This significantly
increases the performance of the downsampler.