### PR TITLE
[query] Some cleanups around generating new stats/metadata fields

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/read_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/read_test.go
@@ -204,7 +204,11 @@ func TestPromReadStorageWithFetchError(t *testing.T) {
 	}
 
 	fetchOpts := &storage.FetchOptions{}
-	result := storage.NewPromResult([]*prompb.TimeSeries{})
+	result := storage.PromResult{
+		PromResult: &prompb.QueryResult{
+			Timeseries: []*prompb.TimeSeries{},
+		},
+	}
 	engine := executor.NewMockEngine(ctrl)
 	engine.EXPECT().
 		ExecuteProm(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -398,17 +402,19 @@ func TestReadWithOptions(t *testing.T) {
 	now := xtime.Now()
 	promNow := storage.TimeToPromTimestamp(now)
 
-	r := storage.NewPromResult(
-		[]*prompb.TimeSeries{
-			{
-				Samples: []prompb.Sample{{Value: 1, Timestamp: promNow}},
-				Labels: []prompb.Label{
-					{Name: []byte("a"), Value: []byte("b")},
-					{Name: []byte("remove"), Value: []byte("c")},
+	r := storage.PromResult{
+		PromResult: &prompb.QueryResult{
+			Timeseries: []*prompb.TimeSeries{
+				{
+					Samples: []prompb.Sample{{Value: 1, Timestamp: promNow}},
+					Labels: []prompb.Label{
+						{Name: []byte("a"), Value: []byte("b")},
+						{Name: []byte("remove"), Value: []byte("c")},
+					},
 				},
 			},
 		},
-	)
+	}
 
 	req := &prompb.ReadRequest{
 		Queries: []*prompb.Query{{StartTimestampMs: 10, EndTimestampMs: 100}},

--- a/src/query/storage/fanout/storage_test.go
+++ b/src/query/storage/fanout/storage_test.go
@@ -249,6 +249,8 @@ func TestFanoutReadEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Equal(t, 0, len(res.PromResult.GetTimeseries()))
+	assert.Equal(t, 0, res.Metadata.FetchedSeriesCount)
+	assert.Equal(t, block.ResultMetricMetadata{}, res.Metadata.MetadataByNameMerged())
 }
 
 func TestFanoutReadError(t *testing.T) {

--- a/src/query/storage/m3/storage_test.go
+++ b/src/query/storage/m3/storage_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/encoding"
+	"github.com/m3db/m3/src/query/block"
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
 	"github.com/m3db/m3/src/query/storage/m3/consolidators"
@@ -586,12 +587,16 @@ func TestLocalReadExceedsAggregatedAndPartialAggregated(t *testing.T) {
 func assertFetchResult(t *testing.T, results storage.PromResult, testTag ident.Tag) {
 	require.NotNil(t, results.PromResult)
 	series := results.PromResult.GetTimeseries()
+	meta := results.Metadata
 	require.Equal(t, 1, len(series))
 	labels := series[0].GetLabels()
 	require.Equal(t, 1, len(labels))
 	l := labels[0]
 	assert.Equal(t, testTag.Name.String(), string(l.GetName()))
 	assert.Equal(t, testTag.Value.String(), string(l.GetValue()))
+	merged := meta.MetadataByNameMerged()
+	assert.Equal(t, 1, meta.FetchedSeriesCount)
+	assert.Equal(t, merged, block.ResultMetricMetadata{Unaggregated: 1, WithSamples: 1})
 }
 
 func TestLocalSearchError(t *testing.T) {

--- a/src/query/storage/prometheus/prometheus_storage_test.go
+++ b/src/query/storage/prometheus/prometheus_storage_test.go
@@ -93,32 +93,35 @@ func TestSelectWithMetaInContext(t *testing.T) {
 		Interval:    time.Duration(step),
 	}
 
+	meta := block.NewResultMetadata()
+	meta.AddWarning("warn", "warning")
 	store.EXPECT().FetchProm(ctx, exQuery, gomock.Any()).DoAndReturn(
 		func(_ context.Context, arg1 *storage.FetchQuery, _ *storage.FetchOptions) (storage.PromResult, error) {
-			result := storage.NewPromResult(
-				[]*prompb.TimeSeries{
-					{
-						Labels: []prompb.Label{
-							{Name: []byte("foo"), Value: []byte("bar")},
-							{Name: []byte("qux"), Value: []byte("qzz")},
+			return storage.PromResult{
+				Metadata: meta,
+				PromResult: &prompb.QueryResult{
+					Timeseries: []*prompb.TimeSeries{
+						{
+							Labels: []prompb.Label{
+								{Name: []byte("foo"), Value: []byte("bar")},
+								{Name: []byte("qux"), Value: []byte("qzz")},
+							},
+							Samples: []prompb.Sample{
+								prompb.Sample{Value: 1, Timestamp: 100},
+							},
 						},
-						Samples: []prompb.Sample{
-							{Value: 1, Timestamp: 100},
-						},
-					},
-					{
-						Labels: []prompb.Label{
-							{Name: []byte("foo"), Value: []byte("bar")},
-							{Name: []byte("qux"), Value: []byte("qaz")},
-						},
-						Samples: []prompb.Sample{
-							{Value: 100, Timestamp: 200},
+						{
+							Labels: []prompb.Label{
+								{Name: []byte("foo"), Value: []byte("bar")},
+								{Name: []byte("qux"), Value: []byte("qaz")},
+							},
+							Samples: []prompb.Sample{
+								prompb.Sample{Value: 100, Timestamp: 200},
+							},
 						},
 					},
 				},
-			)
-			result.Metadata.AddWarning("warn", "warning")
-			return result, nil
+			}, nil
 		})
 
 	series := q.Select(true, hints, matchers...)

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -355,16 +355,6 @@ type PromResult struct {
 	Metadata block.ResultMetadata
 }
 
-// NewPromResult returns a new, initialized PromResult
-func NewPromResult(timeseries []*prompb.TimeSeries) PromResult {
-	return PromResult{
-		PromResult: &prompb.QueryResult{
-			Timeseries: timeseries,
-		},
-		Metadata: block.NewResultMetadata(),
-	}
-}
-
 // PromConvertOptions are options controlling the conversion of raw series iterators
 // to a Prometheus-compatible result.
 type PromConvertOptions interface {


### PR DESCRIPTION
- Log JSON errors when serializing MetricStats.
- Use metricNameFromLabels in prom_converter.go.
- Reduce string copies by comparing to byte arrays when possible.
- Initialize the MetricStats map with a size.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
