### PR TITLE
[coordinator] Add readOnly option to namespace config

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/options.go
+++ b/src/cmd/services/m3coordinator/downsample/options.go
@@ -161,6 +161,10 @@ func NewAutoMappingRules(namespaces []m3.ClusterNamespace) ([]AutoMappingRule, e
 			continue
 		}
 
+		if opts.ReadOnly() {
+			continue
+		}
+
 		downsampleOpts, err := opts.DownsampleOptions()
 		if err != nil {
 			errFmt := "unable to resolve downsample options for namespace: %v"

--- a/src/cmd/services/m3coordinator/downsample/options_test.go
+++ b/src/cmd/services/m3coordinator/downsample/options_test.go
@@ -91,6 +91,7 @@ func TestAutoMappingRules(t *testing.T) {
 			ReadOnly:    true,
 		},
 	)
+	require.NoError(t, err)
 
 	rules, err := NewAutoMappingRules(clusters.ClusterNamespaces())
 	require.NoError(t, err)

--- a/src/cmd/services/m3coordinator/downsample/options_test.go
+++ b/src/cmd/services/m3coordinator/downsample/options_test.go
@@ -67,22 +67,30 @@ func TestAutoMappingRules(t *testing.T) {
 
 	session := client.NewMockSession(ctrl)
 
-	clusters, err := m3.NewClusters(m3.UnaggregatedClusterNamespaceDefinition{
-		NamespaceID: ident.StringID("default"),
-		Retention:   48 * time.Hour,
-		Session:     session,
-	}, m3.AggregatedClusterNamespaceDefinition{
-		NamespaceID: ident.StringID("2s:1d"),
-		Resolution:  2 * time.Second,
-		Retention:   24 * time.Hour,
-		Session:     session,
-	}, m3.AggregatedClusterNamespaceDefinition{
-		NamespaceID: ident.StringID("4s:2d"),
-		Resolution:  4 * time.Second,
-		Retention:   48 * time.Hour,
-		Session:     session,
-		Downsample:  &m3.ClusterNamespaceDownsampleOptions{All: false},
-	})
+	clusters, err := m3.NewClusters(
+		m3.UnaggregatedClusterNamespaceDefinition{
+			NamespaceID: ident.StringID("default"),
+			Retention:   48 * time.Hour,
+			Session:     session,
+		}, m3.AggregatedClusterNamespaceDefinition{
+			NamespaceID: ident.StringID("2s:1d"),
+			Resolution:  2 * time.Second,
+			Retention:   24 * time.Hour,
+			Session:     session,
+		}, m3.AggregatedClusterNamespaceDefinition{
+			NamespaceID: ident.StringID("4s:2d"),
+			Resolution:  4 * time.Second,
+			Retention:   48 * time.Hour,
+			Session:     session,
+			Downsample:  &m3.ClusterNamespaceDownsampleOptions{All: false},
+		}, m3.AggregatedClusterNamespaceDefinition{
+			NamespaceID: ident.StringID("10s:4d"),
+			Resolution:  10 * time.Second,
+			Retention:   96 * time.Hour,
+			Session:     session,
+			ReadOnly:    true,
+		},
+	)
 
 	rules, err := NewAutoMappingRules(clusters.ClusterNamespaces())
 	require.NoError(t, err)

--- a/src/query/storage/m3/cluster.go
+++ b/src/query/storage/m3/cluster.go
@@ -101,6 +101,7 @@ type ClusterNamespaceOptions struct {
 	// and/or error if call to access a field is not relevant/correct.
 	attributes storagemetadata.Attributes
 	downsample *ClusterNamespaceDownsampleOptions
+	readOnly   bool
 }
 
 // NewClusterNamespaceOptions creates new cluster namespace options.
@@ -117,6 +118,11 @@ func NewClusterNamespaceOptions(
 // Attributes returns the storage attributes of the cluster namespace.
 func (o ClusterNamespaceOptions) Attributes() storagemetadata.Attributes {
 	return o.attributes
+}
+
+// ReadOnly returns the value of ReadOnly option for a cluster namespace.
+func (o ClusterNamespaceOptions) ReadOnly() bool {
+	return o.readOnly
 }
 
 // DownsampleOptions returns the downsample options for a cluster namespace,
@@ -206,6 +212,7 @@ type AggregatedClusterNamespaceDefinition struct {
 	Retention   time.Duration
 	Resolution  time.Duration
 	Downsample  *ClusterNamespaceDownsampleOptions
+	ReadOnly    bool
 }
 
 // Validate validates the cluster namespace definition.
@@ -386,6 +393,7 @@ func newAggregatedClusterNamespace(
 				Resolution:  def.Resolution,
 			},
 			downsample: def.Downsample,
+			readOnly:   def.ReadOnly,
 		},
 		session: def.Session,
 	}, nil

--- a/src/query/storage/m3/config.go
+++ b/src/query/storage/m3/config.go
@@ -87,6 +87,9 @@ type ClusterStaticNamespaceConfiguration struct {
 	// Downsample is the configuration for downsampling options to use with
 	// the namespace.
 	Downsample *DownsampleClusterStaticNamespaceConfiguration `yaml:"downsample"`
+
+	// ReadOnly prevents any writes to this namespace.
+	ReadOnly bool `yaml:"readOnly"`
 }
 
 func (c ClusterStaticNamespaceConfiguration) metricsType() (storagemetadata.MetricsType, error) {
@@ -296,6 +299,7 @@ func (c ClustersStaticConfiguration) NewStaticClusters(
 				Retention:   n.Retention,
 				Resolution:  n.Resolution,
 				Downsample:  &downsampleOpts,
+				ReadOnly:    n.ReadOnly,
 			}
 			aggregatedClusterNamespaces = append(aggregatedClusterNamespaces, def)
 		}

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -790,6 +790,12 @@ func (s *m3storage) Write(
 		if !exists {
 			err = fmt.Errorf("no configured cluster namespace for: retention=%s,"+
 				" resolution=%s", attrs.Retention.String(), attrs.Resolution.String())
+			break
+		}
+		if namespace.Options().ReadOnly() {
+			err = fmt.Errorf(
+				"cannot write to read only namespace %s (%s:%s)",
+				namespace.NamespaceID(), attrs.Resolution.String(), attrs.Retention.String())
 		}
 	default:
 		metricsType := attributes.MetricsType

--- a/src/query/storage/m3/storage_test.go
+++ b/src/query/storage/m3/storage_test.go
@@ -300,17 +300,19 @@ func TestWriteToReadOnlyNamespaceFail(t *testing.T) {
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()
 
-	clusters, err := NewClusters(UnaggregatedClusterNamespaceDefinition{
-		NamespaceID: ident.StringID("unaggregated"),
-		Session:     client.NewMockSession(ctrl),
-		Retention:   time.Hour,
-	}, AggregatedClusterNamespaceDefinition{
-		NamespaceID: ident.StringID("aggregated_readonly"),
-		Session:     client.NewMockSession(ctrl),
-		Retention:   24 * time.Hour,
-		Resolution:  time.Minute,
-		ReadOnly:    true,
-	})
+	clusters, err := NewClusters(
+		UnaggregatedClusterNamespaceDefinition{
+			NamespaceID: ident.StringID("unaggregated"),
+			Session:     client.NewMockSession(ctrl),
+			Retention:   time.Hour,
+		}, AggregatedClusterNamespaceDefinition{
+			NamespaceID: ident.StringID("aggregated_readonly"),
+			Session:     client.NewMockSession(ctrl),
+			Retention:   24 * time.Hour,
+			Resolution:  time.Minute,
+			ReadOnly:    true,
+		},
+	)
 	require.NoError(t, err)
 
 	store := newTestStorage(t, clusters)

--- a/src/query/storage/m3/storage_test.go
+++ b/src/query/storage/m3/storage_test.go
@@ -296,6 +296,43 @@ func TestLocalWriteUnaggregatedNamespaceUninitializedError(t *testing.T) {
 		fmt.Sprintf("unexpected error string: %v", err.Error()))
 }
 
+func TestWriteToReadOnlyNamespaceFail(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	defer ctrl.Finish()
+
+	clusters, err := NewClusters(UnaggregatedClusterNamespaceDefinition{
+		NamespaceID: ident.StringID("unaggregated"),
+		Session:     client.NewMockSession(ctrl),
+		Retention:   time.Hour,
+	}, AggregatedClusterNamespaceDefinition{
+		NamespaceID: ident.StringID("aggregated_readonly"),
+		Session:     client.NewMockSession(ctrl),
+		Retention:   24 * time.Hour,
+		Resolution:  time.Minute,
+		ReadOnly:    true,
+	})
+	require.NoError(t, err)
+
+	store := newTestStorage(t, clusters)
+
+	opts := newWriteQuery(t).Options()
+
+	opts.Attributes = storagemetadata.Attributes{
+		MetricsType: storagemetadata.AggregatedMetricsType,
+		Retention:   24 * time.Hour,
+		Resolution:  time.Minute,
+	}
+
+	writeQuery, err := storage.NewWriteQuery(opts)
+	require.NoError(t, err)
+
+	err = store.Write(context.TODO(), writeQuery)
+	assert.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "cannot write to read only namespace aggregated_readonly"),
+		fmt.Sprintf("unexpected error string: %v", err.Error()))
+}
+
 func TestLocalWriteAggregatedInvalidMetricsTypeError(t *testing.T) {
 	ctrl := xtest.NewController(t)
 	defer ctrl.Finish()

--- a/src/query/storage/promremote/types_test.go
+++ b/src/query/storage/promremote/types_test.go
@@ -33,9 +33,8 @@ import (
 
 func TestNamespaces(t *testing.T) {
 	tcs := []struct {
-		name               string
-		endpoint           EndpointOptions
-		expectedDownsample *bool
+		name     string
+		endpoint EndpointOptions
 	}{
 		{
 			name: "raw",
@@ -45,7 +44,6 @@ func TestNamespaces(t *testing.T) {
 					MetricsType: storagemetadata.UnaggregatedMetricsType,
 				},
 			},
-			expectedDownsample: nil,
 		},
 		{
 			name: "donwsampled",


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `readOnly` option to namespace config. Such namespace does not accept any writes. 
No auto-mapping rules get created for it, regardless of `downsample.all` setting.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
