### PR TITLE
[query] Configurable metric metadata stats count

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -111,6 +111,9 @@ var (
 		Size:                  4096,
 		KillWorkerProbability: 0.001,
 	}
+
+	// By default, return up to 4 metric metadata stats per request.
+	defaultMaxMetricMetadataStats = 4
 )
 
 // Configuration is the configuration for the query service.
@@ -437,6 +440,11 @@ type PerQueryLimitsConfiguration struct {
 
 	// RequireExhaustive results in an error if the query exceeds any limit.
 	RequireExhaustive *bool `yaml:"requireExhaustive"`
+
+	// MaxMetricMetadataStats limits the number of metric metadata stats to return
+	// as a response header after a query. If unset, defaults to 4. If set to zero,
+	// no metric metadata stats will be returned as a response header.
+	MaxMetricMetadataStats *int `yaml:"maxMetricMetadataStats"`
 }
 
 // AsFetchOptionsBuilderLimitsOptions converts this configuration to
@@ -457,12 +465,18 @@ func (l *PerQueryLimitsConfiguration) AsFetchOptionsBuilderLimitsOptions() handl
 		requireExhaustive = *r
 	}
 
+	maxMetricMetadataStats := defaultMaxMetricMetadataStats
+	if v := l.MaxMetricMetadataStats; v != nil {
+		maxMetricMetadataStats = *v
+	}
+
 	return handleroptions.FetchOptionsBuilderLimitsOptions{
-		SeriesLimit:       int(seriesLimit),
-		InstanceMultiple:  l.InstanceMultiple,
-		DocsLimit:         int(docsLimit),
-		RangeLimit:        l.MaxFetchedRange,
-		RequireExhaustive: requireExhaustive,
+		SeriesLimit:            seriesLimit,
+		InstanceMultiple:       l.InstanceMultiple,
+		DocsLimit:              docsLimit,
+		RangeLimit:             l.MaxFetchedRange,
+		RequireExhaustive:      requireExhaustive,
+		MaxMetricMetadataStats: maxMetricMetadataStats,
 	}
 }
 

--- a/src/cmd/services/m3query/config/config_test.go
+++ b/src/cmd/services/m3query/config/config_test.go
@@ -24,13 +24,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/m3db/m3/src/query/models"
-	xconfig "github.com/m3db/m3/src/x/config"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/validator.v2"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
+	"github.com/m3db/m3/src/query/models"
+	xconfig "github.com/m3db/m3/src/x/config"
 )
 
 const testConfigFile = "./testdata/config.yml"
@@ -103,6 +104,18 @@ func TestConfigLoading(t *testing.T) {
 	assert.Equal(t, HTTPConfiguration{EnableH2C: true}, cfg.HTTP)
 
 	// TODO: assert on more fields here.
+}
+
+func TestDefaultAsFetchOptionsBuilderLimitsOptions(t *testing.T) {
+	limits := LimitsConfiguration{}
+	assert.Equal(t, handleroptions.FetchOptionsBuilderLimitsOptions{
+		SeriesLimit:            defaultStorageQuerySeriesLimit,
+		InstanceMultiple:       float32(0),
+		DocsLimit:              defaultStorageQueryDocsLimit,
+		RangeLimit:             0,
+		RequireExhaustive:      defaultRequireExhaustive,
+		MaxMetricMetadataStats: defaultMaxMetricMetadataStats,
+	}, limits.PerQuery.AsFetchOptionsBuilderLimitsOptions())
 }
 
 func TestConfigValidation(t *testing.T) {

--- a/src/query/api/v1/handler/graphite/find_test.go
+++ b/src/query/api/v1/handler/graphite/find_test.go
@@ -292,9 +292,8 @@ func testFind(t *testing.T, opts testFindOptions) {
 							{Name: b("__g1__"), Values: bs("bug", "bar", "baz")},
 						},
 						Metadata: block.ResultMetadata{
-							LocalOnly:      true,
-							Exhaustive:     lt.ex,
-							MetadataByName: make(map[string]*block.ResultMetricMetadata),
+							LocalOnly:  true,
+							Exhaustive: lt.ex,
 						},
 					}
 				},
@@ -318,10 +317,9 @@ func testFind(t *testing.T, opts testFindOptions) {
 							{Name: b("__g1__"), Values: bs("baz", "bix", "bug")},
 						},
 						Metadata: block.ResultMetadata{
-							LocalOnly:      false,
-							Exhaustive:     true,
-							Warnings:       warnings,
-							MetadataByName: make(map[string]*block.ResultMetricMetadata),
+							LocalOnly:  false,
+							Exhaustive: true,
+							Warnings:   warnings,
 						},
 					}
 				},
@@ -367,9 +365,8 @@ func testFind(t *testing.T, opts testFindOptions) {
 							{Name: b("__g3__"), Values: bs("baz0", "baz1", "baz2")},
 						},
 						Metadata: block.ResultMetadata{
-							LocalOnly:      true,
-							Exhaustive:     true,
-							MetadataByName: make(map[string]*block.ResultMetricMetadata),
+							LocalOnly:  true,
+							Exhaustive: true,
 						},
 					}
 				},

--- a/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/fetch_options.go
@@ -97,6 +97,7 @@ type FetchOptionsBuilderLimitsOptions struct {
 	ReturnedDatapointsLimit     int
 	ReturnedSeriesMetadataLimit int
 	RequireExhaustive           bool
+	MaxMetricMetadataStats      int
 }
 
 type fetchOptionsBuilder struct {
@@ -309,6 +310,14 @@ func (b fetchOptionsBuilder) newFetchOptions(
 	}
 
 	fetchOpts.ReturnedSeriesMetadataLimit = returnedSeriesMetadataLimit
+
+	returnedMaxMetricMetadataStats, err := ParseLimit(req, headers.LimitMaxMetricMetadataStatsHeader,
+		"returnedMaxMetricMetadataStats", b.opts.Limits.MaxMetricMetadataStats)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fetchOpts.MaxMetricMetadataStats = returnedMaxMetricMetadataStats
 
 	requireExhaustive, err := ParseRequireExhaustive(req, b.opts.Limits.RequireExhaustive)
 	if err != nil {

--- a/src/query/api/v1/handler/prometheus/handleroptions/headers.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/headers.go
@@ -31,12 +31,6 @@ import (
 	"github.com/m3db/m3/src/x/headers"
 )
 
-const (
-	// maxMetricStatsInHeader is the maximum number of metric stats to
-	// serialize into the headers.MetricStats header.
-	maxMetricStatsInHeader = 10
-)
-
 // ReturnedDataLimited is info about whether data was limited by a query.
 type ReturnedDataLimited struct {
 	Series     int
@@ -129,13 +123,15 @@ func AddDBResultResponseHeaders(
 	}
 
 	// Also report the top metadata by name, in JSON.
-	if len(meta.MetadataByName) > 0 {
-		stats := meta.TopMetadataByName(maxMetricStatsInHeader)
-		js, err := json.Marshal(stats)
-		if err != nil {
-			return err
+	if fetchOpts != nil && fetchOpts.MaxMetricMetadataStats > 0 {
+		if len(meta.MetadataByName) > 0 {
+			stats := meta.TopMetadataByName(fetchOpts.MaxMetricMetadataStats)
+			js, err := json.Marshal(stats)
+			if err != nil {
+				return err
+			}
+			w.Header().Add(headers.MetricStats, string(js))
 		}
-		w.Header().Add(headers.MetricStats, string(js))
 	}
 
 	if meta.FetchedMetadataCount > 0 {

--- a/src/query/api/v1/handler/prometheus/handleroptions/headers.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/headers.go
@@ -110,8 +110,8 @@ func AddDBResultResponseHeaders(
 		w.Header().Add(headers.FetchedSeriesWithSamplesCount, fmt.Sprint(merged.WithSamples))
 	}
 
-	if len(meta.Namespaces) > 0 {
-		w.Header().Add(headers.NamespacesHeader, strings.Join(meta.Namespaces, ","))
+	if namespaces := meta.GetNamespaces(); len(namespaces) > 0 {
+		w.Header().Add(headers.NamespacesHeader, strings.Join(namespaces, ","))
 	}
 
 	if meta.FetchedResponses > 0 {
@@ -124,8 +124,7 @@ func AddDBResultResponseHeaders(
 
 	// Also report the top metadata by name, in JSON.
 	if fetchOpts != nil && fetchOpts.MaxMetricMetadataStats > 0 {
-		if len(meta.MetadataByName) > 0 {
-			stats := meta.TopMetadataByName(fetchOpts.MaxMetricMetadataStats)
+		if stats := meta.TopMetadataByName(fetchOpts.MaxMetricMetadataStats); len(stats) > 0 {
 			js, err := json.Marshal(stats)
 			if err != nil {
 				return err

--- a/src/query/api/v1/handler/prometheus/remote/read_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/read_test.go
@@ -317,10 +317,9 @@ func TestMultipleRead(t *testing.T) {
 			},
 		},
 		Metadata: block.ResultMetadata{
-			Exhaustive:     true,
-			LocalOnly:      true,
-			Warnings:       []block.Warning{{Name: "foo", Message: "bar"}},
-			MetadataByName: make(map[string]*block.ResultMetricMetadata),
+			Exhaustive: true,
+			LocalOnly:  true,
+			Warnings:   []block.Warning{{Name: "foo", Message: "bar"}},
 		},
 	}
 
@@ -334,10 +333,9 @@ func TestMultipleRead(t *testing.T) {
 			},
 		},
 		Metadata: block.ResultMetadata{
-			Exhaustive:     false,
-			LocalOnly:      true,
-			Warnings:       []block.Warning{},
-			MetadataByName: make(map[string]*block.ResultMetricMetadata),
+			Exhaustive: false,
+			LocalOnly:  true,
+			Warnings:   []block.Warning{},
 		},
 	}
 

--- a/src/query/api/v1/handler/prometheus/remote/tag_values_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/tag_values_test.go
@@ -185,9 +185,8 @@ func testTagValuesWithMatch(
 			},
 		},
 		Metadata: block.ResultMetadata{
-			Exhaustive:     false,
-			Warnings:       []block.Warning{{Name: "foo", Message: "bar"}},
-			MetadataByName: make(map[string]*block.ResultMetricMetadata),
+			Exhaustive: false,
+			Warnings:   []block.Warning{{Name: "foo", Message: "bar"}},
 		},
 	}
 

--- a/src/query/graphite/storage/m3_wrapper_test.go
+++ b/src/query/graphite/storage/m3_wrapper_test.go
@@ -164,8 +164,7 @@ func buildResult(
 	return block.Result{
 		Blocks: []block.Block{bl},
 		Metadata: block.ResultMetadata{
-			Resolutions:    resos,
-			MetadataByName: make(map[string]*block.ResultMetricMetadata),
+			Resolutions: resos,
 		},
 	}
 }

--- a/src/query/remote/client.go
+++ b/src/query/remote/client.go
@@ -259,7 +259,8 @@ func (c *grpcClient) FetchProm(
 		result,
 		c.opts.ReadWorkerPool(),
 		c.opts.TagOptions(),
-		c.opts.PromConvertOptions())
+		c.opts.PromConvertOptions(),
+		options)
 }
 
 func (c *grpcClient) fetchRaw(

--- a/src/query/remote/server_test.go
+++ b/src/query/remote/server_test.go
@@ -538,10 +538,9 @@ func TestBatchedCompleteTags(t *testing.T) {
 				CompleteNameOnly: nameOnly,
 				CompletedTags:    tags,
 				Metadata: block.ResultMetadata{
-					Exhaustive:     false,
-					LocalOnly:      true,
-					Warnings:       []block.Warning{{Name: "foo", Message: "bar"}},
-					MetadataByName: make(map[string]*block.ResultMetricMetadata),
+					Exhaustive: false,
+					LocalOnly:  true,
+					Warnings:   []block.Warning{{Name: "foo", Message: "bar"}},
 				},
 			}
 

--- a/src/query/storage/fanout/storage.go
+++ b/src/query/storage/fanout/storage.go
@@ -208,7 +208,7 @@ func (s *fanoutStorage) FetchProm(
 
 	result.Metadata.Resolutions = resolutions
 	return storage.SeriesIteratorsToPromResult(ctx, result,
-		s.opts.ReadWorkerPool(), s.opts.TagOptions(), s.opts.PromConvertOptions())
+		s.opts.ReadWorkerPool(), s.opts.TagOptions(), s.opts.PromConvertOptions(), options)
 }
 
 func (s *fanoutStorage) FetchCompressed(

--- a/src/query/storage/fetch.go
+++ b/src/query/storage/fetch.go
@@ -29,12 +29,17 @@ import (
 	"github.com/m3db/m3/src/query/storage/m3/storagemetadata"
 )
 
+const (
+	defaultMaxMetricMetadataStats = 4
+)
+
 // NewFetchOptions creates a new fetch options.
 func NewFetchOptions() *FetchOptions {
 	return &FetchOptions{
-		SeriesLimit: 0,
-		DocsLimit:   0,
-		BlockType:   models.TypeSingleBlock,
+		SeriesLimit:            0,
+		DocsLimit:              0,
+		MaxMetricMetadataStats: defaultMaxMetricMetadataStats,
+		BlockType:              models.TypeSingleBlock,
 		FanoutOptions: &FanoutOptions{
 			FanoutUnaggregated:        FanoutDefault,
 			FanoutAggregated:          FanoutDefault,

--- a/src/query/storage/m3/storage.go
+++ b/src/query/storage/m3/storage.go
@@ -433,7 +433,7 @@ func (s *m3storage) fetchCompressed(
 			}
 
 			blockMeta := block.NewResultMetadata()
-			blockMeta.Namespaces = append(blockMeta.Namespaces, namespaceID.String())
+			blockMeta.AddNamespace(namespaceID.String())
 			blockMeta.FetchedResponses = metadata.Responses
 			blockMeta.FetchedBytesEstimate = metadata.EstimateTotalBytes
 			blockMeta.Exhaustive = metadata.Exhaustive
@@ -637,7 +637,7 @@ func (s *m3storage) CompleteTags(
 			}
 
 			blockMeta := block.NewResultMetadata()
-			blockMeta.Namespaces = append(blockMeta.Namespaces, namespaceID.String())
+			blockMeta.AddNamespace(namespaceID.String())
 			blockMeta.FetchedResponses = metadata.Responses
 			blockMeta.FetchedBytesEstimate = metadata.EstimateTotalBytes
 			blockMeta.Exhaustive = metadata.Exhaustive
@@ -745,7 +745,7 @@ func (s *m3storage) SearchCompressed(
 			}
 
 			blockMeta := block.NewResultMetadata()
-			blockMeta.Namespaces = append(blockMeta.Namespaces, namespaceID.String())
+			blockMeta.AddNamespace(namespaceID.String())
 			blockMeta.FetchedResponses = metadata.Responses
 			blockMeta.FetchedBytesEstimate = metadata.EstimateTotalBytes
 			blockMeta.Exhaustive = metadata.Exhaustive

--- a/src/query/storage/m3/storage_test.go
+++ b/src/query/storage/m3/storage_test.go
@@ -495,6 +495,7 @@ func TestLocalWritesWithExpiredContext(t *testing.T) {
 func buildFetchOpts() *storage.FetchOptions {
 	opts := storage.NewFetchOptions()
 	opts.SeriesLimit = 100
+	opts.MaxMetricMetadataStats = 1
 	return opts
 }
 
@@ -635,7 +636,7 @@ func assertFetchResult(t *testing.T, results storage.PromResult, testTag ident.T
 	assert.Equal(t, testTag.Value.String(), string(l.GetValue()))
 	merged := meta.MetadataByNameMerged()
 	assert.Equal(t, 1, meta.FetchedSeriesCount)
-	assert.Equal(t, merged, block.ResultMetricMetadata{Unaggregated: 1, WithSamples: 1})
+	assert.Equal(t, block.ResultMetricMetadata{Unaggregated: 1, WithSamples: 1}, merged)
 }
 
 func TestLocalSearchError(t *testing.T) {

--- a/src/query/storage/prom_converter_test.go
+++ b/src/query/storage/prom_converter_test.go
@@ -44,6 +44,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func buildFetchOpts() *FetchOptions {
+	opts := NewFetchOptions()
+	opts.MaxMetricMetadataStats = 1
+	return opts
+}
+
 func fr(
 	t *testing.T,
 	its encoding.SeriesIterators,
@@ -81,7 +87,7 @@ func verifyExpandPromSeries(
 	}
 
 	results, err := SeriesIteratorsToPromResult(
-		context.Background(), fetchResult, pools, nil, NewPromConvertOptions())
+		context.Background(), fetchResult, pools, nil, NewPromConvertOptions(), buildFetchOpts())
 	assert.NoError(t, err)
 
 	require.NotNil(t, results)
@@ -129,7 +135,7 @@ func TestContextCanceled(t *testing.T) {
 	iters := seriesiter.NewMockSeriesIters(ctrl, ident.Tag{}, 1, 2)
 	fetchResult := fr(t, iters, makeTag("foo", "bar", 1)...)
 	_, err = SeriesIteratorsToPromResult(
-		ctx, fetchResult, pool, nil, NewPromConvertOptions())
+		ctx, fetchResult, pool, nil, NewPromConvertOptions(), buildFetchOpts())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "context canceled")
 }
@@ -296,7 +302,7 @@ func TestDecodeIteratorsWithEmptySeries(t *testing.T) {
 
 	opts := models.NewTagOptions()
 	res, err := SeriesIteratorsToPromResult(
-		context.Background(), buildIters(), nil, opts, NewPromConvertOptions())
+		context.Background(), buildIters(), nil, opts, NewPromConvertOptions(), buildFetchOpts())
 	require.NoError(t, err)
 	verifyResult(t, res)
 
@@ -305,7 +311,7 @@ func TestDecodeIteratorsWithEmptySeries(t *testing.T) {
 	pool.Init()
 
 	res, err = SeriesIteratorsToPromResult(
-		context.Background(), buildIters(), pool, opts, NewPromConvertOptions())
+		context.Background(), buildIters(), pool, opts, NewPromConvertOptions(), buildFetchOpts())
 	require.NoError(t, err)
 	verifyResult(t, res)
 }
@@ -579,7 +585,7 @@ func testSeriesIteratorsToPromResult(
 	assert.NoError(t, err)
 
 	res, err := SeriesIteratorsToPromResult(
-		context.Background(), fetchResult, nil, models.NewTagOptions(), opts)
+		context.Background(), fetchResult, nil, models.NewTagOptions(), opts, buildFetchOpts())
 	require.NoError(t, err)
 	verifyResult(t, want, res)
 }

--- a/src/query/storage/types.go
+++ b/src/query/storage/types.go
@@ -126,6 +126,8 @@ type FetchOptions struct {
 	RequireExhaustive bool
 	// RequireNoWait results in an error if the query execution must wait for permits.
 	RequireNoWait bool
+	// MaxMetricMetadataStats is the maximum number of metric metadata stats to return.
+	MaxMetricMetadataStats int
 	// BlockType is the block type that the fetch function returns.
 	BlockType models.FetchedBlockType
 	// FanoutOptions are the options for the fetch namespace fanout.

--- a/src/x/headers/headers.go
+++ b/src/x/headers/headers.go
@@ -124,6 +124,10 @@ const (
 	// M3 returns an error if query execution must wait for permits.
 	LimitRequireNoWaitHeader = M3HeaderPrefix + "Limit-Require-No-Wait"
 
+	// LimitMaxMetricMetadataStatsHeader is the M3 header that limits
+	// the number of metric metadata stats returned in M3-Metric-Stats.
+	LimitMaxMetricMetadataStatsHeader = M3HeaderPrefix + "Limit-Max-Metric-Metadata-Stats"
+
 	// UnaggregatedStoragePolicy specifies the unaggregated storage policy.
 	UnaggregatedStoragePolicy = "unaggregated"
 


### PR DESCRIPTION
Allows metric metadata stats to be disabled via config or request header.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
