### PR TITLE
[agg] Do not use uber/multierr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	go.uber.org/atomic v1.9.0
 	go.uber.org/config v1.4.0
 	go.uber.org/goleak v1.1.10
-	go.uber.org/multierr v1.7.0
+	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.0
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/src/aggregator/aggregator/entry_test.go
+++ b/src/aggregator/aggregator/entry_test.go
@@ -1468,6 +1468,7 @@ func TestEntryAddTimedEntryClosed(t *testing.T) {
 	require.Equal(t, errEntryClosed, e.AddTimed(testTimedMetric, testTimedMetadata))
 }
 
+//nolint: dupl
 func TestEntryAddTimedMetricTooLate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1490,14 +1491,14 @@ func TestEntryAddTimedMetricTooLate(t *testing.T) {
 			timeNanos: now.UnixNano() - 11*time.Second.Nanoseconds(),
 			storagePolicies: policy.StoragePolicies{
 				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour),
-				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour * 2),
+				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour*2),
 			},
 		},
 		{
 			timeNanos: now.UnixNano() - 12*time.Second.Nanoseconds(),
 			storagePolicies: policy.StoragePolicies{
 				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour),
-				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour * 2),
+				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour*2),
 			},
 		},
 		{

--- a/src/aggregator/aggregator/entry_test.go
+++ b/src/aggregator/aggregator/entry_test.go
@@ -1483,31 +1483,51 @@ func TestEntryAddTimedMetricTooLate(t *testing.T) {
 	e.opts = e.opts.SetBufferForPastTimedMetricFn(timedAggregationBufferPastFn)
 
 	inputs := []struct {
-		timeNanos     int64
-		storagePolicy policy.StoragePolicy
+		timeNanos       int64
+		storagePolicies policy.StoragePolicies
 	}{
 		{
-			timeNanos:     now.UnixNano() - 11*time.Second.Nanoseconds(),
-			storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour),
+			timeNanos: now.UnixNano() - 11*time.Second.Nanoseconds(),
+			storagePolicies: policy.StoragePolicies{
+				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour),
+				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour * 2),
+			},
 		},
 		{
-			timeNanos:     now.UnixNano() - 12*time.Second.Nanoseconds(),
-			storagePolicy: policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour),
+			timeNanos: now.UnixNano() - 12*time.Second.Nanoseconds(),
+			storagePolicies: policy.StoragePolicies{
+				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour),
+				policy.NewStoragePolicy(10*time.Second, xtime.Second, time.Hour * 2),
+			},
 		},
 		{
-			timeNanos:     now.UnixNano() - 61*time.Second.Nanoseconds(),
-			storagePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour),
+			timeNanos: now.UnixNano() - 61*time.Second.Nanoseconds(),
+			storagePolicies: policy.StoragePolicies{
+				policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour),
+			},
 		},
 		{
-			timeNanos:     now.UnixNano() - 62*time.Second.Nanoseconds(),
-			storagePolicy: policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour),
+			timeNanos: now.UnixNano() - 62*time.Second.Nanoseconds(),
+			storagePolicies: policy.StoragePolicies{
+				policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour),
+			},
 		},
 	}
 
 	for i, input := range inputs {
 		metric := testTimedMetric
 		metric.TimeNanos = input.timeNanos
-		err := e.AddTimed(metric, metadata.TimedMetadata{StoragePolicy: input.storagePolicy})
+		err := e.AddTimedWithStagedMetadatas(metric, metadata.StagedMetadatas{
+			metadata.StagedMetadata{
+				Metadata: metadata.Metadata{
+					Pipelines: metadata.PipelineMetadatas{
+						metadata.PipelineMetadata{
+							StoragePolicies: input.storagePolicies,
+						},
+					},
+				},
+			},
+		})
 		if i%2 == 0 {
 			require.NoError(t, err)
 			for _, l := range e.lists.lists {
@@ -1516,7 +1536,6 @@ func TestEntryAddTimedMetricTooLate(t *testing.T) {
 		} else {
 			require.True(t, xerrors.IsInvalidParams(err))
 			require.True(t, xerrors.Is(err, errTooFarInThePast))
-			require.Equal(t, errTooFarInThePast, xerrors.InnerError(err))
 			require.True(t, strings.Contains(err.Error(), "datapoint for aggregation too far in past"))
 			require.True(t, strings.Contains(err.Error(), "timestamp="))
 			require.True(t, strings.Contains(err.Error(), "past_limit="))


### PR DESCRIPTION
the various m3 errors don't work well with uber/multierr.

For example if you do m3errors.Is(uberMultierr, target) and uberMultierr
contains a m3.InnerError, it won't find it.

uber/multierr is probably better but we'll need to first retrofit a lot
of the m3.InnerError types to support Is(err).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
