### PR TITLE
[tools] add get/delete topic command to m3ctl

### DIFF
--- a/src/cmd/tools/m3ctl/README.md
+++ b/src/cmd/tools/m3ctl/README.md
@@ -12,6 +12,8 @@ You can:
 * delete namespaces
 * list placements
 * delete placements
+* list topics
+* delete topics
 * add nodes
 * remove nodes
 
@@ -33,6 +35,8 @@ m3ctl get ns
 m3ctl delete ns -id default
 # list service placements (m3db/m3coordinator/m3aggregator)
 m3ctl get pl <service>
+# list topics
+m3ctl get topic --header 'Cluster-Environment-Name: namespace/m3db-cluster-name, Topic-Name: aggregator_ingest'
 # point to some remote and list namespaces
 m3ctl -endpoint http://localhost:7201 get ns
 # check the namespaces in a kubernetes cluster

--- a/src/cmd/tools/m3ctl/main/main.go
+++ b/src/cmd/tools/m3ctl/main/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/m3db/m3/src/cmd/tools/m3ctl/apply"
 	"github.com/m3db/m3/src/cmd/tools/m3ctl/namespaces"
 	"github.com/m3db/m3/src/cmd/tools/m3ctl/placements"
+	"github.com/m3db/m3/src/cmd/tools/m3ctl/topics"
 	"github.com/m3db/m3/src/query/generated/proto/admin"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -210,11 +211,45 @@ database creation, database init, adding a node, and replacing a node, are suppo
 		},
 	}
 
+	getTopicCmd := &cobra.Command{
+		Use:     "topic",
+		Short:   "Get topic from the remote endpoint",
+		Aliases: []string{"t"},
+		Run: func(cmd *cobra.Command, args []string) {
+			logger.Debug("running command", zap.String("command", cmd.Name()))
+
+			resp, err := topics.DoGet(endPoint, headers, logger)
+			if err != nil {
+				logger.Fatal("get topic failed", zap.Error(err))
+			}
+
+			os.Stdout.Write(resp) //nolint:errcheck
+		},
+	}
+
+	deleteTopicCmd := &cobra.Command{
+		Use:     "topic",
+		Short:   "Delete topic from the remote endpoint",
+		Aliases: []string{"t"},
+		Run: func(cmd *cobra.Command, args []string) {
+			logger.Debug("running command", zap.String("command", cmd.Name()))
+
+			resp, err := topics.DoDelete(endPoint, headers, logger)
+			if err != nil {
+				logger.Fatal("delete topic failed", zap.Error(err))
+			}
+
+			os.Stdout.Write(resp) //nolint:errcheck
+		},
+	}
+
 	rootCmd.AddCommand(getCmd, applyCmd, deleteCmd)
 	getCmd.AddCommand(getNamespaceCmd)
 	getCmd.AddCommand(getPlacementCmd)
+	getCmd.AddCommand(getTopicCmd)
 	deleteCmd.AddCommand(deletePlacementCmd)
 	deleteCmd.AddCommand(deleteNamespaceCmd)
+	deleteCmd.AddCommand(deleteTopicCmd)
 
 	var headersSlice []string
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug log output level (cannot use JSON output)")

--- a/src/cmd/tools/m3ctl/topics/delete.go
+++ b/src/cmd/tools/m3ctl/topics/delete.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package topics implements topic endpoint interaction.
+package topics
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/m3db/m3/src/cmd/tools/m3ctl/client"
+)
+
+// DoDelete does the delete api calls for topics
+func DoDelete(
+	endpoint string,
+	headers map[string]string,
+	logger *zap.Logger,
+) ([]byte, error) {
+	url := fmt.Sprintf("%s%s", endpoint, DefaultPath)
+	return client.DoDelete(url, headers, logger)
+}

--- a/src/cmd/tools/m3ctl/topics/get.go
+++ b/src/cmd/tools/m3ctl/topics/get.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package topics implements topic endpoint interaction.
+package topics
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/m3db/m3/src/cmd/tools/m3ctl/client"
+)
+
+// DoGet calls the backend api for get topics
+func DoGet(
+	endpoint string,
+	headers map[string]string,
+	logger *zap.Logger,
+) ([]byte, error) {
+	url := fmt.Sprintf("%s%s", endpoint, DefaultPath)
+	return client.DoGet(url, headers, logger)
+}

--- a/src/cmd/tools/m3ctl/topics/types.go
+++ b/src/cmd/tools/m3ctl/topics/types.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package topics implements topic endpoint interaction.
+package topics
+
+const (
+	// DefaultPath is the url path for api calls for topics
+	DefaultPath = "/api/v1/topic"
+)

--- a/src/x/generated/mock.go
+++ b/src/x/generated/mock.go
@@ -22,6 +22,7 @@
 package generated
 
 import (
+
 	// https://github.com/golang/mock/issues/494
 	_ "github.com/golang/mock/mockgen/model"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds `get topic`, `delete topic` commands in order to manage m3db topics through m3ctl.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
Adds additional command to m3ctl.

**Does this PR require updating code package or user-facing documentation?**:
Updated README.md