### PR TITLE
Automatically set GOMAXPROCS for multi process

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -932,4 +932,7 @@ type MultiProcessConfiguration struct {
 	PerCPU float64 `yaml:"perCPU" validate:"min=0.0, max=1.0"`
 	// GoMaxProcs if set will explicitly set the child GOMAXPROCs env var.
 	GoMaxProcs int `yaml:"goMaxProcs"`
+	// AutoGoMaxProcs automatically sets GoMaxProcs to be parent GOMAXPROCS / Count. It uses the ceiling to round up
+	// when it's not evenly divisible.
+	AutoGoMaxProcs bool `yaml:"AutoGoMaxProcs"`
 }

--- a/src/query/server/multi_process.go
+++ b/src/query/server/multi_process.go
@@ -139,8 +139,20 @@ func multiProcessRun(
 				fmt.Sprintf("%s=%d", multiProcessInstanceEnvVar, i+1),
 			}
 
+			if cfg.MultiProcess.AutoGoMaxProcs {
+				goMaxProcs := runtime.GOMAXPROCS(0)
+				cfg.MultiProcess.GoMaxProcs = goMaxProcs / count
+				if goMaxProcs%count != 0 {
+					logger.Sugar().Warnf("%s (%v) is not divisible by %v. consider changing to improve "+
+						"scheduling", goMaxProcsEnvVar, goMaxProcs, count)
+					cfg.MultiProcess.GoMaxProcs++
+				}
+				logger.Sugar().Infof("automatically setting %s=%v/%v", goMaxProcsEnvVar, goMaxProcs, count)
+			}
+
 			// Set GOMAXPROCS correctly if configured.
 			if v := cfg.MultiProcess.GoMaxProcs; v > 0 {
+				logger.Sugar().Infof("setting %s=%v", goMaxProcsEnvVar, v)
 				newEnv = append(newEnv,
 					fmt.Sprintf("%s=%d", goMaxProcsEnvVar, v))
 			}


### PR DESCRIPTION
This uses the number of subprocesses to determine the value of
GOMAXPROCS for the sub process. Ideally we evenly divide the total cores
across the subprocesses to avoid waiting for a core. This emulates the
default value of GOMAXPROCS=# of cores.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
