### PR TITLE
[coordinator] Allow MatchResult to be re-used during rule matching

### DIFF
--- a/src/cmd/services/m3coordinator/downsample/downsampler_test.go
+++ b/src/cmd/services/m3coordinator/downsample/downsampler_test.go
@@ -492,12 +492,14 @@ func TestDownsamplerAggregationWithRulesStore(t *testing.T) {
 	})
 	for {
 		now := time.Now().UnixNano()
-		res, err := appenderImpl.matcher.ForwardMatch(testMatchID, now, now+1, rules.MatchOptions{
+		matchResult := &rules.MatchResult{}
+		err := appenderImpl.matcher.ForwardMatch(testMatchID, now, now+1, &rules.MatchOptions{
 			NameAndTagsFn:       appenderImpl.nameTagFn,
 			SortedTagIteratorFn: appenderImpl.tagIterFn,
+			MatchResult:         matchResult,
 		})
 		require.NoError(t, err)
-		results := res.ForExistingIDAt(now)
+		results := matchResult.ForExistingIDAt(now)
 		if !results.IsDefault() {
 			break
 		}

--- a/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
+++ b/src/cmd/services/m3coordinator/downsample/metrics_appender_test.go
@@ -67,7 +67,7 @@ func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
 	for i := 0; i < count; i++ {
 		matcher := matcher.NewMockMatcher(ctrl)
 		matcher.EXPECT().ForwardMatch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(encodedID id.ID, _, _ int64, _ rules.MatchOptions) (rules.MatchResult, error) {
+			DoAndReturn(func(encodedID id.ID, _, _ int64, opts *rules.MatchOptions) error {
 				// NB: ensure tags are cleared correctly between runs.
 				bs := encodedID.Bytes()
 
@@ -86,7 +86,7 @@ func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
 				}
 
 				decoder.Close()
-				return rules.NewMatchResult(1, 1,
+				result := rules.NewMatchResult(1, 1,
 					metadata.StagedMetadatas{},
 					[]rules.IDWithMetadatas{
 						{
@@ -95,7 +95,10 @@ func TestSamplesAppenderPoolResetsTagsAcrossSamples(t *testing.T) {
 						},
 					},
 					true,
-				), nil
+				)
+				opts.MatchResult = &result
+
+				return nil
 			})
 
 		appender := appenderPool.Get()

--- a/src/metrics/integration/match_rule_update_stress_test.go
+++ b/src/metrics/integration/match_rule_update_stress_test.go
@@ -225,7 +225,7 @@ func TestMatchWithRuleUpdatesStress(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			it := iterPool.Get()
-			matchOpts := rules.MatchOptions{
+			matchOpts := &rules.MatchOptions{
 				NameAndTagsFn: m3.NameAndTags,
 				SortedTagIteratorFn: func(tagPairs []byte) id.SortedTagIterator {
 					it.Reset(tagPairs)
@@ -234,9 +234,10 @@ func TestMatchWithRuleUpdatesStress(t *testing.T) {
 			}
 
 			for i := 0; i < matchIter; i++ {
-				res, err := matcher.ForwardMatch(input.idFn(i), input.fromNanos, input.toNanos, matchOpts)
+				matchOpts.MatchResult = &rules.MatchResult{}
+				err := matcher.ForwardMatch(input.idFn(i), input.fromNanos, input.toNanos, matchOpts)
 				require.NoError(t, err)
-				results = append(results, res)
+				results = append(results, *matchOpts.MatchResult)
 				expected = append(expected, input.expected)
 			}
 			iterPool.Put(it)

--- a/src/metrics/matcher/cache/list_test.go
+++ b/src/metrics/matcher/cache/list_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/m3db/m3/src/metrics/rules"
 	xtime "github.com/m3db/m3/src/x/time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 )
 
@@ -293,13 +295,17 @@ func (t testValue) ID() id.ID {
 	return namespace.NewTestID(string(t.id), string(t.namespace))
 }
 
+func validateResult(t *testing.T, expected rules.MatchResult, actual rules.MatchResult) {
+	require.True(t, cmp.Equal(expected, actual, cmpopts.EquateEmpty(), cmp.AllowUnexported(rules.MatchResult{})))
+}
+
 func validateList(t *testing.T, l *list, expected []testValue) {
 	require.Equal(t, len(expected), l.Len())
 	i := 0
 	for elem := l.Front(); elem != nil; elem = elem.next {
 		require.Equal(t, expected[i].namespace, elem.namespace)
 		require.Equal(t, expected[i].id, elem.id)
-		require.Equal(t, expected[i].result, elem.result)
+		validateResult(t, expected[i].result, elem.result)
 		i++
 	}
 	if len(expected) == 0 {

--- a/src/metrics/matcher/match.go
+++ b/src/metrics/matcher/match.go
@@ -91,8 +91,8 @@ func (m *matcher) LatestRollupRules(namespace []byte, timeNanos int64) ([]view.R
 func (m *matcher) ForwardMatch(
 	id id.ID,
 	fromNanos, toNanos int64,
-	opts rules.MatchOptions,
-) (rules.MatchResult, error) {
+	opts *rules.MatchOptions,
+) error {
 	sw := m.metrics.matchLatency.Start()
 	defer sw.Stop()
 	return m.cache.ForwardMatch(id, fromNanos, toNanos, opts)
@@ -131,8 +131,8 @@ func (m *noCacheMatcher) LatestRollupRules(namespace []byte, timeNanos int64) ([
 func (m *noCacheMatcher) ForwardMatch(
 	id id.ID,
 	fromNanos, toNanos int64,
-	opts rules.MatchOptions,
-) (rules.MatchResult, error) {
+	opts *rules.MatchOptions,
+) error {
 	sw := m.metrics.matchLatency.Start()
 	defer sw.Stop()
 	return m.namespaces.ForwardMatch(id, fromNanos, toNanos, opts)

--- a/src/metrics/matcher/matcher_mock.go
+++ b/src/metrics/matcher/matcher_mock.go
@@ -72,12 +72,11 @@ func (mr *MockMatcherMockRecorder) Close() *gomock.Call {
 }
 
 // ForwardMatch mocks base method.
-func (m *MockMatcher) ForwardMatch(arg0 id.ID, arg1, arg2 int64, arg3 rules.MatchOptions) (rules.MatchResult, error) {
+func (m *MockMatcher) ForwardMatch(arg0 id.ID, arg1, arg2 int64, arg3 *rules.MatchOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ForwardMatch", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(rules.MatchResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ForwardMatch indicates an expected call of ForwardMatch.

--- a/src/metrics/matcher/namespaces.go
+++ b/src/metrics/matcher/namespaces.go
@@ -188,12 +188,12 @@ func (n *namespaces) LatestRollupRules(namespace []byte, timeNanos int64) ([]vie
 	return ruleSet.LatestRollupRules(namespace, timeNanos)
 }
 
-func (n *namespaces) ForwardMatch(id id.ID, fromNanos, toNanos int64,
-	opts rules.MatchOptions) (rules.MatchResult, error) {
+func (n *namespaces) ForwardMatch(id id.ID, fromNanos, toNanos int64, opts *rules.MatchOptions) error {
 	namespace := n.nsResolver.Resolve(id)
 	ruleSet, exists := n.ruleSet(namespace)
 	if !exists {
-		return rules.EmptyMatchResult, nil
+		opts.MatchResult = &rules.EmptyMatchResult
+		return nil
 	}
 	return ruleSet.ForwardMatch(id, fromNanos, toNanos, opts)
 }

--- a/src/metrics/matcher/namespaces_test.go
+++ b/src/metrics/matcher/namespaces_test.go
@@ -331,13 +331,16 @@ func newMemCache() cache.Cache {
 	return &memCache{namespaces: make(map[string]memResults), nsResolver: namespace.Default}
 }
 
-func (c *memCache) ForwardMatch(id id.ID, _, _ int64, _ rules.MatchOptions) (rules.MatchResult, error) {
+func (c *memCache) ForwardMatch(id id.ID, _, _ int64, opts *rules.MatchOptions) error {
 	c.RLock()
 	defer c.RUnlock()
 	if results, exists := c.namespaces[string(c.nsResolver.Resolve(id))]; exists {
-		return results.results[string(id.Bytes())], nil
+		result := results.results[string(id.Bytes())]
+		opts.MatchResult = &result
+		return nil
 	}
-	return rules.EmptyMatchResult, nil
+	opts.MatchResult = &rules.EmptyMatchResult
+	return nil
 }
 
 func (c *memCache) Register(namespace []byte, source rules.Matcher) {

--- a/src/metrics/matcher/ruleset.go
+++ b/src/metrics/matcher/ruleset.go
@@ -161,22 +161,23 @@ func (r *ruleSet) Tombstoned() bool {
 	return tombstoned
 }
 
-func (r *ruleSet) ForwardMatch(id id.ID, fromNanos, toNanos int64, opts rules.MatchOptions) (
-	rules.MatchResult, error) {
+func (r *ruleSet) ForwardMatch(id id.ID, fromNanos, toNanos int64, opts *rules.MatchOptions) error {
 	callStart := r.nowFn()
 	r.RLock()
 	if r.activeSet == nil {
 		r.RUnlock()
 		r.metrics.nilMatcher.Inc(1)
-		return rules.EmptyMatchResult, nil
+		opts.MatchResult = &rules.EmptyMatchResult
+		return nil
 	}
-	res, err := r.activeSet.ForwardMatch(id, fromNanos, toNanos, opts)
+	err := r.activeSet.ForwardMatch(id, fromNanos, toNanos, opts)
 	r.RUnlock()
 	if err != nil {
-		return rules.EmptyMatchResult, err
+		opts.MatchResult = &rules.EmptyMatchResult
+		return err
 	}
 	r.metrics.match.ReportSuccess(r.nowFn().Sub(callStart))
-	return res, nil
+	return nil
 }
 
 func (r *ruleSet) toRuleSet(value kv.Value) (interface{}, error) {

--- a/src/metrics/matcher/ruleset_test.go
+++ b/src/metrics/matcher/ruleset_test.go
@@ -63,9 +63,10 @@ func TestRuleSetProperties(t *testing.T) {
 func TestRuleSetMatchNoMatcher(t *testing.T) {
 	_, _, rs := testRuleSet()
 	nowNanos := rs.nowFn().UnixNano()
-	res, err := rs.ForwardMatch(testID("foo"), nowNanos, nowNanos, rules.MatchOptions{})
+	opts := &rules.MatchOptions{}
+	err := rs.ForwardMatch(testID("foo"), nowNanos, nowNanos, opts)
 	require.NoError(t, err)
-	require.Equal(t, rules.EmptyMatchResult, res)
+	require.Equal(t, rules.EmptyMatchResult, *opts.MatchResult)
 }
 
 func TestRuleSetForwardMatchWithMatcher(t *testing.T) {
@@ -79,9 +80,10 @@ func TestRuleSetForwardMatchWithMatcher(t *testing.T) {
 		toNanos   = now.Add(time.Second).UnixNano()
 	)
 
-	res, err := rs.ForwardMatch(testID("foo"), fromNanos, toNanos, rules.MatchOptions{})
+	opts := &rules.MatchOptions{}
+	err := rs.ForwardMatch(testID("foo"), fromNanos, toNanos, opts)
 	require.NoError(t, err)
-	require.Equal(t, mockMatcher.res, res)
+	require.Equal(t, mockMatcher.res, *opts.MatchResult)
 	require.Equal(t, []byte("foo"), mockMatcher.id)
 	require.Equal(t, fromNanos, mockMatcher.fromNanos)
 	require.Equal(t, toNanos, mockMatcher.toNanos)
@@ -225,12 +227,13 @@ func (mm *mockMatcher) LatestRollupRules(_ []byte, _ int64) ([]view.RollupRule, 
 func (mm *mockMatcher) ForwardMatch(
 	id id.ID,
 	fromNanos, toNanos int64,
-	_ rules.MatchOptions,
-) (rules.MatchResult, error) {
+	opts *rules.MatchOptions,
+) error {
 	mm.id = id.Bytes()
 	mm.fromNanos = fromNanos
 	mm.toNanos = toNanos
-	return mm.res, nil
+	opts.MatchResult = &mm.res
+	return nil
 }
 
 type mockRuleSet struct {

--- a/src/metrics/metadata/metadata.go
+++ b/src/metrics/metadata/metadata.go
@@ -461,6 +461,20 @@ type StagedMetadata struct {
 	Tombstoned bool `json:"tombstoned,omitempty"`
 }
 
+// Reset resets the StagedMetadata for reuse.
+func (sm *StagedMetadata) Reset() {
+	sm.CutoverNanos = 0
+	sm.Tombstoned = false
+	sm.Pipelines = sm.Pipelines[:0]
+}
+
+// Clone creates a copy of StagedMetadata.
+func (sm StagedMetadata) Clone() StagedMetadata {
+	clone := sm
+	clone.Pipelines = sm.Pipelines.Clone()
+	return clone
+}
+
 // Equal returns true if two staged metadatas are considered equal.
 func (sm StagedMetadata) Equal(other StagedMetadata) bool {
 	return sm.Metadata.Equal(other.Metadata) &&
@@ -526,6 +540,15 @@ func (sms StagedMetadatas) Equal(other StagedMetadatas) bool {
 		}
 	}
 	return true
+}
+
+// Clone creates a copy of the StagedMetadatas.
+func (sms StagedMetadatas) Clone() StagedMetadatas {
+	clone := make(StagedMetadatas, 0, len(sms))
+	for _, sm := range sms {
+		clone = append(clone, sm.Clone())
+	}
+	return clone
 }
 
 // IsDefault determines whether the list of staged metadata is a default list.

--- a/src/metrics/metadata/metadata_test.go
+++ b/src/metrics/metadata/metadata_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/m3db/m3/src/metrics/transformation"
 	xtime "github.com/m3db/m3/src/x/time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1332,4 +1334,23 @@ func TestStagedMetadatasDropReturnsIsDropPolicyAppliedTrue(t *testing.T) {
 	require.True(t, StagedMetadatas{
 		StagedMetadata{Metadata: DropMetadata, CutoverNanos: 123},
 	}.IsDropPolicyApplied())
+}
+
+func TestStagedMetadataClone(t *testing.T) {
+	mdClone := testLargeStagedMetadatas[0].Clone()
+	require.True(t, cmp.Equal(testLargeStagedMetadatas[0], mdClone, cmpopts.EquateEmpty()))
+
+	mdsClone := testLargeStagedMetadatas.Clone()
+	require.True(t, cmp.Equal(testLargeStagedMetadatas, mdsClone, cmpopts.EquateEmpty()))
+}
+
+func TestStagedMetadataReset(t *testing.T) {
+	md := testLargeStagedMetadatas[0].Clone()
+	md.Reset()
+
+	require.Equal(t, StagedMetadata{
+		Metadata: Metadata{
+			Pipelines: []PipelineMetadata{},
+		},
+	}, md)
 }

--- a/src/metrics/rules/active_ruleset_test.go
+++ b/src/metrics/rules/active_ruleset_test.go
@@ -577,8 +577,10 @@ func TestActiveRuleSetForwardMatchWithMappingRules(t *testing.T) {
 	for i, input := range inputs {
 		input := input
 		t.Run(fmt.Sprintf("input %d", i), func(t *testing.T) {
-			res, err := as.ForwardMatch(input.ID(), input.matchFrom, input.matchTo, testMatchOptions())
+			matchOpts := testMatchOptions()
+			err := as.ForwardMatch(input.ID(), input.matchFrom, input.matchTo, matchOpts)
 			require.NoError(t, err)
+			res := matchOpts.MatchResult
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.True(t, cmp.Equal(input.forExistingIDResult, res.ForExistingIDAt(0), testStagedMetadatasCmptOpts...))
 			require.Equal(t, 0, res.NumNewRollupIDs())
@@ -607,9 +609,11 @@ func TestActiveRuleSetForwardMatchWithAnyKeepOriginal(t *testing.T) {
 	for i, input := range inputs {
 		input := input
 		t.Run(fmt.Sprintf("input %d", i), func(t *testing.T) {
-			res, err := as.ForwardMatch(input.ID(), input.matchFrom, input.matchTo, testMatchOptions())
+			matchOpts := testMatchOptions()
+			err := as.ForwardMatch(input.ID(), input.matchFrom, input.matchTo, matchOpts)
 			require.NoError(t, err)
-			require.Equal(t, res.keepOriginal, input.keepOriginal)
+			res := matchOpts.MatchResult
+			require.Equal(t, input.keepOriginal, res.keepOriginal)
 			require.Equal(t, 3, res.NumNewRollupIDs())
 		})
 	}
@@ -1466,8 +1470,10 @@ func TestActiveRuleSetForwardMatchWithRollupRules(t *testing.T) {
 	for i, input := range inputs {
 		input := input
 		t.Run(fmt.Sprintf("input %d", i), func(t *testing.T) {
-			res, err := as.ForwardMatch(input.ID(), input.matchFrom, input.matchTo, testMatchOptions())
+			matchOpts := testMatchOptions()
+			err := as.ForwardMatch(input.ID(), input.matchFrom, input.matchTo, matchOpts)
 			require.NoError(t, err)
+			res := matchOpts.MatchResult
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.True(t, cmp.Equal(input.forExistingIDResult, res.ForExistingIDAt(0), testStagedMetadatasCmptOpts...))
 			require.Equal(t, len(input.forNewRollupIDsResult), res.NumNewRollupIDs())
@@ -2706,8 +2712,10 @@ func TestActiveRuleSetForwardMatchWithMappingRulesAndRollupRules(t *testing.T) {
 	for i, input := range inputs {
 		input := input
 		t.Run(fmt.Sprintf("input %d", i), func(t *testing.T) {
-			res, err := as.ForwardMatch(input.ID(), input.matchFrom, input.matchTo, testMatchOptions())
+			matchOpts := testMatchOptions()
+			err := as.ForwardMatch(input.ID(), input.matchFrom, input.matchTo, matchOpts)
 			require.NoError(t, err)
+			res := matchOpts.MatchResult
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.True(t, cmp.Equal(input.forExistingIDResult, res.ForExistingIDAt(0), testStagedMetadatasCmptOpts...))
 			require.Equal(t, len(input.forNewRollupIDsResult), res.NumNewRollupIDs())
@@ -2810,15 +2818,16 @@ func TestMatchedKeepOriginal(t *testing.T) {
 
 	for name, tt := range cases {
 		t.Run(name, func(t *testing.T) {
-			res, err := as.ForwardMatch(
+			matchOpts := testMatchOptions()
+			err := as.ForwardMatch(
 				namespace.NewTestID("baz=bat,foo=bar", "ns"),
 				tt.cutoverNanos,
 				tt.cutoverNanos+10000,
-				testMatchOptions(),
+				matchOpts,
 			)
 			require.NoError(t, err)
-			require.Equal(t, 1, res.NumNewRollupIDs())
-			require.Equal(t, tt.expectKeepOriginal, res.KeepOriginal())
+			require.Equal(t, 1, matchOpts.MatchResult.NumNewRollupIDs())
+			require.Equal(t, tt.expectKeepOriginal, matchOpts.MatchResult.KeepOriginal())
 		})
 	}
 }
@@ -3131,9 +3140,11 @@ func testMappingRules(t *testing.T) []*mappingRule {
 		},
 	}
 
-	return []*mappingRule{mappingRule1, mappingRule2, mappingRule3, mappingRule4,
+	return []*mappingRule{
+		mappingRule1, mappingRule2, mappingRule3, mappingRule4,
 		mappingRule5, mappingRule6, mappingRule7, mappingRule8, mappingRule9,
-		mappingRule10, mappingRule11}
+		mappingRule10, mappingRule11,
+	}
 }
 
 func testKeepOriginalRollupRules(t *testing.T) []*rollupRule {

--- a/src/metrics/rules/ruleset.go
+++ b/src/metrics/rules/ruleset.go
@@ -57,7 +57,9 @@ var (
 // Matcher matches metrics against rules to determine applicable policies.
 type Matcher interface {
 	// ForwardMatch matches the applicable policies for a metric id between [fromNanos, toNanos).
-	ForwardMatch(id metricid.ID, fromNanos, toNanos int64, opts MatchOptions) (MatchResult, error)
+	// Result for forward match is provided via the MatchResult specified in the
+	// MatchOptions parameter.
+	ForwardMatch(id metricid.ID, fromNanos, toNanos int64, opts *MatchOptions) error
 }
 
 // Fetcher fetches rules.

--- a/src/metrics/rules/ruleset_test.go
+++ b/src/metrics/rules/ruleset_test.go
@@ -2190,8 +2190,8 @@ func testRollupRulesConfig() []*rulepb.RollupRule {
 	}
 }
 
-func testMatchOptions() MatchOptions {
-	return MatchOptions{
+func testMatchOptions() *MatchOptions {
+	return &MatchOptions{
 		NameAndTagsFn: func(b []byte) ([]byte, []byte, error) {
 			idx := bytes.Index(b, []byte("|"))
 			if idx == -1 {
@@ -2200,6 +2200,7 @@ func testMatchOptions() MatchOptions {
 			return b[:idx], b[idx+1:], nil
 		},
 		SortedTagIteratorFn: filters.NewMockSortedTagIterator,
+		MatchResult:         &MatchResult{},
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Creating a new MatchResult each time we want to generate rule
matches for a write has shown to be problematic via profiling.
More specifically, creating MatchResults this way requires us
to allocate O(rule) pipeline slices that end up escaping to the
heap. This ends up causing more frequent GCs which drive up
CPU utilization.

To rememdy this, a MatchResult is now provided to rule matching
code which allows us to make use of the same MatchResult. This
change required us to do any merging of MatchResult data on the
final MatchResult object instead of intermediate structures (
which were the source of the allocations), so a big part of this
change is reworking how we merge result data into the final
MatchResult.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
