### PR TITLE
[query] Close iterators in dedupe map

### DIFF
--- a/src/query/storage/m3/consolidators/id_dedupe_map.go
+++ b/src/query/storage/m3/consolidators/id_dedupe_map.go
@@ -136,10 +136,12 @@ func (m *idDedupeMap) doUpdate(
 	}
 	if existsBetter {
 		// Existing result is already better
+		iter.Close()
 		return nil
 	}
 
 	// Override
+	existing.iter.Close()
 	m.series[id] = multiResultSeries{
 		attrs: attrs,
 		iter:  iter,

--- a/src/query/storage/m3/consolidators/id_dedupe_map_test.go
+++ b/src/query/storage/m3/consolidators/id_dedupe_map_test.go
@@ -74,7 +74,7 @@ func idIt(
 			Value:          dp.val,
 		}, xtime.Second, nil).AnyTimes()
 	it.EXPECT().Err().Return(nil).AnyTimes()
-	it.EXPECT().Close().AnyTimes()
+	it.EXPECT().Close()
 
 	return it
 }
@@ -105,7 +105,7 @@ func rangeIt(
 	it.EXPECT().Next().Return(false).AnyTimes()
 
 	it.EXPECT().Err().Return(nil).AnyTimes()
-	it.EXPECT().Close().AnyTimes()
+	it.EXPECT().Close()
 
 	return it
 }

--- a/src/query/storage/m3/consolidators/tag_dedupe_map.go
+++ b/src/query/storage/m3/consolidators/tag_dedupe_map.go
@@ -149,6 +149,7 @@ func (m *tagDedupeMap) doUpdate(
 
 	if existsBetter {
 		// Existing result is already better
+		iter.Close()
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
While working on https://github.com/m3db/m3/pull/4003 I've noticed that `tagDedupeMap` was closing the overridden iterator in https://github.com/m3db/m3/compare/linasm/close-iters-in-dedupe-map?expand=1#diff-235f34602720b8af1391774299386a457d93a2e11824d642d57c60322b1a0b52R157, but `idDedupeMap` was missing such close (which looked like an oversight). This PR adds closing of iterators that are not accepted by iterator deduping logics.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
