### PR TITLE
[cluster] Avoid nondeterminism in `mostUnderLoadedInstance()`

### DIFF
--- a/src/cluster/placement/algo/sharded_helper.go
+++ b/src/cluster/placement/algo/sharded_helper.go
@@ -502,6 +502,9 @@ func (ph *helper) mostUnderLoadedInstance() (placement.Instance, bool) {
 			maxLoadGap = loadGap
 			res = instance
 		}
+		if loadGap == maxLoadGap && res != nil && res.ID() > id {
+			res = instance
+		}
 		if loadGap < 0 {
 			totalLoadSurplus -= loadGap
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Makes instance selection in `sharded_helper::mostUnderLoadedInstance()` deterministic. Before this, the method would occasionally select a different instance than usual, which would cause flakiness in `TestOptimize()` test, e.g.:
- https://buildkite.com/chronosphereopensource/oss-m3-monorepo-public/builds/364#7bb51f4e-9bd3-446f-8cab-c2a5b383b053/896
- https://buildkite.com/chronosphereopensource/oss-m3-monorepo-public/builds/320#cd3cc8da-c15c-4af3-834f-81e1afad78d2/999 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
