### PR TITLE
[coordinator] Prevent TChannel leaks

### DIFF
--- a/src/dbnode/client/connection_pool.go
+++ b/src/dbnode/client/connection_pool.go
@@ -206,6 +206,10 @@ func (p *connPool) connectEvery(interval time.Duration, stutter time.Duration) {
 				if p.status == statusOpen {
 					p.pool = append(p.pool, conn{channel, client})
 					p.poolLen = int64(len(p.pool))
+				} else {
+					// NB(antanas): just being defensive.
+					// It's likely a corner case and happens only during server shutdown.
+					channel.Close()
 				}
 				p.Unlock()
 			}()

--- a/src/dbnode/client/connection_pool_test.go
+++ b/src/dbnode/client/connection_pool_test.go
@@ -46,8 +46,8 @@ var (
 )
 
 type noopPooledChannel struct {
-	address string
-	closed  int32
+	address    string
+	closeCount int32
 }
 
 func asNoopPooledChannel(c Channel) *noopPooledChannel {
@@ -58,12 +58,12 @@ func asNoopPooledChannel(c Channel) *noopPooledChannel {
 	return cc
 }
 
-func (c *noopPooledChannel) Closed() bool {
-	return atomic.LoadInt32(&c.closed) == 1
+func (c *noopPooledChannel) CloseCount() int {
+	return int(atomic.LoadInt32(&c.closeCount))
 }
 
 func (c *noopPooledChannel) Close() {
-	atomic.StoreInt32(&c.closed, 1)
+	atomic.AddInt32(&c.closeCount, 1)
 }
 
 func (c *noopPooledChannel) GetSubChannel(

--- a/src/dbnode/client/connection_pool_test.go
+++ b/src/dbnode/client/connection_pool_test.go
@@ -47,9 +47,25 @@ var (
 
 type noopPooledChannel struct {
 	address string
+	closed  int32
 }
 
-func (c *noopPooledChannel) Close() {}
+func asNoopPooledChannel(c Channel) *noopPooledChannel {
+	cc, ok := c.(*noopPooledChannel)
+	if !ok {
+		panic("not a noopPooledChannel")
+	}
+	return cc
+}
+
+func (c *noopPooledChannel) Closed() bool {
+	return atomic.LoadInt32(&c.closed) == 1
+}
+
+func (c *noopPooledChannel) Close() {
+	atomic.StoreInt32(&c.closed, 1)
+}
+
 func (c *noopPooledChannel) GetSubChannel(
 	serviceName string,
 	opts ...tchannel.SubChannelOption,

--- a/src/dbnode/client/session.go
+++ b/src/dbnode/client/session.go
@@ -785,6 +785,7 @@ func (s *session) DedicatedConnection(
 		}
 
 		if err := s.healthCheckNewConnFn(client, s.opts, opts.BootstrappedNodesOnly); err != nil {
+			channel.Close()
 			multiErr = multiErr.Add(err)
 			return
 		}

--- a/src/dbnode/client/session_test.go
+++ b/src/dbnode/client/session_test.go
@@ -461,8 +461,9 @@ func TestDedicatedConnection(t *testing.T) {
 
 	var channels []*noopPooledChannel
 	s.opts = NewOptions().SetNewConnectionFn(func(_ string, _ string, _ Options) (Channel, rpc.TChanNode, error) {
-		channels = append(channels, &noopPooledChannel{"test", 0})
-		return channels[len(channels)-1], nil, nil
+		c := &noopPooledChannel{"test", 0}
+		channels = append(channels, c)
+		return c, nil, nil
 	})
 	_, _, err = s.DedicatedConnection(shardID, DedicatedConnectionOptions{})
 	require.NotNil(t, err)

--- a/src/dbnode/client/session_test.go
+++ b/src/dbnode/client/session_test.go
@@ -445,25 +445,30 @@ func TestDedicatedConnection(t *testing.T) {
 
 	_, ch, err := s.DedicatedConnection(shardID, DedicatedConnectionOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, &noopPooledChannel{"remote1"}, ch)
+	assert.Equal(t, "remote1", asNoopPooledChannel(ch).address)
 
 	_, ch2, err := s.DedicatedConnection(shardID, DedicatedConnectionOptions{ShardStateFilter: shard.Available})
 	require.NoError(t, err)
-	assert.Equal(t, &noopPooledChannel{"remote2"}, ch2)
+	assert.Equal(t, "remote2", asNoopPooledChannel(ch2).address)
 
 	s.healthCheckNewConnFn = testHealthCheck(nil, true)
 	_, ch3, err := s.DedicatedConnection(shardID, DedicatedConnectionOptions{BootstrappedNodesOnly: true})
 	require.NoError(t, err)
-	assert.Equal(t, &noopPooledChannel{"remote1"}, ch3)
+	assert.Equal(t, "remote1", asNoopPooledChannel(ch3).address)
 
 	healthErr := errors.New("unhealthy")
 	s.healthCheckNewConnFn = testHealthCheck(healthErr, false)
 
+	ch = &noopPooledChannel{"test", 0}
+	s.opts = NewOptions().SetNewConnectionFn(func(_ string, _ string, _ Options) (Channel, rpc.TChanNode, error) {
+		return ch, nil, nil
+	})
 	_, _, err = s.DedicatedConnection(shardID, DedicatedConnectionOptions{})
 	require.NotNil(t, err)
 	multiErr, ok := err.(xerror.MultiError) // nolint: errorlint
 	assert.True(t, ok, "expecting MultiError")
 	assert.True(t, multiErr.Contains(healthErr))
+	assert.True(t, asNoopPooledChannel(ch).Closed())
 }
 
 func testSessionClusterConnectConsistencyLevel(
@@ -621,9 +626,9 @@ func testHealthCheck(err error, bootstrappedNodesOnly bool) func(rpc.TChanNode, 
 }
 
 func noopNewConnection(
-	channelName string,
+	_ string,
 	addr string,
-	opts Options,
+	_ Options,
 ) (Channel, rpc.TChanNode, error) {
-	return &noopPooledChannel{addr}, nil, nil
+	return &noopPooledChannel{addr, 0}, nil, nil
 }

--- a/src/dbnode/client/session_test.go
+++ b/src/dbnode/client/session_test.go
@@ -468,7 +468,8 @@ func TestDedicatedConnection(t *testing.T) {
 	multiErr, ok := err.(xerror.MultiError) // nolint: errorlint
 	assert.True(t, ok, "expecting MultiError")
 	assert.True(t, multiErr.Contains(healthErr))
-	assert.True(t, asNoopPooledChannel(ch).Closed())
+	// 2 because of 2 remote hosts failing health check
+	assert.Equal(t, 2, asNoopPooledChannel(ch).CloseCount())
 }
 
 func testSessionClusterConnectConsistencyLevel(

--- a/src/dbnode/client/session_test.go
+++ b/src/dbnode/client/session_test.go
@@ -469,6 +469,7 @@ func TestDedicatedConnection(t *testing.T) {
 	multiErr, ok := err.(xerror.MultiError) // nolint: errorlint
 	assert.True(t, ok, "expecting MultiError")
 	assert.True(t, multiErr.Contains(healthErr))
+	// 2 because of 2 remote hosts failing health check
 	assert.Len(t, channels, 2)
 	assert.Equal(t, 1, channels[0].CloseCount())
 	assert.Equal(t, 1, channels[1].CloseCount())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # Channel leak in DedicatedConnection 

**Special notes for your reviewer**:

Minimal changes to fix the connection leak. I have another PR to refactor code a bit to extract connection code into func.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
