### PR TITLE
[tools] Add service type to m3ctl apply command

### DIFF
--- a/src/cmd/tools/m3ctl/README.md
+++ b/src/cmd/tools/m3ctl/README.md
@@ -52,6 +52,7 @@ Here's one to initialize a topology:
 ```yaml
 ---
 operation: init
+service: m3db
 num_shards: 64
 replication_factor: 1
 instances:

--- a/src/cmd/tools/m3ctl/yaml/examples/init.yaml
+++ b/src/cmd/tools/m3ctl/yaml/examples/init.yaml
@@ -1,5 +1,6 @@
 ---
 operation: init
+service: m3db
 request:
   num_shards: 64
   replication_factor: 1

--- a/src/cmd/tools/m3ctl/yaml/examples/new_node.yaml
+++ b/src/cmd/tools/m3ctl/yaml/examples/new_node.yaml
@@ -1,5 +1,6 @@
 ---
 operation: newNode
+service: m3db
 request:
   instances:
     - id: node1

--- a/src/cmd/tools/m3ctl/yaml/examples/replace_node.yaml
+++ b/src/cmd/tools/m3ctl/yaml/examples/replace_node.yaml
@@ -1,5 +1,6 @@
 ---
 operation: replaceNode
+service: m3db
 request:
   leavingInstanceIDs:
   - oldnodeid1

--- a/src/cmd/tools/m3ctl/yaml/peeker.go
+++ b/src/cmd/tools/m3ctl/yaml/peeker.go
@@ -36,6 +36,7 @@ import (
 func peeker(data []byte) (string, proto.Message, error) {
 	type peeker struct {
 		Operation string
+		Service   string
 	}
 	peek := &peeker{}
 
@@ -48,6 +49,11 @@ func peeker(data []byte) (string, proto.Message, error) {
 
 	// now the payload is of known type
 	// unmarshal it and return the proto.Message
+	if peek.Service == "" {
+		peek.Service = "m3db"
+	}
+	placementPath := placements.DefaultPath + peek.Service + "/placement"
+
 	switch peek.Operation {
 	case opCreate:
 		payload := struct{ Request admin.DatabaseCreateRequest }{}
@@ -60,21 +66,21 @@ func peeker(data []byte) (string, proto.Message, error) {
 		if err := yaml.Unmarshal(data, &payload); err != nil {
 			return "", nil, err
 		}
-		return fmt.Sprintf("%s/init", placements.DefaultPath), &payload.Request, nil
+		return fmt.Sprintf("%s/init", placementPath), &payload.Request, nil
 	case opReplace:
 		payload := struct{ Request admin.PlacementReplaceRequest }{}
 		if err := yaml.Unmarshal(data, &payload); err != nil {
 			return "", nil, err
 		}
-		return fmt.Sprintf("%s/replace", placements.DefaultPath), &payload.Request, nil
+		return fmt.Sprintf("%s/replace", placementPath), &payload.Request, nil
 	case opNewNode:
 		payload := struct{ Request admin.PlacementInitRequest }{}
 		if err := yaml.Unmarshal(data, &payload); err != nil {
 			return "", nil, err
 		}
-		return fmt.Sprintf("%s", placements.DefaultPath), &payload.Request, nil
+		return placementPath, &payload.Request, nil
 	default:
-		return "", nil, fmt.Errorf("Unknown operation specified in the yaml\n")
+		return "", nil, fmt.Errorf("unknown operation specified in the yaml")
 	}
 
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is required for `apply` command to work after https://github.com/m3db/m3/pull/3979 was integrated.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
Updated examples.

**Does this PR require updating code package or user-facing documentation?**:
NONE
