### PR TITLE
[all] make genny-gen to fix master

### DIFF
--- a/src/m3ninx/index/segment/builder/fields_map_new.go
+++ b/src/m3ninx/index/segment/builder/fields_map_new.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/m3ninx/index/segment/builder/ids_map_new.go
+++ b/src/m3ninx/index/segment/builder/ids_map_new.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/m3ninx/index/segment/builder/postings_map_new.go
+++ b/src/m3ninx/index/segment/builder/postings_map_new.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/m3ninx/index/segment/mem/fields_map_new.go
+++ b/src/m3ninx/index/segment/mem/fields_map_new.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/query/graphite/storage/series_metadata_map_new.go
+++ b/src/query/graphite/storage/series_metadata_map_new.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**What this PR does / why we need it**:
Master build got broken after a PR from 2021 (https://github.com/m3db/m3/pull/4015) was merged in 2022 resulting in incorrect copyright year in some of the generated files (genny).
This PR regenerates the files making them contain copyright year 2022.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
