### PR TITLE
[query] resolutionThresholdForCounterNormalization configurable

### DIFF
--- a/src/cmd/services/m3query/config/config.go
+++ b/src/cmd/services/m3query/config/config.go
@@ -364,7 +364,12 @@ type PrometheusQueryConfiguration struct {
 // ConvertOptionsOrDefault creates storage.PromConvertOptions based on the given configuration.
 func (c PrometheusQueryConfiguration) ConvertOptionsOrDefault() storage.PromConvertOptions {
 	opts := storage.NewPromConvertOptions()
+
 	if v := c.Convert; v != nil {
+		if value := v.ResolutionThresholdForCounterNormalization; value != nil {
+			opts = opts.SetResolutionThresholdForCounterNormalization(*value)
+		}
+
 		opts = opts.SetValueDecreaseTolerance(v.ValueDecreaseTolerance)
 
 		// Default to max time so that it's always applicable if value
@@ -381,6 +386,11 @@ func (c PrometheusQueryConfiguration) ConvertOptionsOrDefault() storage.PromConv
 
 // PrometheusConvertConfiguration configures Prometheus time series conversions.
 type PrometheusConvertConfiguration struct {
+	// ResolutionThresholdForCounterNormalization sets the resolution threshold starting from which
+	// Prometheus counter normalization is performed in order to avoid Prometheus counter
+	// extrapolation artifacts.
+	ResolutionThresholdForCounterNormalization *time.Duration `yaml:"resolutionThresholdForCounterNormalization"`
+
 	// ValueDecreaseTolerance allows for setting a specific amount of tolerance
 	// to avoid returning a decrease if it's below a certain tolerance.
 	// This is useful for applications that have precision issues emitting

--- a/src/cmd/services/m3query/config/config_test.go
+++ b/src/cmd/services/m3query/config/config_test.go
@@ -25,16 +25,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
+	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/query/storage"
+	xconfig "github.com/m3db/m3/src/x/config"
 	xtime "github.com/m3db/m3/src/x/time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/validator.v2"
 	"gopkg.in/yaml.v2"
-
-	"github.com/m3db/m3/src/query/api/v1/handler/prometheus/handleroptions"
-	"github.com/m3db/m3/src/query/models"
-	xconfig "github.com/m3db/m3/src/x/config"
 )
 
 const testConfigFile = "./testdata/config.yml"

--- a/src/cmd/services/m3query/config/testdata/config.yml
+++ b/src/cmd/services/m3query/config/testdata/config.yml
@@ -59,3 +59,10 @@ limits:
     maxFetchedSeries: 12000
     maxFetchedDocs: 11000
     requireExhaustive: true
+
+query:
+  prometheus:
+    convert:
+      resolutionThresholdForCounterNormalization: 10m
+      valueDecreaseTolerance: 0.0000000001
+      valueDecreaseToleranceUntil: 2022-01-01T00:00:00Z

--- a/src/query/storage/options.go
+++ b/src/query/storage/options.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultResolutionThresholdForCounterNormalization = time.Hour
+	defaultResolutionThresholdForCounterNormalization = 5 * time.Minute
 )
 
 type promConvertOptions struct {

--- a/src/query/test/seriesiter/mock_iter.go
+++ b/src/query/test/seriesiter/mock_iter.go
@@ -106,6 +106,7 @@ func NewMockSeriesIteratorFromBase(
 	mockIter.EXPECT().Tags().Return(tags).AnyTimes()
 	mockIter.EXPECT().Start().Return(now.Add(-time.Hour)).AnyTimes()
 	mockIter.EXPECT().End().Return(now).AnyTimes()
+	mockIter.EXPECT().FirstAnnotation().Return(nil).AnyTimes()
 	mockIter.EXPECT().Close().Do(func() {
 		// Make sure to close the tags generated when closing the iter
 		tags.Close()


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes `resolutionThresholdForCounterNormalization` configurable.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE

