### PR TITLE
[dbnode] Add duplicate reconciliation on query

### DIFF
--- a/src/dbnode/integration/index_block_orphaned_entry_test.go
+++ b/src/dbnode/integration/index_block_orphaned_entry_test.go
@@ -25,6 +25,7 @@ package integration
 import (
 	"fmt"
 	"math/rand"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -32,6 +33,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/m3db/m3/src/dbnode/client"
 	"github.com/m3db/m3/src/dbnode/namespace"
@@ -99,7 +101,7 @@ func TestIndexBlockOrphanedEntry(t *testing.T) {
 		filesets, err := fs.IndexFileSetsAt(setup.FilePathPrefix(), nsID, newBlock.Add(-blockSize))
 		require.NoError(t, err)
 		return len(filesets) == 1
-	}, 30*time.Second)
+	}, 60*time.Second)
 	require.True(t, found)
 
 	// Do post-block rotation writes
@@ -129,110 +131,6 @@ func TestIndexBlockOrphanedEntry(t *testing.T) {
 	}, 30*time.Second)
 	assert.True(t, found, fmt.Sprintf("series %s never indexed\n", missing))
 	assert.NoError(t, err)
-}
-
-func TestIndexBlockOrphanedIndexValuesUpdatedAcrossTimes(t *testing.T) {
-	// Write a metric concurrently for multiple index blocks to generate
-	// multiple entries for the same series
-	var (
-		numIDs = 10
-		ids    = make([]ident.ID, 0, numIDs)
-
-		nsID = testNamespaces[0]
-
-		writesPerWorker = 5
-		writeTimes      = make([]xtime.UnixNano, 0, writesPerWorker)
-		retention       = blockSize * time.Duration(1+writesPerWorker)
-	)
-
-	retOpts := DefaultIntegrationTestRetentionOpts.SetRetentionPeriod(retention)
-	nsOpts := namespace.NewOptions().
-		SetRetentionOptions(retOpts).
-		SetIndexOptions(namespace.NewIndexOptions().SetEnabled(true)).
-		SetColdWritesEnabled(true)
-
-	setup := generateTestSetup(t, nsOpts)
-	defer setup.Close()
-
-	// Start the server
-	log := setup.StorageOpts().InstrumentOptions().Logger()
-	require.NoError(t, setup.StartServer())
-
-	// Stop the server
-	defer func() {
-		assert.NoError(t, setup.StopServer())
-		log.Debug("server is now down")
-	}()
-
-	client := setup.M3DBClient()
-	session, err := client.DefaultSession()
-	require.NoError(t, err)
-
-	var (
-		nowFn = setup.DB().Options().ClockOptions().NowFn()
-		// NB: write in the middle of a block to avoid block boundaries.
-		now = nowFn().Truncate(blockSize / 2)
-	)
-
-	for i := 0; i < writesPerWorker; i++ {
-		writeTime := xtime.ToUnixNano(now.Add(time.Duration(i) * -blockSize))
-		writeTimes = append(writeTimes, writeTime)
-	}
-
-	for i := 0; i < numIDs; i++ {
-		fooID := ident.StringID(fmt.Sprintf("foo.%v", i))
-		ids = append(ids, fooID)
-
-		writeConcurrentMetricsAcrossTime(t, setup, session, writeTimes, fooID)
-	}
-
-	notFoundIds := make(notFoundIDs, 0, len(ids)*len(writeTimes))
-	for _, id := range ids {
-		for _, writeTime := range writeTimes {
-			notFoundIds = append(notFoundIds, notFoundID{id: id, runAt: writeTime})
-		}
-	}
-
-	queryIDs := func() {
-		found := xclock.WaitUntil(func() bool {
-			filteredIds := notFoundIds[:0]
-			for _, id := range notFoundIds {
-				ok, err := isIndexedCheckedWithTime(
-					t, session, nsID, id.id, genTags(id.id), id.runAt,
-				)
-				if !ok || err != nil {
-					filteredIds = append(filteredIds, id)
-				}
-			}
-
-			if len(filteredIds) == 0 {
-				return true
-			}
-
-			notFoundIds = filteredIds
-			return false
-		}, time.Second*30)
-
-		require.True(t, found, fmt.Sprintf("series %s never indexed\n", notFoundIds))
-	}
-
-	// queryIDs()
-
-	// Fast-forward to a block rotation
-	newBlock := xtime.Now().Truncate(blockSize).Add(blockSize)
-	newCurrentTime := newBlock.Add(30 * time.Minute) // Add extra to account for buffer past
-	setup.SetNowFn(newCurrentTime)
-
-	// Wait for flush
-	log.Info("waiting for block rotation to complete")
-	found := xclock.WaitUntil(func() bool {
-		filesets, err := fs.IndexFileSetsAt(setup.FilePathPrefix(), nsID, newBlock.Add(-blockSize))
-		require.NoError(t, err)
-		return len(filesets) == 1
-	}, 30*time.Second)
-	require.True(t, found)
-
-	queryIDs()
 }
 
 func writeConcurrentMetrics(
@@ -304,12 +202,185 @@ func generateTestSetup(t *testing.T, nsOpts namespace.Options) TestSetup {
 				},
 			}
 			return s.SetIndexOptions(
-				s.IndexOptions().
-					SetForegroundCompactionPlannerOptions(compactionOpts))
+				s.IndexOptions().SetForegroundCompactionPlannerOptions(compactionOpts))
 		})
 	require.NoError(t, err)
 
 	return testSetup
+}
+
+func TestIndexBlockOrphanedIndexValuesUpdatedAcrossTimes(t *testing.T) {
+	tests := []struct {
+		name     string
+		numIDs   int
+		interval time.Duration
+	}{
+		{
+			name:     "12 series every 100 nanos",
+			numIDs:   12,
+			interval: 100,
+		},
+		{
+			name:     "12 series every block",
+			numIDs:   12,
+			interval: blockSize,
+		},
+		{
+			name:     "120 series every 100 nanos",
+			numIDs:   120,
+			interval: 100,
+		},
+		{
+			name:     "120 series every block",
+			numIDs:   120,
+			interval: blockSize,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testIndexBlockOrphanedIndexValuesUpdatedAcrossTimes(t, tt.numIDs, tt.interval)
+		})
+	}
+}
+
+func testIndexBlockOrphanedIndexValuesUpdatedAcrossTimes(
+	t *testing.T, numIDs int, writeInterval time.Duration,
+) {
+	// Write a metric concurrently for multiple index blocks to generate
+	// multiple entries for the same series
+	var (
+		concurrentWriteMax = runtime.NumCPU() / 2
+		ids                = make([]ident.ID, 0, numIDs)
+		writerCh           = make(chan func(), concurrentWriteMax)
+
+		nsID = testNamespaces[0]
+
+		writesPerWorker = 5
+		writeTimes      = make([]xtime.UnixNano, 0, writesPerWorker)
+		retention       = blockSize * time.Duration(1+writesPerWorker)
+
+		seed = time.Now().UnixNano()
+		rng  = rand.New(rand.NewSource(seed))
+	)
+
+	retOpts := DefaultIntegrationTestRetentionOpts.SetRetentionPeriod(retention)
+	nsOpts := namespace.NewOptions().
+		SetRetentionOptions(retOpts).
+		SetIndexOptions(namespace.NewIndexOptions().SetEnabled(true)).
+		SetColdWritesEnabled(true)
+
+	setup := generateTestSetup(t, nsOpts)
+	defer setup.Close()
+
+	// Start the server
+	log := setup.StorageOpts().InstrumentOptions().Logger()
+	log.Info("running test with seed", zap.Int("seed", int(seed)))
+	require.NoError(t, setup.StartServer())
+
+	// Stop the server
+	defer func() {
+		assert.NoError(t, setup.StopServer())
+		log.Debug("server is now down")
+	}()
+
+	client := setup.M3DBClient()
+	session, err := client.DefaultSession()
+	require.NoError(t, err)
+
+	var (
+		nowFn = setup.DB().Options().ClockOptions().NowFn()
+		// NB: write in the middle of a block to avoid block boundaries.
+		now = nowFn().Truncate(blockSize / 2)
+	)
+
+	for i := 0; i < writesPerWorker; i++ {
+		writeTime := xtime.ToUnixNano(now.Add(time.Duration(i) * -writeInterval))
+		writeTimes = append(writeTimes, writeTime)
+	}
+
+	fns := make([]func(), 0, numIDs*writesPerWorker)
+	for i := 0; i < numIDs; i++ {
+		fooID := ident.StringID(fmt.Sprintf("foo.%v", i))
+		ids = append(ids, fooID)
+		fns = append(fns, writeConcurrentMetricsAcrossTime(t, setup, session, writeTimes, fooID)...)
+	}
+
+	rng.Shuffle(len(fns), func(i, j int) { fns[i], fns[j] = fns[j], fns[i] })
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentWriteMax; i++ {
+		wg.Add(1)
+		go func() {
+			for writeFn := range writerCh {
+				writeFn()
+			}
+
+			wg.Done()
+		}()
+	}
+
+	for _, fn := range fns {
+		writerCh <- fn
+	}
+
+	close(writerCh)
+	wg.Wait()
+
+	queryIDs := func() {
+		notFoundIds := make(notFoundIDs, 0, len(ids)*len(writeTimes))
+		for _, id := range ids {
+			for _, writeTime := range writeTimes {
+				notFoundIds = append(notFoundIds, notFoundID{id: id, runAt: writeTime})
+			}
+		}
+
+		found := xclock.WaitUntil(func() bool {
+			filteredIds := notFoundIds[:0]
+			for _, id := range notFoundIds {
+				ok, err := isIndexedCheckedWithTime(
+					t, session, nsID, id.id, genTags(id.id), id.runAt,
+				)
+				if !ok || err != nil {
+					filteredIds = append(filteredIds, id)
+				}
+			}
+
+			if len(filteredIds) == 0 {
+				return true
+			}
+
+			notFoundIds = filteredIds
+			return false
+		}, time.Second*30)
+
+		require.True(t, found, fmt.Sprintf("series %s never indexed\n", notFoundIds))
+	}
+
+	// Ensure all IDs are eventually queryable, even when only in the foreground
+	// segments.
+	queryIDs()
+
+	// Write metrics for a different series to push current foreground segment
+	// to the background. After this, all documents for foo.X exist in background segments
+	barID := ident.StringID("bar")
+	writeConcurrentMetrics(t, setup, session, barID)
+
+	queryIDs()
+
+	// Fast-forward to a block rotation
+	newBlock := xtime.Now().Truncate(blockSize).Add(blockSize)
+	newCurrentTime := newBlock.Add(30 * time.Minute) // Add extra to account for buffer past
+	setup.SetNowFn(newCurrentTime)
+
+	// Wait for flush
+	log.Info("waiting for block rotation to complete")
+	found := xclock.WaitUntil(func() bool {
+		filesets, err := fs.IndexFileSetsAt(setup.FilePathPrefix(), nsID, newBlock.Add(-blockSize))
+		require.NoError(t, err)
+		return len(filesets) == 1
+	}, 30*time.Second)
+	require.True(t, found)
+
+	queryIDs()
 }
 
 type notFoundID struct {
@@ -318,7 +389,7 @@ type notFoundID struct {
 }
 
 func (i notFoundID) String() string {
-	return fmt.Sprintf("{ID: %s, time: %s}", i.id.String(), i.runAt.String())
+	return fmt.Sprintf("{%s: %s}", i.id.String(), i.runAt.String())
 }
 
 type notFoundIDs []notFoundID
@@ -340,20 +411,19 @@ func writeConcurrentMetricsAcrossTime(
 	session client.Session,
 	writeTimes []xtime.UnixNano,
 	seriesID ident.ID,
-) {
-	var wg sync.WaitGroup
+) []func() {
 	workerPool := xsync.NewWorkerPool(concurrentWorkers)
 	workerPool.Init()
 
 	mdID := setup.Namespaces()[0].ID()
+	fns := make([]func(), 0, len(writeTimes))
+
 	for j, writeTime := range writeTimes {
 		j, writeTime := j, writeTime
-		wg.Add(1)
-		workerPool.Go(func() {
-			defer wg.Done()
+		fns = append(fns, func() {
 			writeMetric(t, session, mdID, seriesID, writeTime, float64(j))
 		})
 	}
 
-	wg.Wait()
+	return fns
 }

--- a/src/dbnode/integration/index_block_orphaned_entry_test.go
+++ b/src/dbnode/integration/index_block_orphaned_entry_test.go
@@ -216,6 +216,16 @@ func TestIndexBlockOrphanedIndexValuesUpdatedAcrossTimes(t *testing.T) {
 		interval time.Duration
 	}{
 		{
+			name:     "4 series every 100 nanos",
+			numIDs:   4,
+			interval: 100,
+		},
+		{
+			name:     "4 series every block",
+			numIDs:   4,
+			interval: blockSize,
+		},
+		{
 			name:     "12 series every 100 nanos",
 			numIDs:   12,
 			interval: 100,
@@ -260,7 +270,7 @@ func testIndexBlockOrphanedIndexValuesUpdatedAcrossTimes(
 		retention       = blockSize * time.Duration(1+writesPerWorker)
 
 		seed = time.Now().UnixNano()
-		rng  = rand.New(rand.NewSource(seed))
+		rng  = rand.New(rand.NewSource(seed)) // nolint:gosec
 	)
 
 	retOpts := DefaultIntegrationTestRetentionOpts.SetRetentionPeriod(retention)

--- a/src/dbnode/storage/index/block.go
+++ b/src/dbnode/storage/index/block.go
@@ -172,6 +172,7 @@ type blockMetrics struct {
 	aggregateDocsMatched            tally.Histogram
 	entryReconciledOnQuery          tally.Counter
 	entryUnreconciledOnQuery        tally.Counter
+	entryReconcilingDuplicates      tally.Counter
 }
 
 func newBlockMetrics(s tally.Scope) blockMetrics {
@@ -194,12 +195,13 @@ func newBlockMetrics(s tally.Scope) blockMetrics {
 			"skip_type": "not-immutable",
 		}).Counter(segmentFreeMmap),
 
-		querySeriesMatched:       s.Histogram("query-series-matched", buckets),
-		queryDocsMatched:         s.Histogram("query-docs-matched", buckets),
-		aggregateSeriesMatched:   s.Histogram("aggregate-series-matched", buckets),
-		aggregateDocsMatched:     s.Histogram("aggregate-docs-matched", buckets),
-		entryReconciledOnQuery:   s.Counter("entry-reconciled-on-query"),
-		entryUnreconciledOnQuery: s.Counter("entry-unreconciled-on-query"),
+		querySeriesMatched:         s.Histogram("query-series-matched", buckets),
+		queryDocsMatched:           s.Histogram("query-docs-matched", buckets),
+		aggregateSeriesMatched:     s.Histogram("aggregate-series-matched", buckets),
+		aggregateDocsMatched:       s.Histogram("aggregate-docs-matched", buckets),
+		entryReconciledOnQuery:     s.Counter("entry-reconciled-on-query"),
+		entryUnreconciledOnQuery:   s.Counter("entry-unreconciled-on-query"),
+		entryReconcilingDuplicates: s.Counter("entry-trying-reconciling-duplicates"),
 	}
 }
 
@@ -590,7 +592,16 @@ func (b *block) docWithinQueryRange(doc doc.Document, opts QueryOptions) bool {
 	} else {
 		b.metrics.entryUnreconciledOnQuery.Inc(1)
 	}
+
 	defer closer.Close()
+	if reconciled && onIndexSeries != md.OnIndexSeries {
+		// NB: attempt to reconcile the index series here, especially in the case
+		// of foreground segments, since reconciling duplicate index entry writes
+		// only happens when the entry has been moved to background segment
+		// processing, and compacted.
+		b.metrics.entryReconcilingDuplicates.Inc(1)
+		md.OnIndexSeries.TryReconcileDuplicates()
+	}
 
 	var (
 		inBlock                bool

--- a/src/m3ninx/index/segment/builder/multi_segments_builder.go
+++ b/src/m3ninx/index/segment/builder/multi_segments_builder.go
@@ -151,7 +151,15 @@ func (b *builderFromSegments) AddSegments(segments []segment.Segment) error {
 			negativeOffsets = append(negativeOffsets, currOffset)
 			if b.idSet.Contains(d.ID) {
 				if d.OnIndexSeries != nil {
-					// Reconcile any duplicate series.
+					// NB: it is important to ensure duplicate entries get reconciled, as
+					// an entry being duplicated here may indicate that it is not the same
+					// entry as that stored in the shard's index map. Without this step,
+					// situations can arise when an entry may not be correctly indexed in
+					// all blocks, as the full index range for this entry may be split
+					// between the entry in the shard index map that would be persited,
+					// and this duplicated entry which will eventually expire and never
+					// get written to disk. Reconciling merges the full index ranges into
+					// the entry persisted in the shard index map.
 					d.OnIndexSeries.TryReconcileDuplicates()
 				}
 


### PR DESCRIPTION
Duplicate reconciliation was added to the background compaction
mechanism in https://github.com/m3db/m3/pull/3999, but this does not
account for cases where reconciliation is needed for series that are
indexed in the foreground segments. This attempts to reconcile duplicate
series if reconciliation is required.
