### PR TITLE
[query] Fix error handling in toPromConcurrently

### DIFF
--- a/src/query/storage/prom_converter.go
+++ b/src/query/storage/prom_converter.go
@@ -188,9 +188,13 @@ func toPromConcurrently(
 	fastWorkerPool := readWorkerPool.FastContextCheck(100)
 	for i := 0; i < count; i++ {
 		i := i
+
 		iter, tags, err := fetchResult.IterTagsAtIndex(i, tagOptions)
 		if err != nil {
-			return PromResult{}, err
+			mu.Lock()
+			multiErr = multiErr.Add(err)
+			mu.Unlock()
+			break
 		}
 
 		wg.Add(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this change, an error returned from `IterTagsAtIndex` would cause early return from `toPromConcurrently`, skipping `wg.Wait()` and possibly leaving other iterators being processed in the background. Then, the caller of `toPromConcurrently` would close those iterators (which are still being processed), causing runtime panics.
Fixed by replacing early `return` with a `break`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
