### PR TITLE
[commitlog] Add setter functions for the onFlush callback

### DIFF
--- a/src/dbnode/persist/fs/commitlog/commit_log.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log.go
@@ -466,7 +466,7 @@ func (l *commitLog) write() {
 	// We use these to make the batch and non-batched write paths the same
 	// by turning non-batched writes into a batch of size one while avoiding
 	// any allocations.
-	var singleBatch = make([]writes.BatchWrite, 1)
+	singleBatch := make([]writes.BatchWrite, 1)
 	var batch []writes.BatchWrite
 
 	for write := range l.writes {
@@ -666,7 +666,8 @@ func (l *commitLog) openWriters() (persist.CommitLogFile, persist.CommitLogFile,
 		l.writerState.activeFiles = persist.CommitLogFiles{primaryFile, secondaryFile}
 		l.writerState.writers = []commitLogWriter{
 			l.writerState.primary.writer,
-			l.writerState.secondary.writer}
+			l.writerState.secondary.writer,
+		}
 
 		return primaryFile, secondaryFile, nil
 	}

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -197,10 +197,10 @@ func snapshotCounterValue(
 }
 
 type mockCommitLogWriter struct {
-	openFn     func() (persist.CommitLogFile, error)
-	writeFn    func(ts.Series, ts.Datapoint, xtime.Unit, ts.Annotation) error
-	flushFn    func(sync bool) error
-	closeFn    func() error
+	openFn       func() (persist.CommitLogFile, error)
+	writeFn      func(ts.Series, ts.Datapoint, xtime.Unit, ts.Annotation) error
+	flushFn      func(sync bool) error
+	closeFn      func() error
 	setOnFlushFn func(f func(err error))
 }
 
@@ -218,8 +218,7 @@ func newMockCommitLogWriter() *mockCommitLogWriter {
 		closeFn: func() error {
 			return nil
 		},
-		setOnFlushFn: func (f func(err error)) {
-
+		setOnFlushFn: func(f func(err error)) {
 		},
 	}
 }
@@ -245,7 +244,7 @@ func (w *mockCommitLogWriter) Close() error {
 	return w.closeFn()
 }
 
-func (w *mockCommitLogWriter) setOnFlush(f func (err error)) {
+func (w *mockCommitLogWriter) setOnFlush(f func(err error)) {
 	w.setOnFlushFn(f)
 }
 
@@ -714,7 +713,7 @@ func TestCommitLogIteratorUsesPredicateFilterForCorruptFiles(t *testing.T) {
 	nextCommitlogFilePath, _, err := NextFile(opts)
 	require.NoError(t, err)
 	err = ioutil.WriteFile(
-		nextCommitlogFilePath, []byte("not-a-valid-commitlog-file"), os.FileMode(0666))
+		nextCommitlogFilePath, []byte("not-a-valid-commitlog-file"), os.FileMode(0o666))
 	require.NoError(t, err)
 
 	// Make sure the corrupt file is visibile.

--- a/src/dbnode/persist/fs/commitlog/commit_log_test.go
+++ b/src/dbnode/persist/fs/commitlog/commit_log_test.go
@@ -197,10 +197,11 @@ func snapshotCounterValue(
 }
 
 type mockCommitLogWriter struct {
-	openFn  func() (persist.CommitLogFile, error)
-	writeFn func(ts.Series, ts.Datapoint, xtime.Unit, ts.Annotation) error
-	flushFn func(sync bool) error
-	closeFn func() error
+	openFn     func() (persist.CommitLogFile, error)
+	writeFn    func(ts.Series, ts.Datapoint, xtime.Unit, ts.Annotation) error
+	flushFn    func(sync bool) error
+	closeFn    func() error
+	setOnFlushFn func(f func(err error))
 }
 
 func newMockCommitLogWriter() *mockCommitLogWriter {
@@ -216,6 +217,9 @@ func newMockCommitLogWriter() *mockCommitLogWriter {
 		},
 		closeFn: func() error {
 			return nil
+		},
+		setOnFlushFn: func (f func(err error)) {
+
 		},
 	}
 }
@@ -239,6 +243,10 @@ func (w *mockCommitLogWriter) Flush(sync bool) error {
 
 func (w *mockCommitLogWriter) Close() error {
 	return w.closeFn()
+}
+
+func (w *mockCommitLogWriter) setOnFlush(f func (err error)) {
+	w.setOnFlushFn(f)
 }
 
 func newTestCommitLog(t *testing.T, opts Options) *commitLog {

--- a/src/dbnode/persist/fs/commitlog/read_write_prop_test.go
+++ b/src/dbnode/persist/fs/commitlog/read_write_prop_test.go
@@ -715,3 +715,7 @@ func (c *corruptingChunkWriter) isOpen() bool {
 func (c *corruptingChunkWriter) sync() error {
 	return c.chunkWriter.sync()
 }
+
+func (c *corruptingChunkWriter) setOnFlush(f func(err error))  {
+	c.chunkWriter.setOnFlush(f)
+}

--- a/src/dbnode/persist/fs/commitlog/read_write_prop_test.go
+++ b/src/dbnode/persist/fs/commitlog/read_write_prop_test.go
@@ -716,6 +716,6 @@ func (c *corruptingChunkWriter) sync() error {
 	return c.chunkWriter.sync()
 }
 
-func (c *corruptingChunkWriter) setOnFlush(f func(err error))  {
+func (c *corruptingChunkWriter) setOnFlush(f func(err error)) {
 	c.chunkWriter.setOnFlush(f)
 }

--- a/src/dbnode/persist/fs/commitlog/writer.go
+++ b/src/dbnode/persist/fs/commitlog/writer.go
@@ -82,7 +82,7 @@ type commitLogWriter interface {
 	// setOnFlush will provide/override a callback that will be called after successful flush calls.
 	// Implementors MAY choose to not implement such a callback mechanism, however if
 	// such a mechanism is implemented they SHOULD properly implement this method.
-	setOnFlush(func (err error))
+	setOnFlush(func(err error))
 
 	// Close the reader
 	Close() error
@@ -92,7 +92,7 @@ type chunkWriter interface {
 	io.Writer
 
 	reset(f xos.File)
-	setOnFlush(func (err error))
+	setOnFlush(func(err error))
 	close() error
 	isOpen() bool
 	sync() error
@@ -255,7 +255,7 @@ func (w *writer) Flush(sync bool) error {
 }
 
 func (w *writer) setOnFlush(f func(err error)) {
-   w.chunkWriter.setOnFlush(f)
+	w.chunkWriter.setOnFlush(f)
 }
 
 func (w *writer) sync() error {

--- a/src/dbnode/persist/fs/commitlog/writer.go
+++ b/src/dbnode/persist/fs/commitlog/writer.go
@@ -79,6 +79,9 @@ type commitLogWriter interface {
 	// a new chunk to be created. Optionally forces the data to be FSync'd to disk.
 	Flush(sync bool) error
 
+	// setOnFlush will provide/override a callback that will be called after successful flush calls.
+	// Implementors MAY choose to not implement such a callback mechanism, however if
+	// such a mechanism is implemented they SHOULD properly implement this method.
 	setOnFlush(func (err error))
 
 	// Close the reader


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This commit adds a `setOnFlush` method to both the `commitLogWriter` and `chunkWriter` intefaces.

This function is necessary to get around a subtle bug in the `WriteWait` commitlog strategy
causing `pendingFlushFns` calls (and therefore `commitLog.Write` returning) to lag.

The issue is that after the first call to `RotateLogs`, when `onFlush` is called, it ends up reading
from the wrong list of `pendingFlushFns`. This is hard to detect as this occurs after the data has
already been flushed to the correct file on disk and only affects reporting completion.

It is not caught by any tests because the next call to `RotateLogs` (or `Close`) will resolve the problem.
Additionally, we mostly test the default `WriteBehind` strategy rather than the `WriteWait` strategy.

**Special notes for your reviewer**:
I was unable to come up with a satisfactory test for this issue since it resolves itself. We discovered this because we have a scenario where we depend on the implied guarantee that in the `WriteWait` strategy, all flushes before `RotateLogs` will eventually be flushed and return either success or failure after `RotateLogs` and we found that we were blocked waiting for `Write` to return.


**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
