### PR TITLE
[x/debug] Fix panic when placement is nil

### DIFF
--- a/src/x/debug/debug.go
+++ b/src/x/debug/debug.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"time"
 
+	xerrors "github.com/m3db/m3/src/x/errors"
 	"github.com/m3db/m3/src/x/instrument"
 	xhttp "github.com/m3db/m3/src/x/net/http"
 
@@ -131,7 +132,7 @@ func (i *zipWriter) WriteZip(w io.Writer, r *http.Request) error {
 		}
 		err = p.Write(fw, r)
 		if err != nil {
-			return err
+			return xerrors.Wrapf(err, "error writing '%v'", filename)
 		}
 	}
 	return nil

--- a/src/x/debug/ext/ext.go
+++ b/src/x/debug/ext/ext.go
@@ -59,8 +59,7 @@ func NewPlacementAndNamespaceZipWriterWithDefaultSources(
 		}
 
 		for _, service := range services {
-			placementInfoSource, err := NewPlacementInfoSource(service,
-				placementsOpts, instrumentOpts)
+			placementInfoSource, err := NewPlacementInfoSource(service, placementsOpts)
 			if err != nil {
 				return nil, fmt.Errorf("unable to create placementInfoSource: %w", err)
 			}

--- a/src/x/debug/ext/placement.go
+++ b/src/x/debug/ext/placement.go
@@ -21,6 +21,7 @@
 package extdebug
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -59,10 +60,7 @@ func (p *placementInfoSource) Write(w io.Writer, httpReq *http.Request) error {
 	}
 
 	if placement == nil {
-		if _, err := w.Write([]byte("{}")); err != nil {
-			return err
-		}
-		return nil
+		return errors.New("placement does not exist")
 	}
 
 	placementProto, err := placement.Proto()

--- a/src/x/debug/ext/placement_test.go
+++ b/src/x/debug/ext/placement_test.go
@@ -55,6 +55,5 @@ func TestNilPlacement(t *testing.T) {
 	require.NoError(t, err)
 
 	buff := bytes.NewBuffer([]byte{})
-	require.NoError(t, p.Write(buff, &http.Request{}))
-	require.Equal(t, "{}", buff.String())
+	require.Error(t, p.Write(buff, &http.Request{}))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes a panic in debug handler caused by `nil` placement. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
