### PR TITLE
[query] Start using seriesIterators.pool

### DIFF
--- a/src/dbnode/encoding/series_iterators.go
+++ b/src/dbnode/encoding/series_iterators.go
@@ -31,7 +31,7 @@ func NewSeriesIterators(
 	iters []SeriesIterator,
 	pool MutableSeriesIteratorsPool,
 ) MutableSeriesIterators {
-	return &seriesIterators{iters: iters}
+	return &seriesIterators{iters: iters, pool: pool}
 }
 
 func (iters *seriesIterators) Iters() []SeriesIterator {


### PR DESCRIPTION
**What this PR does / why we need it**:
`seriesIterators` was designed to use pooling but it was ineffective because `pool` field was not being assigned from the constructor.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
