### PR TITLE
[query] More robust multiResult locking

### DIFF
--- a/src/query/storage/m3/consolidators/multi_fetch_result.go
+++ b/src/query/storage/m3/consolidators/multi_fetch_result.go
@@ -125,7 +125,7 @@ func (r *multiResult) FinalResultWithAttrs() (
 	r.Lock()
 	defer r.Unlock()
 
-	result, err := r.finalResultWithLock()
+	result, dedupedList, err := r.finalResultWithLock()
 	if err != nil {
 		return result, nil, err
 	}
@@ -140,7 +140,7 @@ func (r *multiResult) FinalResultWithAttrs() (
 				attrs = append(attrs, r.seenFirstAttrs)
 			}
 		} else {
-			for _, res := range r.dedupeMap.list() {
+			for _, res := range dedupedList {
 				attrs = append(attrs, res.attrs)
 			}
 		}
@@ -153,21 +153,25 @@ func (r *multiResult) FinalResult() (SeriesFetchResult, error) {
 	r.Lock()
 	defer r.Unlock()
 
-	return r.finalResultWithLock()
+	res, _, err := r.finalResultWithLock()
+
+	return res, err
 }
 
-func (r *multiResult) finalResultWithLock() (SeriesFetchResult, error) {
+func (r *multiResult) finalResultWithLock() (SeriesFetchResult, []multiResultSeries, error) {
 	err := r.err.LastError()
 	if err != nil {
-		return NewEmptyFetchResult(r.metadata), err
+		return NewEmptyFetchResult(r.metadata), nil, err
 	}
 
 	if r.mergedIterators != nil {
-		return NewSeriesFetchResult(r.mergedIterators, nil, r.metadata)
+		res, err := NewSeriesFetchResult(r.mergedIterators, nil, r.metadata)
+		return res, nil, err
 	}
 
 	if len(r.seenIters) == 0 {
-		return NewSeriesFetchResult(encoding.EmptySeriesIterators, nil, r.metadata)
+		res, err := NewSeriesFetchResult(encoding.EmptySeriesIterators, nil, r.metadata)
+		return res, nil, err
 	}
 
 	// otherwise have to create a new seriesiters
@@ -193,7 +197,9 @@ func (r *multiResult) finalResultWithLock() (SeriesFetchResult, error) {
 		r.mergedTags[i] = &dedupedList[i].tags
 	}
 
-	return NewSeriesFetchResult(r.mergedIterators, r.mergedTags, r.metadata)
+	res, err := NewSeriesFetchResult(r.mergedIterators, r.mergedTags, r.metadata)
+
+	return res, dedupedList, err
 }
 
 func (r *multiResult) Results() []MultiFetchResults {


### PR DESCRIPTION
**What this PR does / why we need it**:
`multiResult.FinalResult` was protected by a lock, but a similar method `multiResult.FinalResultWithAttrs` (that wraps a `FinalResult` call) was not. I am not sure if this was causing any issues, but I will protect the whole `multiResult.FinalResultWithAttrs` with a lock.
Also, took the opportunity to avoid a double call to `dedupeMap.list()` (which is expensive in both CPU and allocations).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
