### PR TITLE
[query] Simplify iterator stitching

### DIFF
--- a/src/query/storage/m3/consolidators/id_dedupe_map.go
+++ b/src/query/storage/m3/consolidators/id_dedupe_map.go
@@ -111,7 +111,7 @@ func (m *idDedupeMap) doUpdate(
 	iter encoding.SeriesIterator,
 	attrs storagemetadata.Attributes,
 ) error {
-	if stitched, ok, err := stitchIfNeeded(existing, tags, iter, attrs); err != nil {
+	if stitched, ok, err := stitchIfNeeded(existing, iter); err != nil {
 		return err
 	} else if ok {
 		m.series[id] = stitched

--- a/src/query/storage/m3/consolidators/tag_dedupe_map.go
+++ b/src/query/storage/m3/consolidators/tag_dedupe_map.go
@@ -103,7 +103,7 @@ func (m *tagDedupeMap) doUpdate(
 	iter encoding.SeriesIterator,
 	attrs storagemetadata.Attributes,
 ) error {
-	if stitched, ok, err := stitchIfNeeded(existing, tags, iter, attrs); err != nil {
+	if stitched, ok, err := stitchIfNeeded(existing, iter); err != nil {
 		return err
 	} else if ok {
 		m.mapWrapper.set(tags, stitched)
@@ -182,12 +182,10 @@ func combineIters(first, second encoding.SeriesIterator) (encoding.SeriesIterato
 
 func stitchIfNeeded(
 	existing multiResultSeries,
-	tags models.Tags,
 	iter encoding.SeriesIterator,
-	attrs storagemetadata.Attributes,
 ) (multiResultSeries, bool, error) {
 	// Stitching based on matching start/end.
-	if iter.Start().Equal(existing.iter.End()) {
+	if iter.Start().Equal(existing.iter.End()) || iter.End().Equal(existing.iter.Start()) {
 		combinedIter, err := combineIters(existing.iter, iter)
 		if err != nil {
 			return multiResultSeries{}, false, err
@@ -197,19 +195,6 @@ func stitchIfNeeded(
 			attrs: existing.attrs,
 			iter:  combinedIter,
 			tags:  existing.tags,
-		}, true, nil
-	}
-
-	if iter.End().Equal(existing.iter.Start()) {
-		combinedIter, err := combineIters(iter, existing.iter)
-		if err != nil {
-			return multiResultSeries{}, false, err
-		}
-
-		return multiResultSeries{
-			attrs: attrs,
-			iter:  combinedIter,
-			tags:  tags,
 		}, true, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It does not really matter in which order we combine the iterators. But this change both simplifies the implementation, and makes it slightly easier to reason about iterator lifecycles.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
