### PR TITLE
[query] Remove the output of m3db placement from /debug/dump

### DIFF
--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
 	// needed for pprof handler registration
 	_ "net/http/pprof"
 	"time"
@@ -367,21 +366,11 @@ func (h *Handler) RegisterRoutes() error {
 		config                = h.options.Config()
 	)
 
-	var placementServices []handleroptions.ServiceNameAndDefaults
-	for _, serviceName := range h.options.PlacementServiceNames() {
-		service := handleroptions.ServiceNameAndDefaults{
-			ServiceName: serviceName,
-			Defaults:    serviceOptionDefaults,
-		}
-
-		placementServices = append(placementServices, service)
-	}
-
 	debugWriter, err := extdebug.NewPlacementAndNamespaceZipWriterWithDefaultSources(
 		h.options.CPUProfileDuration(),
 		clusterClient,
 		placementOpts,
-		placementServices,
+		nil,
 		instrumentOpts)
 	if err != nil {
 		return fmt.Errorf("unable to create debug writer: %v", err)

--- a/src/query/api/v1/httpd/handler.go
+++ b/src/query/api/v1/httpd/handler.go
@@ -52,7 +52,6 @@ import (
 	"github.com/m3db/m3/src/query/parser/promql"
 	"github.com/m3db/m3/src/query/util/queryhttp"
 	xdebug "github.com/m3db/m3/src/x/debug"
-	extdebug "github.com/m3db/m3/src/x/debug/ext"
 	xhttp "github.com/m3db/m3/src/x/net/http"
 )
 
@@ -366,11 +365,8 @@ func (h *Handler) RegisterRoutes() error {
 		config                = h.options.Config()
 	)
 
-	debugWriter, err := extdebug.NewPlacementAndNamespaceZipWriterWithDefaultSources(
+	debugWriter, err := xdebug.NewZipWriterWithDefaultSources(
 		h.options.CPUProfileDuration(),
-		clusterClient,
-		placementOpts,
-		nil,
 		instrumentOpts)
 	if err != nil {
 		return fmt.Errorf("unable to create debug writer: %v", err)

--- a/src/query/api/v1/httpd/handler_test.go
+++ b/src/query/api/v1/httpd/handler_test.go
@@ -61,7 +61,6 @@ var (
 	testM3DBOpts              = m3storage.NewOptions(encoding.NewOptions())
 	defaultLookbackDuration   = time.Minute
 	defaultCPUProfileduration = 5 * time.Second
-	defaultPlacementServices  = []string{"m3db"}
 	svcDefaultOptions         = []handleroptions3.ServiceOptionsDefault{
 		func(o handleroptions3.ServiceOptions) handleroptions3.ServiceOptions {
 			return o
@@ -118,7 +117,6 @@ func setupHandler(
 		models.QueryContextOptions{},
 		instrumentOpts,
 		defaultCPUProfileduration,
-		defaultPlacementServices,
 		svcDefaultOptions,
 		NewQueryRouter(),
 		NewQueryRouter(),
@@ -406,7 +404,7 @@ func TestCustomRoutes(t *testing.T) {
 		config.Configuration{LookbackDuration: &defaultLookbackDuration}, nil,
 		fetchOptsBuilder, fetchOptsBuilder, fetchOptsBuilder,
 		models.QueryContextOptions{}, instrumentOpts, defaultCPUProfileduration,
-		defaultPlacementServices, svcDefaultOptions, NewQueryRouter(), NewQueryRouter(),
+		svcDefaultOptions, NewQueryRouter(), NewQueryRouter(),
 		graphiteStorage.M3WrappedStorageOptions{}, testM3DBOpts, NewGraphiteRenderRouter(), NewGraphiteFindRouter(),
 		defaultLookbackDuration,
 	)

--- a/src/query/api/v1/options/handler.go
+++ b/src/query/api/v1/options/handler.go
@@ -196,11 +196,6 @@ type HandlerOptions interface {
 	// SetCPUProfileDuration sets the cpu profile duration.
 	SetCPUProfileDuration(c time.Duration) HandlerOptions
 
-	// PlacementServiceNames returns the placement service names.
-	PlacementServiceNames() []string
-	// SetPlacementServiceNames sets the placement service names.
-	SetPlacementServiceNames(n []string) HandlerOptions
-
 	// ServiceOptionDefaults returns the service option defaults.
 	ServiceOptionDefaults() []placementhandleroptions.ServiceOptionsDefault
 	// SetServiceOptionDefaults sets the service option defaults.
@@ -306,7 +301,6 @@ type handlerOptions struct {
 	queryContextOptions               models.QueryContextOptions
 	instrumentOpts                    instrument.Options
 	cpuProfileDuration                time.Duration
-	placementServiceNames             []string
 	serviceOptionDefaults             []placementhandleroptions.ServiceOptionsDefault
 	nowFn                             clock.NowFn
 	queryRouter                       QueryRouter
@@ -349,7 +343,6 @@ func NewHandlerOptions(
 	queryContextOptions models.QueryContextOptions,
 	instrumentOpts instrument.Options,
 	cpuProfileDuration time.Duration,
-	placementServiceNames []string,
 	serviceOptionDefaults []placementhandleroptions.ServiceOptionsDefault,
 	queryRouter QueryRouter,
 	instantQueryRouter QueryRouter,
@@ -381,7 +374,6 @@ func NewHandlerOptions(
 		queryContextOptions:               queryContextOptions,
 		instrumentOpts:                    instrumentOpts,
 		cpuProfileDuration:                cpuProfileDuration,
-		placementServiceNames:             placementServiceNames,
 		serviceOptionDefaults:             serviceOptionDefaults,
 		nowFn:                             time.Now,
 		queryRouter:                       queryRouter,
@@ -524,17 +516,6 @@ func (o *handlerOptions) SetCPUProfileDuration(
 	c time.Duration) HandlerOptions {
 	opts := *o
 	opts.cpuProfileDuration = c
-	return &opts
-}
-
-func (o *handlerOptions) PlacementServiceNames() []string {
-	return o.placementServiceNames
-}
-
-func (o *handlerOptions) SetPlacementServiceNames(
-	n []string) HandlerOptions {
-	opts := *o
-	opts.placementServiceNames = n
 	return &opts
 }
 

--- a/src/query/server/query.go
+++ b/src/query/server/query.go
@@ -668,7 +668,7 @@ func Run(runOpts RunOptions) RunResult {
 	handlerOptions, err := options.NewHandlerOptions(downsamplerAndWriter,
 		tagOptions, engine, engineCache.Get, m3dbClusters, clusterClient, cfg,
 		runOpts.DBConfig, fetchOptsBuilder, graphiteFindFetchOptsBuilder, graphiteRenderFetchOptsBuilder,
-		queryCtxOpts, instrumentOptions, cpuProfileDuration, []string{handleroptions3.M3DBServiceName},
+		queryCtxOpts, instrumentOptions, cpuProfileDuration,
 		serviceOptionDefaults, httpd.NewQueryRouter(), httpd.NewQueryRouter(),
 		graphiteStorageOpts, tsdbOpts, httpd.NewGraphiteRenderRouter(), httpd.NewGraphiteFindRouter(), lookbackDuration)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Excludes m3db namespace and placement output from the `/debug/dump` of m3query. In coordinator, the ETCD details were not being configured correctly and handler wasn't working as intended, sometimes returning wrong namespaces/placements and sometimes failing.

Namespaces and placements remain being returned in `/debug/dump` of dbnode  under 9004 port.

https://github.com/m3db/m3/blob/6f5a50adcea52f44d3646114f28b29ba9e30fa32/src/dbnode/server/server.go#L861-L874

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
