### PR TITLE
[query] Align namespace stitching point with resolution

### DIFF
--- a/src/query/storage/m3/cluster_resolver.go
+++ b/src/query/storage/m3/cluster_resolver.go
@@ -357,7 +357,8 @@ func aggregatedNamespaces(
 
 		var (
 			dataLatency        = nsOpts.DataLatency()
-			dataAvailableUntil = now.Add(-dataLatency).Truncate(nsOpts.Attributes().Resolution)
+			resolution         = nsOpts.Attributes().Resolution
+			dataAvailableUntil = now.Add(-dataLatency).Truncate(resolution)
 		)
 		if dataLatency > 0 && end.After(dataAvailableUntil) {
 			resolvedNs.narrowing.end = dataAvailableUntil

--- a/src/query/storage/m3/cluster_resolver.go
+++ b/src/query/storage/m3/cluster_resolver.go
@@ -357,7 +357,7 @@ func aggregatedNamespaces(
 
 		var (
 			dataLatency        = nsOpts.DataLatency()
-			dataAvailableUntil = now.Add(-dataLatency)
+			dataAvailableUntil = now.Add(-dataLatency).Truncate(nsOpts.Attributes().Resolution)
 		)
 		if dataLatency > 0 && end.After(dataAvailableUntil) {
 			resolvedNs.narrowing.end = dataAvailableUntil

--- a/src/query/storage/m3/cluster_resolver_test.go
+++ b/src/query/storage/m3/cluster_resolver_test.go
@@ -710,7 +710,7 @@ func TestResolveNamespaceWithDataLatency(t *testing.T) {
 		actualNamespaces[c.NamespaceID().String()] = c.narrowing
 	}
 
-	stitchAt := now.Add(-dataLatency)
+	stitchAt := now.Add(-dataLatency).Truncate(10 * time.Minute)
 	expectedNamespaces := map[string]narrowing{
 		"default":        {start: stitchAt},
 		"aggregated_60d": {end: stitchAt},


### PR DESCRIPTION
**What this PR does / why we need it**:
Truncate the stitching point to the resolution of aggregated namespace to avoid artefacts with different resolution Prometheus counters.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
