### PR TITLE
[query] Fix SeriesIteratorAccumulator.FirstAnnotation

### DIFF
--- a/src/dbnode/encoding/series_iterator_accumulator.go
+++ b/src/dbnode/encoding/series_iterator_accumulator.go
@@ -77,14 +77,16 @@ func (it *seriesIteratorAccumulator) Add(iter SeriesIterator) error {
 	}
 
 	if !iter.Next() {
+		err := iter.Err()
 		iter.Close()
-		return iter.Err()
+		return err
 	}
 
 	firstAnnotation := iter.FirstAnnotation()
 	if !it.iters.push(iter) {
+		err := iter.Err()
 		iter.Close()
-		return nil
+		return err
 	}
 
 	iterStart := iter.Start()

--- a/src/dbnode/encoding/series_iterator_accumulator_test.go
+++ b/src/dbnode/encoding/series_iterator_accumulator_test.go
@@ -58,7 +58,7 @@ func TestSeriesIteratorAccumulator(t *testing.T) {
 	values := []accumulatorInput{
 		{
 			values: []testValue{
-				{1.0, start.Add(-1 * time.Second), xtime.Second, nil},
+				{1.0, start.Add(-1 * time.Second), xtime.Second, []byte{5}},
 				{2.0, start.Add(1 * time.Second), xtime.Second, nil},
 			},
 			id: "foo0",
@@ -262,6 +262,7 @@ func TestAccumulatorMocked(t *testing.T) {
 	base := NewMockSeriesIterator(ctrl)
 	base.EXPECT().ID().Return(ident.StringID("base")).AnyTimes()
 	base.EXPECT().Namespace().Return(ident.StringID("ns")).AnyTimes()
+	base.EXPECT().FirstAnnotation().Return(annotation)
 	base.EXPECT().Next().Return(true)
 	dp := ts.Datapoint{TimestampNanos: start, Value: 88}
 	base.EXPECT().Current().Return(dp, xtime.Second, annotation).AnyTimes()

--- a/src/dbnode/encoding/series_iterator_accumulator_test.go
+++ b/src/dbnode/encoding/series_iterator_accumulator_test.go
@@ -58,7 +58,7 @@ func TestSeriesIteratorAccumulator(t *testing.T) {
 	values := []accumulatorInput{
 		{
 			values: []testValue{
-				{1.0, start.Add(-1 * time.Second), xtime.Second, []byte{5}},
+				{1.0, start.Add(-1 * time.Second), xtime.Second, []byte{4}},
 				{2.0, start.Add(1 * time.Second), xtime.Second, nil},
 			},
 			id: "foo0",
@@ -106,7 +106,7 @@ func TestSeriesIteratorAccumulator(t *testing.T) {
 		end:                     end,
 		input:                   values,
 		expected:                ex,
-		expectedFirstAnnotation: []byte{5},
+		expectedFirstAnnotation: []byte{4},
 	}
 
 	assertTestSeriesAccumulatorIterator(t, test)

--- a/src/query/storage/m3/consolidators/id_dedupe_map_test.go
+++ b/src/query/storage/m3/consolidators/id_dedupe_map_test.go
@@ -64,6 +64,7 @@ func idIt(
 	it.EXPECT().Namespace().Return(ident.StringID("ns")).AnyTimes()
 	it.EXPECT().Start().Return(dp.t).AnyTimes()
 	it.EXPECT().End().Return(dp.t.Add(time.Hour)).AnyTimes()
+	it.EXPECT().FirstAnnotation().Return(nil).AnyTimes()
 
 	tagIter := ident.MustNewTagStringsIterator(tags...)
 	it.EXPECT().Tags().Return(tagIter).AnyTimes()
@@ -92,6 +93,7 @@ func rangeIt(
 	it.EXPECT().Namespace().Return(ident.StringID("ns")).AnyTimes()
 	it.EXPECT().Start().Return(start).AnyTimes()
 	it.EXPECT().End().Return(end).AnyTimes()
+	it.EXPECT().FirstAnnotation().Return(nil).AnyTimes()
 	it.EXPECT().Next().Return(true).MaxTimes(1)
 
 	tagIter := ident.MustNewTagStringsIterator(tags...)

--- a/src/query/storage/m3/consolidators/tag_dedupe_map_test.go
+++ b/src/query/storage/m3/consolidators/tag_dedupe_map_test.go
@@ -77,6 +77,7 @@ func it(
 	it.EXPECT().Namespace().Return(ident.StringID("ns")).AnyTimes()
 	it.EXPECT().Start().Return(dp.t).AnyTimes()
 	it.EXPECT().End().Return(dp.t.Add(time.Hour)).AnyTimes()
+	it.EXPECT().FirstAnnotation().Return(nil).AnyTimes()
 
 	tagIter := ident.MustNewTagStringsIterator(tags...)
 	it.EXPECT().Tags().Return(tagIter).AnyTimes()
@@ -106,6 +107,7 @@ func notReadIt(
 	it.EXPECT().Namespace().Return(ident.StringID("ns")).AnyTimes()
 	it.EXPECT().Start().Return(dp.t).AnyTimes()
 	it.EXPECT().End().Return(dp.t.Add(time.Hour)).AnyTimes()
+	it.EXPECT().FirstAnnotation().Return(nil).AnyTimes()
 
 	tagIter := ident.MustNewTagStringsIterator(tags...)
 	it.EXPECT().Tags().Return(tagIter).AnyTimes()


### PR DESCRIPTION
**What this PR does / why we need it**:
`SeriesIteratorAccumulator.FirstAnnotation` was not always returning the annotation value because it was trying to get it from internal iterators which may have already skipped their first datapoint because of internal start-end range filter.
With this change, the value for `SeriesIteratorAccumulator.FirstAnnotation` will be taken from the underlying `SeriesIterator.FirstAnnotation`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
NONE

**Does this PR require updating code package or user-facing documentation?**:
NONE
