### PR TITLE
[DOCS] Update broken Snappy link

### DIFF
--- a/site/content/reference/m3coordinator/api/remote.md
+++ b/site/content/reference/m3coordinator/api/remote.md
@@ -31,7 +31,7 @@ None.
 
 ### Data Params
 
-Binary [snappy compressed](http://google.github.io/snappy/) Prometheus [WriteRequest protobuf message](https://github.com/prometheus/prometheus/blob/10444e8b1dc69ffcddab93f09ba8dfa6a4a2fddb/prompb/remote.proto#L22-L24).
+Binary [snappy compressed](https://github.com/google/snappy) Prometheus [WriteRequest protobuf message](https://github.com/prometheus/prometheus/blob/10444e8b1dc69ffcddab93f09ba8dfa6a4a2fddb/prompb/remote.proto#L22-L24).
 
 ### Available Tuning Params
 
@@ -103,4 +103,4 @@ None.
 
 ### Data Params
 
-Binary [snappy compressed](http://google.github.io/snappy/) Prometheus [WriteRequest protobuf message](https://github.com/prometheus/prometheus/blob/10444e8b1dc69ffcddab93f09ba8dfa6a4a2fddb/prompb/remote.proto#L26-L28).
+Binary [snappy compressed](https://github.com/google/snappy) Prometheus [WriteRequest protobuf message](https://github.com/prometheus/prometheus/blob/10444e8b1dc69ffcddab93f09ba8dfa6a4a2fddb/prompb/remote.proto#L26-L28).


### PR DESCRIPTION
Updates Snappy link that is 404ing