### PR TITLE
Add GRPC dial options support to etcd cluster options

### DIFF
--- a/src/cluster/client/etcd/config.go
+++ b/src/cluster/client/etcd/config.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/uber-go/tally"
+	"google.golang.org/grpc"
 
 	"github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/services"
@@ -39,6 +40,8 @@ type ClusterConfig struct {
 	KeepAlive        *KeepAliveConfig `yaml:"keepAlive"`
 	TLS              *TLSConfig       `yaml:"tls"`
 	AutoSyncInterval time.Duration    `yaml:"autoSyncInterval"`
+
+	DialOptions []grpc.DialOption `yaml:"-"` // nonserializable
 }
 
 // NewCluster creates a new Cluster.
@@ -50,6 +53,7 @@ func (c ClusterConfig) NewCluster() Cluster {
 	return NewCluster().
 		SetZone(c.Zone).
 		SetEndpoints(c.Endpoints).
+		SetDialOptions(c.DialOptions).
 		SetKeepAliveOptions(keepAliveOpts).
 		SetTLSOptions(c.TLS.newOptions()).
 		SetAutoSyncInterval(c.AutoSyncInterval)

--- a/src/cluster/client/etcd/options.go
+++ b/src/cluster/client/etcd/options.go
@@ -30,6 +30,8 @@ import (
 	"os"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/x/instrument"
 	"github.com/m3db/m3/src/x/retry"
@@ -418,6 +420,7 @@ type cluster struct {
 	tlsOpts          TLSOptions
 	autoSyncInterval time.Duration
 	dialTimeout      time.Duration
+	dialOptions      []grpc.DialOption
 }
 
 func (c cluster) Zone() string {
@@ -474,5 +477,14 @@ func (c cluster) DialTimeout() time.Duration {
 func (c cluster) SetDialTimeout(dialTimeout time.Duration) Cluster {
 	c.dialTimeout = dialTimeout
 
+	return c
+}
+
+func (c cluster) DialOptions() []grpc.DialOption {
+	return c.dialOptions
+}
+
+func (c cluster) SetDialOptions(opts []grpc.DialOption) Cluster {
+	c.dialOptions = opts
 	return c
 }

--- a/src/cluster/client/etcd/types.go
+++ b/src/cluster/client/etcd/types.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/m3db/m3/src/cluster/client"
 	"github.com/m3db/m3/src/cluster/services"
 	"github.com/m3db/m3/src/x/instrument"
@@ -161,6 +163,11 @@ type Cluster interface {
 
 	DialTimeout() time.Duration
 	SetDialTimeout(value time.Duration) Cluster
+
+	// DialOptions are used by the etcd client to connect to etcd peers. They can be used to customize
+	// the low level networking behavior of the client (e.g. to forward connections over a proxy).
+	DialOptions() []grpc.DialOption
+	SetDialOptions(opts []grpc.DialOption) Cluster
 }
 
 // Client is an etcd-backed m3cluster client.


### PR DESCRIPTION
**What this PR does / why we need it**:

GRPC dial options are useful for a variety of use cases--adding default headers (via a stream interceptor), injecting code into the low level connection flow via
a net.Dialer (e.g. to support proxying across network boundaries).

This diff adds an option on clusters to pass through GRPC.DialOptions for these use cases. Defaults of nil should match current behavior.




**Does this PR introduce a user-facing and/or backwards incompatible change?**:

```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
