### PR TITLE
[commitlog] Add the ability to configure pools before allocation

### DIFF
--- a/src/dbnode/persist/fs/commitlog/options.go
+++ b/src/dbnode/persist/fs/commitlog/options.go
@@ -95,7 +95,7 @@ type options struct {
 }
 
 type optionsInput struct {
-	fsOptions    fs.Options
+	fsOptions fs.Options
 	// allows differentiating between explicitly nil and unset
 	fsOptionsSet bool
 
@@ -123,7 +123,7 @@ func WithIdentPoolOptions(o ident.PoolOptions) OptionSetter {
 }
 
 // WithBytesPoolOptions is an OptionsSetter that provides options to BytesPool
-func WithBytesPoolOptions (o pool.ObjectPoolOptions) OptionSetter {
+func WithBytesPoolOptions(o pool.ObjectPoolOptions) OptionSetter {
 	return func(input *optionsInput) {
 		input.bytePoolOptions = o
 	}
@@ -152,7 +152,7 @@ func NewOptions(setters ...OptionSetter) Options {
 		backlogQueueSize:        defaultBacklogQueueSize,
 		backlogQueueChannelSize: defaultBacklogQueueChannelSize,
 		bytesPool: pool.NewCheckedBytesPool(nil, presetOptions.bytePoolOptions, func(s []pool.Bucket) pool.BytesPool {
-			return pool.NewBytesPool(s,  presetOptions.bytePoolOptions)
+			return pool.NewBytesPool(s, presetOptions.bytePoolOptions)
 		}),
 		readConcurrency: defaultReadConcurrency,
 		failureCallback: nil,

--- a/src/dbnode/persist/fs/options.go
+++ b/src/dbnode/persist/fs/options.go
@@ -110,17 +110,78 @@ type options struct {
 	indexReaderAutovalidateIndexSegments bool
 	encodingOptions                      msgpack.LegacyEncodingOptions
 }
+// the bools allow explicitly setting the field to nil
+type optionsInput struct {
+	tagEncoderPool       serialize.TagEncoderPool
+	tagEncoderPoolSet    bool
+
+	tagDecoderPool       serialize.TagDecoderPool
+	tagDecoderPoolSet    bool
+
+	fstOptions           fst.Options
+	fstOptionsSet        bool
+}
+
+// OptionSetter is a function that modifies the behavior of NewOptions
+type OptionSetter func(o *optionsInput)
+
+// WithTagEncoderPool is an OptionSetter that provides custom serialize.TagEncoderPool
+// Passing nil will be equivalent to calling Options.SetTagEncoderPool(nil)
+// on the result of NewOptions
+func WithTagEncoderPool(o serialize.TagEncoderPool) OptionSetter {
+	return func(input *optionsInput) {
+		input.tagEncoderPool = o
+		input.tagEncoderPoolSet = true
+	}
+}
+
+// WithTagDecodePool is an OptionSetter that provides custom serialize.TagDecoder
+// Passing nil will be equivalent to calling Options.SetTagDecoderPool(nil)
+// on the result of NewOptions
+func WithTagDecodePool(o serialize.TagDecoderPool) OptionSetter {
+	return func(input *optionsInput) {
+		input.tagDecoderPool = o
+		input.tagDecoderPoolSet = true
+	}
+}
+
+// WithFstOptions is an OptionSetter that provides custom fst.Options
+// Passing nil will be equivalent to calling Options.SetFSTOptions(nil)
+// on the result of NewOptions
+func WithFstOptions(o fst.Options) OptionSetter {
+	return func(input *optionsInput) {
+		input.fstOptions = o
+		input.fstOptionsSet = true
+	}
+}
 
 // NewOptions creates a new set of fs options
-func NewOptions() Options {
-	tagEncoderPool := serialize.NewTagEncoderPool(
-		serialize.NewTagEncoderOptions(), pool.NewObjectPoolOptions())
-	tagEncoderPool.Init()
-	tagDecoderPool := serialize.NewTagDecoderPool(
-		serialize.NewTagDecoderOptions(serialize.TagDecoderOptionsConfig{}),
-		pool.NewObjectPoolOptions())
-	tagDecoderPool.Init()
-	fstOptions := fst.NewOptions()
+func NewOptions(setters ...OptionSetter) Options {
+	input := optionsInput{}
+	for _, setter := range setters {
+		setter(&input)
+	}
+	if !input.tagEncoderPoolSet && input.tagEncoderPool == nil {
+		input.tagEncoderPool = serialize.NewTagEncoderPool(
+			serialize.NewTagEncoderOptions(), pool.NewObjectPoolOptions())
+	}
+
+	if !input.tagDecoderPoolSet && input.tagDecoderPool == nil {
+		input.tagDecoderPool = serialize.NewTagDecoderPool(
+			serialize.NewTagDecoderOptions(serialize.TagDecoderOptionsConfig{}),
+			pool.NewObjectPoolOptions())
+	}
+
+	if !input.fstOptionsSet && input.fstOptions == nil {
+		input.fstOptions = fst.NewOptions()
+	}
+
+	if input.tagEncoderPool != nil {
+		input.tagEncoderPool.Init()
+	}
+	if input.tagDecoderPool != nil {
+		input.tagDecoderPool.Init()
+	}
 
 	return &options{
 		clockOpts:                            clock.NewOptions(),
@@ -140,9 +201,9 @@ func NewOptions() Options {
 		seekReaderBufferSize:                 defaultSeekReaderBufferSize,
 		mmapEnableHugePages:                  defaultMmapEnableHugePages,
 		mmapHugePagesThreshold:               defaultMmapHugePagesThreshold,
-		tagEncoderPool:                       tagEncoderPool,
-		tagDecoderPool:                       tagDecoderPool,
-		fstOptions:                           fstOptions,
+		tagEncoderPool:                       input.tagEncoderPool,
+		tagDecoderPool:                       input.tagDecoderPool,
+		fstOptions:                           input.fstOptions,
 		fstWriterOptions:                     defaultFSTWriterOptions,
 		indexReaderAutovalidateIndexSegments: defaultIndexReaderAutovalidateIndexSegments,
 		encodingOptions:                      msgpack.DefaultLegacyEncodingOptions,

--- a/src/dbnode/persist/fs/options.go
+++ b/src/dbnode/persist/fs/options.go
@@ -76,8 +76,8 @@ const (
 
 var (
 	defaultFilePathPrefix   = os.TempDir()
-	defaultNewFileMode      = os.FileMode(0666)
-	defaultNewDirectoryMode = os.ModeDir | os.FileMode(0755)
+	defaultNewFileMode      = os.FileMode(0o666)
+	defaultNewDirectoryMode = os.ModeDir | os.FileMode(0o755)
 	defaultFSTWriterOptions = fst.WriterOptions{}
 
 	errTagEncoderPoolNotSet = errors.New("tag encoder pool is not set")
@@ -110,16 +110,16 @@ type options struct {
 	indexReaderAutovalidateIndexSegments bool
 	encodingOptions                      msgpack.LegacyEncodingOptions
 }
-// the bools allow explicitly setting the field to nil
+
 type optionsInput struct {
-	tagEncoderPool       serialize.TagEncoderPool
-	tagEncoderPoolSet    bool
+	tagEncoderPool serialize.TagEncoderPool
+	tagDecoderPool serialize.TagDecoderPool
+	fstOptions     fst.Options
 
-	tagDecoderPool       serialize.TagDecoderPool
-	tagDecoderPoolSet    bool
-
-	fstOptions           fst.Options
-	fstOptionsSet        bool
+	// the bools allow explicitly setting the field to nil
+	tagEncoderPoolSet bool
+	tagDecoderPoolSet bool
+	fstOptionsSet     bool
 }
 
 // OptionSetter is a function that modifies the behavior of NewOptions


### PR DESCRIPTION
There are several places where we allocate large pools of memory
in constructors and provide setters to override those pools.
In general, this is fine as it allows us to provide larger or smaller
pools. However, in super memory constrained settings, we prefer to
avoid the initial alloc and GC all together and provide
the properly sized pools to the constructor.

This PR provides the ability to do this for certain properties
of fs.Options and commitlog.Options.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
