### PR TITLE
Add method in log/config that returns a Zap Config

### DIFF
--- a/src/x/log/config.go
+++ b/src/x/log/config.go
@@ -53,6 +53,12 @@ type encoderConfig struct {
 
 // BuildLogger builds a new Logger based on the configuration.
 func (cfg Configuration) BuildLogger() (*zap.Logger, error) {
+	logger, _, err := cfg.BuildLoggerAndReturnConfig()
+	return logger, err
+}
+
+// BuildLoggerAndReturnConfig builds a new Logger based on the configuration and returns a zap.Config object.
+func (cfg Configuration) BuildLoggerAndReturnConfig() (*zap.Logger, *zap.Config, error) {
 	zc := zap.Config{
 		Level:             zap.NewAtomicLevelAt(zap.InfoLevel),
 		Development:       false,
@@ -77,12 +83,12 @@ func (cfg Configuration) BuildLogger() (*zap.Logger, error) {
 	if len(cfg.Level) != 0 {
 		var parsedLevel zap.AtomicLevel
 		if err := parsedLevel.UnmarshalText([]byte(cfg.Level)); err != nil {
-			return nil, fmt.Errorf("unable to parse log level %s: %v", cfg.Level, err)
+			return nil, nil, fmt.Errorf("unable to parse log level %s: %w", cfg.Level, err)
 		}
 		zc.Level = parsedLevel
 	}
-
-	return zc.Build()
+	logger, err := zc.Build()
+	return logger, &zc, err
 }
 
 func (cfg Configuration) newEncoderConfig() zapcore.EncoderConfig {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR adds a method that returns a Zap Logger Configuration object while building the logger. This allows other methods to optionally receive the Zap Config object so they can dynamically change the logging level for example. 
Fixes #

**Special notes for your reviewer**: This has been tested in an external library as well as the unit test here.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
