### PR TITLE
[m3msg] Message pooling cleanup

### DIFF
--- a/src/msg/producer/config/writer.go
+++ b/src/msg/producer/config/writer.go
@@ -93,22 +93,23 @@ func (c *ConnectionConfiguration) NewOptions(iOpts instrument.Options) writer.Co
 
 // WriterConfiguration configs the writer options.
 type WriterConfiguration struct {
-	TopicName                         string                         `yaml:"topicName" validate:"nonzero"`
-	TopicServiceOverride              kv.OverrideConfiguration       `yaml:"topicServiceOverride"`
-	TopicWatchInitTimeout             *time.Duration                 `yaml:"topicWatchInitTimeout"`
-	PlacementOptions                  placement.Configuration        `yaml:"placement"`
-	PlacementServiceOverride          services.OverrideConfiguration `yaml:"placementServiceOverride"`
-	PlacementWatchInitTimeout         *time.Duration                 `yaml:"placementWatchInitTimeout"`
-	MessagePool                       *pool.ObjectPoolConfiguration  `yaml:"messagePool"`
-	MessageQueueNewWritesScanInterval *time.Duration                 `yaml:"messageQueueNewWritesScanInterval"`
-	MessageQueueFullScanInterval      *time.Duration                 `yaml:"messageQueueFullScanInterval"`
-	MessageQueueScanBatchSize         *int                           `yaml:"messageQueueScanBatchSize"`
-	InitialAckMapSize                 *int                           `yaml:"initialAckMapSize"`
-	CloseCheckInterval                *time.Duration                 `yaml:"closeCheckInterval"`
-	AckErrorRetry                     *retry.Configuration           `yaml:"ackErrorRetry"`
-	Encoder                           *proto.Configuration           `yaml:"encoder"`
-	Decoder                           *proto.Configuration           `yaml:"decoder"`
-	Connection                        *ConnectionConfiguration       `yaml:"connection"`
+	TopicName                 string                         `yaml:"topicName" validate:"nonzero"`
+	TopicServiceOverride      kv.OverrideConfiguration       `yaml:"topicServiceOverride"`
+	TopicWatchInitTimeout     *time.Duration                 `yaml:"topicWatchInitTimeout"`
+	PlacementOptions          placement.Configuration        `yaml:"placement"`
+	PlacementServiceOverride  services.OverrideConfiguration `yaml:"placementServiceOverride"`
+	PlacementWatchInitTimeout *time.Duration                 `yaml:"placementWatchInitTimeout"`
+	// MessagePool configuration is deprecated for producer side.
+	MessagePool                       *pool.ObjectPoolConfiguration `yaml:"messagePool"`
+	MessageQueueNewWritesScanInterval *time.Duration                `yaml:"messageQueueNewWritesScanInterval"`
+	MessageQueueFullScanInterval      *time.Duration                `yaml:"messageQueueFullScanInterval"`
+	MessageQueueScanBatchSize         *int                          `yaml:"messageQueueScanBatchSize"`
+	InitialAckMapSize                 *int                          `yaml:"initialAckMapSize"`
+	CloseCheckInterval                *time.Duration                `yaml:"closeCheckInterval"`
+	AckErrorRetry                     *retry.Configuration          `yaml:"ackErrorRetry"`
+	Encoder                           *proto.Configuration          `yaml:"encoder"`
+	Decoder                           *proto.Configuration          `yaml:"decoder"`
+	Connection                        *ConnectionConfiguration      `yaml:"connection"`
 
 	// StaticMessageRetry configs a static message retry policy.
 	StaticMessageRetry *StaticMessageRetryConfiguration `yaml:"staticMessageRetry"`
@@ -169,9 +170,6 @@ func (c *WriterConfiguration) NewOptions(
 
 	if c.PlacementWatchInitTimeout != nil {
 		opts = opts.SetPlacementWatchInitTimeout(*c.PlacementWatchInitTimeout)
-	}
-	if c.MessagePool != nil {
-		opts = opts.SetMessagePoolOptions(c.MessagePool.NewObjectPoolOptions(iOpts))
 	}
 	opts, err = c.setRetryOptions(opts, iOpts)
 	if err != nil {

--- a/src/msg/producer/config/writer_test.go
+++ b/src/msg/producer/config/writer_test.go
@@ -75,8 +75,6 @@ placementServiceOverride:
   namespaces:
     placement: n2
 placementWatchInitTimeout: 2s
-messagePool:
-  size: 5
 messageRetry:
   initialBackoff: 1ms
 messageQueueNewWritesScanInterval: 200ms
@@ -112,7 +110,6 @@ decoder:
 	require.Equal(t, "testTopic", wOpts.TopicName())
 	require.Equal(t, time.Second, wOpts.TopicWatchInitTimeout())
 	require.Equal(t, 2*time.Second, wOpts.PlacementWatchInitTimeout())
-	require.Equal(t, 5, wOpts.MessagePoolOptions().Size())
 	require.NotNil(t, wOpts.MessageRetryNanosFn())
 	require.Equal(t, 200*time.Millisecond, wOpts.MessageQueueNewWritesScanInterval())
 	require.Equal(t, 10*time.Second, wOpts.MessageQueueFullScanInterval())

--- a/src/msg/producer/ref_counted.go
+++ b/src/msg/producer/ref_counted.go
@@ -103,13 +103,12 @@ func (rm *RefCountedMessage) IsDroppedOrConsumed() bool {
 }
 
 func (rm *RefCountedMessage) finalize(r FinalizeReason) bool {
+	if rm.isDroppedOrConsumed.Load() {
+		return false
+	}
 	// NB: This lock prevents the message from being finalized when its still
 	// being read.
 	rm.mu.Lock()
-	if rm.isDroppedOrConsumed.Load() {
-		rm.mu.Unlock()
-		return false
-	}
 	rm.isDroppedOrConsumed.Store(true)
 	rm.mu.Unlock()
 	if rm.onFinalizeFn != nil {

--- a/src/msg/producer/ref_counted.go
+++ b/src/msg/producer/ref_counted.go
@@ -43,10 +43,6 @@ type RefCountedMessage struct {
 
 // NewRefCountedMessage creates RefCountedMessage.
 func NewRefCountedMessage(m Message, fn OnFinalizeFn) *RefCountedMessage {
-	if fn == nil {
-		// in non-test code the finalizer is always set.
-		fn = noopFinalizer
-	}
 	return &RefCountedMessage{
 		Message:      m,
 		size:         uint64(m.Size()),
@@ -116,10 +112,9 @@ func (rm *RefCountedMessage) finalize(r FinalizeReason) bool {
 	}
 	rm.isDroppedOrConsumed.Store(true)
 	rm.mu.Unlock()
-
-	rm.onFinalizeFn(rm)
+	if rm.onFinalizeFn != nil {
+		rm.onFinalizeFn(rm)
+	}
 	rm.Message.Finalize(r)
 	return true
 }
-
-func noopFinalizer(rm *RefCountedMessage) {}

--- a/src/msg/producer/writer/consumer_service_writer.go
+++ b/src/msg/producer/writer/consumer_service_writer.go
@@ -165,12 +165,8 @@ func initShardWriters(
 			opts.InstrumentOptions().TimerOptions(),
 			opts.WithoutConsumerScope(),
 		)
-		mPool messagePool
+		mPool = newMessagePool()
 	)
-	if opts.MessagePoolOptions() != nil {
-		mPool = newMessagePool(opts.MessagePoolOptions())
-		mPool.Init()
-	}
 	for i := range sws {
 		switch ct {
 		case topic.Shared:

--- a/src/msg/producer/writer/consumer_writer_test.go
+++ b/src/msg/producer/writer/consumer_writer_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/m3db/m3/src/msg/generated/proto/msgpb"
 	"github.com/m3db/m3/src/msg/protocol/proto"
-	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/retry"
 	xtest "github.com/m3db/m3/src/x/test"
 )
@@ -545,7 +544,6 @@ func testOptions() Options {
 		SetTopicName("topicName").
 		SetTopicWatchInitTimeout(100 * time.Millisecond).
 		SetPlacementWatchInitTimeout(100 * time.Millisecond).
-		SetMessagePoolOptions(pool.NewObjectPoolOptions().SetSize(1)).
 		SetMessageQueueNewWritesScanInterval(100 * time.Millisecond).
 		SetMessageQueueFullScanInterval(200 * time.Millisecond).
 		SetMessageRetryNanosFn(

--- a/src/msg/producer/writer/message.go
+++ b/src/msg/producer/writer/message.go
@@ -45,10 +45,7 @@ type message struct {
 }
 
 func newMessage() *message {
-	return &message{
-		retryAtNanos: 0,
-		retried:      0,
-	}
+	return &message{}
 }
 
 // Set sets the message.
@@ -61,6 +58,7 @@ func (m *message) Set(meta metadata, rm *producer.RefCountedMessage, initNanos i
 
 // Close resets the states of the message.
 func (m *message) Close() {
+	m.RefCountedMessage = nil
 	m.retryAtNanos = 0
 	m.retried = 0
 	m.isAcked.Store(false)

--- a/src/msg/producer/writer/message_pool_test.go
+++ b/src/msg/producer/writer/message_pool_test.go
@@ -25,18 +25,15 @@ import (
 
 	"github.com/m3db/m3/src/msg/generated/proto/msgpb"
 	"github.com/m3db/m3/src/msg/producer"
-	"github.com/m3db/m3/src/x/pool"
 	xtest "github.com/m3db/m3/src/x/test"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestMessagePool(t *testing.T) {
-	p := newMessagePool(pool.NewObjectPoolOptions().SetSize(1))
-	p.Init()
+	p := newMessagePool()
 
 	ctrl := xtest.NewController(t)
-	defer ctrl.Finish()
 
 	mm := producer.NewMockMessage(ctrl)
 	mm.EXPECT().Size().Return(3)
@@ -60,15 +57,4 @@ func TestMessagePool(t *testing.T) {
 	m.Close()
 	require.Nil(t, m.pb.Value)
 	p.Put(m)
-
-	m = p.Get()
-	require.Nil(t, m.pb.Value)
-	require.True(t, m.IsDroppedOrConsumed())
-	require.Equal(t, int64(500), m.InitNanos())
-
-	mm.EXPECT().Size().Return(3)
-	mm.EXPECT().Bytes().Return([]byte("foo"))
-	m.Set(metadata{}, producer.NewRefCountedMessage(mm, nil), 600)
-	require.False(t, m.IsDroppedOrConsumed())
-	require.Equal(t, int64(600), m.InitNanos())
 }

--- a/src/msg/producer/writer/message_writer_benchmark_test.go
+++ b/src/msg/producer/writer/message_writer_benchmark_test.go
@@ -42,7 +42,7 @@ func BenchmarkScanMessageQueue(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		w := newMessageWriter(
 			200,
-			testMessagePool(opts),
+			newMessagePool(),
 			opts,
 			testMessageWriterMetrics(),
 		).(*messageWriterImpl)

--- a/src/msg/producer/writer/options.go
+++ b/src/msg/producer/writer/options.go
@@ -30,7 +30,6 @@ import (
 	"github.com/m3db/m3/src/msg/protocol/proto"
 	"github.com/m3db/m3/src/msg/topic"
 	"github.com/m3db/m3/src/x/instrument"
-	"github.com/m3db/m3/src/x/pool"
 	"github.com/m3db/m3/src/x/retry"
 )
 
@@ -313,12 +312,6 @@ type Options interface {
 	// SetPlacementWatchInitTimeout sets the timeout for placement watch initialization.
 	SetPlacementWatchInitTimeout(value time.Duration) Options
 
-	// MessagePoolOptions returns the options of pool for messages.
-	MessagePoolOptions() pool.ObjectPoolOptions
-
-	// SetMessagePoolOptions sets the options of pool for messages.
-	SetMessagePoolOptions(value pool.ObjectPoolOptions) Options
-
 	// MessageRetryNanosFn returns the MessageRetryNanosFn.
 	MessageRetryNanosFn() MessageRetryNanosFn
 
@@ -411,7 +404,6 @@ type writerOptions struct {
 	placementOpts                     placement.Options
 	placementWatchInitTimeout         time.Duration
 	messageRetryNanosFn               MessageRetryNanosFn
-	messagePoolOptions                pool.ObjectPoolOptions
 	messageQueueNewWritesScanInterval time.Duration
 	messageQueueFullScanInterval      time.Duration
 	messageQueueScanBatchSize         int
@@ -505,16 +497,6 @@ func (opts *writerOptions) PlacementWatchInitTimeout() time.Duration {
 func (opts *writerOptions) SetPlacementWatchInitTimeout(value time.Duration) Options {
 	o := *opts
 	o.placementWatchInitTimeout = value
-	return &o
-}
-
-func (opts *writerOptions) MessagePoolOptions() pool.ObjectPoolOptions {
-	return opts.messagePoolOptions
-}
-
-func (opts *writerOptions) SetMessagePoolOptions(value pool.ObjectPoolOptions) Options {
-	o := *opts
-	o.messagePoolOptions = value
 	return &o
 }
 

--- a/src/msg/producer/writer/options_test.go
+++ b/src/msg/producer/writer/options_test.go
@@ -45,8 +45,6 @@ func TestOptions(t *testing.T) {
 	require.Equal(t, defaultMessageQueueFullScanInterval, opts.MessageQueueFullScanInterval())
 	require.Equal(t, time.Minute, opts.SetMessageQueueFullScanInterval(time.Minute).MessageQueueFullScanInterval())
 
-	require.Nil(t, opts.MessagePoolOptions())
-
 	require.Equal(t, defaultInitialAckMapSize, opts.InitialAckMapSize())
 	require.Equal(t, 123, opts.SetInitialAckMapSize(123).InitialAckMapSize())
 

--- a/src/msg/producer/writer/shard_writer.go
+++ b/src/msg/producer/writer/shard_writer.go
@@ -59,7 +59,7 @@ type sharedShardWriter struct {
 func newSharedShardWriter(
 	shard uint32,
 	router ackRouter,
-	mPool messagePool,
+	mPool *messagePool,
 	opts Options,
 	m messageWriterMetrics,
 ) shardWriter {
@@ -125,7 +125,7 @@ type replicatedShardWriter struct {
 
 	shard          uint32
 	numberOfShards uint32
-	mPool          messagePool
+	mPool          *messagePool
 	ackRouter      ackRouter
 	opts           Options
 	logger         *zap.Logger
@@ -140,7 +140,7 @@ type replicatedShardWriter struct {
 func newReplicatedShardWriter(
 	shard, numberOfShards uint32,
 	router ackRouter,
-	mPool messagePool,
+	mPool *messagePool,
 	opts Options,
 	m messageWriterMetrics,
 ) shardWriter {

--- a/src/msg/producer/writer/shard_writer_test.go
+++ b/src/msg/producer/writer/shard_writer_test.go
@@ -42,7 +42,7 @@ func TestSharedShardWriter(t *testing.T) {
 
 	a := newAckRouter(2)
 	opts := testOptions()
-	sw := newSharedShardWriter(1, a, testMessagePool(opts), opts, testMessageWriterMetrics())
+	sw := newSharedShardWriter(1, a, newMessagePool(), opts, testMessageWriterMetrics())
 	defer sw.Close()
 
 	cw1 := newConsumerWriter("i1", a, opts, testConsumerWriterMetrics())
@@ -118,7 +118,7 @@ func TestReplicatedShardWriter(t *testing.T) {
 
 	a := newAckRouter(3)
 	opts := testOptions()
-	sw := newReplicatedShardWriter(1, 200, a, testMessagePool(opts), opts, testMessageWriterMetrics()).(*replicatedShardWriter)
+	sw := newReplicatedShardWriter(1, 200, a, newMessagePool(), opts, testMessageWriterMetrics()).(*replicatedShardWriter)
 	defer sw.Close()
 
 	lis1, err := net.Listen("tcp", "127.0.0.1:0")
@@ -230,7 +230,7 @@ func TestReplicatedShardWriterRemoveMessageWriter(t *testing.T) {
 
 	router := newAckRouter(2).(*router)
 	opts := testOptions()
-	sw := newReplicatedShardWriter(1, 200, router, testMessagePool(opts), opts, testMessageWriterMetrics()).(*replicatedShardWriter)
+	sw := newReplicatedShardWriter(1, 200, router, newMessagePool(), opts, testMessageWriterMetrics()).(*replicatedShardWriter)
 
 	lis1, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -346,7 +346,7 @@ func TestReplicatedShardWriterUpdate(t *testing.T) {
 
 	a := newAckRouter(4)
 	opts := testOptions()
-	sw := newReplicatedShardWriter(1, 200, a, testMessagePool(opts), opts, testMessageWriterMetrics()).(*replicatedShardWriter)
+	sw := newReplicatedShardWriter(1, 200, a, newMessagePool(), opts, testMessageWriterMetrics()).(*replicatedShardWriter)
 	defer sw.Close()
 
 	cw1 := newConsumerWriter("i1", a, opts, testConsumerWriterMetrics())

--- a/src/msg/producer/writer/shard_writer_test.go
+++ b/src/msg/producer/writer/shard_writer_test.go
@@ -230,7 +230,9 @@ func TestReplicatedShardWriterRemoveMessageWriter(t *testing.T) {
 
 	router := newAckRouter(2).(*router)
 	opts := testOptions()
-	sw := newReplicatedShardWriter(1, 200, router, newMessagePool(), opts, testMessageWriterMetrics()).(*replicatedShardWriter)
+	sw := newReplicatedShardWriter(
+		1, 200, router, newMessagePool(), opts, testMessageWriterMetrics(),
+	).(*replicatedShardWriter)
 
 	lis1, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
* Fix a potential memory leak as `message` wrapper did not clear `message.RefCountedMessage` pointer - rarely hit in practice due to frequent reuse and limited size of internal `messageWriter` buffer of `scanBatchSize`, but still potentially bloating memory usage.
* Simplify `message` pooling on Producer - best option is to always use the dynamic-sized pool - need to change this in consumer as well. It cleans up the tests as well as they were assuming specific pool implementation behavior.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
m3msg producer MessagePool configuration is deprecated, pooling is always enabled.
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
