### PR TITLE
[aggregator] Refactor elem/flush metrics

### DIFF
--- a/src/aggregator/aggregator/counter_elem_gen.go
+++ b/src/aggregator/aggregator/counter_elem_gen.go
@@ -228,7 +228,9 @@ func (e *CounterElem) AddUnique(
 func (e *CounterElem) expireValuesWithLock(
 	targetNanos int64,
 	isEarlierThanFn isEarlierThanFn,
-	flushMetrics flushMetrics) {
+	flushMetrics *flushMetrics,
+) {
+	var expiredCount int64
 	e.flushStateToExpire = e.flushStateToExpire[:0]
 	if len(e.values) == 0 {
 		return
@@ -272,7 +274,7 @@ func (e *CounterElem) expireValuesWithLock(
 			e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
 			delete(e.values, e.minStartTime)
 			e.minStartTime = currAgg.startAt
-			flushMetrics.valuesExpired.Inc(1)
+			expiredCount++
 
 			// it's safe to access this outside the agg lock since it was closed in a previous iteration.
 			// This is to make sure there aren't too many cached source sets taking up
@@ -288,6 +290,7 @@ func (e *CounterElem) expireValuesWithLock(
 			break
 		}
 	}
+	flushMetrics.valuesExpired.Inc(expiredCount)
 }
 
 func (e *CounterElem) expireFlushState() {
@@ -735,7 +738,8 @@ func (e *CounterElem) processValue(
 	resolution time.Duration,
 	latenessAllowed time.Duration,
 	jitter time.Duration,
-	flushMetrics flushMetrics) {
+	flushMetrics *flushMetrics,
+) {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
@@ -751,7 +755,7 @@ func (e *CounterElem) processValue(
 			l.Error("reflushing aggregation without resendEnabled", zap.Any("consumeState", cState))
 		})
 	}
-	flushMetrics.valuesProcessed.Inc(1)
+
 	for aggTypeIdx, aggType := range e.aggTypes {
 		var extraDp transformation.Datapoint
 		value := cState.values[aggTypeIdx]
@@ -865,10 +869,11 @@ func (e *CounterElem) processValue(
 		// forward lag = current time - (agg timestamp + lateness allowed + jitter)
 		// use expectedProcessingTime instead of the aggregation timestamp since the aggregation timestamp could be
 		// in the past for updated aggregations (resendEnabled).
+		lag := xtime.Since(expectedProcessingTime.Add(latenessAllowed))
 		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
-			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed + jitter)))
+			RecordDuration(lag)
 		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
-			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed)))
+			RecordDuration(lag + jitter)
 	}
 	fState.flushed = true
 	e.flushState[cState.startAt] = fState

--- a/src/aggregator/aggregator/entry_test.go
+++ b/src/aggregator/aggregator/entry_test.go
@@ -1164,7 +1164,7 @@ func TestAddUntimed_ResendEnabledMigrationRaceWithFlusher(t *testing.T) {
 	require.NoError(t, e.addUntimed(mu, metadatas))
 
 	// continue consuming the aggregation
-	elem.expireValuesWithLock(int64(t2), isStandardMetricEarlierThan, flushMetrics{})
+	elem.expireValuesWithLock(int64(t2), isStandardMetricEarlierThan, newFlushMetrics(tally.NoopScope))
 
 	// target the aggregation being flushed again...it should still be open since it migrated to resendEnabled before
 	// closing.

--- a/src/aggregator/aggregator/generic_elem.go
+++ b/src/aggregator/aggregator/generic_elem.go
@@ -291,7 +291,9 @@ func (e *GenericElem) AddUnique(
 func (e *GenericElem) expireValuesWithLock(
 	targetNanos int64,
 	isEarlierThanFn isEarlierThanFn,
-	flushMetrics flushMetrics) {
+	flushMetrics *flushMetrics,
+) {
+	var expiredCount int64
 	e.flushStateToExpire = e.flushStateToExpire[:0]
 	if len(e.values) == 0 {
 		return
@@ -335,7 +337,7 @@ func (e *GenericElem) expireValuesWithLock(
 			e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
 			delete(e.values, e.minStartTime)
 			e.minStartTime = currAgg.startAt
-			flushMetrics.valuesExpired.Inc(1)
+			expiredCount++
 
 			// it's safe to access this outside the agg lock since it was closed in a previous iteration.
 			// This is to make sure there aren't too many cached source sets taking up
@@ -351,6 +353,7 @@ func (e *GenericElem) expireValuesWithLock(
 			break
 		}
 	}
+	flushMetrics.valuesExpired.Inc(expiredCount)
 }
 
 func (e *GenericElem) expireFlushState() {
@@ -798,7 +801,8 @@ func (e *GenericElem) processValue(
 	resolution time.Duration,
 	latenessAllowed time.Duration,
 	jitter time.Duration,
-	flushMetrics flushMetrics) {
+	flushMetrics *flushMetrics,
+) {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
@@ -814,7 +818,7 @@ func (e *GenericElem) processValue(
 			l.Error("reflushing aggregation without resendEnabled", zap.Any("consumeState", cState))
 		})
 	}
-	flushMetrics.valuesProcessed.Inc(1)
+
 	for aggTypeIdx, aggType := range e.aggTypes {
 		var extraDp transformation.Datapoint
 		value := cState.values[aggTypeIdx]
@@ -928,10 +932,11 @@ func (e *GenericElem) processValue(
 		// forward lag = current time - (agg timestamp + lateness allowed + jitter)
 		// use expectedProcessingTime instead of the aggregation timestamp since the aggregation timestamp could be
 		// in the past for updated aggregations (resendEnabled).
+		lag := xtime.Since(expectedProcessingTime.Add(latenessAllowed))
 		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
-			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed + jitter)))
+			RecordDuration(lag)
 		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
-			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed)))
+			RecordDuration(lag + jitter)
 	}
 	fState.flushed = true
 	e.flushState[cState.startAt] = fState

--- a/src/aggregator/aggregator/list.go
+++ b/src/aggregator/aggregator/list.go
@@ -786,6 +786,9 @@ const (
 	timedMetricListType
 )
 
+// keep in sync with metricListType values
+const numMetricListTypes = 3
+
 func (t metricListType) String() string {
 	switch t {
 	case standardMetricListType:

--- a/src/aggregator/aggregator/list.go
+++ b/src/aggregator/aggregator/list.go
@@ -781,13 +781,12 @@ func (l *timedMetricList) Close() {
 type metricListType int
 
 const (
+	// NB(vytenis): keep this zero-indexed
 	standardMetricListType metricListType = iota
 	forwardedMetricListType
 	timedMetricListType
+	invalidMetricListType // must be the last value in the list - used as a sentinel value for metric scope generation
 )
-
-// keep in sync with metricListType values
-const numMetricListTypes = 3
 
 func (t metricListType) String() string {
 	switch t {

--- a/src/aggregator/aggregator/timer_elem_gen.go
+++ b/src/aggregator/aggregator/timer_elem_gen.go
@@ -228,7 +228,9 @@ func (e *TimerElem) AddUnique(
 func (e *TimerElem) expireValuesWithLock(
 	targetNanos int64,
 	isEarlierThanFn isEarlierThanFn,
-	flushMetrics flushMetrics) {
+	flushMetrics *flushMetrics,
+) {
+	var expiredCount int64
 	e.flushStateToExpire = e.flushStateToExpire[:0]
 	if len(e.values) == 0 {
 		return
@@ -272,7 +274,7 @@ func (e *TimerElem) expireValuesWithLock(
 			e.flushStateToExpire = append(e.flushStateToExpire, e.minStartTime)
 			delete(e.values, e.minStartTime)
 			e.minStartTime = currAgg.startAt
-			flushMetrics.valuesExpired.Inc(1)
+			expiredCount++
 
 			// it's safe to access this outside the agg lock since it was closed in a previous iteration.
 			// This is to make sure there aren't too many cached source sets taking up
@@ -288,6 +290,7 @@ func (e *TimerElem) expireValuesWithLock(
 			break
 		}
 	}
+	flushMetrics.valuesExpired.Inc(expiredCount)
 }
 
 func (e *TimerElem) expireFlushState() {
@@ -735,7 +738,8 @@ func (e *TimerElem) processValue(
 	resolution time.Duration,
 	latenessAllowed time.Duration,
 	jitter time.Duration,
-	flushMetrics flushMetrics) {
+	flushMetrics *flushMetrics,
+) {
 	var (
 		transformations  = e.parsedPipeline.Transformations
 		discardNaNValues = e.opts.DiscardNaNAggregatedValues()
@@ -751,7 +755,7 @@ func (e *TimerElem) processValue(
 			l.Error("reflushing aggregation without resendEnabled", zap.Any("consumeState", cState))
 		})
 	}
-	flushMetrics.valuesProcessed.Inc(1)
+
 	for aggTypeIdx, aggType := range e.aggTypes {
 		var extraDp transformation.Datapoint
 		value := cState.values[aggTypeIdx]
@@ -865,10 +869,11 @@ func (e *TimerElem) processValue(
 		// forward lag = current time - (agg timestamp + lateness allowed + jitter)
 		// use expectedProcessingTime instead of the aggregation timestamp since the aggregation timestamp could be
 		// in the past for updated aggregations (resendEnabled).
+		lag := xtime.Since(expectedProcessingTime.Add(latenessAllowed))
 		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: false}).
-			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed + jitter)))
+			RecordDuration(lag)
 		flushMetrics.forwardLag(forwardKey{fwdType: fwdType, jitter: true}).
-			RecordDuration(xtime.Since(expectedProcessingTime.Add(latenessAllowed)))
+			RecordDuration(lag + jitter)
 	}
 	fState.flushed = true
 	e.flushState[cState.startAt] = fState


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Some of these (dynamic) metrics are on critical path, and storing entire (and pretty large struct) embedded as a lockless cache bloats the element struct size itself, taking overall hundreds of megabytes of memory, when the lock-protected global metric map is ~1mb.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
