### PR TITLE
Allow non-blocking flushes across writers

### DIFF
--- a/src/aggregator/client/config.go
+++ b/src/aggregator/client/config.go
@@ -58,6 +58,7 @@ type Configuration struct {
 	MaxBatchSize               int                             `yaml:"maxBatchSize"`
 	MaxTimerBatchSize          int                             `yaml:"maxTimerBatchSize"`
 	QueueSize                  int                             `yaml:"queueSize"`
+	QueueSizeBytes             int                             `yaml:"queueSizeBytes"`
 	QueueDropType              *DropType                       `yaml:"queueDropType"`
 	Connection                 ConnectionConfiguration         `yaml:"connection"`
 }
@@ -190,6 +191,9 @@ func (c *Configuration) newClientOptions(
 		}
 		if c.QueueSize != 0 {
 			opts = opts.SetInstanceQueueSize(c.QueueSize)
+		}
+		if c.QueueSizeBytes != 0 {
+			opts = opts.SetInstanceMaxQueueSizeBytes(c.QueueSizeBytes)
 		}
 		if c.QueueDropType != nil {
 			opts = opts.SetQueueDropType(*c.QueueDropType)

--- a/src/aggregator/client/conn.go
+++ b/src/aggregator/client/conn.go
@@ -102,9 +102,9 @@ func newConnection(addr string, opts ConnectionOptions) *connection {
 		),
 		metrics: newConnectionMetrics(opts.InstrumentOptions().MetricsScope()),
 	}
+
 	c.connectWithLockFn = c.connectWithLock
 	c.writeWithLockFn = c.writeWithLock
-
 	return c
 }
 

--- a/src/aggregator/client/options.go
+++ b/src/aggregator/client/options.go
@@ -58,6 +58,12 @@ const (
 	// before it must wait for an existing batch to be flushed to an instance.
 	defaultInstanceQueueSize = 128
 
+	// defaultInstanceMaxQueueSizeBytes determines how many bytes across all payloads
+	// can be buffered in the queue before the eviction policy kicks in (policy is
+	// specified in DropType)
+	// 0 = no-limit (size-based limiting disabled by default)
+	defaultInstanceMaxQueueSizeBytes = 0
+
 	// By default traffic is cut over to shards 10 minutes before the designated
 	// cutover time in case there are issues with the instances owning the shards.
 	defaultShardCutoverWarmupDuration = 10 * time.Minute
@@ -212,6 +218,16 @@ type Options interface {
 	// InstanceQueueSize returns the instance queue size.
 	InstanceQueueSize() int
 
+	// SetInstanceQueueSize sets the instance max
+	// queue size threshold in bytes across all items in the queue.
+	SetInstanceMaxQueueSizeBytes(value int) Options
+
+	// InstanceMaxQueueSizeBytes returns the instance max
+	// queue size threshold in bytes across all items in the queue
+	// after which the eviction policy (dictated by DropType)
+	// should be triggered.
+	InstanceMaxQueueSizeBytes() int
+
 	// SetQueueDropType sets the strategy for which metrics should metrics should be dropped when
 	// the queue is full.
 	SetQueueDropType(value DropType) Options
@@ -247,6 +263,7 @@ type options struct {
 	forceFlushEvery            time.Duration
 	maxTimerBatchSize          int
 	instanceQueueSize          int
+	instanceMaxQueueSizeBytes  int
 	dropType                   DropType
 	maxBatchSize               int
 	flushWorkerCount           int
@@ -267,6 +284,7 @@ func NewOptions() Options {
 		flushWorkerCount:           defaultFlushWorkerCount,
 		maxTimerBatchSize:          defaultMaxTimerBatchSize,
 		instanceQueueSize:          defaultInstanceQueueSize,
+		instanceMaxQueueSizeBytes:  defaultInstanceMaxQueueSizeBytes,
 		dropType:                   defaultDropType,
 		maxBatchSize:               defaultMaxBatchSize,
 		rwOpts:                     xio.NewOptions(),
@@ -434,6 +452,16 @@ func (o *options) SetInstanceQueueSize(value int) Options {
 
 func (o *options) InstanceQueueSize() int {
 	return o.instanceQueueSize
+}
+
+func (o *options) SetInstanceMaxQueueSizeBytes(value int) Options {
+	opts := *o
+	opts.instanceMaxQueueSizeBytes = value
+	return &opts
+}
+
+func (o *options) InstanceMaxQueueSizeBytes() int {
+	return o.instanceMaxQueueSizeBytes
 }
 
 func (o *options) SetQueueDropType(value DropType) Options {

--- a/src/aggregator/client/queue_mock.go
+++ b/src/aggregator/client/queue_mock.go
@@ -108,3 +108,17 @@ func (mr *MockinstanceQueueMockRecorder) Size() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockinstanceQueue)(nil).Size))
 }
+
+// SizeBytes mocks base method.
+func (m *MockinstanceQueue) SizeBytes() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SizeBytes")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// SizeBytes indicates an expected call of SizeBytes.
+func (mr *MockinstanceQueueMockRecorder) SizeBytes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SizeBytes", reflect.TypeOf((*MockinstanceQueue)(nil).SizeBytes))
+}

--- a/src/aggregator/client/writer_benchmark_test.go
+++ b/src/aggregator/client/writer_benchmark_test.go
@@ -149,6 +149,7 @@ type testNoOpQueue struct{}
 func (q testNoOpQueue) Enqueue(protobuf.Buffer) error { return nil }
 func (q testNoOpQueue) Close() error                  { return nil }
 func (q testNoOpQueue) Size() int                     { return 0 }
+func (q testNoOpQueue) SizeBytes() int                { return 0 }
 func (q testNoOpQueue) Flush()                        {}
 
 type testSerialWriter struct {

--- a/src/aggregator/client/writer_mgr_test.go
+++ b/src/aggregator/client/writer_mgr_test.go
@@ -21,19 +21,25 @@
 package client
 
 import (
+	"context"
 	"errors"
+	"net"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/m3db/m3/src/cluster/placement"
+	"github.com/m3db/m3/src/metrics/metric"
+	"github.com/m3db/m3/src/metrics/metric/unaggregated"
+	"github.com/m3db/m3/src/x/clock"
+	xtest "github.com/m3db/m3/src/x/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/goleak"
-
-	"github.com/m3db/m3/src/cluster/placement"
-	"github.com/m3db/m3/src/x/clock"
 )
 
 var (
@@ -65,6 +71,144 @@ func TestWriterManagerAddInstancesSingleRef(t *testing.T) {
 	require.Equal(t, int32(2), w.refCount.n)
 }
 
+// TestWriterManagerMultipleWriters tries to recreate the scenario that
+// has multiple writers out of which one is slow. We have had multiple
+// incidents where one slow writer blocks all the other writers in the
+// aggregator client and cascades into a variety of issues including
+// dropped metrics, OOM etc.
+// How does this test mimic the slow writer?
+// It first creates a custom dialer for the TcpClient and
+// and makes the writeFn block on the context.Context. An instance created
+// with this overridden connection options struct creates a slow writer.
+// After the writer/instance is created, we re-override the write with
+// another custom dialer and replace the write with non-blocking
+// instructions. These writers are called normal writers. Instances added after
+// updating the opts with the re-overridden dialer creates normal writers.
+// The test creates several normal writers and one slow writer.
+// First it writes and flushes to the slow writer and get it to block.
+// It then begins a loop of writing one payload to every writer: slow and normal.
+// We initiate every write-loop in a separate goroutine.
+// We keep track of completed writes of the normal clients by way of the
+// counter writesCompleted.
+// As soon as all write-loops are done, meaning that all writers have
+// finished writing all that had to write, the context is canceled. This unblocks
+// the slow writer and then we perform the necessary validations.
+func TestWriterManagerMultipleWriters(t *testing.T) {
+	ctrl := xtest.NewController(t)
+	waitForSlowWriter := make(chan bool)
+
+	var writesCompleted atomic.Int32
+	var flushInProgressCnt atomic.Int32
+
+	const (
+		numIterations      = 10
+		numNormalInstances = 16
+	)
+
+	ctx := context.Background()
+	ctx, cancelFn := context.WithCancel(ctx)
+	defer cancelFn()
+
+	slowMockConn := NewMockConn(ctrl)
+	slowMockConn.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (n int, err error) {
+		// Block till all normal writers have finished writing
+		// all write loops below
+		waitForSlowWriter <- true
+		<-ctx.Done()
+		return len(b), nil
+	}).AnyTimes()
+	slowMockConn.EXPECT().SetWriteDeadline(gomock.Any()).AnyTimes()
+
+	slowWriterDialerFn := func(c context.Context, network string, address string) (net.Conn, error) {
+		return slowMockConn, nil
+	}
+
+	normalMockConn := NewMockConn(ctrl)
+	normalMockConn.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (n int, err error) {
+		writesCompleted.Inc()
+		return len(b), nil
+	}).AnyTimes()
+	normalMockConn.EXPECT().SetWriteDeadline(gomock.Any()).AnyTimes()
+
+	normalWriterDialerFn := func(ctx context.Context, network string, address string) (net.Conn, error) {
+		return normalMockConn, nil
+	}
+
+	// Override opts for slow writer
+	slowConnOpts := testConnectionOptions().SetContextDialer(slowWriterDialerFn)
+
+	opts := testOptions().SetConnectionOptions(slowConnOpts).SetFlushWorkerCount(256)
+	mgr := mustMakeInstanceWriterManager(opts)
+
+	slowInstance := placement.NewInstance().
+		SetID("slowTestID").
+		SetEndpoint("SlowTestEp")
+
+	// Add slow writer/instance
+	require.NoError(t, mgr.AddInstances([]placement.Instance{slowInstance}))
+
+	// Re-override opts for normal writers
+	mgr.opts = mgr.opts.SetConnectionOptions(testConnectionOptions().SetContextDialer(normalWriterDialerFn))
+
+	instances := []placement.Instance{}
+	for i := 0; i < numNormalInstances; i++ {
+		instances = append(instances, placement.NewInstance().
+			SetID("testID"+strconv.Itoa(i)).
+			SetEndpoint("testEp"+strconv.Itoa(i)),
+		)
+	}
+
+	// Create normal writers
+	require.NoError(t, mgr.AddInstances(instances))
+
+	// start slow writer asynchronously and wait till it blocks
+	err := mgr.Write(slowInstance, 0, testCounterPayloadUnion(0))
+	require.NoError(t, err)
+
+	go mgr.Flush() //nolint:errcheck
+	<-waitForSlowWriter
+
+	// Now the following write loop which contains writes over
+	// the slow writer and normal writers should be non-blocking.
+	var wg sync.WaitGroup
+	for i := 0; i < numIterations; i++ {
+		wg.Add(1)
+		go func(iterationID int64) {
+			defer wg.Done()
+
+			payload := testCounterPayloadUnion(iterationID)
+			// The following Write() to the slow instance should increment
+			// flushInProgressCnt during Flush()
+			err := mgr.Write(slowInstance, 0, payload)
+			require.NoError(t, err)
+
+			for _, instance := range instances {
+				err := mgr.Write(instance, 0, payload)
+				require.NoError(t, err)
+			}
+
+			err = mgr.Flush()
+			if err != nil {
+				require.True(t, strings.Contains(err.Error(), ErrFlushInProgress.Error()))
+				flushInProgressCnt.Inc()
+			}
+		}(int64(i))
+	}
+
+	wg.Wait()
+
+	// Now that all normal writers have finished writing
+	// cancel the slow writer and compare write counts
+	// to validate.
+	cancelFn()
+
+	// Unfortunately we cannot compare the write counts because due to the
+	// unpredictable nature of how the goroutines race against each other
+	// some normal writes could be combined into one flush. Thus making the
+	// actual count less than the expected count.
+	require.Equal(t, int32(numIterations), flushInProgressCnt.Load())
+}
+
 func TestWriterManagerRemoveInstancesClosed(t *testing.T) {
 	mgr := mustMakeInstanceWriterManager(testOptions())
 	mgr.Lock()
@@ -90,7 +234,7 @@ func TestWriterManagerRemoveInstancesSuccess(t *testing.T) {
 	mgr.Lock()
 	require.Equal(t, 1, len(mgr.writers))
 	w := mgr.writers[testPlacementInstance.ID()].instanceWriter.(*writer)
-	require.False(t, w.closed)
+	require.False(t, w.closed.Load())
 	mgr.Unlock()
 
 	// Remove the instance list again and assert the writer is now removed.
@@ -101,9 +245,7 @@ func TestWriterManagerRemoveInstancesSuccess(t *testing.T) {
 	require.NoError(t, mgr.RemoveInstances(toRemove))
 	require.Equal(t, 0, len(mgr.writers))
 	require.True(t, clock.WaitUntil(func() bool {
-		w.Lock()
-		defer w.Unlock()
-		return w.closed
+		return w.closed.Load()
 	}, 3*time.Second))
 }
 
@@ -303,11 +445,7 @@ func TestWriterManagerCloseSuccess(t *testing.T) {
 	require.True(t, clock.WaitUntil(func() bool {
 		for _, w := range mgr.writers {
 			wr := w.instanceWriter.(*writer)
-			wr.Lock()
-			closed := wr.closed
-			wr.Unlock()
-
-			if !closed {
+			if !wr.closed.Load() {
 				return false
 			}
 		}
@@ -322,4 +460,20 @@ func mustMakeInstanceWriterManager(opts Options) *writerManager {
 	}
 
 	return wm.(*writerManager)
+}
+
+func testCounterPayloadUnion(val int64) payloadUnion {
+	payload := payloadUnion{
+		payloadType: untimedType,
+		untimed: untimedPayload{
+			metric: unaggregated.MetricUnion{
+				Type:       metric.CounterType,
+				ID:         []byte("foo"),
+				CounterVal: val,
+			},
+			metadatas: testStagedMetadatas,
+		},
+	}
+
+	return payload
 }

--- a/src/aggregator/client/writer_test.go
+++ b/src/aggregator/client/writer_test.go
@@ -22,10 +22,12 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"sort"
 	"strings"
 	"sync"
@@ -43,6 +45,7 @@ import (
 	"github.com/m3db/m3/src/x/instrument"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 )
@@ -56,8 +59,8 @@ func TestWriterWriteClosed(t *testing.T) {
 		},
 	}
 	w := newInstanceWriter(testPlacementInstance, testOptions()).(*writer)
-	w.closed = true
-	require.Equal(t, errInstanceWriterClosed, w.Write(0, payload))
+	w.closed.Store(true)
+	require.Equal(t, ErrInstanceWriterClosed, w.Write(0, payload))
 }
 
 func TestWriterWriteUntimedCounterEncodeError(t *testing.T) {
@@ -88,6 +91,68 @@ func TestWriterWriteUntimedCounterEncodeError(t *testing.T) {
 		},
 	}
 	require.Equal(t, errTestEncodeMetric, w.Write(0, payload))
+}
+
+// TestWriterFlushInProgress tests that a writer does not
+// have multiple flushes in progress at the same time. It
+// can only ever have one flush active at any given point in
+// time.
+func TestWriterFlushInProgress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	blockCh := make(chan bool)
+	ctx := context.Background()
+	ctx, cancelFn := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelFn()
+
+	slowMockConn := NewMockConn(ctrl)
+	slowMockConn.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (n int, err error) {
+		// notify that the slow writer is about to block
+		blockCh <- true
+		<-ctx.Done()
+		return len(b), nil
+	})
+	slowMockConn.EXPECT().SetWriteDeadline(gomock.Any())
+
+	slowWriterDialerFn := func(c context.Context, network string, address string) (net.Conn, error) {
+		return slowMockConn, nil
+	}
+
+	slowConnOpts := NewConnectionOptions().SetContextDialer(slowWriterDialerFn)
+	opts := testOptions().SetConnectionOptions(slowConnOpts)
+	w := newInstanceWriter(testPlacementInstance, opts).(*writer)
+
+	payload := payloadUnion{
+		payloadType: untimedType,
+		untimed: untimedPayload{
+			metric:    testCounter,
+			metadatas: testStagedMetadatas,
+		},
+	}
+
+	require.Equal(t, nil, w.Write(0, payload))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w.Flush() //nolint:errcheck
+	}()
+
+	// wait for previous flush to block
+	<-blockCh
+
+	// now any newly initiated Flush should fail with err "in-progress"
+	// Note that if we didn't wait on blockCh above then this following
+	// Flush() can finish before the previous flush which defeats the
+	// purpose of the test :-)
+	require.EqualError(t, w.Flush(), ErrFlushInProgress.Error())
+
+	// unblock the slow writer
+	cancelFn()
+
+	wg.Wait()
 }
 
 func TestWriterWriteUntimedCounterEncoderExists(t *testing.T) {
@@ -151,7 +216,89 @@ func TestWriterWriteUntimedCounterEncoderDoesNotExist(t *testing.T) {
 	require.NoError(t, w.Write(0, payload))
 }
 
-func TestWriterWriteUntimedCounterWithFlushingZeroSizeBefore(t *testing.T) {
+func TestWriterEncoderSizeLimitItems(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	opts := testOptions().SetMaxBatchSize(1).SetInstanceQueueSize(1)
+	w := newInstanceWriter(testPlacementInstance, opts).(*writer)
+
+	payload := payloadUnion{
+		payloadType: untimedType,
+		untimed: untimedPayload{
+			metric:    testCounter,
+			metadatas: testStagedMetadatas,
+		},
+	}
+
+	// Perform a write which should enqueue the buf
+	require.NoError(t, w.Write(0, payload))
+	sizeBefore := w.QueueSize()
+
+	i := 0
+	numWrites := 10
+	for i < numWrites {
+		require.NoError(t, w.Write(0, payload))
+		i++
+	}
+
+	// All writes must respect the queue size of 1
+	// meaning that after numWrites attempts,
+	// the queueSize should still be 1 and the
+	// enqueued len in the encoders must be 0
+	// since all buffers would have been relinquished
+	// on write since each write exceeded maxBatchSize of 1
+	sizeAfter := w.QueueSize()
+
+	enc, exists := w.encodersByShard[0]
+	require.True(t, exists)
+	require.NotNil(t, enc)
+	require.Equal(t, 1, len(w.encodersByShard))
+	require.Equal(t, sizeBefore, sizeAfter)
+	require.Equal(t, 0, w.encodersByShard[0].Len())
+}
+
+func TestWriterEncoderSizeLimitBytes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// The encoded length of the payload below is 155 bytes.
+	// Set the MaxBatchSize to 200 so that it is relinquished
+	// after we write the payload twice.
+	// The queue is configured with a size limit of 300 bytes
+	// Therefore it can hold one such relinquished buffer of total
+	// size (155+155) 310. Any more attempts to write should
+	// respect the size limit and the queue size should remain 310
+	// Whereas the encoders should be fully drained for even number
+	// of writes.
+	opts := testOptions().SetMaxBatchSize(1).SetInstanceMaxQueueSizeBytes(300)
+	w := newInstanceWriter(testPlacementInstance, opts).(*writer)
+
+	payload := payloadUnion{
+		payloadType: untimedType,
+		untimed: untimedPayload{
+			metric:    testCounter,
+			metadatas: testStagedMetadatas,
+		},
+	}
+
+	i := 0
+	numWrites := 10
+	for i < numWrites {
+		require.NoError(t, w.Write(0, payload))
+		i++
+	}
+
+	enc, exists := w.encodersByShard[0]
+	require.True(t, exists)
+	require.NotNil(t, enc)
+	require.Equal(t, 1, len(w.encodersByShard))
+	require.Equal(t, 310, w.QueueSizeBytes())
+	require.Equal(t, 0, w.encodersByShard[0].Len())
+}
+
+//nolint:dupl
+func TestWriterWriteUntimedCounterWithWriteZeroSizeBefore(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -179,6 +326,7 @@ func TestWriterWriteUntimedCounterWithFlushingZeroSizeBefore(t *testing.T) {
 			enqueuedBuf = buf
 			return nil
 		})
+
 	w := newInstanceWriter(testPlacementInstance, testOptions().SetMaxBatchSize(3)).(*writer)
 	w.queue = queue
 	w.newLockedEncoderFn = func(protobuf.UnaggregatedOptions) *lockedEncoder {
@@ -201,7 +349,8 @@ func TestWriterWriteUntimedCounterWithFlushingZeroSizeBefore(t *testing.T) {
 	require.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7}, enqueuedBuf.Bytes())
 }
 
-func TestWriterWriteUntimedCounterWithFlushingPositiveSizeBefore(t *testing.T) {
+//nolint:dupl
+func TestWriterWriteUntimedCounterWithWritePositiveSizeBefore(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -230,6 +379,7 @@ func TestWriterWriteUntimedCounterWithFlushingPositiveSizeBefore(t *testing.T) {
 			return nil
 		})
 	w := newInstanceWriter(testPlacementInstance, testOptions().SetMaxBatchSize(3)).(*writer)
+
 	w.queue = queue
 	w.newLockedEncoderFn = func(protobuf.UnaggregatedOptions) *lockedEncoder {
 		return &lockedEncoder{UnaggregatedEncoder: encoder}
@@ -505,6 +655,7 @@ func TestWriterWriteUntimedBatchTimerEnqueueError(t *testing.T) {
 	errTestEnqueue := errors.New("test enqueue error")
 	queue := NewMockinstanceQueue(ctrl)
 	queue.EXPECT().Enqueue(gomock.Any()).Return(errTestEnqueue)
+
 	opts := testOptions().
 		SetMaxTimerBatchSize(1).
 		SetMaxBatchSize(1)
@@ -581,6 +732,7 @@ func TestWriterWriteForwardedWithFlushingZeroSizeBefore(t *testing.T) {
 			return nil
 		})
 	w := newInstanceWriter(testPlacementInstance, testOptions().SetMaxBatchSize(3)).(*writer)
+
 	w.queue = queue
 	w.newLockedEncoderFn = func(protobuf.UnaggregatedOptions) *lockedEncoder {
 		return &lockedEncoder{UnaggregatedEncoder: encoder}
@@ -631,6 +783,7 @@ func TestWriterWriteForwardedWithFlushingPositiveSizeBefore(t *testing.T) {
 			return nil
 		})
 	w := newInstanceWriter(testPlacementInstance, testOptions().SetMaxBatchSize(3)).(*writer)
+
 	w.queue = queue
 	w.newLockedEncoderFn = func(protobuf.UnaggregatedOptions) *lockedEncoder {
 		return &lockedEncoder{UnaggregatedEncoder: encoder}
@@ -707,8 +860,8 @@ func TestWriterWriteForwardedEnqueueError(t *testing.T) {
 
 func TestWriterFlushClosed(t *testing.T) {
 	w := newInstanceWriter(testPlacementInstance, testOptions()).(*writer)
-	w.closed = true
-	require.Equal(t, errInstanceWriterClosed, w.Flush())
+	w.closed.Store(true)
+	require.Equal(t, ErrInstanceWriterClosed, w.Flush())
 }
 
 func TestWriterFlushPartialError(t *testing.T) {
@@ -765,13 +918,91 @@ func TestWriterFlushPartialError(t *testing.T) {
 
 func TestWriterCloseAlreadyClosed(t *testing.T) {
 	w := newInstanceWriter(testPlacementInstance, testOptions()).(*writer)
-	w.closed = true
-	require.Equal(t, errInstanceWriterClosed, w.Close())
+	w.closed.Store(true)
+	require.Equal(t, ErrInstanceWriterClosed, w.Close())
 }
 
 func TestWriterCloseSuccess(t *testing.T) {
 	w := newInstanceWriter(testPlacementInstance, testOptions()).(*writer)
 	require.NoError(t, w.Close())
+}
+
+//nolint:dupl
+func TestWriterCloseFlushInProgress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	numWrites := 0
+
+	blockCh := make(chan bool)
+	ctx := context.Background()
+	ctx, cancelFn := context.WithTimeout(ctx, 2*time.Second)
+	defer cancelFn()
+
+	slowMockConn := NewMockConn(ctrl)
+	slowMockConn.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (n int, err error) {
+		// notify that the slow writer is about to block
+		blockCh <- true
+		<-ctx.Done()
+		numWrites++
+		return len(b), nil
+	}).Times(2)
+	slowMockConn.EXPECT().SetWriteDeadline(gomock.Any()).Times(2)
+
+	slowWriterDialerFn := func(c context.Context, network string, address string) (net.Conn, error) {
+		return slowMockConn, nil
+	}
+
+	slowConnOpts := NewConnectionOptions().SetContextDialer(slowWriterDialerFn)
+	opts := testOptions().SetConnectionOptions(slowConnOpts)
+	w := newInstanceWriter(testPlacementInstance, opts).(*writer)
+
+	payload := payloadUnion{
+		payloadType: untimedType,
+		untimed: untimedPayload{
+			metric:    testCounter,
+			metadatas: testStagedMetadatas,
+		},
+	}
+
+	require.Equal(t, nil, w.Write(0, payload))
+
+	var wg sync.WaitGroup
+
+	// Initiate first flush
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w.Flush() //nolint:errcheck
+	}()
+
+	// Wait for the first flush to block
+	<-blockCh
+
+	// Now buffer up some additional data
+	require.Equal(t, nil, w.Write(0, payload))
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w.Close() //nolint:errcheck
+	}()
+
+	// Wait for Close()-flush to busy-loop behind first flush
+	// 200ms is enough time for the Close()-flush to
+	// start busy-looping since the _closeFlushSoakTimeMs is
+	// 100ms
+	time.Sleep(200 * time.Millisecond)
+
+	// Unblock the slow writer
+	cancelFn()
+
+	// Unblock the Close()-flush
+	<-blockCh
+
+	// Wait for first flush and Close() to complete
+	wg.Wait()
+
+	assert.Equal(t, 2, numWrites)
 }
 
 func TestWriterConcurrentWriteStress(t *testing.T) {
@@ -1090,13 +1321,11 @@ func TestRefCountedWriter(t *testing.T) {
 	w := newRefCountedWriter(testPlacementInstance, opts)
 	w.IncRef()
 
-	require.False(t, w.instanceWriter.(*writer).closed)
+	require.False(t, w.instanceWriter.(*writer).closed.Load())
 	w.DecRef()
 	require.True(t, clock.WaitUntil(func() bool {
 		wr := w.instanceWriter.(*writer)
-		wr.Lock()
-		defer wr.Unlock()
-		return wr.closed
+		return wr.closed.Load()
 	}, 3*time.Second))
 }
 

--- a/src/x/errors/errors.go
+++ b/src/x/errors/errors.go
@@ -428,3 +428,21 @@ func (e Errors) Error() string {
 	buf.WriteString("]")
 	return buf.String()
 }
+
+// GetErrorsFromMultiError returns all errors in the multierror
+// as an array of type "error". In case err is not of type
+// MultiError then it simply returns an array with err in it.
+// In case err is nil then the function will return nil as well.
+func GetErrorsFromMultiError(err error) []error {
+	if err == nil {
+		return nil
+	}
+
+	merr, ok := GetInnerMultiError(err)
+	if ok {
+		// is a MultiError
+		return merr.Errors()
+	}
+
+	return []error{err}
+}

--- a/src/x/errors/errors_test.go
+++ b/src/x/errors/errors_test.go
@@ -130,3 +130,52 @@ func TestErrorsIsAnErrorAndFormatsErrors(t *testing.T) {
 	assert.Equal(t, "[<some error: foo=2, bar=baz>, "+
 		"<some other error: foo=42, bar=qux>]", errs.Error())
 }
+
+func TestGetErrorsFromMultiError(t *testing.T) {
+	tests := []struct {
+		name               string
+		createMultiErrorFn func() error
+		expectedNumErrors  int
+	}{
+		{
+			name: "standard MultiError with multiple errors",
+			createMultiErrorFn: func() error {
+				err := NewMultiError()
+				for _, errMsg := range []string{"foo", "bar", "baz"} {
+					err = err.Add(errors.New(errMsg))
+				}
+				return err
+			},
+			expectedNumErrors: 3,
+		},
+		{
+			name: "empty MultiError",
+			createMultiErrorFn: func() error {
+				return NewMultiError()
+			},
+			expectedNumErrors: 0,
+		},
+		{
+			name: "nil MultiError",
+			createMultiErrorFn: func() error {
+				return nil
+			},
+			expectedNumErrors: 0,
+		},
+		{
+			name: "not a MultiError",
+			createMultiErrorFn: func() error {
+				return errors.New("random-error")
+			},
+			expectedNumErrors: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.createMultiErrorFn()
+			assert.Equal(t, test.expectedNumErrors, len(GetErrorsFromMultiError(err)),
+				"%q failed", test.name)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The aggregator client performed locking on a per-writer or per-queue basis. This protects against racy access to the underlying conn and queue but does not protect against re-ordering. ie. in case multiple flushes happen at the same time for a writer any one can win. This possibility instructed the users of the client to synchronize the entire flush call at the writer manager level and made it so that all flushes would be blocked until the ongoing flushes for each writer is completed. This means that a slow writer will block the flush of all other writers. 
We therefore want the ability to flush writers at their own speeds effectively only blocking themselves in case they are slow. As such this PR makes sure that a writer will only have one active flush by using an "in-progress" flag to bail early if one is already in progress. Now that we make sure we only have one flush active for any given writer we don't need locks to protect the queue. The queue is only read from and written to in the context of a single flush. i.e. No enqueuing in the queue buf happens in the context of the Write() call anymore. Write() will simply push data into the encoders. 
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
No
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
No
```documentation-note

```
