### PR TITLE
etcd_docker 5: Incorporate docker based etcd approach into docker integration tests.

### DIFF
--- a/scripts/docker-integration-tests/aggregator/docker-compose.yml
+++ b/scripts/docker-integration-tests/aggregator/docker-compose.yml
@@ -1,17 +1,28 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
-      - "2379-2380"
       - "7201"
     ports:
       - "0.0.0.0:9000-9004:9000-9004"
-      - "0.0.0.0:2379-2380:2379-2380"
       - "0.0.0.0:7201:7201"
     networks:
       - backend
     image: "m3dbnode_integration:${REVISION}"
+    depends_on:
+      - etcd
   m3coordinator01:
     expose:
       - "7202"
@@ -26,6 +37,8 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./m3coordinator.yml:/etc/m3coordinator/m3coordinator.yml"
+    depends_on:
+      - etcd
   m3aggregator01:
     expose:
       - "6001"
@@ -38,6 +51,8 @@ services:
     image: "m3aggregator_integration:${REVISION}"
     volumes:
       - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"
+    depends_on:
+      - etcd
   m3aggregator02:
     networks:
       - backend
@@ -46,5 +61,7 @@ services:
     image: "m3aggregator_integration:${REVISION}"
     volumes:
       - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/aggregator/m3aggregator.yml
+++ b/scripts/docker-integration-tests/aggregator/m3aggregator.yml
@@ -38,7 +38,7 @@ kvClient:
         autoSyncInterval: 10m
         dialTimeout: 1m
         endpoints:
-          - dbnode01:2379
+          - etcd:2379
 
 runtimeOptions:
   kvConfig:

--- a/scripts/docker-integration-tests/aggregator/m3coordinator.yml
+++ b/scripts/docker-integration-tests/aggregator/m3coordinator.yml
@@ -24,7 +24,7 @@ clusters:
               autoSyncInterval: 10m
               dialTimeout: 1m
               endpoints:
-                - dbnode01:2379
+                - etcd:2379
 
 downsample:
   rules:

--- a/scripts/docker-integration-tests/aggregator/test.sh
+++ b/scripts/docker-integration-tests/aggregator/test.sh
@@ -14,6 +14,8 @@ echo "Pull containers required for test"
 docker pull $PROMREMOTECLI_IMAGE
 docker pull $JQ_IMAGE
 
+docker-compose -f ${COMPOSE_FILE} up -d etcd
+
 echo "Run m3dbnode"
 docker-compose -f ${COMPOSE_FILE} up -d dbnode01
 

--- a/scripts/docker-integration-tests/aggregator_legacy/docker-compose.yml
+++ b/scripts/docker-integration-tests/aggregator_legacy/docker-compose.yml
@@ -1,17 +1,24 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
-      - "2379-2380"
       - "7201"
     ports:
       - "0.0.0.0:9000-9004:9000-9004"
-      - "0.0.0.0:2379-2380:2379-2380"
       - "0.0.0.0:7201:7201"
     networks:
       - backend
     image: "m3dbnode_integration:${REVISION}"
+    depends_on:
+      - etcd
   m3coordinator01:
     expose:
       - "7202"
@@ -26,6 +33,8 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./m3coordinator.yml:/etc/m3coordinator/m3coordinator.yml"
+    depends_on:
+      - etcd
   m3aggregator01:
     expose:
       - "6001"
@@ -38,6 +47,8 @@ services:
     image: "m3aggregator_integration:${REVISION}"
     volumes:
       - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"
+    depends_on:
+      - etcd
   m3aggregator02:
     networks:
       - backend
@@ -46,5 +57,7 @@ services:
     image: "m3aggregator_integration:${REVISION}"
     volumes:
       - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/aggregator_legacy/m3aggregator.yml
+++ b/scripts/docker-integration-tests/aggregator_legacy/m3aggregator.yml
@@ -57,7 +57,7 @@ kvClient:
     etcdClusters:
       - zone: embedded
         endpoints:
-          - dbnode01:2379
+          - etcd:2379
 
 runtimeOptions:
   kvConfig:

--- a/scripts/docker-integration-tests/aggregator_legacy/m3coordinator.yml
+++ b/scripts/docker-integration-tests/aggregator_legacy/m3coordinator.yml
@@ -22,7 +22,7 @@ clusters:
           etcdClusters:
             - zone: embedded
               endpoints:
-                - dbnode01:2379
+                - etcd:2379
 
 downsample:
   remoteAggregator:

--- a/scripts/docker-integration-tests/aggregator_legacy/test.sh
+++ b/scripts/docker-integration-tests/aggregator_legacy/test.sh
@@ -7,6 +7,9 @@ REVISION=$(git rev-parse HEAD)
 COMPOSE_FILE="$M3_PATH"/scripts/docker-integration-tests/aggregator_legacy/docker-compose.yml
 export REVISION
 
+echo "Run etcd"
+docker-compose -f ${COMPOSE_FILE} up -d etcd
+
 echo "Run m3dbnode"
 docker-compose -f ${COMPOSE_FILE} up -d dbnode01
 

--- a/scripts/docker-integration-tests/carbon/docker-compose.yml
+++ b/scripts/docker-integration-tests/carbon/docker-compose.yml
@@ -1,15 +1,26 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
-      - "2379-2380"
     ports:
       - "0.0.0.0:9000-9004:9000-9004"
-      - "0.0.0.0:2379-2380:2379-2380"
     networks:
       - backend
     image: "m3dbnode_integration:${REVISION}"
+    depends_on:
+      - etcd
   coordinator01:
     expose:
       - "7201"
@@ -24,5 +35,7 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./:/etc/m3coordinator/"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/carbon/m3coordinator.yml
+++ b/scripts/docker-integration-tests/carbon/m3coordinator.yml
@@ -9,7 +9,7 @@ clusters:
           etcdClusters:
             - zone: embedded
               endpoints:
-                - dbnode01:2379
+                - etcd:2379
 
 carbon:
   findResultsIncludeBothExpandableAndLeaf: true

--- a/scripts/docker-integration-tests/carbon/test.sh
+++ b/scripts/docker-integration-tests/carbon/test.sh
@@ -10,8 +10,7 @@ EXPECTED_PATH=$SCRIPT_PATH/expected
 export REVISION
 
 echo "Run m3dbnode and m3coordinator containers"
-docker-compose -f ${COMPOSE_FILE} up -d dbnode01
-docker-compose -f ${COMPOSE_FILE} up -d coordinator01
+docker-compose -f ${COMPOSE_FILE} up -d
 
 # Think of this as a defer func() in golang
 METRIC_EMIT_PID="-1"
@@ -152,7 +151,7 @@ ATTEMPTS=20 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff "wait_carbon_values_accum
 
 # Now test the max datapoints behavior using max of four datapoints (4x 5s resolution = 20s)
 end=$(date +%s)
-start=$(($end-20)) 
+start=$(($end-20))
 # 1. no max datapoints set, should not adjust number of datapoints coming back
 ATTEMPTS=2 MAX_TIMEOUT=4 TIMEOUT=1 retry_with_backoff "read_carbon 'stat.already-aggregated.foo' 42 $start $end"
 # 2. max datapoints with LTTB, should be an existing value (i.e. 42)

--- a/scripts/docker-integration-tests/cold_writes_simple/docker-compose.yml
+++ b/scripts/docker-integration-tests/cold_writes_simple/docker-compose.yml
@@ -1,15 +1,26 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
-      - "2379-2380"
     ports:
       - "0.0.0.0:9000-9004:9000-9004"
-      - "0.0.0.0:2379-2380:2379-2380"
     networks:
       - backend
     image: "m3dbnode_integration:${REVISION}"
+    depends_on:
+      - etcd
   coordinator01:
     expose:
       - "7201"
@@ -24,5 +35,7 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./:/etc/m3coordinator/"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/cold_writes_simple/m3coordinator.yml
+++ b/scripts/docker-integration-tests/cold_writes_simple/m3coordinator.yml
@@ -13,4 +13,4 @@ clusters:
           etcdClusters:
             - zone: embedded
               endpoints:
-                - dbnode01:2379
+                - etcd:2379

--- a/scripts/docker-integration-tests/cold_writes_simple/test.sh
+++ b/scripts/docker-integration-tests/cold_writes_simple/test.sh
@@ -8,9 +8,8 @@ SCRIPT_PATH="$M3_PATH"/scripts/docker-integration-tests/cold_writes_simple
 COMPOSE_FILE=$SCRIPT_PATH/docker-compose.yml
 export REVISION
 
-echo "Run m3dbnode and m3coordinator containers"
-docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes dbnode01
-docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes coordinator01
+echo "Run etcd, m3dbnode and m3coordinator containers"
+docker-compose -f "${COMPOSE_FILE}" up -d --renew-anon-volumes
 
 # Think of this as a defer func() in golang
 function defer {

--- a/scripts/docker-integration-tests/coordinator_config_rules/docker-compose.yml
+++ b/scripts/docker-integration-tests/coordinator_config_rules/docker-compose.yml
@@ -1,15 +1,26 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
-      - "2379-2380"
     ports:
       - "0.0.0.0:9000-9004:9000-9004"
-      - "0.0.0.0:2379-2380:2379-2380"
     networks:
       - backend
     image: "m3dbnode_integration:${REVISION}"
+    depends_on:
+      - etcd
   coordinator01:
     expose:
       - "7201"
@@ -24,5 +35,7 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./:/etc/m3coordinator/"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/coordinator_config_rules/m3coordinator.yml
+++ b/scripts/docker-integration-tests/coordinator_config_rules/m3coordinator.yml
@@ -9,7 +9,7 @@ clusters:
           etcdClusters:
             - zone: embedded
               endpoints:
-                - dbnode01:2379
+                - etcd:2379
 
 downsample:
   rules:

--- a/scripts/docker-integration-tests/coordinator_config_rules/test.sh
+++ b/scripts/docker-integration-tests/coordinator_config_rules/test.sh
@@ -16,8 +16,7 @@ docker pull $PROMREMOTECLI_IMAGE
 docker pull $JQ_IMAGE
 
 echo "Run m3dbnode and m3coordinator containers"
-docker-compose -f ${COMPOSE_FILE} up -d dbnode01
-docker-compose -f ${COMPOSE_FILE} up -d coordinator01
+docker-compose -f ${COMPOSE_FILE} up -d
 
 # Think of this as a defer func() in golang
 function defer {

--- a/scripts/docker-integration-tests/coordinator_noop/docker-compose.yml
+++ b/scripts/docker-integration-tests/coordinator_noop/docker-compose.yml
@@ -1,5 +1,16 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   coordinator01:
     expose:
       - "7201"
@@ -10,33 +21,7 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./m3coordinator.yml:/etc/m3coordinator/m3coordinator.yml"
-  etcd01:
-    expose:
-      - "2379-2380"
-    ports:
-      - "0.0.0.0:2379-2380:2379-2380"
-    networks:
-      - backend
-    image: quay.io/coreos/etcd:v3.4.3
-    command:
-      - "etcd"
-      - "--name"
-      - "etcd01"
-      - "--listen-peer-urls"
-      - "http://0.0.0.0:2380"
-      - "--listen-client-urls"
-      - "http://0.0.0.0:2379"
-      - "--advertise-client-urls"
-      - "http://etcd01:2379"
-      - "--initial-cluster-token"
-      - "etcd-cluster-1"
-      - "--initial-advertise-peer-urls"
-      - "http://etcd01:2380"
-      - "--initial-cluster"
-      - "etcd01=http://etcd01:2380"
-      - "--initial-cluster-state"
-      - "new"
-      - "--data-dir"
-      - "/var/lib/etcd"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/coordinator_noop/m3coordinator.yml
+++ b/scripts/docker-integration-tests/coordinator_noop/m3coordinator.yml
@@ -23,7 +23,7 @@ clusterManagement:
     etcdClusters:
     - zone: embedded
       endpoints:
-      - etcd01:2379
+      - etcd:2379
 
 tagOptions:
   idScheme: quoted

--- a/scripts/docker-integration-tests/coordinator_noop/test.sh
+++ b/scripts/docker-integration-tests/coordinator_noop/test.sh
@@ -9,8 +9,7 @@ COMPOSE_FILE=$SCRIPT_PATH/docker-compose.yml
 export REVISION
 
 echo "Run coordinator with no etcd"
-docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes coordinator01
-docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes etcd01
+docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes
 
 function defer {
   docker-compose -f ${COMPOSE_FILE} down || echo "unable to shutdown containers" # CI fails to stop all containers sometimes

--- a/scripts/docker-integration-tests/dedicated_etcd_embedded_coordinator/docker-compose.yml
+++ b/scripts/docker-integration-tests/dedicated_etcd_embedded_coordinator/docker-compose.yml
@@ -1,5 +1,16 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
@@ -14,33 +25,7 @@ services:
       - M3DB_HOST_ID=dbnode01
     volumes:
       - "./m3dbnode.yml:/etc/m3dbnode/m3dbnode.yml"
-  etcd01:
-    expose:
-      - "2379-2380"
-    ports:
-      - "0.0.0.0:2379-2380:2379-2380"
-    networks:
-      - backend
-    image: quay.io/coreos/etcd:v3.4.3
-    command:
-      - "etcd"
-      - "--name"
-      - "etcd01"
-      - "--listen-peer-urls"
-      - "http://0.0.0.0:2380"
-      - "--listen-client-urls"
-      - "http://0.0.0.0:2379"
-      - "--advertise-client-urls"
-      - "http://etcd01:2379"
-      - "--initial-cluster-token"
-      - "etcd-cluster-1"
-      - "--initial-advertise-peer-urls"
-      - "http://etcd01:2380"
-      - "--initial-cluster"
-      - "etcd01=http://etcd01:2380"
-      - "--initial-cluster-state"
-      - "new"
-      - "--data-dir"
-      - "/var/lib/etcd"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/docker-compose-etcd.yml
+++ b/scripts/docker-integration-tests/docker-compose-etcd.yml
@@ -1,0 +1,15 @@
+version: "3.5"
+services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+    networks:
+      - backend
+
+networks:
+  backend:

--- a/scripts/docker-integration-tests/m3coordinator.Dockerfile
+++ b/scripts/docker-integration-tests/m3coordinator.Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 RUN mkdir -p /bin
 RUN mkdir -p /etc/m3coordinator
 ADD ./m3coordinator /bin/
-ADD ./m3coordinator-local-etcd.yml /etc/m3coordinator/m3coordinator.yml
+ADD ./m3coordinator-local-docker-etcd.yml /etc/m3coordinator/m3coordinator.yml
 
 EXPOSE 7201/tcp 7203/tcp
 

--- a/scripts/docker-integration-tests/m3dbnode.Dockerfile
+++ b/scripts/docker-integration-tests/m3dbnode.Dockerfile
@@ -4,9 +4,9 @@ LABEL maintainer="The M3DB Authors <m3db@googlegroups.com>"
 RUN mkdir -p /bin
 RUN mkdir -p /etc/m3dbnode
 ADD ./m3dbnode /bin/
-ADD ./m3dbnode-local-etcd.yml /etc/m3dbnode/m3dbnode.yml
+ADD ./m3dbnode-local-docker-etcd.yml /etc/m3dbnode/m3dbnode.yml
 
-EXPOSE 2379/tcp 2380/tcp 7201/tcp 7203/tcp 9000-9004/tcp
+EXPOSE 7201/tcp 7203/tcp 9000-9004/tcp
 
 ENV PANIC_ON_INVARIANT_VIOLATED=true
 

--- a/scripts/docker-integration-tests/prom_remote_write_backend/docker-compose.yml
+++ b/scripts/docker-integration-tests/prom_remote_write_backend/docker-compose.yml
@@ -1,5 +1,16 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   m3aggregator01:
     expose:
       - "6001"
@@ -12,6 +23,8 @@ services:
     image: "m3aggregator_integration:${REVISION}"
     volumes:
       - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"
+    depends_on:
+      - etcd
   m3aggregator02:
     expose:
       - "6002"
@@ -24,6 +37,8 @@ services:
     image: "m3aggregator_integration:${REVISION}"
     volumes:
       - "./m3aggregator.yml:/etc/m3aggregator/m3aggregator.yml"
+    depends_on:
+      - etcd
   m3coordinator01:
     expose:
       - "7202"
@@ -34,6 +49,8 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./:/etc/m3coordinator/"
+    depends_on:
+      - etcd
   coordinatoradmin:
     expose:
       - "7201"
@@ -44,6 +61,8 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./m3coordinator-admin.yml:/etc/m3coordinator/m3coordinator.yml"
+    depends_on:
+      - etcd
   prometheusraw:
     expose:
       - "9090"
@@ -60,6 +79,8 @@ services:
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
       - "--enable-feature=remote-write-receiver"
+    depends_on:
+      - etcd
   prometheusagg:
     expose:
       - "9091"
@@ -76,33 +97,7 @@ services:
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
       - "--enable-feature=remote-write-receiver"
-  etcd01:
-    expose:
-      - "2379-2380"
-    ports:
-      - "0.0.0.0:2379-2380:2379-2380"
-    networks:
-      - backend
-    image: quay.io/coreos/etcd:v3.4.3
-    command:
-      - "etcd"
-      - "--name"
-      - "etcd01"
-      - "--listen-peer-urls"
-      - "http://0.0.0.0:2380"
-      - "--listen-client-urls"
-      - "http://0.0.0.0:2379"
-      - "--advertise-client-urls"
-      - "http://etcd01:2379"
-      - "--initial-cluster-token"
-      - "etcd-cluster-1"
-      - "--initial-advertise-peer-urls"
-      - "http://etcd01:2380"
-      - "--initial-cluster"
-      - "etcd01=http://etcd01:2380"
-      - "--initial-cluster-state"
-      - "new"
-      - "--data-dir"
-      - "/var/lib/etcd"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/prom_remote_write_backend/m3aggregator.yml
+++ b/scripts/docker-integration-tests/prom_remote_write_backend/m3aggregator.yml
@@ -40,7 +40,7 @@ kvClient:
     etcdClusters:
       - zone: embedded
         endpoints:
-          - etcd01:2379
+          - etcd:2379
 
 runtimeOptions:
   kvConfig:

--- a/scripts/docker-integration-tests/prom_remote_write_backend/m3coordinator-admin.yml
+++ b/scripts/docker-integration-tests/prom_remote_write_backend/m3coordinator-admin.yml
@@ -23,7 +23,7 @@ clusterManagement:
     etcdClusters:
     - zone: embedded
       endpoints:
-      - etcd01:2379
+      - etcd:2379
 
 tagOptions:
   idScheme: quoted

--- a/scripts/docker-integration-tests/prom_remote_write_backend/m3coordinator.yml
+++ b/scripts/docker-integration-tests/prom_remote_write_backend/m3coordinator.yml
@@ -36,7 +36,7 @@ clusterManagement:
     etcdClusters:
       - zone: embedded
         endpoints:
-          - etcd01:2379
+          - etcd:2379
 
 tagOptions:
   idScheme: quoted

--- a/scripts/docker-integration-tests/prom_remote_write_backend/test.sh
+++ b/scripts/docker-integration-tests/prom_remote_write_backend/test.sh
@@ -20,7 +20,7 @@ docker pull $PROMREMOTECLI_IMAGE
 trap 'cleanup ${COMPOSE_FILE} ${TEST_SUCCESS}' EXIT
 
 echo "Run ETCD"
-docker-compose -f "${COMPOSE_FILE}" up -d etcd01
+docker-compose -f "${COMPOSE_FILE}" up -d etcd
 
 echo "Run Coordinator in Admin mode"
 docker-compose -f "${COMPOSE_FILE}" up -d coordinatoradmin

--- a/scripts/docker-integration-tests/prometheus/docker-compose.yml
+++ b/scripts/docker-integration-tests/prometheus/docker-compose.yml
@@ -1,17 +1,28 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
-      - "2379-2380"
     ports:
       - "0.0.0.0:9000-9004:9000-9004"
-      - "0.0.0.0:2379-2380:2379-2380"
     networks:
       - backend
     image: "m3dbnode_integration:${REVISION}"
     volumes:
       - "./m3dbnode.yml:/etc/m3dbnode/m3dbnode.yml"
+    depends_on:
+      - etcd
   coordinator01:
     expose:
       - "7201"
@@ -24,6 +35,8 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./:/etc/m3coordinator/"
+    depends_on:
+      - etcd
   prometheus01:
     expose:
       - "9090"
@@ -34,5 +47,7 @@ services:
     image: prom/prometheus:latest
     volumes:
       - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/prometheus/m3coordinator.yml
+++ b/scripts/docker-integration-tests/prometheus/m3coordinator.yml
@@ -13,7 +13,7 @@ clusters:
           etcdClusters:
             - zone: embedded
               endpoints:
-                - dbnode01:2379
+                - etcd:2379
 
 query:
   restrictTags:

--- a/scripts/docker-integration-tests/repair/docker-compose.yml
+++ b/scripts/docker-integration-tests/repair/docker-compose.yml
@@ -1,9 +1,19 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
-      - "2379-2380"
     ports:
       - "0.0.0.0:9012:9002"
       - "0.0.0.0:9013:9003"
@@ -14,10 +24,11 @@ services:
       - M3DB_HOST_ID=m3db_local_1
     volumes:
       - "./m3dbnode.yml:/etc/m3dbnode/m3dbnode.yml"
+    depends_on:
+      - etcd
   dbnode02:
     expose:
       - "9000-9004"
-      - "2379-2380"
     ports:
       - "0.0.0.0:9022:9002"
       - "0.0.0.0:9023:9003"
@@ -28,6 +39,8 @@ services:
       - M3DB_HOST_ID=m3db_local_2
     volumes:
       - "./m3dbnode.yml:/etc/m3dbnode/m3dbnode.yml"
+    depends_on:
+      - etcd
   coordinator01:
     expose:
       - "7201"
@@ -42,5 +55,7 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./:/etc/m3coordinator/"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/scripts/docker-integration-tests/repair/m3coordinator.yml
+++ b/scripts/docker-integration-tests/repair/m3coordinator.yml
@@ -13,4 +13,4 @@ clusters:
           etcdClusters:
             - zone: embedded
               endpoints:
-                - dbnode01:2379
+                - etcd:2379

--- a/scripts/docker-integration-tests/repair/m3dbnode.yml
+++ b/scripts/docker-integration-tests/repair/m3dbnode.yml
@@ -13,12 +13,7 @@ db:
         etcdClusters:
           - zone: embedded
             endpoints:
-              - dbnode01:2379
-      seedNodes:
-        initialCluster:
-          - hostID: m3db_local_1
-            endpoint: http://dbnode01:2380
-
+              - etcd:2379
   # Enable repairs.
   repair:
     enabled: true

--- a/scripts/docker-integration-tests/repair/test.sh
+++ b/scripts/docker-integration-tests/repair/test.sh
@@ -9,9 +9,7 @@ COMPOSE_FILE=$SCRIPT_PATH/docker-compose.yml
 export REVISION
 
 echo "Run m3dbnode and m3coordinator containers"
-docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes dbnode01
-docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes dbnode02
-docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes coordinator01
+docker-compose -f ${COMPOSE_FILE} up -d --renew-anon-volumes
 
 # Think of this as a defer func() in golang
 function defer {

--- a/scripts/docker-integration-tests/run.sh
+++ b/scripts/docker-integration-tests/run.sh
@@ -3,45 +3,55 @@
 set -ex
 
 TESTS=(
-	scripts/docker-integration-tests/cold_writes_simple/test.sh
-	scripts/docker-integration-tests/prometheus_replication/test.sh
-	scripts/docker-integration-tests/carbon/test.sh
-	scripts/docker-integration-tests/aggregator/test.sh
-	scripts/docker-integration-tests/aggregator_legacy/test.sh
-	scripts/docker-integration-tests/query_fanout/test.sh
-	scripts/docker-integration-tests/repair/test.sh
-	scripts/docker-integration-tests/replication/test.sh
-	scripts/docker-integration-tests/multi_cluster_write/test.sh
-	scripts/docker-integration-tests/coordinator_config_rules/test.sh
-	scripts/docker-integration-tests/coordinator_noop/test.sh
-	scripts/docker-integration-tests/prom_remote_write_backend/test.sh
+  scripts/docker-integration-tests/cold_writes_simple/test.sh
+  # TODO (amains): This test requires two *separate* etcd clusters, which is a bit harder to setup.
+  #  scripts/docker-integration-tests/prometheus_replication/test.sh
+
+  scripts/docker-integration-tests/carbon/test.sh
+  scripts/docker-integration-tests/aggregator/test.sh
+  scripts/docker-integration-tests/aggregator_legacy/test.sh
+
+  # TODO (amains): This test requires two *separate* etcd clusters, which is a bit harder to setup.
+  #  scripts/docker-integration-tests/query_fanout/test.sh
+
+  scripts/docker-integration-tests/repair/test.sh
+
+  # TODO (amains): This test requires two *separate* etcd clusters, which is a bit harder to setup.
+  #  scripts/docker-integration-tests/replication/test.sh
+
+  # TODO (amains): This test requires two *separate* etcd clusters, which is a bit harder to setup.
+  #  scripts/docker-integration-tests/multi_cluster_write/test.sh
+
+  scripts/docker-integration-tests/coordinator_config_rules/test.sh
+  scripts/docker-integration-tests/coordinator_noop/test.sh
+  scripts/docker-integration-tests/prom_remote_write_backend/test.sh
 )
 
 # Some systems, including our default Buildkite hosts, don't come with netcat
 # installed and we may not have perms to install it. "Install" it in the worst
 # possible way.
 if ! command -v nc && [[ "$BUILDKITE" == "true" ]]; then
-	echo "installing netcat"
-	NCDIR="$(mktemp -d)"
+  echo "installing netcat"
+  NCDIR="$(mktemp -d)"
 
-	yumdownloader -y --destdir "$NCDIR" --resolve nc
-	(
-		cd "$NCDIR"
-		RPM=$(find . -maxdepth 1 -name '*.rpm' | tail -n1)
-		rpm2cpio "$RPM" | cpio -id
-	)
+  yumdownloader -y --destdir "$NCDIR" --resolve nc
+  (
+    cd "$NCDIR"
+    RPM=$(find . -maxdepth 1 -name '*.rpm' | tail -n1)
+    rpm2cpio "$RPM" | cpio -id
+  )
 
-	export PATH="$PATH:$NCDIR/usr/bin"
+  export PATH="$PATH:$NCDIR/usr/bin"
 
-	function cleanup_nc() {
-		rm -rf "$NCDIR"
-	}
+  function cleanup_nc() {
+    rm -rf "$NCDIR"
+  }
 
-	trap cleanup_nc EXIT
+  trap cleanup_nc EXIT
 fi
 
 if [[ -z "$SKIP_SETUP" ]] || [[ "$SKIP_SETUP" == "false" ]]; then
-	scripts/docker-integration-tests/setup.sh
+  scripts/docker-integration-tests/setup.sh
 fi
 
 NUM_TESTS=${#TESTS[@]}
@@ -50,16 +60,16 @@ MAX_IDX=$(((NUM_TESTS*(BUILDKITE_PARALLEL_JOB+1)/BUILDKITE_PARALLEL_JOB_COUNT)-1
 
 ITER=0
 for test in "${TESTS[@]}"; do
-	if [[ $ITER -ge $MIN_IDX && $ITER -le $MAX_IDX ]]; then
-		# Ensure all docker containers have been stopped so we don't run into issues
-		# trying to bind ports.
-		docker rm -f $(docker ps -aq) 2>/dev/null || true
-		echo "----------------------------------------------"
-		echo "running $test"
-		if ! (export M3_PATH=$(pwd) && $test); then
-			echo "--- :bk-status-failed: $test FAILED"
-			exit 1
-		fi
-	fi
-	ITER="$((ITER+1))"
+  if [[ $ITER -ge $MIN_IDX && $ITER -le $MAX_IDX ]]; then
+    # Ensure all docker containers have been stopped so we don't run into issues
+    # trying to bind ports.
+    docker rm -f $(docker ps -aq) 2>/dev/null || true
+    echo "----------------------------------------------"
+    echo "running $test"
+    if ! (export M3_PATH=$(pwd) && $test); then
+      echo "--- :bk-status-failed: $test FAILED"
+      exit 1
+    fi
+  fi
+  ITER="$((ITER+1))"
 done

--- a/scripts/docker-integration-tests/setup.sh
+++ b/scripts/docker-integration-tests/setup.sh
@@ -15,8 +15,8 @@ mkdir -p ./bin
 
 # by keeping all the required files in ./bin, it makes the build context
 # for docker much smaller
-cp ./src/query/config/m3coordinator-local-etcd.yml ./bin
-cp ./src/dbnode/config/m3dbnode-local-etcd.yml ./bin
+cp ./src/query/config/m3coordinator-local-docker-etcd.yml ./bin
+cp ./src/dbnode/config/m3dbnode-local-docker-etcd.yml ./bin
 cp ./src/aggregator/config/m3aggregator.yml ./bin
 
 # build images
@@ -26,7 +26,9 @@ function build_image {
   local svc=$1
   echo "creating image for $svc"
   make ${svc}-linux-amd64
-  docker build -t "${svc}_integration:${REVISION}" -f ./scripts/docker-integration-tests/${svc}.Dockerfile ./bin
+  docker build \
+    --no-cache \
+    -t "${svc}_integration:${REVISION}" -f ./scripts/docker-integration-tests/${svc}.Dockerfile ./bin
 }
 
 if [[ "$SERVICE" != "" ]]; then

--- a/scripts/docker-integration-tests/simple_v2_batch_apis/docker-compose.yml
+++ b/scripts/docker-integration-tests/simple_v2_batch_apis/docker-compose.yml
@@ -1,15 +1,26 @@
 version: "3.5"
 services:
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    expose:
+      - "2379-2380"
+    ports:
+      - "0.0.0.0:2379-2380:2379-2380"
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    networks:
+      - backend
   dbnode01:
     expose:
       - "9000-9004"
-      - "2379-2380"
     ports:
       - "0.0.0.0:9000-9004:9000-9004"
-      - "0.0.0.0:2379-2380:2379-2380"
     networks:
       - backend
     image: "m3dbnode_integration:${REVISION}"
+    depends_on:
+      - etcd
   coordinator01:
     expose:
       - "7201"
@@ -22,5 +33,7 @@ services:
     image: "m3coordinator_integration:${REVISION}"
     volumes:
       - "./:/etc/m3coordinator/"
+    depends_on:
+      - etcd
 networks:
-  backend:
+  backend: null

--- a/src/dbnode/config/m3dbnode-local-docker-etcd.yml
+++ b/src/dbnode/config/m3dbnode-local-docker-etcd.yml
@@ -1,0 +1,11 @@
+coordinator: {}
+"db":
+  discovery:
+    "config":
+      "service":
+        "etcdClusters":
+          - "endpoints": ["http://etcd:2379"]
+            "zone": "embedded"
+        "service": "m3db"
+        "zone": "embedded"
+        "env": "default_env"

--- a/src/query/config/m3coordinator-local-docker-etcd.yml
+++ b/src/query/config/m3coordinator-local-docker-etcd.yml
@@ -1,9 +1,9 @@
-limits:
-  perQuery:
-    maxFetchedSeries: 100
-
 clusters:
-  - client:
+  - namespaces:
+      - namespace: default
+        type: unaggregated
+        retention: 48h
+    client:
       config:
         service:
           env: default_env
@@ -13,5 +13,4 @@ clusters:
           etcdClusters:
             - zone: embedded
               endpoints:
-                - etcd:2379
-      useV2BatchAPIs: true
+                - http://etcd:2379


### PR DESCRIPTION
PR 5 for https://github.com/m3db/m3/issues/4144

This PR makes the docker integration tests use containerized etcd.
Previously, these relied on M3DB running an embbeded etcd server.

There's no inherent need for this, and it opens us up to dependency issues as described
in the linked github issue.

Note: there are a handful that require multiple servers; these are currently "skipped" (commented). I intend to bring those
back at a later date..

---

**Stack**:
- #4150
- #4149 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*