### PR TITLE
Raise ExternalTimeout for htmltest

### DIFF
--- a/site/.htmltest.yml
+++ b/site/.htmltest.yml
@@ -1,6 +1,7 @@
 DirectoryPath: site/public
 IgnoreDirectoryMissingTrailingSlash: true
 CheckExternal: true
+ExternalTimeout: 30
 IgnoreAltMissing: false
 CheckImages: false
 CheckScripts: false


### PR DESCRIPTION
Got a failure for https://graphite.readthedocs.io/en/latest/functions.html -- the site might just be slow. Spurious failures here seem likely,
so bumping timeout to 30s.