### PR TITLE
[4189] Fix colliding filters by updating match method for MultiCharSequenceFilter to iterate through all patterns for the most complete match and not return on the first pattern found

### DIFF
--- a/src/metrics/filters/filter.go
+++ b/src/metrics/filters/filter.go
@@ -585,14 +585,35 @@ func (f *multiCharSequenceFilter) matches(val []byte) ([]byte, bool) {
 		return nil, false
 	}
 
+	var matchIndex int
+	var bestPattern []byte
 	for _, pattern := range f.patterns {
-		if f.backwards && bytes.HasSuffix(val, pattern) {
-			return val[:len(val)-len(pattern)], true
+		if len(pattern) > len(val) {
+			continue
 		}
 
-		if !f.backwards && bytes.HasPrefix(val, pattern) {
-			return val[len(pattern):], true
+		if f.backwards {
+			if bytes.HasSuffix(val, pattern) {
+				if bestPattern == nil || len(pattern) > len(bestPattern) {
+					bestPattern = pattern
+					matchIndex = len(val) - len(pattern)
+				}
+			}
+		} else {
+			if bytes.HasPrefix(val, pattern) {
+				if bestPattern == nil || len(pattern) > len(bestPattern) {
+					bestPattern = pattern
+					matchIndex = len(pattern)
+				}
+			}
 		}
+	}
+
+	if bestPattern != nil {
+		if f.backwards {
+			return val[:matchIndex], true
+		}
+		return val[matchIndex:], true
 	}
 
 	return nil, false

--- a/src/metrics/filters/filter.go
+++ b/src/metrics/filters/filter.go
@@ -594,14 +594,14 @@ func (f *multiCharSequenceFilter) matches(val []byte) ([]byte, bool) {
 
 		if f.backwards {
 			if bytes.HasSuffix(val, pattern) {
-				if bestPattern == nil || len(pattern) > len(bestPattern) {
+				if len(pattern) > len(bestPattern) {
 					bestPattern = pattern
 					matchIndex = len(val) - len(pattern)
 				}
 			}
 		} else {
 			if bytes.HasPrefix(val, pattern) {
-				if bestPattern == nil || len(pattern) > len(bestPattern) {
+				if len(pattern) > len(bestPattern) {
 					bestPattern = pattern
 					matchIndex = len(pattern)
 				}

--- a/src/metrics/filters/filter.go
+++ b/src/metrics/filters/filter.go
@@ -597,6 +597,10 @@ func (f *multiCharSequenceFilter) matches(val []byte) ([]byte, bool) {
 				if len(pattern) > len(bestPattern) {
 					bestPattern = pattern
 					matchIndex = len(val) - len(pattern)
+					// No need to continue searching through remaining patterns if a complete match is found
+					if len(bestPattern) == len(val) {
+						break
+					}
 				}
 			}
 		} else {
@@ -604,6 +608,10 @@ func (f *multiCharSequenceFilter) matches(val []byte) ([]byte, bool) {
 				if len(pattern) > len(bestPattern) {
 					bestPattern = pattern
 					matchIndex = len(pattern)
+					// No need to continue searching through remaining patterns if a complete match is found
+					if len(bestPattern) == len(val) {
+						break
+					}
 				}
 			}
 		}

--- a/src/metrics/filters/filter_benchmark_test.go
+++ b/src/metrics/filters/filter_benchmark_test.go
@@ -125,6 +125,14 @@ func BenchmarkRangeFilterRangeMatchNegation(b *testing.B) {
 	benchRangeFilterRange(b, []byte("!a-z"), []byte("p"), false)
 }
 
+func BenchmarkMultiRangeFilterPrefixCollision(b *testing.B) {
+	benchMultiRangeFilter(b, []byte("test_1,test_1_suffix"), false, [][]byte{[]byte("test_1"), []byte("test_1_suffix")})
+}
+
+func BenchmarkMultiRangeFilterSuffixCollision(b *testing.B) {
+	benchMultiRangeFilter(b, []byte("test_1,prefix_test_1"), true, [][]byte{[]byte("test_1"), []byte("prefix_test_1")})
+}
+
 func BenchmarkMultiRangeFilterTwo(b *testing.B) {
 	benchMultiRangeFilter(b, []byte("test_1,test_2"), false, [][]byte{[]byte("test_1"), []byte("fake_1")})
 }

--- a/src/metrics/filters/filter_benchmark_test.go
+++ b/src/metrics/filters/filter_benchmark_test.go
@@ -126,11 +126,13 @@ func BenchmarkRangeFilterRangeMatchNegation(b *testing.B) {
 }
 
 func BenchmarkMultiRangeFilterPrefixCollision(b *testing.B) {
-	benchMultiRangeFilter(b, []byte("test_1,test_1_suffix,extra_unused_pattern"), false, [][]byte{[]byte("test_1"), []byte("test_1_suffix")})
+	benchMultiRangeFilter(b, []byte("test_1,test_1_suffix,extra_unused_pattern"),
+		false, [][]byte{[]byte("test_1"), []byte("test_1_suffix")})
 }
 
 func BenchmarkMultiRangeFilterSuffixCollision(b *testing.B) {
-	benchMultiRangeFilter(b, []byte("test_1,prefix_test_1,extra_unused_pattern"), true, [][]byte{[]byte("test_1"), []byte("prefix_test_1")})
+	benchMultiRangeFilter(b, []byte("test_1,prefix_test_1,extra_unused_pattern"),
+		true, [][]byte{[]byte("test_1"), []byte("prefix_test_1")})
 }
 
 func BenchmarkMultiRangeFilterTwo(b *testing.B) {

--- a/src/metrics/filters/filter_benchmark_test.go
+++ b/src/metrics/filters/filter_benchmark_test.go
@@ -126,11 +126,11 @@ func BenchmarkRangeFilterRangeMatchNegation(b *testing.B) {
 }
 
 func BenchmarkMultiRangeFilterPrefixCollision(b *testing.B) {
-	benchMultiRangeFilter(b, []byte("test_1,test_1_suffix"), false, [][]byte{[]byte("test_1"), []byte("test_1_suffix")})
+	benchMultiRangeFilter(b, []byte("test_1,test_1_suffix,extra_unused_pattern"), false, [][]byte{[]byte("test_1"), []byte("test_1_suffix")})
 }
 
 func BenchmarkMultiRangeFilterSuffixCollision(b *testing.B) {
-	benchMultiRangeFilter(b, []byte("test_1,prefix_test_1"), true, [][]byte{[]byte("test_1"), []byte("prefix_test_1")})
+	benchMultiRangeFilter(b, []byte("test_1,prefix_test_1,extra_unused_pattern"), true, [][]byte{[]byte("test_1"), []byte("prefix_test_1")})
 }
 
 func BenchmarkMultiRangeFilterTwo(b *testing.B) {

--- a/src/metrics/filters/filter_test.go
+++ b/src/metrics/filters/filter_test.go
@@ -32,10 +32,12 @@ func TestPrefixCompositeR2Filter(t *testing.T) {
 	id1 := "arachne_failures_by_rack"
 	f, err := newMultiCharSequenceFilter([]byte("arachne_failures,arachne_failures_by_rack"), false)
 	require.NoError(t, err)
-	_, matches1 := f.matches([]byte(id0))
+	val1, matches1 := f.matches([]byte(id0))
 	require.True(t, matches1)
-	_, matches2 := f.matches([]byte(id1))
+	require.True(t, len(val1) == 0)
+	val2, matches2 := f.matches([]byte(id1))
 	require.True(t, matches2)
+	require.True(t, len(val2) == 0)
 }
 
 func TestNewFilterFromFilterValueInvalidPattern(t *testing.T) {

--- a/src/metrics/filters/filter_test.go
+++ b/src/metrics/filters/filter_test.go
@@ -36,7 +36,6 @@ func TestPrefixCompositeR2Filter(t *testing.T) {
 	require.True(t, matches1)
 	_, matches2 := f.matches([]byte(id1))
 	require.True(t, matches2)
-
 }
 
 func TestNewFilterFromFilterValueInvalidPattern(t *testing.T) {

--- a/src/metrics/filters/filter_test.go
+++ b/src/metrics/filters/filter_test.go
@@ -354,6 +354,11 @@ func TestMultiCharSequenceFilter(t *testing.T) {
 	require.NoError(t, err)
 	validateLookup(t, f, "arachne_failures", true, "")
 	validateLookup(t, f, "arachne_failures_by_rack", true, "")
+
+	f, err = newMultiCharSequenceFilter([]byte("arachne_failures,test_arachne_failures"), true)
+	require.NoError(t, err)
+	validateLookup(t, f, "arachne_failures", true, "")
+	validateLookup(t, f, "test_arachne_failures", true, "")
 }
 
 func validateLookup(t *testing.T, f chainFilter, val string, expectedMatch bool, expectedRemainder string) {

--- a/src/metrics/filters/filter_test.go
+++ b/src/metrics/filters/filter_test.go
@@ -27,19 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrefixCompositeR2Filter(t *testing.T) {
-	id0 := "arachne_failures"
-	id1 := "arachne_failures_by_rack"
-	f, err := newMultiCharSequenceFilter([]byte("arachne_failures,arachne_failures_by_rack"), false)
-	require.NoError(t, err)
-	val1, matches1 := f.matches([]byte(id0))
-	require.True(t, matches1)
-	require.True(t, len(val1) == 0)
-	val2, matches2 := f.matches([]byte(id1))
-	require.True(t, matches2)
-	require.True(t, len(val2) == 0)
-}
-
 func TestNewFilterFromFilterValueInvalidPattern(t *testing.T) {
 	inputs := []string{"ab]c[sdf", "abc[z-a]", "*con[tT]ains*"}
 	for _, input := range inputs {
@@ -362,6 +349,11 @@ func TestMultiCharSequenceFilter(t *testing.T) {
 	validateLookup(t, f, "12test", true, "12")
 	validateLookup(t, f, "12test2", true, "12")
 	validateLookup(t, f, "123book", true, "123")
+
+	f, err = newMultiCharSequenceFilter([]byte("arachne_failures,arachne_failures_by_rack"), false)
+	require.NoError(t, err)
+	validateLookup(t, f, "arachne_failures", true, "")
+	validateLookup(t, f, "arachne_failures_by_rack", true, "")
 }
 
 func validateLookup(t *testing.T, f chainFilter, val string, expectedMatch bool, expectedRemainder string) {

--- a/src/metrics/filters/filter_test.go
+++ b/src/metrics/filters/filter_test.go
@@ -27,6 +27,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPrefixCompositeR2Filter(t *testing.T) {
+	id0 := "arachne_failures"
+	id1 := "arachne_failures_by_rack"
+	f, err := newMultiCharSequenceFilter([]byte("arachne_failures,arachne_failures_by_rack"), false)
+	require.NoError(t, err)
+	_, matches1 := f.matches([]byte(id0))
+	require.True(t, matches1)
+	_, matches2 := f.matches([]byte(id1))
+	require.True(t, matches2)
+
+}
+
 func TestNewFilterFromFilterValueInvalidPattern(t *testing.T) {
 	inputs := []string{"ab]c[sdf", "abc[z-a]", "*con[tT]ains*"}
 	for _, input := range inputs {

--- a/src/metrics/filters/filter_test.go
+++ b/src/metrics/filters/filter_test.go
@@ -350,15 +350,15 @@ func TestMultiCharSequenceFilter(t *testing.T) {
 	validateLookup(t, f, "12test2", true, "12")
 	validateLookup(t, f, "123book", true, "123")
 
-	f, err = newMultiCharSequenceFilter([]byte("arachne_failures,arachne_failures_by_rack"), false)
+	f, err = newMultiCharSequenceFilter([]byte("test,test_post,extra_unused_filter"), false)
 	require.NoError(t, err)
-	validateLookup(t, f, "arachne_failures", true, "")
-	validateLookup(t, f, "arachne_failures_by_rack", true, "")
+	validateLookup(t, f, "test", true, "")
+	validateLookup(t, f, "test_post", true, "")
 
-	f, err = newMultiCharSequenceFilter([]byte("arachne_failures,test_arachne_failures"), true)
+	f, err = newMultiCharSequenceFilter([]byte("test,pre_test,extra_unused_filter"), true)
 	require.NoError(t, err)
-	validateLookup(t, f, "arachne_failures", true, "")
-	validateLookup(t, f, "test_arachne_failures", true, "")
+	validateLookup(t, f, "test", true, "")
+	validateLookup(t, f, "pre_test", true, "")
 }
 
 func validateLookup(t *testing.T, f chainFilter, val string, expectedMatch bool, expectedRemainder string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**: Currently, the multiCharSequenceFilter `matches` function returns on the first pattern found [here](https://github.com/m3db/m3/blob/37c5a40d655a7cdde9cbc3725b4f377ded761d53/src/metrics/filters/filter.go#L589-L595) even if there are other patterns available with better matches. This results in a suboptimal byte[] val being returned which causes the public `matches` function to return a false negative [here](https://github.com/m3db/m3/blob/37c5a40d655a7cdde9cbc3725b4f377ded761d53/src/metrics/filters/filter.go#L662). The `len(val)` is not zero because a suboptimal val was returned when a better pattern could have been found if the multiCharSequenceFilter `matches` function iterated through all patterns available and looked for the best match.

<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/m3db/m3/issues/4189

**Special notes for your reviewer**: Please provide any go style improvements or tips you think are relevant

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
Benchmark Test Results Before and After Changes to `matches` method of `multiCharSequenceFilter`:

| testname                           | old-bench-test-results.txt sec/op | new-bench-test-results.txt sec/op | sec/op vs base         |
|------------------------------------|-----------------------------------|-----------------------------------|------------------------|
| MultiRangeFilterPrefixCollision-10 | 10.61n ± 1%                       | 16.27n ± 4%                       | +53.47% (p=0.000 n=10) |
| MultiRangeFilterSuffixCollision-10 | 11.51n ± 7%                       | 17.00n ± 3%                       | +47.65% (p=0.000 n=10) |
| MultiRangeFilterTwo-10             | 17.48n ± 5%                       | 17.91n ± 2%                       | +2.43% (p=0.004 n=10)  |
| MultiRangeFilterSelectTwo-10       | 21.45n ± 3%                       | 24.30n ± 2%                       | +13.31% (p=0.000 n=10) |
| MultiRangeFilterTrieTwo-10         | 16.44n ± 4%                       | 16.07n ± 2%                       | ~ (p=0.342 n=10)       |
| MultiRangeFilterSix-10             | 38.89n ± 1%                       | 42.51n ± 2%                       | +9.32% (p=0.000 n=10)  |
| MultiRangeFilterSelectSix-10       | 56.47n ± 0%                       | 65.47n ± 1%                       | +15.94% (p=0.000 n=10) |
| MultiRangeFilterTrieSix-10         | 33.67n ± 0%                       | 33.97n ± 4%                       | +0.89% (p=0.005 n=10)  |
| geomean                            | 22.04n                            | 25.57n                            | +16.04%                |