### PR TITLE
[coordinator] Add config for forwarding remote write with percent of unique series

### DIFF
--- a/src/query/api/v1/handler/prometheus/handleroptions/options.go
+++ b/src/query/api/v1/handler/prometheus/handleroptions/options.go
@@ -45,4 +45,20 @@ type PromWriteHandlerForwardTargetOptions struct {
 	Method string `yaml:"method"`
 	// Headers to send along with requests to the target.
 	Headers map[string]string `yaml:"headers"`
+	// NoRetry disables retries for a forwarding target (useful for say
+	// when shadowing data to a shadow cluster, but could be useful outside
+	// of that use case too potentially).
+	NoRetry bool `yaml:"noRetry"`
+	// Shadow defines options that are specific only to shadowing data.
+	Shadow *PromWriteHandlerForwardTargetShadowOptions `yaml:"shadow"`
+}
+
+// PromWriteHandlerForwardTargetShadowOptions is a prometheus write
+// handler forwarder target shadow options.
+type PromWriteHandlerForwardTargetShadowOptions struct {
+	// Percent of requests to shadow to the target, between [0,1].
+	Percent float64 `yaml:"percent"`
+	// Hash is the hash algorithm to use for determining which series to shadow.
+	// Accepted values are: "xxhash" and "murmur3"
+	Hash string `yaml:"hash"`
 }

--- a/src/query/api/v1/handler/prometheus/remote/test/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/test/write.go
@@ -23,6 +23,7 @@ package test
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"time"
 
 	"github.com/m3db/m3/src/query/generated/proto/prompb"
@@ -37,17 +38,18 @@ import (
 // write request.
 func GeneratePromWriteRequest() *prompb.WriteRequest {
 	req := &prompb.WriteRequest{
-		Timeseries: []prompb.TimeSeries{{
-			Labels: []prompb.Label{
-				{Name: []byte(model.MetricNameLabel), Value: []byte("first")},
-				{Name: []byte("foo"), Value: []byte("bar")},
-				{Name: []byte("biz"), Value: []byte("baz")},
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: []byte(model.MetricNameLabel), Value: []byte("first")},
+					{Name: []byte("foo"), Value: []byte("bar")},
+					{Name: []byte("biz"), Value: []byte("baz")},
+				},
+				Samples: []prompb.Sample{
+					{Value: 1.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
+					{Value: 2.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
+				},
 			},
-			Samples: []prompb.Sample{
-				{Value: 1.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
-				{Value: 2.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
-			},
-		},
 			{
 				Labels: []prompb.Label{
 					{Name: []byte(model.MetricNameLabel), Value: []byte("second")},
@@ -58,7 +60,8 @@ func GeneratePromWriteRequest() *prompb.WriteRequest {
 					{Value: 3.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
 					{Value: 4.0, Timestamp: time.Now().UnixNano() / int64(time.Millisecond)},
 				},
-			}},
+			},
+		},
 	}
 	return req
 }
@@ -83,4 +86,24 @@ func GeneratePromWriteRequestBodyBytes(
 
 	compressed := snappy.Encode(nil, data)
 	return compressed
+}
+
+// ReadPromWriteRequestBody reads a Prometheus remote
+// write request body.
+func ReadPromWriteRequestBody(
+	t require.TestingT,
+	body io.Reader,
+) *prompb.WriteRequest {
+	require.NotNil(t, body)
+
+	data, err := ioutil.ReadAll(body)
+	require.NoError(t, err)
+
+	decoded, err := snappy.Decode(nil, data)
+	require.NoError(t, err)
+
+	req := &prompb.WriteRequest{}
+	require.NoError(t, proto.Unmarshal(decoded, req))
+
+	return req
 }

--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -54,7 +55,10 @@ import (
 	xsync "github.com/m3db/m3/src/x/sync"
 	xtime "github.com/m3db/m3/src/x/time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/snappy"
+	murmur3 "github.com/m3db/stackmurmur3/v2"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
@@ -215,6 +219,8 @@ type promWriteMetrics struct {
 	forwardErrors            tally.Counter
 	forwardDropped           tally.Counter
 	forwardLatency           tally.Histogram
+	forwardShadowKeep        tally.Counter
+	forwardShadowDrop        tally.Counter
 }
 
 func (m *promWriteMetrics) incError(err error) {
@@ -242,6 +248,8 @@ func newPromWriteMetrics(scope tally.Scope) (promWriteMetrics, error) {
 		forwardErrors:            scope.SubScope("forward").Counter("errors"),
 		forwardDropped:           scope.SubScope("forward").Counter("dropped"),
 		forwardLatency:           scope.SubScope("forward").Histogram("latency", buckets.WriteLatencyBuckets),
+		forwardShadowKeep:        scope.SubScope("forward").SubScope("shadow").Counter("keep"),
+		forwardShadowDrop:        scope.SubScope("forward").SubScope("shadow").Counter("drop"),
 	}, nil
 }
 
@@ -257,9 +265,8 @@ func (h *PromWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var (
-		req    = checkedReq.Request
-		opts   = checkedReq.Options
-		result = checkedReq.CompressResult
+		req  = checkedReq.Request
+		opts = checkedReq.Options
 	)
 	// Begin async forwarding.
 	// NB(r): Be careful about not returning buffers to pool
@@ -270,13 +277,22 @@ func (h *PromWriteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			target := target // Capture for lambda.
 			forward := func() {
 				now := h.nowFn()
-				err := h.forwardRetrier.Attempt(func() error {
-					// Consider propagating baggage without tying
-					// context to request context in future.
-					ctx, cancel := context.WithTimeout(h.forwardContext, h.forwardTimeout)
-					defer cancel()
-					return h.forward(ctx, result, r.Header, target)
-				})
+
+				var (
+					attempt = func() error {
+						// Consider propagating baggage without tying
+						// context to request context in future.
+						ctx, cancel := context.WithTimeout(h.forwardContext, h.forwardTimeout)
+						defer cancel()
+						return h.forward(ctx, checkedReq, r.Header, target)
+					}
+					err error
+				)
+				if target.NoRetry {
+					err = attempt()
+				} else {
+					err = h.forwardRetrier.Attempt(attempt)
+				}
 
 				// Record forward ingestion delay.
 				// NB: this includes any time for retries.
@@ -535,16 +551,27 @@ func (h *PromWriteHandler) write(
 
 func (h *PromWriteHandler) forward(
 	ctx context.Context,
-	request prometheus.ParsePromCompressedRequestResult,
+	res parseRequestResult,
 	header http.Header,
 	target handleroptions.PromWriteHandlerForwardTargetOptions,
 ) error {
+	body := bytes.NewReader(res.CompressResult.CompressedBody)
+	if shadowOpts := target.Shadow; shadowOpts != nil {
+		// Need to send a subset of the original series to the shadow target.
+		buffer, err := h.buildForwardShadowRequestBody(res, shadowOpts)
+		if err != nil {
+			return err
+		}
+		// Read the body from the shadow request body just built.
+		body.Reset(buffer)
+	}
+
 	method := target.Method
 	if method == "" {
 		method = http.MethodPost
 	}
 	url := target.URL
-	req, err := http.NewRequest(method, url, bytes.NewReader(request.CompressedBody))
+	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return err
 	}
@@ -585,6 +612,88 @@ func (h *PromWriteHandler) forward(
 	}
 
 	return nil
+}
+
+func (h *PromWriteHandler) buildForwardShadowRequestBody(
+	res parseRequestResult,
+	shadowOpts *handleroptions.PromWriteHandlerForwardTargetShadowOptions,
+) ([]byte, error) {
+	if shadowOpts.Percent < 0 || shadowOpts.Percent > 1 {
+		return nil, fmt.Errorf("forwarding shadow percent out of range [0,1]: %f",
+			shadowOpts.Percent)
+	}
+
+	// Need to apply shadow percent.
+	var hash func([]byte) uint64
+	switch shadowOpts.Hash {
+	case "":
+		fallthrough
+	case "xxhash":
+		hash = xxhash.Sum64
+	case "murmur3":
+		hash = murmur3.Sum64
+	default:
+		return nil, fmt.Errorf("unknown hash function: %s", shadowOpts.Hash)
+	}
+
+	var buffer []byte
+	for i := 0; i < len(res.Request.Timeseries); i++ {
+		ts := res.Request.Timeseries[i]
+
+		// Build an ID of the series to hash.
+		buffer = buildPseudoIDWithLabelsLikelySorted(ts.Labels, buffer[:0])
+
+		// Use a range of 10k to allow for setting 0.01% having an effect
+		// when shadow percent is set (i.e. with percent=0.0001)
+		if hash(buffer)%10000 <= uint64(shadowOpts.Percent*10000) {
+			// Keep this series, it falls below the volume target of shards.
+			h.metrics.forwardShadowKeep.Inc(1)
+			continue
+		}
+
+		h.metrics.forwardShadowDrop.Inc(1)
+
+		// Skip forwarding this series, not in shadow volume of shards.
+		// Swap it with the tail and continue.
+		res.Request.Timeseries[i] = res.Request.Timeseries[len(res.Request.Timeseries)-1]
+		res.Request.Timeseries = res.Request.Timeseries[:len(res.Request.Timeseries)-1]
+
+		// Process the series we put at the index again
+		i--
+	}
+
+	encoded, err := proto.Marshal(res.Request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal forwarding shadow request: %w", err)
+	}
+
+	return snappy.Encode(buffer[:0], encoded), nil
+}
+
+// buildPseudoIDWithLabelsLikelySorted will build a pseudo ID that can be
+// hashed/etc (but not used as primary key since not escaped), it expects the
+// input labels to be likely sorted (so can avoid invoking sort in the regular
+// case where series have labels already sorted when sent to remote write
+// endpoint, which is commonly the case).
+func buildPseudoIDWithLabelsLikelySorted(
+	labels []prompb.Label,
+	buffer []byte,
+) []byte {
+	for i, l := range labels {
+		if i > 0 && bytes.Compare(l.Name, labels[i-1].Name) < 0 {
+			// Sort.
+			sort.Sort(sortableLabels(labels))
+			// Rebuild.
+			return buildPseudoIDWithLabelsLikelySorted(labels, buffer[:0])
+		}
+		buffer = append(buffer, l.Name...)
+		buffer = append(buffer, '=')
+		buffer = append(buffer, l.Value...)
+		if i < len(labels)-1 {
+			buffer = append(buffer, ',')
+		}
+	}
+	return buffer
 }
 
 func (h *PromWriteHandler) maybeLogLabelsWithTooLongLiterals(logger *zap.Logger, label prompb.Label) {
@@ -730,4 +839,12 @@ func (i *promTSIter) SetCurrentMetadata(metadata ts.Metadata) {
 		return
 	}
 	i.metadatas[i.idx] = metadata
+}
+
+type sortableLabels []prompb.Label
+
+func (t sortableLabels) Len() int      { return len(t) }
+func (t sortableLabels) Swap(i, j int) { t[i], t[j] = t[j], t[i] }
+func (t sortableLabels) Less(i, j int) bool {
+	return bytes.Compare(t[i].Name, t[j].Name) == -1
 }

--- a/src/query/api/v1/handler/prometheus/remote/write_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/write_test.go
@@ -568,14 +568,14 @@ func testPromWriteForwardWithShadow(
 	require.NoError(t, resp.Body.Close())
 
 	select {
-	case <-time.After(10 * time.Second):
-		require.FailNow(t, "timeout waiting for fwd request")
 	case fwdReq := <-forwardRecvReqCh:
 		assert.InEpsilon(t, testOpts.expectedFwded, len(fwdReq.Timeseries),
 			testOpts.expectedFwdedAllowedVariance,
 			fmt.Sprintf("expected=%v, actual=%v, allowed_variance=%v",
 				testOpts.expectedFwded, len(fwdReq.Timeseries),
 				testOpts.expectedFwdedAllowedVariance))
+	case <-time.After(10 * time.Second):
+		require.FailNow(t, "timeout waiting for fwd request")
 	}
 }
 


### PR DESCRIPTION
This helps shadow flow of data to a specific % of unique series which helps control cardinality when shadowing traffic to a smaller cluster than that of the cluster where the data is being forwarded from.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
