### PR TITLE
[dbnode] Add IndexResults from subsequent bootstrap runs

### DIFF
--- a/src/dbnode/storage/bootstrap/bootstrapper/base.go
+++ b/src/dbnode/storage/bootstrap/bootstrapper/base.go
@@ -189,6 +189,7 @@ func (b baseBootstrapper) Bootstrap(
 			finalResult.DataResult.SetUnfulfilled(currNamespace.DataResult.Unfulfilled().Copy())
 			if currNamespace.Metadata.Options().IndexOptions().Enabled() {
 				finalResult.IndexResult.SetUnfulfilled(currNamespace.IndexResult.Unfulfilled().Copy())
+				finalResult.IndexResult.IndexResults().AddResults(currNamespace.IndexResult.IndexResults())
 			}
 
 			// Map is by value, set the result altered struct.

--- a/src/dbnode/storage/bootstrap/util.go
+++ b/src/dbnode/storage/bootstrap/util.go
@@ -674,6 +674,15 @@ func (nt *NamespacesTester) TestUnfulfilledForNamespace(
 	}
 }
 
+// TestIndexResultForNamespace verifies index result.
+func (nt *NamespacesTester) TestIndexResultForNamespace(
+	md namespace.Metadata,
+	expected result.IndexBootstrapResult,
+) {
+	ns := nt.ResultForNamespace(md.ID())
+	require.Equal(nt.t, expected, ns.IndexResult)
+}
+
 // TestUnfulfilledForNamespaceIsEmpty ensures the given namespace has an empty
 // unfulfilled range.
 func (nt *NamespacesTester) TestUnfulfilledForNamespaceIsEmpty(


### PR DESCRIPTION
dbnode was not updating in-memory index state to contain the blocks that have been peer bootstrapped. This was the case  because peer bootstrapping is the second bootstrapper run (after filesystem bootstrapper), and there was no code to add the peer-bootstrapped index blocks into final bootstrap result. This PR adds that piece of code to `src/dbnode/storage/bootstrap/bootstrapper/base.go`.