### PR TITLE
[coordinator] Fix inverted interpretation of Prometheus remote write shadow sampling config

### DIFF
--- a/src/query/api/v1/handler/prometheus/remote/write.go
+++ b/src/query/api/v1/handler/prometheus/remote/write.go
@@ -650,13 +650,15 @@ func (h *PromWriteHandler) buildForwardShadowRequestBody(
 
 		// Use a range of 10k to allow for setting 0.01% having an effect
 		// when shadow percent is set (i.e. with percent=0.0001)
-		if hash(buffer)%10000 <= uint64(shadowOpts.Percent*10000) {
-			// Keep this series, it falls below the volume target of shards.
-			h.metrics.forwardShadowKeep.Inc(1)
+		if hash(buffer)%10000 >= uint64(shadowOpts.Percent*10000) {
+			// Skip forwarding this series, not in shadow volume of shards.
+			// Swap it with the tail and continue.
+			h.metrics.forwardShadowDrop.Inc(1)
 			continue
 		}
 
-		h.metrics.forwardShadowDrop.Inc(1)
+		// Keep this series, it falls below the volume target of shards.
+		h.metrics.forwardShadowKeep.Inc(1)
 
 		// Skip forwarding this series, not in shadow volume of shards.
 		// Swap it with the tail and continue.

--- a/src/query/api/v1/handler/prometheus/remote/write_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/write_test.go
@@ -463,10 +463,11 @@ func TestPromWriteForwardWithShadow(t *testing.T) {
 		{0.75, 10000, 0.05},
 		{1, 10000, 0},
 	} {
-		for _, hash := range []string{"", "murmur3", "xxhash"} {
-			t.Run(fmt.Sprintf("hash='%s', params=%+v", hash, tt), func(t *testing.T) {
+		for _, h := range []string{"", "murmur3", "xxhash"} {
+			h := h
+			t.Run(fmt.Sprintf("hash='%s', params=%+v", h, tt), func(t *testing.T) {
 				testPromWriteForwardWithShadow(t, testPromWriteForwardWithShadowOptions{
-					hash:                         hash,
+					hash:                         h,
 					numSeries:                    tt.numSeries,
 					percent:                      tt.percent,
 					expectedFwded:                int(float64(tt.numSeries) * tt.percent),

--- a/src/query/api/v1/handler/prometheus/remote/write_test.go
+++ b/src/query/api/v1/handler/prometheus/remote/write_test.go
@@ -451,40 +451,37 @@ func TestPromWriteLiteralIsTooLongError(t *testing.T) {
 	}
 }
 
-func TestPromWriteForwardWithShadowDefaultHash(t *testing.T) {
-	testPromWriteForwardWithShadow(t, testPromWriteForwardWithShadowOptions{
-		numSeries:                    10000,
-		percent:                      0.5,
-		expectedFwded:                5000,
-		expectedFwdedAllowedVariance: 0.05,
-	})
-}
-
-func TestPromWriteForwardWithShadowXXHash(t *testing.T) {
-	testPromWriteForwardWithShadow(t, testPromWriteForwardWithShadowOptions{
-		numSeries:                    10000,
-		percent:                      0.5,
-		hash:                         "xxhash",
-		expectedFwded:                5000,
-		expectedFwdedAllowedVariance: 0.05,
-	})
-}
-
-func TestPromWriteForwardWithShadowMurmur3(t *testing.T) {
-	testPromWriteForwardWithShadow(t, testPromWriteForwardWithShadowOptions{
-		numSeries:                    10000,
-		percent:                      0.5,
-		hash:                         "murmur3",
-		expectedFwded:                5000,
-		expectedFwdedAllowedVariance: 0.05,
-	})
+func TestPromWriteForwardWithShadow(t *testing.T) {
+	for _, tt := range []struct {
+		percent         float64
+		numSeries       int
+		allowedVariance float64
+	}{
+		{0, 10000, 0},
+		{0.25, 10000, 0.05},
+		{0.5, 10000, 0.05},
+		{0.75, 10000, 0.05},
+		{1, 10000, 0},
+	} {
+		for _, hash := range []string{"", "murmur3", "xxhash"} {
+			t.Run(fmt.Sprintf("hash='%s', params=%+v", hash, tt), func(t *testing.T) {
+				testPromWriteForwardWithShadow(t, testPromWriteForwardWithShadowOptions{
+					hash:                         hash,
+					numSeries:                    tt.numSeries,
+					percent:                      tt.percent,
+					expectedFwded:                int(float64(tt.numSeries) * tt.percent),
+					expectedFwdedAllowedVariance: tt.allowedVariance,
+				})
+			})
+		}
+	}
 }
 
 type testPromWriteForwardWithShadowOptions struct {
 	numSeries                    int
 	percent                      float64
 	hash                         string
-	expectedFwded                int64
+	expectedFwded                int
 	expectedFwdedAllowedVariance float64
 }
 
@@ -569,11 +566,17 @@ func testPromWriteForwardWithShadow(
 
 	select {
 	case fwdReq := <-forwardRecvReqCh:
-		assert.InEpsilon(t, testOpts.expectedFwded, len(fwdReq.Timeseries),
-			testOpts.expectedFwdedAllowedVariance,
-			fmt.Sprintf("expected=%v, actual=%v, allowed_variance=%v",
-				testOpts.expectedFwded, len(fwdReq.Timeseries),
-				testOpts.expectedFwdedAllowedVariance))
+		if testOpts.expectedFwdedAllowedVariance > 0 {
+			assert.InEpsilon(t, testOpts.expectedFwded, len(fwdReq.Timeseries),
+				testOpts.expectedFwdedAllowedVariance,
+				fmt.Sprintf("expected=%v, actual=%v, allowed_variance=%v",
+					testOpts.expectedFwded, len(fwdReq.Timeseries),
+					testOpts.expectedFwdedAllowedVariance))
+		} else {
+			assert.Equal(t, testOpts.expectedFwded, len(fwdReq.Timeseries),
+				fmt.Sprintf("expected=%v, actual=%v",
+					testOpts.expectedFwded, len(fwdReq.Timeseries)))
+		}
 	case <-time.After(10 * time.Second):
 		require.FailNow(t, "timeout waiting for fwd request")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes the inverted interpretation of the Prometheus remote write shadow sampling configuration. The intention was that 10% shadow sampling should mean sending 10% of the traffic passing through the coordinator, not sending a copy of 90% of the traffic passing through and dropping 10% of it.

Also added some tests which would have caught this inverted interpretation (instead of only testing 50% shadow sample rates in the unit tests).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
