### PR TITLE
Only configure env configs when specified

### DIFF
--- a/src/dbnode/environment/config.go
+++ b/src/dbnode/environment/config.go
@@ -267,11 +267,11 @@ func (c Configuration) Configure(cfgParams ConfigurationParameters) (ConfigureRe
 		return emptyConfig, err
 	}
 
-	if c.Services != nil {
+	if len(c.Services) > 0 {
 		return c.configureDynamic(cfgParams)
 	}
 
-	if c.Statics != nil {
+	if len(c.Statics) > 0 {
 		return c.configureStatic(cfgParams)
 	}
 


### PR DESCRIPTION
Don't configure `Configuration.Services` or `Configuration. Statics` unless there are entries to specified. In particular, these configure steps should be skipped if the config specifies an empty slice `[]`, which may be unavoidable since yaml marshals a nil slice to `[]`.