### PR TITLE
[#4218] [Aggregator] Export ConsumerServiceFilterConfiguration, ValidateShardSet, and ValidateServiceID

### DIFF
--- a/src/aggregator/aggregator/handler/config.go
+++ b/src/aggregator/aggregator/handler/config.go
@@ -156,7 +156,7 @@ type DynamicBackendConfiguration struct {
 	Producer config.ProducerConfiguration `yaml:"producer"`
 
 	// Filters configs the filter for consumer services.
-	Filters []consumerServiceFilterConfiguration `yaml:"filters"`
+	Filters []ConsumerServiceFilterConfiguration `yaml:"filters"`
 
 	// Filters configs the filter for consumer services.
 	StoragePolicyFilters []storagePolicyFilterConfiguration `yaml:"storagePolicyFilters"`
@@ -209,12 +209,12 @@ func (c storagePolicyFilterConfiguration) NewConsumerServiceFilter() (services.S
 	return c.ServiceID.NewServiceID(), writer.NewStoragePolicyFilter(c.StoragePolicies)
 }
 
-type consumerServiceFilterConfiguration struct {
+type ConsumerServiceFilterConfiguration struct {
 	ServiceID services.ServiceIDConfiguration `yaml:"serviceID" validate:"nonzero"`
 	ShardSet  sharding.ShardSet               `yaml:"shardSet" validate:"nonzero"`
 }
 
-func (c consumerServiceFilterConfiguration) NewConsumerServiceFilter() (services.ServiceID, producer.FilterFunc) {
+func (c ConsumerServiceFilterConfiguration) NewConsumerServiceFilter() (services.ServiceID, producer.FilterFunc) {
 	return c.ServiceID.NewServiceID(), filter.NewShardSetFilter(c.ShardSet)
 }
 

--- a/src/aggregator/sharding/shard_set_test.go
+++ b/src/aggregator/sharding/shard_set_test.go
@@ -68,7 +68,7 @@ func TestShardSetParseShardSet(t *testing.T) {
 
 		err := yaml.Unmarshal([]byte(test.yaml), &cfg)
 		require.NoError(t, err, "received error for test %d", i)
-		validateShardSet(t, test.expected, cfg.Shards)
+		ValidateShardSet(t, test.expected, cfg.Shards)
 	}
 }
 
@@ -85,7 +85,7 @@ func TestParseShardSet(t *testing.T) {
 	for _, test := range tests {
 		parsed, err := ParseShardSet(test.str)
 		require.NoError(t, err)
-		validateShardSet(t, test.expected, parsed)
+		ValidateShardSet(t, test.expected, parsed)
 	}
 }
 
@@ -114,7 +114,7 @@ func TestMustParseShardSet(t *testing.T) {
 
 	for _, test := range tests {
 		parsed := MustParseShardSet(test.str)
-		validateShardSet(t, test.expected, parsed)
+		ValidateShardSet(t, test.expected, parsed)
 	}
 }
 
@@ -127,16 +127,5 @@ func TestMustParseShardSetPanics(t *testing.T) {
 
 	for _, test := range tests {
 		require.Panics(t, func() { MustParseShardSet(test) })
-	}
-}
-
-func validateShardSet(t *testing.T, expectedShards []uint32, actual ShardSet) {
-	expectedSet := make(ShardSet)
-	for _, s := range expectedShards {
-		expectedSet.Add(s)
-	}
-	require.Equal(t, expectedSet, actual)
-	for _, shard := range expectedShards {
-		require.True(t, actual.Contains(shard))
 	}
 }

--- a/src/aggregator/sharding/test_utils.go
+++ b/src/aggregator/sharding/test_utils.go
@@ -1,0 +1,18 @@
+package sharding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ValidateShardSet(t *testing.T, expectedShards []uint32, actual ShardSet) {
+	expectedSet := make(ShardSet)
+	for _, s := range expectedShards {
+		expectedSet.Add(s)
+	}
+	require.Equal(t, expectedSet, actual)
+	for _, shard := range expectedShards {
+		require.True(t, actual.Contains(shard))
+	}
+}

--- a/src/cluster/services/services.go
+++ b/src/cluster/services/services.go
@@ -89,7 +89,7 @@ type client struct {
 }
 
 func (c *client) Metadata(sid ServiceID) (Metadata, error) {
-	if err := validateServiceID(sid); err != nil {
+	if err := ValidateServiceID(sid); err != nil {
 		return nil, err
 	}
 
@@ -112,7 +112,7 @@ func (c *client) Metadata(sid ServiceID) (Metadata, error) {
 }
 
 func (c *client) SetMetadata(sid ServiceID, meta Metadata) error {
-	if err := validateServiceID(sid); err != nil {
+	if err := ValidateServiceID(sid); err != nil {
 		return err
 	}
 
@@ -130,7 +130,7 @@ func (c *client) SetMetadata(sid ServiceID, meta Metadata) error {
 }
 
 func (c *client) DeleteMetadata(sid ServiceID) error {
-	if err := validateServiceID(sid); err != nil {
+	if err := ValidateServiceID(sid); err != nil {
 		return err
 	}
 
@@ -144,7 +144,7 @@ func (c *client) DeleteMetadata(sid ServiceID) error {
 }
 
 func (c *client) PlacementService(sid ServiceID, opts placement.Options) (placement.Service, error) {
-	if err := validateServiceID(sid); err != nil {
+	if err := ValidateServiceID(sid); err != nil {
 		return nil, err
 	}
 
@@ -245,7 +245,7 @@ func (c *client) Unadvertise(sid ServiceID, id string) error {
 }
 
 func (c *client) Query(sid ServiceID, opts QueryOptions) (Service, error) {
-	if err := validateServiceID(sid); err != nil {
+	if err := ValidateServiceID(sid); err != nil {
 		return nil, err
 	}
 
@@ -277,7 +277,7 @@ func (c *client) Query(sid ServiceID, opts QueryOptions) (Service, error) {
 }
 
 func (c *client) Watch(sid ServiceID, opts QueryOptions) (Watch, error) {
-	if err := validateServiceID(sid); err != nil {
+	if err := ValidateServiceID(sid); err != nil {
 		return nil, err
 	}
 
@@ -359,7 +359,7 @@ func (c *client) Watch(sid ServiceID, opts QueryOptions) (Watch, error) {
 }
 
 func (c *client) HeartbeatService(sid ServiceID) (HeartbeatService, error) {
-	if err := validateServiceID(sid); err != nil {
+	if err := ValidateServiceID(sid); err != nil {
 		return nil, err
 	}
 

--- a/src/cluster/services/util.go
+++ b/src/cluster/services/util.go
@@ -69,7 +69,7 @@ func serviceKey(s ServiceID) string {
 	return fmt.Sprintf(keyFormat, s.Environment(), s.Name())
 }
 
-func validateServiceID(sid ServiceID) error {
+func ValidateServiceID(sid ServiceID) error {
 	if sid.Name() == "" {
 		return errNoServiceName
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:  Fixes #4218. This PR exports the following methods so they can be used more generally elsewhere easily without duplicating code:

* validateShardSet
* validateServiceId

This PR also exports the `consumerServiceFilterConfiguration` struct will allow unit tests for it to be written for it

**Does this PR introduce a user-facing and/or backwards incompatible change?**: No

**Does this PR require updating code package or user-facing documentation?**: No
