### PR TITLE
[dbnode] Fix regexp LRU cache bug

### DIFF
--- a/src/x/cache/lru_cache.go
+++ b/src/x/cache/lru_cache.go
@@ -238,6 +238,10 @@ func (c *LRU) PutWithTTL(key string, value interface{}, ttl time.Duration) {
 // making it a property of the cache to support access specific
 // loading arguments which might not be bundled into the key.
 func (c *LRU) Get(ctx context.Context, key string, loader LoaderFunc) (interface{}, error) {
+	if loader == nil {
+		return c.GetWithTTL(ctx, key, nil)
+	}
+
 	return c.GetWithTTL(ctx, key, func(ctx context.Context, key string) (interface{}, time.Time, error) {
 		val, err := loader(ctx, key)
 		return val, time.Time{}, err
@@ -443,7 +447,7 @@ func (c *LRU) updateCacheEntryWithLock(
 		c.entries[key] = entry
 	}
 
-	entry.value, entry.err = value, err
+	entry.key, entry.value, entry.err = key, value, err
 
 	// Re-adjust expiration and mark as both most recently access and most recently used
 	if expiresAt.IsZero() {

--- a/src/x/cache/lru_cache_test.go
+++ b/src/x/cache/lru_cache_test.go
@@ -650,6 +650,24 @@ func TestLRU_EnforceMaxEntries(t *testing.T) {
 	assert.Len(t, lru.entries, maxEntries)
 }
 
+func TestLRU_PutAboveLimit(t *testing.T) {
+	var (
+		maxEntries = 2
+		lru        = NewLRU(&LRUOptions{MaxEntries: maxEntries, TTL: time.Second, Now: time.Now})
+	)
+
+	for i := 0; i < 3*maxEntries; i++ {
+		key, value := strconv.Itoa(i), fmt.Sprintf("value for %d", i)
+		lru.Put(key, value)
+
+		res, ok := lru.TryGet(key)
+		require.True(t, ok)
+		require.Equal(t, value, res.(string))
+	}
+
+	assert.Len(t, lru.entries, maxEntries)
+}
+
 var defaultKeys = []string{
 	"key-0", "key-1", "key-2", "key-3", "key-4", "key-5", "key-6", "key-7", "key-8", "key-9", "key10",
 }


### PR DESCRIPTION
LRU cache (used for caching compiled query regexps in m3db) was not accepting any additional entries after becoming full. This was happening because `entry.key` was never being set, and then removal did not work.