### PR TITLE
[query] Fix matching of disjunction including empty string

### DIFF
--- a/src/m3ninx/index/regexp_prop_test.go
+++ b/src/m3ninx/index/regexp_prop_test.go
@@ -77,10 +77,9 @@ func TestRegexpCompilationProperty(t *testing.T) {
 func compileRegexp(x string, t *testing.T) *regexp.Regexp {
 	ast, err := parseRegexp(x)
 	require.NoError(t, err)
-	astp, err := ensureRegexpUnanchored(ast)
+	astp, err := EnsureRegexpUnanchored(ast)
 	require.NoError(t, err)
-	ast2p, err := ensureRegexpAnchored(astp)
-	require.NoError(t, err)
+	ast2p := EnsureRegexpAnchored(astp)
 	re, err := regexp.Compile(ast2p.String())
 	require.NoError(t, err)
 	return re

--- a/src/m3ninx/index/regexp_test.go
+++ b/src/m3ninx/index/regexp_test.go
@@ -57,162 +57,162 @@ func TestEnsureRegexpUnachoredee(t *testing.T) {
 
 func TestEnsureRegexpUnachored(t *testing.T) {
 	testCases := []testCase{
-		testCase{
+		{
 			name:           "naked ^",
 			input:          "^",
 			expectedOutput: "emp{}",
 		},
-		testCase{
+		{
 			name:           "naked $",
 			input:          "$",
 			expectedOutput: "emp{}",
 		},
-		testCase{
+		{
 			name:           "empty string ^$",
 			input:          "^$",
 			expectedOutput: "cat{}",
 		},
-		testCase{
+		{
 			name:           "invalid naked concat ^$",
 			input:          "$^",
 			expectedOutput: "cat{eot{}bot{}}",
 		},
-		testCase{
+		{
 			name:           "simple case of ^",
 			input:          "^abc",
 			expectedOutput: "str{abc}",
 		},
-		testCase{
+		{
 			name:           "simple case of $",
 			input:          "abc$",
 			expectedOutput: "str{abc}",
 		},
-		testCase{
+		{
 			name:           "simple case of both ^ & $",
 			input:          "^abc$",
 			expectedOutput: "str{abc}",
 		},
-		testCase{
+		{
 			name:           "weird case of internal ^",
 			input:          "^a^bc$",
 			expectedOutput: "cat{lit{a}bot{}str{bc}}",
 		},
-		testCase{
+		{
 			name:           "weird case of internal $",
 			input:          "^a$bc$",
 			expectedOutput: "cat{lit{a}eot{}str{bc}}",
 		},
-		testCase{
+		{
 			name:           "alternate of sub expressions with only legal ^ and $",
 			input:          "(?:^abc$)|(?:^xyz$)",
 			expectedOutput: "alt{str{abc}str{xyz}}",
 		},
-		testCase{
+		{
 			name:           "concat of sub expressions with only legal ^ and $",
 			input:          "(^abc$)(?:^xyz$)",
 			expectedOutput: "cat{cap{cat{str{abc}eot{}}}bot{}str{xyz}}",
 		},
-		testCase{
+		{
 			name:           "alternate of sub expressions with illegal ^ and $",
 			input:          "(?:^a$bc$)|(?:^xyz$)",
 			expectedOutput: "alt{cat{lit{a}eot{}str{bc}}str{xyz}}",
 		},
-		testCase{
+		{
 			name:           "concat of sub expressions with illegal ^ and $",
 			input:          "(?:^a$bc$)(?:^xyz$)",
 			expectedOutput: "cat{lit{a}eot{}str{bc}eot{}bot{}str{xyz}}",
 		},
-		testCase{
+		{
 			name:           "question mark case both boundaries success",
 			input:          "(?:^abc$)?",
 			expectedOutput: "que{str{abc}}",
 		},
-		testCase{
+		{
 			name:           "question mark case only ^",
 			input:          "(?:^abc)?",
 			expectedOutput: "que{str{abc}}",
 		},
-		testCase{
+		{
 			name:           "question mark case only $",
 			input:          "(?:abc$)?",
 			expectedOutput: "que{str{abc}}",
 		},
-		testCase{
+		{
 			name:           "question concat case $",
 			input:          "abc$?",
 			expectedOutput: "str{abc}",
 		},
-		testCase{
+		{
 			name:           "star mark case both boundaries success",
 			input:          "(?:^abc$)*",
 			expectedOutput: "cat{que{str{abc}}star{cat{bot{}str{abc}eot{}}}}",
 		},
-		testCase{
+		{
 			name:           "star mark case only ^",
 			input:          "(?:^abc)*",
 			expectedOutput: "cat{que{str{abc}}star{cat{bot{}str{abc}}}}",
 		},
-		testCase{
+		{
 			name:           "star mark case only $",
 			input:          "(?:abc$)*",
 			expectedOutput: "cat{que{str{abc}}star{cat{str{abc}eot{}}}}",
 		},
-		testCase{
+		{
 			name:           "star concat case $",
 			input:          "abc$*",
 			expectedOutput: "cat{str{abc}star{eot{}}}",
 		},
-		testCase{
+		{
 			name:           "star concat case ^",
 			input:          "^*abc",
 			expectedOutput: "cat{star{bot{}}str{abc}}",
 		},
-		testCase{
+		{
 			name:           "plus mark case both boundaries success",
 			input:          "(?:^abc$)+",
 			expectedOutput: "cat{str{abc}star{cat{bot{}str{abc}eot{}}}}",
 		},
-		testCase{
+		{
 			name:           "plus mark case with capturing group",
 			input:          "(^abc$)+",
 			expectedOutput: "cat{cap{str{abc}}star{cap{cat{bot{}str{abc}eot{}}}}}",
 		},
-		testCase{
+		{
 			name:           "plus mark case only ^",
 			input:          "(?:^abc)+",
 			expectedOutput: "cat{str{abc}star{cat{bot{}str{abc}}}}",
 		},
-		testCase{
+		{
 			name:           "plus mark case only $",
 			input:          "(?:abc$)+",
 			expectedOutput: "cat{str{abc}star{cat{str{abc}eot{}}}}",
 		},
-		testCase{
+		{
 			name:           "plus concat case $",
 			input:          "abc$+",
 			expectedOutput: "cat{str{abc}star{eot{}}}",
 		},
-		testCase{
+		{
 			name:           "plus concat case ^",
 			input:          "^+abc",
 			expectedOutput: "cat{star{bot{}}str{abc}}",
 		},
-		testCase{
+		{
 			name:           "repeat case both boundaries success",
 			input:          "(?:^abc$){3,4}",
 			expectedOutput: "cat{str{abc}rep{2,3 cat{bot{}str{abc}eot{}}}}",
 		},
-		testCase{
+		{
 			name:           "repeat case unbounded max",
 			input:          "(?:^abc$){3,}",
 			expectedOutput: "cat{str{abc}rep{2,-1 cat{bot{}str{abc}eot{}}}}",
 		},
-		testCase{
+		{
 			name:           "repeat case unbounded max with 1 min",
 			input:          "(?:^abc$){1,2}",
 			expectedOutput: "cat{str{abc}rep{0,1 cat{bot{}str{abc}eot{}}}}",
 		},
-		testCase{
+		{
 			name:           "repeat case unbounded max with 0 min",
 			input:          "(?:^abc$){0,2}",
 			expectedOutput: "rep{0,2 cat{bot{}str{abc}eot{}}}",
@@ -222,7 +222,7 @@ func TestEnsureRegexpUnachored(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			re, err := parseRegexp(tc.input)
 			require.NoError(t, err)
-			parsed, err := ensureRegexpUnanchored(re)
+			parsed, err := EnsureRegexpUnanchored(re)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedOutput, dumpRegexp(parsed))
 		})
@@ -231,57 +231,57 @@ func TestEnsureRegexpUnachored(t *testing.T) {
 
 func TestEnsureRegexpAnchored(t *testing.T) {
 	testCases := []testCase{
-		testCase{
+		{
 			name:           "naked ^",
 			input:          "(?:)",
 			expectedOutput: "cat{bot{}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "invalid naked concat ^$",
 			input:          "$^",
 			expectedOutput: "cat{bot{}eot{}bot{}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "simple case of literal",
 			input:          "abc",
 			expectedOutput: "cat{bot{}str{abc}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "weird case of internal ^",
 			input:          "a^bc",
 			expectedOutput: "cat{bot{}lit{a}bot{}str{bc}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "weird case of internal $",
 			input:          "a$bc",
 			expectedOutput: "cat{bot{}lit{a}eot{}str{bc}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "alternate of sub expressions with only legal ^ and $",
 			input:          "abc|xyz",
 			expectedOutput: "cat{bot{}alt{str{abc}str{xyz}}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "concat of sub expressions with only legal ^ and $",
 			input:          "(?:abc)(?:xyz)",
 			expectedOutput: "cat{bot{}str{abcxyz}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "question mark case both boundaries success",
 			input:          "(?:abc)?",
 			expectedOutput: "cat{bot{}que{str{abc}}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "star mark case both boundaries success",
 			input:          "(?:abc)*",
 			expectedOutput: "cat{bot{}star{str{abc}}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "plus mark case both boundaries success",
 			input:          "(?:abc)+",
 			expectedOutput: "cat{bot{}plus{str{abc}}eot{\\z}}",
 		},
-		testCase{
+		{
 			name:           "repeat case both boundaries success",
 			input:          "(?:abc){3,4}",
 			expectedOutput: "cat{bot{}str{abc}str{abc}str{abc}que{str{abc}}eot{\\z}}",
@@ -291,8 +291,7 @@ func TestEnsureRegexpAnchored(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			re, err := parseRegexp(tc.input)
 			require.NoError(t, err)
-			parsed, err := ensureRegexpAnchored(re)
-			require.NoError(t, err)
+			parsed := EnsureRegexpAnchored(re)
 			assert.Equal(t, tc.expectedOutput, dumpRegexp(parsed))
 		})
 	}

--- a/src/query/storage/index_test.go
+++ b/src/query/storage/index_test.go
@@ -236,6 +236,72 @@ func TestFetchQueryToM3Query(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "disjunction with empty (no field) match, no parens",
+			expected: "disjunction(negation(field(env)), regexp(env,one|))",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchRegexp,
+					Name:  []byte("env"),
+					Value: []byte("one|"),
+				},
+			},
+		},
+		{
+			name:     "disjunction with empty (no field) match",
+			expected: "disjunction(negation(field(env)), regexp(env,(|one|two)))",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchRegexp,
+					Name:  []byte("env"),
+					Value: []byte("(|one|two)"),
+				},
+			},
+		},
+		{
+			name:     "disjunction with non trivial empty (no field) match",
+			expected: "disjunction(negation(field(env)), regexp(env,\\d*|one))",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchRegexp,
+					Name:  []byte("env"),
+					Value: []byte("\\d*|one"),
+				},
+			},
+		},
+		{
+			name:     "disjunction with both empty (no field) matches",
+			expected: "disjunction(negation(field(env)), regexp(env,(|)))",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchRegexp,
+					Name:  []byte("env"),
+					Value: []byte("(|)"),
+				},
+			},
+		},
+		{
+			name:     "negated disjunction with empty (no field) match",
+			expected: "conjunction(field(env),negation(regexp(env,(|one))))",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchNotRegexp,
+					Name:  []byte("env"),
+					Value: []byte("(|one)"),
+				},
+			},
+		},
+		{
+			name:     "negated disjunction with both empty (no field) matches",
+			expected: "conjunction(field(env),negation(regexp(env,(|))))",
+			matchers: models.Matchers{
+				{
+					Type:  models.MatchNotRegexp,
+					Name:  []byte("env"),
+					Value: []byte("(|)"),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/src/x/regexp/empty_matcher.go
+++ b/src/x/regexp/empty_matcher.go
@@ -1,4 +1,24 @@
-// Package regexp contains regexp processing related utilities.
+// Copyright (c) 2023  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//Package regexp contains regexp processing related utilities.
 package regexp
 
 import (

--- a/src/x/regexp/empty_matcher.go
+++ b/src/x/regexp/empty_matcher.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//Package regexp contains regexp processing related utilities.
+// Package regexp contains regexp processing related utilities.
 package regexp
 
 import (

--- a/src/x/regexp/empty_matcher.go
+++ b/src/x/regexp/empty_matcher.go
@@ -1,0 +1,95 @@
+// Package regexp contains regexp processing related utilities.
+package regexp
+
+import (
+	"regexp"
+	"regexp/syntax"
+
+	"github.com/m3db/m3/src/m3ninx/index"
+)
+
+// MatchesEmptyValue returns true if the given regexp would match an empty value.
+func MatchesEmptyValue(expr []byte) (bool, error) {
+	parsed, err := syntax.Parse(string(expr), syntax.Perl)
+	if err != nil {
+		return false, err //nolint:propagate_error
+	}
+
+	switch matchesEmptyValueAnalytically(parsed) {
+	case yes:
+		return true, nil
+	case no:
+		return false, nil
+	default: // unknown - only now we resort to compilation and actual attempt to match the regexp
+		return matchesEmptyValueEmpirically(parsed)
+	}
+}
+
+func matchesEmptyValueAnalytically(r *syntax.Regexp) threeValuedLogic {
+	switch r.Op {
+	case syntax.OpEmptyMatch:
+		return yes
+
+	case syntax.OpLiteral:
+		if len(r.Rune) == 0 {
+			return yes
+		}
+		return no
+
+	case syntax.OpCharClass:
+		return no
+
+	case syntax.OpStar:
+		return yes
+
+	case syntax.OpCapture, syntax.OpPlus:
+		return matchesEmptyValueAnalytically(r.Sub[0])
+
+	case syntax.OpConcat:
+		var res = yes
+		for _, s := range r.Sub {
+			if m := matchesEmptyValueAnalytically(s); m == no {
+				return no
+			} else if m == unknown {
+				res = unknown
+			}
+		}
+		return res
+
+	case syntax.OpAlternate:
+		var res = no
+		for _, s := range r.Sub {
+			if m := matchesEmptyValueAnalytically(s); m == yes {
+				return yes
+			} else if m == unknown {
+				res = unknown
+			}
+		}
+		return res
+
+	default:
+		// If we even hit this case then we should fall back to
+		// compiling and running the regexp against an empty string.
+		return unknown
+	}
+}
+
+// matchesEmptyValueEmpirically follows the logic of index.CompileRegex(expr).
+func matchesEmptyValueEmpirically(r *syntax.Regexp) (bool, error) {
+	unanchored, err := index.EnsureRegexpUnanchored(r)
+	if err != nil {
+		return false, err //nolint:propagate_error
+	}
+
+	anchored := index.EnsureRegexpAnchored(unanchored)
+
+	return regexp.Match(anchored.String(), nil)
+}
+
+type threeValuedLogic uint8
+
+const (
+	no threeValuedLogic = iota
+	yes
+	unknown
+)

--- a/src/x/regexp/empty_matcher_test.go
+++ b/src/x/regexp/empty_matcher_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2023  Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package regexp
 
 import (

--- a/src/x/regexp/empty_matcher_test.go
+++ b/src/x/regexp/empty_matcher_test.go
@@ -1,0 +1,70 @@
+package regexp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchesEmptyValue(t *testing.T) {
+	tests := []struct {
+		given string
+		want  bool
+	}{
+		{given: "", want: true},
+		{given: "x", want: false},
+		{given: ".*", want: true},
+		{given: ".+", want: false},
+		{given: "x*", want: true},
+		{given: "x+", want: false},
+		{given: "|", want: true},
+		{given: "\\|", want: false},
+		{given: "[|]", want: false},
+		{given: "(|)", want: true},
+		{given: "a|b", want: false},
+		{given: "a||b", want: true},
+		{given: "a|", want: true},
+		{given: "|a", want: true},
+		{given: "|a|", want: true},
+		{given: "a|b|c", want: false},
+		{given: "||a|||b||||c||||", want: true},
+		{given: "()", want: true},
+		{given: "()*", want: true},
+		{given: "()+", want: true},
+		{given: "(ab)", want: false},
+		{given: "(ab)+", want: false},
+		{given: "(a|b)", want: false},
+		{given: "(a||b)", want: true},
+		{given: "(a|)", want: true},
+		{given: "(|a)", want: true},
+		{given: "(\\|a)", want: false},
+		{given: "([|])", want: false},
+		{given: "([|]a)", want: false},
+		{given: "([|a])", want: false},
+		{given: ".*|a", want: true},
+		{given: ".+|a", want: false},
+		{given: ".*|.+", want: true},
+		{given: ".*|.*", want: true},
+		{given: ".+|.+", want: false},
+		{given: "a(|)", want: false},
+		{given: "a(|)b", want: false},
+		{given: "(|)(|)", want: true},
+		{given: "(|)a(|)", want: false},
+		{given: "(|).*(|)", want: true},
+		{given: "(|).+(|)", want: false},
+		{given: "\\d*", want: true},
+		{given: "\\d+", want: false},
+		{given: "(\\d*|a)", want: true},
+		{given: "(a|\\d*)", want: true},
+		{given: "(|\\d*)", want: true},
+		{given: "a(\\d*)", want: false},
+		{given: "(\\d*)a", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.given, func(t *testing.T) {
+			res, err := MatchesEmptyValue([]byte(tt.given))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, res)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #4212

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
PromQL queries with regexp OR selectors matching an empty value will now include time series that do not have the given label set (which is the expected behaviour in PromQL).
For example, given time series: foo{bar="a"} and foo{}
and the query: foo{bar=~"|a"} both time series will be now returned by the query.
Prior to this fix, only foo{bar="a"} was being returned.
```

**Does this PR require updating code package or user-facing documentation?**:

```documentation-note
NONE
```
