### PR TITLE
[aggregator client] Export function NewClientOptions

### DIFF
--- a/src/aggregator/client/config.go
+++ b/src/aggregator/client/config.go
@@ -83,7 +83,7 @@ func (c *Configuration) NewClient(
 	instrumentOpts instrument.Options,
 	rwOpts xio.Options,
 ) (Client, error) {
-	opts, err := c.newClientOptions(kvClient, clockOpts, instrumentOpts, rwOpts)
+	opts, err := c.NewClientOptions(kvClient, clockOpts, instrumentOpts, rwOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,9 @@ var (
 	errLegacyClientNoWatcherConfig     = errors.New("no placement watcher config set")
 )
 
-func (c *Configuration) newClientOptions(
+// NewClientOptions creates Options that can be used to
+// create a New Aggregator Client.
+func (c *Configuration) NewClientOptions(
 	kvClient m3clusterclient.Client,
 	clockOpts clock.Options,
 	instrumentOpts instrument.Options,

--- a/src/aggregator/client/config_test.go
+++ b/src/aggregator/client/config_test.go
@@ -140,7 +140,7 @@ func TestNewClientOptions(t *testing.T) {
 	clockOpts := clock.NewOptions()
 	instrumentOpts := instrument.NewOptions()
 	rwOpts := xio.NewOptions()
-	opts, err := cfg.newClientOptions(kvClient, clockOpts, instrumentOpts, rwOpts)
+	opts, err := cfg.NewClientOptions(kvClient, clockOpts, instrumentOpts, rwOpts)
 	require.NoError(t, err)
 
 	// Verify the constructed options match expectations.


### PR DESCRIPTION
Export the constructor for Options to create an Aggregator Client so that connection options such as SocksProxy can be set.
