### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/scripts/docker-integration-tests/query_fanout/restrict.go
+++ b/scripts/docker-integration-tests/query_fanout/restrict.go
@@ -325,7 +325,7 @@ type values []value
 type value []interface{}
 
 func (r *result) genID() result {
-	tags := make(sort.StringSlice, len(r.Metric))
+	tags := make(sort.StringSlice, 0, len(r.Metric))
 	for k, v := range r.Metric {
 		tags = append(tags, fmt.Sprintf("%s:%s,", k, v))
 	}

--- a/src/cmd/services/m3comparator/main/parser/parser.go
+++ b/src/cmd/services/m3comparator/main/parser/parser.go
@@ -112,7 +112,7 @@ func (v *Value) UnmarshalJSON(data []byte) error {
 // IDOrGenID gets the ID for this result.
 func (r *Series) IDOrGenID() string {
 	if len(r.id) == 0 {
-		tags := make(sort.StringSlice, len(r.Tags))
+		tags := make(sort.StringSlice, 0, len(r.Tags))
 		for _, v := range r.Tags {
 			tags = append(tags, fmt.Sprintf("%s:%s,", v[0], v[1]))
 		}

--- a/src/dbnode/integration/integration_data_verify.go
+++ b/src/dbnode/integration/integration_data_verify.go
@@ -236,7 +236,7 @@ func writeVerifyDebugOutput(
 
 	list := make(readableSeriesList, 0, len(series))
 	for i := range series {
-		tags := make([]readableSeriesTag, len(series[i].Tags.Values()))
+		tags := make([]readableSeriesTag, 0, len(series[i].Tags.Values()))
 		for _, tag := range series[i].Tags.Values() {
 			tags = append(tags, readableSeriesTag{
 				Name:  tag.Name.String(),

--- a/src/query/api/v1/handler/prometheus/response.go
+++ b/src/query/api/v1/handler/prometheus/response.go
@@ -41,7 +41,7 @@ type data struct {
 	// ResultType is the type of Result (matrix, vector, etc.).
 	ResultType string
 	// Result contains the query result (concrete type depends on ResultType).
-	Result     result
+	Result result
 }
 
 type result interface {
@@ -169,7 +169,7 @@ type Values []Value
 type Value []interface{}
 
 func (t *Tags) genID() string {
-	tags := make(sort.StringSlice, len(*t))
+	tags := make(sort.StringSlice, 0, len(*t))
 	for k, v := range *t {
 		tags = append(tags, fmt.Sprintf("%s:%s,", k, v))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output

https://github.com/alingse/go-linter-runner/actions/runs/9242655147/job/25425748900

```
====================================================================================================
append to slice `tags` with non-zero initialized length at https://github.com/m3db/m3/blob/master/src/dbnode/integration/integration_data_verify.go#L241:11
====================================================================================================
```

but the linter can't find the `make(sort.StringSlice, len(*t))` so not reported in the actions output

**Special notes for your reviewer**

this is not cause a real bad bug because the `[]string` was sort and finally called by `WriteString(s)`

so the empty value string was save in the slice but ignored when called by `WriteString`

```go
func (r *result) genID() result {
	tags := make(sort.StringSlice, 0, len(r.Metric))
	for k, v := range r.Metric {
		tags = append(tags, fmt.Sprintf("%s:%s,", k, v))
	}

	sort.Sort(tags)
	var sb strings.Builder
	// NB: this may clash but exact tag values are also checked, and this is a
	// validation endpoint so there's less concern over correctness.
	for _, t := range tags {
		sb.WriteString(t) // this ignore the empty string t
	}
```

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
