### PR TITLE
[integration-tests] Fix etcd use of host.docker.internal on mac

### DIFF
--- a/src/x/test/log.go
+++ b/src/x/test/log.go
@@ -21,14 +21,12 @@
 package test
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
 // NewLogger returns a new test logger.
-func NewLogger(t *testing.T) *zap.Logger {
+func NewLogger(t require.TestingT) *zap.Logger {
 	zc := zap.NewDevelopmentConfig()
 	zc.DisableCaller = true
 	zl, err := zc.Build()


### PR DESCRIPTION
host.docker.internal doesn't work correctly for our etcd integration tests on Mac's, but localhost does. It used to be the case that host.docker.internal didn't resolve at all on Mac's--I encoded this fact into the health check logic for our docker container. Now it does resolve, so I've just switched to an explicit build constraint based version.
