### PR TITLE
[buildkite] Enable passing pipeline tests in buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -265,14 +265,14 @@ steps:
 #        env:
 #          - FOSSA_API_KEY
 #    <<: *common
-  - name: "Check for docker and docs builds :docker: :books:"
-    commands:
-    - ".ci/docker/check_do_docker.sh"
-    - ".buildkite/scripts/check_do_docs.sh"
-    agents:
-      queue: init
-    timeout_in_minutes: 10
-    retry:
-      automatic:
-        limit: 1
-      manual: true
+#  - name: "Check for docker and docs builds :docker: :books:"
+#    commands:
+#    - ".ci/docker/check_do_docker.sh"
+#    - ".buildkite/scripts/check_do_docs.sh"
+#    agents:
+#      queue: init
+#    timeout_in_minutes: 10
+#    retry:
+#      automatic:
+#        limit: 1
+#      manual: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,21 +90,37 @@ steps:
                 - |-
                   make clean install-vendor-m3 test-base
     <<: *common
-#  - name: "Big Unit %n"
-#    command: make clean install-vendor-m3 test-big-base
-#    parallelism: 2
-#    plugins:
-#      docker-compose#v2.5.1:
-#        run: app
-#        workdir: /go/src/github.com/m3db/m3
-#    <<: *common
-#  - name: "Services, Tools"
-#    command: make clean install-vendor-m3 services tools
-#    plugins:
-#      docker-compose#v2.5.1:
-#        run: app
-#        workdir: /go/src/github.com/m3db/m3
-#    <<: *common
+  - name: "Big Unit %n"
+    parallelism: 2
+    plugins:
+      docker-compose#v2.5.1:
+        run: app
+        workdir: /go/src/github.com/m3db/m3
+      kubernetes:
+        <<: *kubernetes
+        podSpec:
+          <<: *podSpec
+          containers:
+            - <<: *commandContainer
+              command:
+                - |-
+                  make clean install-vendor-m3 test-big-base
+    <<: *common
+  - name: "Services, Tools"
+    plugins:
+      docker-compose#v2.5.1:
+        run: app
+        workdir: /go/src/github.com/m3db/m3
+      kubernetes:
+        <<: *kubernetes
+        podSpec:
+          <<: *podSpec
+          containers:
+            - <<: *commandContainer
+              command:
+                - |-
+                  make clean install-vendor-m3 services tools
+    <<: *common
 #  - name: "Lint"
 #    command: make clean lint
 #    env:
@@ -124,23 +140,39 @@ steps:
 #        gopath-checkout#v1.0.1:
 #          import: github.com/m3db/m3
 #    <<: *common
-#  - label: "M3 Cluster Integration Tests"
-#    command: make clean test-ci-cluster-integration
-#    env:
-#      CGO_ENABLED: 0
-#      GIMME_GO_VERSION: 1.18.x
-#    plugins:
-#      gopath-checkout#v1.0.1:
-#        import: github.com/m3db/m3
-#    <<: *common
-#  - label: "M3 Cluster Integration Test Harness Tests"
-#    command: make clean test-ci-test-harness
-#    skip: "NB(nate): temporarily disabling to resolve some tests flakes"
-#    plugins:
-#      docker-compose#v2.5.1:
-#        run: app
-#        workdir: /go/src/github.com/m3db/m3
-#    <<: *common
+  - label: "M3 Cluster Integration Tests"
+    env:
+      CGO_ENABLED: 0
+      GIMME_GO_VERSION: 1.18.x
+    plugins:
+      gopath-checkout#v1.0.1:
+        import: github.com/m3db/m3
+      kubernetes:
+        <<: *kubernetes
+        podSpec:
+          <<: *podSpec
+          containers:
+            - <<: *commandContainer
+              command:
+                - |-
+                  make clean test-ci-cluster-integration
+    <<: *common
+  - label: "M3 Cluster Integration Test Harness Tests"
+    skip: "NB(nate): temporarily disabling to resolve some tests flakes"
+    plugins:
+      docker-compose#v2.5.1:
+        run: app
+        workdir: /go/src/github.com/m3db/m3
+      kubernetes:
+        <<: *kubernetes
+        podSpec:
+          <<: *podSpec
+          containers:
+            - <<: *commandContainer
+              command:
+                - |-
+                  make clean test-ci-test-harness
+    <<: *common
 #  - name: "Prometheus compatibility (:docker:)"
 #    command: make clean install-vendor-m3 docker-compatibility-test
 #    parallelism: 1
@@ -167,30 +199,54 @@ steps:
 #        run: app
 #        workdir: /go/src/github.com/m3db/m3
 #    <<: *common
-#  - name: "Integration (aggregator TCP client) %n"
-#    parallelism: 1
-#    command: make clean install-vendor-m3 test-ci-integration-aggregator aggregator_client=tcp
-#    plugins:
-#      docker-compose#v2.5.1:
-#        run: app
-#        workdir: /go/src/github.com/m3db/m3
-#    <<: *common
-#  - name: "Integration (aggregator m3msg client) %n"
-#    parallelism: 1
-#    command: make clean install-vendor-m3 test-ci-integration-aggregator aggregator_client=m3msg
-#    plugins:
-#      docker-compose#v2.5.1:
-#        run: app
-#        workdir: /go/src/github.com/m3db/m3
-#    <<: *common
-#  - label: "Integration (m3em, cluster, msg, metrics) %n"
-#    parallelism: 4
-#    command: make clean install-vendor-m3 test-ci-integration-m3em test-ci-integration-cluster test-ci-integration-msg test-ci-integration-metrics
-#    plugins:
-#      docker-compose#v2.5.1:
-#        run: app
-#        workdir: /go/src/github.com/m3db/m3
-#    <<: *common
+  - name: "Integration (aggregator TCP client) %n"
+    parallelism: 1
+    plugins:
+      docker-compose#v2.5.1:
+        run: app
+        workdir: /go/src/github.com/m3db/m3
+      kubernetes:
+        <<: *kubernetes
+        podSpec:
+          <<: *podSpec
+          containers:
+            - <<: *commandContainer
+              command:
+                - |-
+                  make clean install-vendor-m3 test-ci-integration-aggregator aggregator_client=tcp
+    <<: *common
+  - name: "Integration (aggregator m3msg client) %n"
+    parallelism: 1
+    plugins:
+      docker-compose#v2.5.1:
+        run: app
+        workdir: /go/src/github.com/m3db/m3
+      kubernetes:
+        <<: *kubernetes
+        podSpec:
+          <<: *podSpec
+          containers:
+            - <<: *commandContainer
+              command:
+                - |-
+                  make clean install-vendor-m3 test-ci-integration-aggregator aggregator_client=m3msg
+    <<: *common
+  - label: "Integration (m3em, cluster, msg, metrics) %n"
+    parallelism: 4
+    plugins:
+      docker-compose#v2.5.1:
+        run: app
+        workdir: /go/src/github.com/m3db/m3
+      kubernetes:
+        <<: *kubernetes
+        podSpec:
+          <<: *podSpec
+          containers:
+            - <<: *commandContainer
+              command:
+                - |-
+                  make clean install-vendor-m3 test-ci-integration-m3em test-ci-integration-cluster test-ci-integration-msg test-ci-integration-metrics
+    <<: *common
 #  - name: "Documentation tests"
 #    command: make clean install-vendor-m3 docs-test
 #    env:
@@ -209,14 +265,14 @@ steps:
 #        env:
 #          - FOSSA_API_KEY
 #    <<: *common
-#  - name: "Check for docker and docs builds :docker: :books:"
-#    commands:
-#    - ".ci/docker/check_do_docker.sh"
-#    - ".buildkite/scripts/check_do_docs.sh"
-#    agents:
-#      queue: init
-#    timeout_in_minutes: 10
-#    retry:
-#      automatic:
-#        limit: 1
-#      manual: true
+  - name: "Check for docker and docs builds :docker: :books:"
+    commands:
+    - ".ci/docker/check_do_docker.sh"
+    - ".buildkite/scripts/check_do_docs.sh"
+    agents:
+      queue: init
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1
+      manual: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Buildkite pipeline is migrated from using AWS queues to GCP queues. It currently only has basic unit tests enabled in the pipeline. This PR enables other passing pipeline steps. Future work needs to be done to fix the remaining broken pipeline steps. 
Fixes #4274 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
No

**Does this PR require updating code package or user-facing documentation?**:
No
