### PR TITLE
[buildkite] Remove deprecated fossa pipeline test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -289,15 +289,6 @@ steps:
 #        gopath-checkout#v1.0.1:
 #          import: github.com/m3db/m3
 #    <<: *common
-#  - label: "FOSSA license scan"
-#    command: make clean install-vendor-m3 fossa
-#    plugins:
-#      docker-compose#v2.5.1:
-#        run: app
-#        workdir: /go/src/github.com/m3db/m3
-#        env:
-#          - FOSSA_API_KEY
-#    <<: *common
   - name: "Check for docker and docs builds :docker: :books:"
     plugins:
       kubernetes:


### PR DESCRIPTION
**What this PR does / why we need it**:
FOSSA is EOL as of December 31, 2023. Removing FOSSA license scan from our pipeline.

Fixes #4274 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
No

**Does this PR require updating code package or user-facing documentation?**:
No
