### PR TITLE
Temporarily comment out quay.io buildkite steps

### DIFF
--- a/.buildkite/image-release-pipeline.yml
+++ b/.buildkite/image-release-pipeline.yml
@@ -1,36 +1,36 @@
 steps:
   # We add a wait step here so that docker images and docs won't get built
   # unless rest of CI passes.
-  - wait
-  - name: ":docker: build quay.io/m3db"
-    command: ".ci/docker/build.sh"
-    env:
-      M3_DOCKER_REPO: quay.io/m3db
-    agents:
-      queue: "buildkite-gcp"
-    timeout_in_minutes: 60
-    retry:
-      automatic:
-        limit: 1
-      manual: true
-    plugins:
-      - docker-login#v2.0.1:
-          server: quay.io
-          username: m3db+buildkite
-          password-env: QUAY_M3DB_TOKEN
-  - name: ":docker: build quay.io/m3"
-    command: ".ci/docker/build.sh"
-    env:
-      M3_DOCKER_REPO: quay.io/m3
-    agents:
-      queue: "buildkite-gcp"
-    timeout_in_minutes: 60
-    retry:
-      automatic:
-        limit: 1
-      manual: true
-    plugins:
-      - docker-login#v2.0.1:
-          server: quay.io
-          username: m3+buildkite
-          password-env: QUAY_M3_TOKEN
+#  - wait
+#  - name: ":docker: build quay.io/m3db"
+#    command: ".ci/docker/build.sh"
+#    env:
+#      M3_DOCKER_REPO: quay.io/m3db
+#    agents:
+#      queue: "buildkite-gcp"
+#    timeout_in_minutes: 60
+#    retry:
+#      automatic:
+#        limit: 1
+#      manual: true
+#    plugins:
+#      - docker-login#v2.0.1:
+#          server: quay.io
+#          username: m3db+buildkite
+#          password-env: QUAY_M3DB_TOKEN
+#  - name: ":docker: build quay.io/m3"
+#    command: ".ci/docker/build.sh"
+#    env:
+#      M3_DOCKER_REPO: quay.io/m3
+#    agents:
+#      queue: "buildkite-gcp"
+#    timeout_in_minutes: 60
+#    retry:
+#      automatic:
+#        limit: 1
+#      manual: true
+#    plugins:
+#      - docker-login#v2.0.1:
+#          server: quay.io
+#          username: m3+buildkite
+#          password-env: QUAY_M3_TOKEN

--- a/.buildkite/image-release-pipeline.yml
+++ b/.buildkite/image-release-pipeline.yml
@@ -1,6 +1,7 @@
 steps:
   # We add a wait step here so that docker images and docs won't get built
   # unless rest of CI passes.
+# Temporarily commenting out the following steps to make pipeline green. ISSUE: https://github.com/m3db/m3/issues/4289
 #  - wait
 #  - name: ":docker: build quay.io/m3db"
 #    command: ".ci/docker/build.sh"


### PR DESCRIPTION
**What this PR does / why we need it**:
Failing build which is caused by failing quay.io step: https://buildkite.com/uberopensource/m3-monorepo-ci-uber-oss/builds/404#019151d7-5dd3-4ea8-af49-05c3168d004f 
We need to make the build green, so temporarily commenting out the quay.io steps, until a solution is found.

Addresses #4289 

