### PR TITLE
[dbnode] Fix the insertion of entries in shard entry list to maintain strictly increasing order of unique index

### DIFF
--- a/src/dbnode/integration/admin_session_fetch_bootstrap_blocks_metadata_test.go
+++ b/src/dbnode/integration/admin_session_fetch_bootstrap_blocks_metadata_test.go
@@ -1,0 +1,145 @@
+package integration
+
+import (
+	"fmt"
+	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/dbnode/integration/generate"
+	"github.com/m3db/m3/src/dbnode/storage/block"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	"github.com/m3db/m3/src/x/ident"
+	xtime "github.com/m3db/m3/src/x/time"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAdminSessionFetchBootstrapBlocksMetadataFromPeer(t *testing.T) {
+
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	numOfActiveSeries := 1000
+	writeBatchSize := 100
+	readBatchSize := 10
+
+	testOpts := NewTestOptions(t).SetUseTChannelClientForWriting(true).SetNumShards(1).SetFetchSeriesBlocksBatchSize(readBatchSize)
+	testSetup, err := NewTestSetup(t, testOpts, nil)
+	require.NoError(t, err)
+	defer testSetup.Close()
+
+	// Start the server
+	log := testSetup.StorageOpts().InstrumentOptions().Logger()
+	require.NoError(t, testSetup.StartServer())
+
+	// Stop the server
+	defer func() {
+		require.NoError(t, testSetup.StopServer())
+		log.Debug("server is now down")
+	}()
+
+	start := testSetup.NowFn()()
+	testSetup.SetNowFn(start)
+
+	// Write test data
+	writeTestData(t, testSetup, testNamespaces[0], start, numOfActiveSeries, writeBatchSize)
+
+	testSetup.SetNowFn(testSetup.NowFn()().Add(10 * time.Minute))
+	end := testSetup.NowFn()()
+
+	// Fetch and verify metadata
+	observedSeries := getTestSetupBootstrapBlocksMetadata(t, testSetup, testNamespaces[0], start, end)
+	verifySeriesMetadata(t, numOfActiveSeries, observedSeries)
+}
+
+func writeTestData(t *testing.T, testSetup TestSetup, namespace ident.ID, start xtime.UnixNano, numOfSeries int, batchSize int) {
+	var wg sync.WaitGroup
+
+	for i := 0; i < numOfSeries; i += batchSize {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < batchSize; j++ {
+				id := fmt.Sprintf("foo_%d_%d", i, j)
+				currInput := generate.BlockConfig{IDs: []string{id}, Start: start, NumPoints: 5}
+				testData := generate.Block(currInput)
+				require.NoError(t, testSetup.WriteBatch(namespace, testData))
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func getTestSetupBootstrapBlocksMetadata(t *testing.T,
+	testSetup TestSetup,
+	namespace ident.ID,
+	start xtime.UnixNano,
+	end xtime.UnixNano,
+) map[string]int {
+	adminClient := testSetup.M3DBVerificationAdminClient()
+	metadatasByShard, err := m3dbClientFetchBootstrapBlocksMetadata(adminClient,
+		namespace, testSetup.ShardSet().AllIDs(), start, end)
+	require.NoError(t, err)
+
+	// Setup only has one shard
+	return getTestsSetupSeriesMetadataMap(metadatasByShard[0])
+}
+
+func getTestsSetupSeriesMetadataMap(metadatas []block.ReplicaMetadata) map[string]int {
+	seriesMap := make(map[string]int, 100000)
+	for _, block := range metadatas {
+		idString := block.ID.String()
+		seriesMap[idString]++
+	}
+	return seriesMap
+}
+
+func m3dbClientFetchBootstrapBlocksMetadata(
+	c client.AdminClient,
+	namespace ident.ID,
+	shards []uint32,
+	start, end xtime.UnixNano,
+) (map[uint32][]block.ReplicaMetadata, error) {
+	session, err := c.DefaultAdminSession()
+	if err != nil {
+		return nil, err
+	}
+	metadatasByShard := make(map[uint32][]block.ReplicaMetadata, 100000)
+	for _, shardID := range shards {
+
+		var metadatas []block.ReplicaMetadata
+		iter, err := session.FetchBootstrapBlocksMetadataFromPeers(namespace,
+			shardID, start, end, result.NewOptions())
+		if err != nil {
+			return nil, err
+		}
+
+		for iter.Next() {
+			host, blockMetadata := iter.Current()
+			metadatas = append(metadatas, block.ReplicaMetadata{
+				Metadata: blockMetadata,
+				Host:     host,
+			})
+		}
+		if err := iter.Err(); err != nil {
+			return nil, err
+		}
+
+		if metadatas != nil {
+			metadatasByShard[shardID] = metadatas
+		}
+	}
+	return metadatasByShard, nil
+}
+
+func verifySeriesMetadata(
+	t *testing.T,
+	expectedTotalSeries int,
+	observed map[string]int,
+) {
+	require.Equal(t, expectedTotalSeries, len(observed))
+	for expectedSeries, count := range observed {
+		require.Equal(t, 1, count, "expected series %s metadata was expected to be observed once", expectedSeries)
+	}
+}

--- a/src/dbnode/integration/options.go
+++ b/src/dbnode/integration/options.go
@@ -70,6 +70,9 @@ const (
 	// defaultUseTChannelClientForWriting determines whether we use the tchannel client for writing by default.
 	defaultUseTChannelClientForWriting = false
 
+	// defaultFetchSeriesBlocksBatchSize is the default fetch series blocks batch size
+	defaultFetchSeriesBlocksBatchSize = 4096
+
 	// defaultUseTChannelClientForTruncation determines whether we use the tchannel client for truncation by default.
 	defaultUseTChannelClientForTruncation = true
 
@@ -335,6 +338,12 @@ type TestOptions interface {
 
 	// CustomAdminOptions gets custom options to apply to the admin client connection.
 	CustomAdminOptions() []client.CustomAdminOption
+
+	// SetFetchSeriesBlocksBatchSize sets the batch size for fetching series blocks in batch.
+	SetFetchSeriesBlocksBatchSize(value int) TestOptions
+
+	// FetchSeriesBlocksBatchSize gets the batch size for fetching series blocks in batch.
+	FetchSeriesBlocksBatchSize() int
 }
 
 type options struct {
@@ -370,6 +379,7 @@ type options struct {
 	writeNewSeriesAsync                                bool
 	protoEncoding                                      bool
 	shardLeavingAndInitializingCountsTowardConsistency bool
+	fetchSeriesBlocksBatchSize                         int
 	assertEqual                                        assertTestDataEqual
 	nowFn                                              func() time.Time
 	reportInterval                                     time.Duration
@@ -410,6 +420,7 @@ func NewTestOptions(t *testing.T) TestOptions {
 		useTChannelClientForTruncation: defaultUseTChannelClientForTruncation,
 		writeNewSeriesAsync:            defaultWriteNewSeriesAsync,
 		reportInterval:                 defaultReportInterval,
+		fetchSeriesBlocksBatchSize:     defaultFetchSeriesBlocksBatchSize,
 	}
 }
 
@@ -784,4 +795,14 @@ func (o *options) SetCustomAdminOptions(value []client.CustomAdminOption) TestOp
 
 func (o *options) CustomAdminOptions() []client.CustomAdminOption {
 	return o.customAdminOpts
+}
+
+func (o *options) SetFetchSeriesBlocksBatchSize(value int) TestOptions {
+	opts := *o
+	opts.fetchSeriesBlocksBatchSize = value
+	return &opts
+}
+
+func (o *options) FetchSeriesBlocksBatchSize() int {
+	return o.fetchSeriesBlocksBatchSize
 }

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -1144,9 +1144,9 @@ func newClients(
 		origin             = newOrigin(id, tchannelNodeAddr)
 		verificationOrigin = newOrigin(id+"-verification", tchannelNodeAddr)
 
-		adminOpts = clientOpts.(client.AdminOptions).SetOrigin(origin).SetSchemaRegistry(schemaReg)
+		adminOpts = clientOpts.(client.AdminOptions).SetOrigin(origin).SetSchemaRegistry(schemaReg).SetFetchSeriesBlocksBatchSize(opts.FetchSeriesBlocksBatchSize())
 
-		verificationAdminOpts = adminOpts.SetOrigin(verificationOrigin).SetSchemaRegistry(schemaReg)
+		verificationAdminOpts = adminOpts.SetOrigin(verificationOrigin).SetSchemaRegistry(schemaReg).SetFetchSeriesBlocksBatchSize(opts.FetchSeriesBlocksBatchSize())
 	)
 
 	if opts.ProtoEncoding() {

--- a/src/dbnode/storage/entry.go
+++ b/src/dbnode/storage/entry.go
@@ -133,7 +133,7 @@ type Entry struct {
 	nowFn                    clock.NowFn
 	metrics                  *EntryMetrics
 	pendingIndexBatchSizeOne []writes.PendingIndexInsert
-	// Index assigned to entry while adding it to the shard
+	// indexInShard is assigned to entry while adding it to the shard.
 	indexInShard xatomic.Uint64
 }
 

--- a/src/dbnode/storage/entry.go
+++ b/src/dbnode/storage/entry.go
@@ -133,6 +133,8 @@ type Entry struct {
 	nowFn                    clock.NowFn
 	metrics                  *EntryMetrics
 	pendingIndexBatchSizeOne []writes.PendingIndexInsert
+	// Index assigned to entry while adding it to the shard
+	indexInShard xatomic.Uint64
 }
 
 // ensure Entry satisfies the `doc.OnIndexSeries` interface.

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -118,7 +118,6 @@ type dbShard struct {
 	opts                  Options
 	seriesOpts            series.Options
 	nowFn                 clock.NowFn
-	state                 dbShardState
 	namespace             namespace.Metadata
 	seriesBlockRetriever  series.QueryableBlockRetriever
 	seriesOnRetrieveBlock block.OnRetrieveBlock
@@ -127,11 +126,14 @@ type dbShard struct {
 	seriesPool            series.DatabaseSeriesPool
 	reverseIndex          NamespaceIndex
 	insertQueue           *dbShardInsertQueue
-	lookup                *shardMap
-	list                  *list.List
-	// protected by dbShard lock
-	lastEntryIndex           uint64
-	bootstrapState           BootstrapState
+
+	// protected by dbShard lock.
+	lastEntryIndex uint64
+	lookup         *shardMap
+	list           *list.List
+	state          dbShardState
+	bootstrapState BootstrapState
+
 	newMergerFn              fs.NewMergerFn
 	newFSMergeWithMemFn      newFSMergeWithMemFn
 	filesetsFn               filesetsFn

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -1506,6 +1506,8 @@ func (s *dbShard) insertNewShardEntryWithLock(entry *Entry) {
 	listElem := s.list.Back()
 	if listElem == nil || listElem.Value.(*Entry).Index < entry.Index {
 		listElem = s.list.PushBack(entry)
+	} else if elem := s.list.Front(); elem == nil || elem.Value.(*Entry).Index > entry.Index {
+		listElem = s.list.PushFront(entry)
 	} else {
 		for listElem != nil && listElem.Value.(*Entry).Index > entry.Index {
 			listElem = listElem.Prev()
@@ -1584,6 +1586,7 @@ func (s *dbShard) insertSeriesBatch(inserts []dbShardInsert) error {
 		entry = inserts[i].entry
 		entriesToInsert = append(entriesToInsert, entry)
 	}
+	s.insertNewShardEntriesWithLock(entriesToInsert)
 	s.Unlock()
 
 	if !anyPendingAction {

--- a/src/dbnode/storage/shard_fetch_blocks_metadata_test.go
+++ b/src/dbnode/storage/shard_fetch_blocks_metadata_test.go
@@ -73,6 +73,7 @@ func TestShardFetchBlocksMetadataV2WithSeriesCachePolicyCacheAll(t *testing.T) {
 	}
 	lastRead := xtime.Now().Add(-time.Minute)
 	for i := int64(0); i < 10; i++ {
+		entryIndex := i + 1
 		id := ident.StringID(fmt.Sprintf("foo.%d", i))
 		tags := ident.NewTags(
 			ident.StringTag("aaa", "bbb"),
@@ -80,12 +81,12 @@ func TestShardFetchBlocksMetadataV2WithSeriesCachePolicyCacheAll(t *testing.T) {
 		)
 		tagsIter := ident.NewTagsIterator(tags)
 		series := addMockSeries(ctrl, shard, id, tags, uint64(i))
-		if i == startCursor {
+		if entryIndex == startCursor {
 			series.EXPECT().
 				FetchBlocksMetadata(gomock.Not(nil), start, end, seriesFetchOpts).
 				Return(block.NewFetchBlocksMetadataResult(id, tagsIter,
 					block.NewFetchBlockMetadataResults()), nil)
-		} else if i > startCursor && i <= startCursor+fetchLimit {
+		} else if entryIndex > startCursor && entryIndex <= startCursor+fetchLimit {
 			ids = append(ids, id)
 			blocks := block.NewFetchBlockMetadataResults()
 			at := start.Add(time.Duration(i))

--- a/src/dbnode/storage/shard_insert_queue.go
+++ b/src/dbnode/storage/shard_insert_queue.go
@@ -59,6 +59,9 @@ func (d dbShardInsertByEntryIndex) Len() int {
 }
 
 func (d dbShardInsertByEntryIndex) Less(i, j int) bool {
+	if d[i].entry == nil || d[j].entry == nil {
+		return true
+	}
 	return d[i].entry.Index < d[j].entry.Index
 }
 func (d dbShardInsertByEntryIndex) Swap(i, j int) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
This PR fixes the logic to insert the entries in shard entry list to maintain the strictly increasing order of entry's unique index added to the list. This will fix the issue of skipping few series IDs while fetching the block metadata for peer bootstrapping. 
During peer bootstrapping the dbnode fetches the series metadata from peers via `FetchBlocksMetadataRawV2` call. The  pagination logic for this call is based on the assumption that entries are added in a strictly increasing order of entry's  unique index to the shard  list. While debugging the issue of data loss during peer bootstrapping it was found that some of the entries are not added in this order. This causes some of the series Ids to be skipped during peer bootstrapping which in turn results in data loss if a particular series id is skipped by every peer.
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
