### PR TITLE
[dbnode] Add extra entry field to fix the strictly increasing order of shard entry list for FetchBlocksMetadata pagination

### DIFF
--- a/src/dbnode/integration/admin_session_fetch_bootstrap_blocks_metadata_test.go
+++ b/src/dbnode/integration/admin_session_fetch_bootstrap_blocks_metadata_test.go
@@ -1,0 +1,149 @@
+package integration
+
+import (
+	"fmt"
+	"github.com/m3db/m3/src/dbnode/client"
+	"github.com/m3db/m3/src/dbnode/integration/generate"
+	"github.com/m3db/m3/src/dbnode/storage/block"
+	"github.com/m3db/m3/src/dbnode/storage/bootstrap/result"
+	"github.com/m3db/m3/src/x/ident"
+	xtime "github.com/m3db/m3/src/x/time"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAdminSessionFetchBootstrapBlocksMetadataFromPeer(t *testing.T) {
+
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	numOfActiveSeries := 1000
+	writeBatchSize := 7
+	readBatchSize := 13
+
+	testOpts := NewTestOptions(t).SetUseTChannelClientForWriting(true).SetNumShards(1).SetFetchSeriesBlocksBatchSize(readBatchSize)
+	testSetup, err := NewTestSetup(t, testOpts, nil)
+	require.NoError(t, err)
+	defer testSetup.Close()
+
+	// Start the server
+	log := testSetup.StorageOpts().InstrumentOptions().Logger()
+	require.NoError(t, testSetup.StartServer())
+
+	// Stop the server
+	defer func() {
+		require.NoError(t, testSetup.StopServer())
+		log.Debug("server is now down")
+	}()
+
+	start := testSetup.NowFn()()
+	testSetup.SetNowFn(start)
+
+	// Write test data
+	writeTestData(t, testSetup, testNamespaces[0], start, numOfActiveSeries, writeBatchSize)
+
+	testSetup.SetNowFn(testSetup.NowFn()().Add(10 * time.Minute))
+	end := testSetup.NowFn()()
+
+	// Fetch and verify metadata
+	observedSeries := newTestSetupBootstrapBlocksMetadata(t, testSetup, testNamespaces[0], start, end)
+	verifySeriesMetadata(t, numOfActiveSeries, observedSeries)
+}
+
+func writeTestData(t *testing.T, testSetup TestSetup, namespace ident.ID, start xtime.UnixNano, numOfSeries int, batchSize int) {
+	var wg sync.WaitGroup
+
+	for i := 0; i < numOfSeries; i += batchSize {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			size := batchSize
+			if numOfSeries-i < batchSize {
+				size = numOfSeries - i
+			}
+			for j := 0; j < size; j++ {
+				id := fmt.Sprintf("foo_%d_%d", i, j)
+				currInput := generate.BlockConfig{IDs: []string{id}, Start: start, NumPoints: 5}
+				testData := generate.Block(currInput)
+				require.NoError(t, testSetup.WriteBatch(namespace, testData))
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func newTestSetupBootstrapBlocksMetadata(t *testing.T,
+	testSetup TestSetup,
+	namespace ident.ID,
+	start xtime.UnixNano,
+	end xtime.UnixNano,
+) map[string]int {
+	adminClient := testSetup.M3DBVerificationAdminClient()
+	metadatasByShard, err := m3dbClientFetchBootstrapBlocksMetadata(adminClient,
+		namespace, testSetup.ShardSet().AllIDs(), start, end)
+	require.NoError(t, err)
+
+	// Setup only has one shard
+	return newTestsSetupSeriesMetadataMap(metadatasByShard[0])
+}
+
+func newTestsSetupSeriesMetadataMap(metadatas []block.ReplicaMetadata) map[string]int {
+	seriesMap := make(map[string]int, 100000)
+	for _, block := range metadatas {
+		idString := block.ID.String()
+		seriesMap[idString]++
+	}
+	return seriesMap
+}
+
+func m3dbClientFetchBootstrapBlocksMetadata(
+	c client.AdminClient,
+	namespace ident.ID,
+	shards []uint32,
+	start, end xtime.UnixNano,
+) (map[uint32][]block.ReplicaMetadata, error) {
+	session, err := c.DefaultAdminSession()
+	if err != nil {
+		return nil, err
+	}
+	metadatasByShard := make(map[uint32][]block.ReplicaMetadata, 100000)
+	for _, shardID := range shards {
+
+		var metadatas []block.ReplicaMetadata
+		iter, err := session.FetchBootstrapBlocksMetadataFromPeers(namespace,
+			shardID, start, end, result.NewOptions())
+		if err != nil {
+			return nil, err
+		}
+
+		for iter.Next() {
+			host, blockMetadata := iter.Current()
+			metadatas = append(metadatas, block.ReplicaMetadata{
+				Metadata: blockMetadata,
+				Host:     host,
+			})
+		}
+		if err := iter.Err(); err != nil {
+			return nil, err
+		}
+
+		if metadatas != nil {
+			metadatasByShard[shardID] = metadatas
+		}
+	}
+	return metadatasByShard, nil
+}
+
+func verifySeriesMetadata(
+	t *testing.T,
+	expectedTotalSeries int,
+	observed map[string]int,
+) {
+	require.Equal(t, expectedTotalSeries, len(observed))
+	for expectedSeries, count := range observed {
+		require.Equal(t, 1, count, "expected series %s metadata was expected to be observed once", expectedSeries)
+	}
+}

--- a/src/dbnode/integration/options.go
+++ b/src/dbnode/integration/options.go
@@ -70,6 +70,9 @@ const (
 	// defaultUseTChannelClientForWriting determines whether we use the tchannel client for writing by default.
 	defaultUseTChannelClientForWriting = false
 
+	// defaultFetchSeriesBlocksBatchSize is the default fetch series blocks batch size
+	defaultFetchSeriesBlocksBatchSize = 4096
+
 	// defaultUseTChannelClientForTruncation determines whether we use the tchannel client for truncation by default.
 	defaultUseTChannelClientForTruncation = true
 
@@ -335,6 +338,12 @@ type TestOptions interface {
 
 	// CustomAdminOptions gets custom options to apply to the admin client connection.
 	CustomAdminOptions() []client.CustomAdminOption
+
+	// SetFetchSeriesBlocksBatchSize sets the batch size for fetching series blocks in batch.
+	SetFetchSeriesBlocksBatchSize(value int) TestOptions
+
+	// FetchSeriesBlocksBatchSize gets the batch size for fetching series blocks in batch.
+	FetchSeriesBlocksBatchSize() int
 }
 
 type options struct {
@@ -370,6 +379,7 @@ type options struct {
 	writeNewSeriesAsync                                bool
 	protoEncoding                                      bool
 	shardLeavingAndInitializingCountsTowardConsistency bool
+	fetchSeriesBlocksBatchSize                         int
 	assertEqual                                        assertTestDataEqual
 	nowFn                                              func() time.Time
 	reportInterval                                     time.Duration
@@ -410,6 +420,7 @@ func NewTestOptions(t *testing.T) TestOptions {
 		useTChannelClientForTruncation: defaultUseTChannelClientForTruncation,
 		writeNewSeriesAsync:            defaultWriteNewSeriesAsync,
 		reportInterval:                 defaultReportInterval,
+		fetchSeriesBlocksBatchSize:     defaultFetchSeriesBlocksBatchSize,
 	}
 }
 
@@ -784,4 +795,14 @@ func (o *options) SetCustomAdminOptions(value []client.CustomAdminOption) TestOp
 
 func (o *options) CustomAdminOptions() []client.CustomAdminOption {
 	return o.customAdminOpts
+}
+
+func (o *options) SetFetchSeriesBlocksBatchSize(value int) TestOptions {
+	opts := *o
+	opts.fetchSeriesBlocksBatchSize = value
+	return &opts
+}
+
+func (o *options) FetchSeriesBlocksBatchSize() int {
+	return o.fetchSeriesBlocksBatchSize
 }

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -1144,9 +1144,9 @@ func newClients(
 		origin             = newOrigin(id, tchannelNodeAddr)
 		verificationOrigin = newOrigin(id+"-verification", tchannelNodeAddr)
 
-		adminOpts = clientOpts.(client.AdminOptions).SetOrigin(origin).SetSchemaRegistry(schemaReg)
+		adminOpts = clientOpts.(client.AdminOptions).SetOrigin(origin).SetSchemaRegistry(schemaReg).SetFetchSeriesBlocksBatchSize(opts.FetchSeriesBlocksBatchSize())
 
-		verificationAdminOpts = adminOpts.SetOrigin(verificationOrigin).SetSchemaRegistry(schemaReg)
+		verificationAdminOpts = adminOpts.SetOrigin(verificationOrigin).SetSchemaRegistry(schemaReg).SetFetchSeriesBlocksBatchSize(opts.FetchSeriesBlocksBatchSize())
 	)
 
 	if opts.ProtoEncoding() {

--- a/src/dbnode/integration/setup.go
+++ b/src/dbnode/integration/setup.go
@@ -1144,9 +1144,15 @@ func newClients(
 		origin             = newOrigin(id, tchannelNodeAddr)
 		verificationOrigin = newOrigin(id+"-verification", tchannelNodeAddr)
 
-		adminOpts = clientOpts.(client.AdminOptions).SetOrigin(origin).SetSchemaRegistry(schemaReg).SetFetchSeriesBlocksBatchSize(opts.FetchSeriesBlocksBatchSize())
+		adminOpts = clientOpts.(client.AdminOptions).
+				SetOrigin(origin).
+				SetSchemaRegistry(schemaReg).
+				SetFetchSeriesBlocksBatchSize(opts.FetchSeriesBlocksBatchSize())
 
-		verificationAdminOpts = adminOpts.SetOrigin(verificationOrigin).SetSchemaRegistry(schemaReg).SetFetchSeriesBlocksBatchSize(opts.FetchSeriesBlocksBatchSize())
+		verificationAdminOpts = adminOpts.
+					SetOrigin(verificationOrigin).
+					SetSchemaRegistry(schemaReg).
+					SetFetchSeriesBlocksBatchSize(opts.FetchSeriesBlocksBatchSize())
 	)
 
 	if opts.ProtoEncoding() {

--- a/src/dbnode/storage/entry.go
+++ b/src/dbnode/storage/entry.go
@@ -133,6 +133,8 @@ type Entry struct {
 	nowFn                    clock.NowFn
 	metrics                  *EntryMetrics
 	pendingIndexBatchSizeOne []writes.PendingIndexInsert
+	// indexInShard is assigned to entry while adding it to the shard.
+	indexInShard xatomic.Uint64
 }
 
 // ensure Entry satisfies the `doc.OnIndexSeries` interface.

--- a/src/dbnode/storage/shard.go
+++ b/src/dbnode/storage/shard.go
@@ -115,21 +115,25 @@ const (
 type dbShard struct {
 	sync.RWMutex
 	block.DatabaseBlockRetriever
-	opts                     Options
-	seriesOpts               series.Options
-	nowFn                    clock.NowFn
-	state                    dbShardState
-	namespace                namespace.Metadata
-	seriesBlockRetriever     series.QueryableBlockRetriever
-	seriesOnRetrieveBlock    block.OnRetrieveBlock
-	namespaceReaderMgr       databaseNamespaceReaderManager
-	increasingIndex          increasingIndex
-	seriesPool               series.DatabaseSeriesPool
-	reverseIndex             NamespaceIndex
-	insertQueue              *dbShardInsertQueue
-	lookup                   *shardMap
-	list                     *list.List
-	bootstrapState           BootstrapState
+	opts                  Options
+	seriesOpts            series.Options
+	nowFn                 clock.NowFn
+	namespace             namespace.Metadata
+	seriesBlockRetriever  series.QueryableBlockRetriever
+	seriesOnRetrieveBlock block.OnRetrieveBlock
+	namespaceReaderMgr    databaseNamespaceReaderManager
+	increasingIndex       increasingIndex
+	seriesPool            series.DatabaseSeriesPool
+	reverseIndex          NamespaceIndex
+	insertQueue           *dbShardInsertQueue
+
+	// protected by dbShard lock.
+	lastEntryIndex uint64
+	lookup         *shardMap
+	list           *list.List
+	state          dbShardState
+	bootstrapState BootstrapState
+
 	newMergerFn              fs.NewMergerFn
 	newFSMergeWithMemFn      newFSMergeWithMemFn
 	filesetsFn               filesetsFn
@@ -1415,6 +1419,10 @@ func (s *dbShard) insertNewShardEntryWithLock(entry *Entry) {
 	// finalize it.
 	copiedID := entry.Series.ID()
 	listElem := s.list.PushBack(entry)
+	// It is important to keep increasing order of shard index since it's used for cursor pagination filtering
+	// when peers bootstrapping in memory block.
+	s.lastEntryIndex++
+	entry.indexInShard.Store(s.lastEntryIndex)
 	s.lookup.SetUnsafe(copiedID, listElem, shardMapSetUnsafeOptions{
 		NoCopyKey:     true,
 		NoFinalizeKey: true,
@@ -1481,7 +1489,6 @@ func (s *dbShard) insertSeriesBatch(inserts []dbShardInsert) error {
 			s.metrics.insertAsyncInsertErrors.Inc(int64(len(inserts) - i))
 			return err
 		}
-
 		// Insert still pending, perform the insert
 		entry = inserts[i].entry
 		s.insertNewShardEntryWithLock(entry)
@@ -1654,13 +1661,13 @@ func (s *dbShard) fetchActiveBlocksMetadata(
 	s.forEachShardEntry(func(entry *Entry) bool {
 		// Break out of the iteration loop once we've accumulated enough entries.
 		if int64(len(res.Results())) >= limit {
-			next := int64(entry.Index)
+			next := int64(entry.indexInShard.Load())
 			nextIndexCursor = &next
 			return false
 		}
 
 		// Fast forward past indexes lower than page token
-		if int64(entry.Index) < indexCursor {
+		if int64(entry.indexInShard.Load()) < indexCursor {
 			return true
 		}
 

--- a/src/dbnode/storage/shard_fetch_blocks_metadata_test.go
+++ b/src/dbnode/storage/shard_fetch_blocks_metadata_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -72,6 +73,7 @@ func TestShardFetchBlocksMetadataV2WithSeriesCachePolicyCacheAll(t *testing.T) {
 	}
 	lastRead := xtime.Now().Add(-time.Minute)
 	for i := int64(0); i < 10; i++ {
+		entryIndex := i + 1
 		id := ident.StringID(fmt.Sprintf("foo.%d", i))
 		tags := ident.NewTags(
 			ident.StringTag("aaa", "bbb"),
@@ -79,12 +81,12 @@ func TestShardFetchBlocksMetadataV2WithSeriesCachePolicyCacheAll(t *testing.T) {
 		)
 		tagsIter := ident.NewTagsIterator(tags)
 		series := addMockSeries(ctrl, shard, id, tags, uint64(i))
-		if i == startCursor {
+		if entryIndex == startCursor {
 			series.EXPECT().
 				FetchBlocksMetadata(gomock.Not(nil), start, end, seriesFetchOpts).
 				Return(block.NewFetchBlocksMetadataResult(id, tagsIter,
 					block.NewFetchBlockMetadataResults()), nil)
-		} else if i > startCursor && i <= startCursor+fetchLimit {
+		} else if entryIndex > startCursor && entryIndex <= startCursor+fetchLimit {
 			ids = append(ids, id)
 			blocks := block.NewFetchBlockMetadataResults()
 			at := start.Add(time.Duration(i))
@@ -295,5 +297,95 @@ func TestShardFetchBlocksMetadataV2WithSeriesCachePolicyNotCacheAll(t *testing.T
 			assert.True(t, expectedBlock.LastRead.Equal(actualBlock.LastRead))
 			assert.Equal(t, expectedBlock.Err, actualBlock.Err)
 		}
+	}
+}
+
+func TestShardFetchBlocksMetadata(t *testing.T) {
+
+	tests := []struct {
+		name              string
+		numOfActiveSeries int
+		WriteBatchSize    int
+		readBatchSize     int
+	}{
+		{name: "Test-case 1", numOfActiveSeries: 1000, WriteBatchSize: 10, readBatchSize: 10},
+		{name: "Test-case 2", numOfActiveSeries: 1000, WriteBatchSize: 7, readBatchSize: 19},
+		{name: "Test-case 3", numOfActiveSeries: 4000, WriteBatchSize: 9, readBatchSize: 7},
+		{name: "Test-case 4", numOfActiveSeries: 5000, WriteBatchSize: 121, readBatchSize: 151},
+		{name: "Test-case 5", numOfActiveSeries: 30000, WriteBatchSize: 1021, readBatchSize: 4096},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := DefaultTestOptions().SetSeriesCachePolicy(series.CacheRecentlyRead)
+			shard := testDatabaseShard(t, opts)
+			defer shard.Close()
+			nowFn := opts.ClockOptions().NowFn()
+			start := nowFn()
+			writeTestData(t, tc.numOfActiveSeries, tc.WriteBatchSize, shard, opts)
+			end := nowFn()
+			verifyFetchedBlockMetadata(t, tc.numOfActiveSeries, tc.readBatchSize, shard, opts, start, end)
+		})
+	}
+}
+
+func writeTestData(t *testing.T, numOfActiveSeries int, writeBatchSize int, shard *dbShard, opts Options) {
+	ctx := opts.ContextPool().Get()
+	defer ctx.Close()
+	nowFn := opts.ClockOptions().NowFn()
+	var wg sync.WaitGroup
+	for i := 0; i < numOfActiveSeries; i += writeBatchSize {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			size := writeBatchSize
+			if numOfActiveSeries-i < writeBatchSize {
+				size = numOfActiveSeries - i
+			}
+			for j := 0; j < size; j++ {
+				id := fmt.Sprintf("foo=%d_%d", i, j)
+				_, err := shard.Write(ctx, ident.StringID(id), xtime.ToUnixNano(nowFn()),
+					1.0, xtime.Second, nil, series.WriteOptions{})
+				require.NoError(t, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func verifyFetchedBlockMetadata(t *testing.T, numOfActiveSeries int, readBatchSize int, shard *dbShard, opts Options, start, end time.Time) {
+	ctx := opts.ContextPool().Get()
+	var (
+		encodedPageToken PageToken
+		err              error
+		result           block.FetchBlocksMetadataResults
+	)
+
+	fetchMetadata := true
+	observedIds := make(map[string]int, numOfActiveSeries)
+	fetchOpts := block.FetchBlocksMetadataOptions{
+		IncludeSizes:     true,
+		IncludeChecksums: true,
+		IncludeLastRead:  true,
+	}
+
+	for i := 0; i < numOfActiveSeries; i += readBatchSize {
+		if fetchMetadata {
+			result, encodedPageToken, err = shard.FetchBlocksMetadataV2(ctx, xtime.ToUnixNano(start), xtime.ToUnixNano(end), int64(readBatchSize), encodedPageToken, fetchOpts)
+			require.NoError(t, err)
+			for _, res := range result.Results() {
+				observedIds[res.ID.String()]++
+			}
+		} else {
+			break
+		}
+		if encodedPageToken == nil {
+			fetchMetadata = false
+		}
+	}
+
+	require.Equal(t, numOfActiveSeries, len(observedIds))
+	for id, _ := range observedIds {
+		require.Equal(t, 1, observedIds[id])
 	}
 }

--- a/src/dbnode/storage/shard_fetch_blocks_metadata_test.go
+++ b/src/dbnode/storage/shard_fetch_blocks_metadata_test.go
@@ -319,7 +319,7 @@ func TestShardFetchBlocksMetadata(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := DefaultTestOptions().SetSeriesCachePolicy(series.CacheRecentlyRead)
 			shard := testDatabaseShard(t, opts)
-			defer shard.Close()
+			defer shard.Close() //nolint:errcheck
 			nowFn := opts.ClockOptions().NowFn()
 			start := nowFn()
 			writeTestData(t, tc.numOfActiveSeries, tc.WriteBatchSize, shard, opts)
@@ -353,7 +353,8 @@ func writeTestData(t *testing.T, numOfActiveSeries int, writeBatchSize int, shar
 	wg.Wait()
 }
 
-func verifyFetchedBlockMetadata(t *testing.T, numOfActiveSeries int, readBatchSize int, shard *dbShard, opts Options, start, end time.Time) {
+func verifyFetchedBlockMetadata(t *testing.T, numOfActiveSeries int,
+	readBatchSize int, shard *dbShard, opts Options, start, end time.Time) {
 	ctx := opts.ContextPool().Get()
 	var (
 		encodedPageToken PageToken
@@ -371,7 +372,8 @@ func verifyFetchedBlockMetadata(t *testing.T, numOfActiveSeries int, readBatchSi
 
 	for i := 0; i < numOfActiveSeries; i += readBatchSize {
 		if fetchMetadata {
-			result, encodedPageToken, err = shard.FetchBlocksMetadataV2(ctx, xtime.ToUnixNano(start), xtime.ToUnixNano(end), int64(readBatchSize), encodedPageToken, fetchOpts)
+			result, encodedPageToken, err = shard.FetchBlocksMetadataV2(ctx, xtime.ToUnixNano(start), xtime.ToUnixNano(end),
+				int64(readBatchSize), encodedPageToken, fetchOpts)
 			require.NoError(t, err)
 			for _, res := range result.Results() {
 				observedIds[res.ID.String()]++
@@ -385,7 +387,7 @@ func verifyFetchedBlockMetadata(t *testing.T, numOfActiveSeries int, readBatchSi
 	}
 
 	require.Equal(t, numOfActiveSeries, len(observedIds))
-	for id, _ := range observedIds {
+	for id := range observedIds {
 		require.Equal(t, 1, observedIds[id])
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
This PR fixes the logic to insert the entries in shard entry list to maintain the strictly increasing order of entry's unique index added to the list. This will fix the issue of skipping few series IDs while fetching the block metadata for peer bootstrapping. 
During peer bootstrapping the dbnode fetches the series metadata from peers via `FetchBlocksMetadataRawV2` call. The  pagination logic for this call is based on the assumption that entries are added in a strictly increasing order of entry's  unique index to the shard  list. While debugging the issue of data loss during peer bootstrapping it was found that some of the entries are not added in this order. This causes some of the series Ids to be skipped during peer bootstrapping which in turn results in data loss if a particular series id is skipped by every peer.

Duplicate of https://github.com/m3db/m3/pull/4293. This PR was created to run buildkite CI checks.
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
