### PR TITLE
Optimize m3.IsRollupID to not allocate

### DIFF
--- a/src/metrics/matcher/config.go
+++ b/src/metrics/matcher/config.go
@@ -119,7 +119,7 @@ func (cfg *Configuration) NewOptions(
 	}
 
 	isRollupIDFn := func(name []byte, tags []byte) bool {
-		return m3.IsRollupID(name, tags, sortedTagIteratorPool)
+		return m3.IsRollupID(name, tags)
 	}
 
 	includeTagKeys := createIncludeTagKeysMap(cfg.IncludeTagKeys)

--- a/src/metrics/metric/id/m3/id_bench_test.go
+++ b/src/metrics/metric/id/m3/id_bench_test.go
@@ -1,0 +1,59 @@
+package m3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Results 2024-10-17:
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/m3db/m3/src/metrics/metric/id/m3
+// BenchmarkIsRollupID
+// BenchmarkIsRollupID-10    	     349	   3404269 ns/op	       0 B/op	       0 allocs/op
+// PASS
+
+func BenchmarkIsRollupID(b *testing.B) {
+	id := []byte("m3+foo+m3_rollup=true,tagName1=tagValue1")
+
+	name, tags, err := NameAndTags(id)
+	require.NoError(b, err)
+
+	assert.Equal(b, []byte("foo"), name)
+	assert.Equal(b, []byte("m3_rollup=true,tagName1=tagValue1"), tags)
+	assert.True(b, IsRollupID(name, tags))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	loopResult := false
+	for i := 0; i < b.N; i++ {
+		result := false
+		for j := 0; j < 100_000; j++ {
+			result = IsRollupID(name, tags)
+		}
+		loopResult = result
+	}
+
+	require.True(b, loopResult)
+}
+
+// Test_IsRollupID_doesntAlloc is a sanity check that IsRollupID doesn't require any iterator allocations.
+// If you hit a failure on this assertion, it *could* be okay to change it to allow for some allocations.
+// However, this is a fairly performance sensitive path--think carefully about what you're doing.
+// It's also possible that a Go version upgrade will change this; consider whether it makes sense to tweak
+// the approach at that time.
+func Test_IsRollupID_doesntAlloc(t *testing.T) {
+	id := []byte("m3+foo+m3_rollup=true,tagName1=tagValue1")
+
+	name, tags, err := NameAndTags(id)
+	require.NoError(t, err)
+
+	allocated := testing.AllocsPerRun(10, func() {
+		IsRollupID(name, tags)
+	})
+
+	assert.Equal(t, 0.0, allocated, "IsRollupID should not require allocating memory")
+}

--- a/src/metrics/metric/id/m3/id_test.go
+++ b/src/metrics/metric/id/m3/id_test.go
@@ -53,7 +53,7 @@ func TestIsRollupIDNilIterator(t *testing.T) {
 		{name: []byte("foo"), tags: []byte("a1=b1,a2=b2"), expected: false},
 	}
 	for _, input := range inputs {
-		require.Equal(t, input.expected, IsRollupID(input.name, input.tags, nil), string(input.tags))
+		require.Equal(t, input.expected, IsRollupID(input.name, input.tags), string(input.tags))
 	}
 }
 
@@ -72,7 +72,7 @@ func TestIsRollupIDExternalIterator(t *testing.T) {
 		return NewPooledSortedTagIterator(nil, p)
 	})
 	for _, input := range inputs {
-		require.Equal(t, input.expected, IsRollupID(input.name, input.tags, p))
+		require.Equal(t, input.expected, IsRollupID(input.name, input.tags))
 	}
 }
 


### PR DESCRIPTION
Currently, m3.IsRollupID either pulls an id.SortedTagIterator from a pool, or makes one itself. There's no reason to do this; we can just directly create an m3
specific iterator on the stack, which doesn't allocate.

N.B.: if there are any pathological use cases where m3.IsRollupID is used with a pool that returns something *other* than an m3.sortedTagIterator, this would change
behavior. That seems highly unlikely/undesirable though.

commit-id:a2e684ae

---

**Stack**:
- #4305
- #4304 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*