### PR TITLE
Support tagfiltertree for fast matching metricIDs to queries

### DIFF
--- a/src/metrics/tagfiltertree/README.md
+++ b/src/metrics/tagfiltertree/README.md
@@ -1,0 +1,22 @@
+# Tag Filter Tree
+
+## Motivation
+There are many instances where we want to match an input metricID against
+a set of tag filters. One such use-case is metric attribution to namespaces.
+Iterating through each filter individually and matching them is extremely expensive
+since it has to be done on each incoming metricID. Therefore, this data structure
+pre-compiles a set of tag filters in order to optimize matches against an input metricID.
+
+## Usage
+First create a trie using New() and then add tagFilters using AddTagFilter().
+The tags within a filter can be specified in any order but to condense the compiled
+output of the trie, try and specify the most common set of tags in the beginning
+and in the same order.
+For instance, in case you have a tag "service" which you anticipate to be present
+in all filters then make sure that is specified first and then specify the remaining tags
+in the filter.
+The trie also supports "*" for a tag value which can be used to ensure the existance of a tag
+in the input metricID.
+
+## Caveats
+The trie might return duplicates and it is up to the caller to de-dup the results.

--- a/src/metrics/tagfiltertree/options.go
+++ b/src/metrics/tagfiltertree/options.go
@@ -1,0 +1,28 @@
+package tagfiltertree
+
+import "github.com/m3db/m3/src/metrics/filters"
+
+// Options is a set of options for the attributor.
+type Options interface {
+	TagFilterOptions() filters.TagsFilterOptions
+	SetTagFilterOptions(tf filters.TagsFilterOptions) Options
+}
+
+type options struct {
+	tagFilterOptions filters.TagsFilterOptions
+}
+
+// NewOptions creates a new set of options.
+func NewOptions() Options {
+	return &options{}
+}
+
+func (o *options) TagFilterOptions() filters.TagsFilterOptions {
+	return o.tagFilterOptions
+}
+
+func (o *options) SetTagFilterOptions(tf filters.TagsFilterOptions) Options {
+	opts := *o
+	opts.tagFilterOptions = tf
+	return &opts
+}

--- a/src/metrics/tagfiltertree/pointer_set.go
+++ b/src/metrics/tagfiltertree/pointer_set.go
@@ -1,0 +1,38 @@
+package tagfiltertree
+
+import "math/bits"
+
+type PointerSet struct {
+	bits [2]uint64 // Using 2 uint64 gives us 128 bits (0 to 127).
+}
+
+// Set adds a pointer at index i (0 <= i < 127).
+func (ps *PointerSet) Set(i byte) {
+	if i < 64 {
+		ps.bits[0] |= (1 << i)
+	} else {
+		ps.bits[1] |= (1 << (i - 64))
+	}
+}
+
+// IsSet checks if a pointer is present at index i.
+func (ps *PointerSet) IsSet(i byte) bool {
+	if i < 64 {
+		return ps.bits[0]&(1<<i) != 0
+	}
+	return ps.bits[1]&(1<<(i-64)) != 0
+}
+
+// CountSetBitsUntil counts how many bits are set to 1 up to index i (inclusive).
+func (ps *PointerSet) CountSetBitsUntil(i byte) int {
+	if i < 64 {
+		// Count bits in the first uint64 up to index i.
+		return bits.OnesCount64(ps.bits[0] & ((1 << (i + 1)) - 1))
+	} else {
+		// Count all bits in the first uint64.
+		count := bits.OnesCount64(ps.bits[0])
+		// Count bits in the second uint64 up to index i - 64.
+		count += bits.OnesCount64(ps.bits[1] & ((1 << (i - 64 + 1)) - 1))
+		return count
+	}
+}

--- a/src/metrics/tagfiltertree/pointer_set_test.go
+++ b/src/metrics/tagfiltertree/pointer_set_test.go
@@ -1,0 +1,61 @@
+package tagfiltertree
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPointerSetCountBits(t *testing.T) {
+	tests := []struct {
+		name     string
+		setBits  []uint64
+		expected int
+	}{
+		{
+			name:     "empty set",
+			setBits:  []uint64{0, 0},
+			expected: 0,
+		},
+		{
+			name:     "single set bit",
+			setBits:  []uint64{0, 1},
+			expected: 1,
+		},
+		{
+			name:     "multiple set bits",
+			setBits:  []uint64{7, 7},
+			expected: 6,
+		},
+		{
+			name:     "all set bits",
+			setBits:  []uint64{math.MaxUint64, math.MaxUint64},
+			expected: 128,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ps := PointerSet{}
+			l := tt.setBits[0]
+			r := tt.setBits[1]
+			var i byte
+			for i = 0; i < 128; i++ {
+				if i < 64 {
+					if l&0x1 == 1 {
+						ps.Set(i)
+					}
+					l >>= 1
+				} else {
+					if r&0x1 == 1 {
+						ps.Set(i)
+					}
+					r >>= 1
+				}
+			}
+
+			require.Equal(t, tt.expected, ps.CountSetBitsUntil(127))
+		})
+	}
+}

--- a/src/metrics/tagfiltertree/tag_filter_tree.go
+++ b/src/metrics/tagfiltertree/tag_filter_tree.go
@@ -1,0 +1,327 @@
+package tagfiltertree
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	_matchall  = "*"
+	_matchNone = "!*"
+)
+
+type Tag struct {
+	Name string
+	Val  string
+	Var  string
+}
+
+// Resolvable is an interface for types that can be stored in the tree.
+type Resolvable[R any] interface {
+	// Resolve resolves the data based on the tags and returns
+	// the data with type R.
+	Resolve(tags map[string]string) (R, error)
+}
+
+// Tree is a tree data structure for tag filters.
+type Tree[T any] struct {
+	Nodes []*node[T]
+}
+
+type NodeValue[T any] struct {
+	Val         string
+	PatternTrie *Trie[T]
+	Tree        *Tree[T]
+	Data        []T
+}
+
+type node[T any] struct {
+	Name           string
+	AbsoluteValues map[string]NodeValue[T]
+	PatternValues  []NodeValue[T]
+}
+
+// New creates a new tree.
+func New[T any]() *Tree[T] {
+	return &Tree[T]{
+		Nodes: make([]*node[T], 0),
+	}
+}
+
+// AddTagFilter adds a tag filter to the tree.
+func (t *Tree[T]) AddTagFilter(tagFilter string, data T) error {
+	tags, err := TagsFromTagFilter(tagFilter)
+	if err != nil {
+		return err
+	}
+	return addNode(t, tags, 0, data)
+}
+
+func (n *node[T]) addValue(filter string, data *T) (*Tree[T], error) {
+	if IsAbsoluteValue(filter) {
+		if n.AbsoluteValues == nil {
+			n.AbsoluteValues = make(map[string]NodeValue[T], 0)
+		}
+		if v, found := n.AbsoluteValues[filter]; found {
+			if data != nil {
+				if v.Data == nil {
+					v.Data = make([]T, 0)
+				}
+				v.Data = append(v.Data, *data)
+				n.AbsoluteValues[filter] = v
+			}
+			return v.Tree, nil
+		}
+
+		newNodeValue := NewNodeValue[T](filter, nil, data)
+		n.AbsoluteValues[filter] = newNodeValue
+
+		return newNodeValue.Tree, nil
+	}
+
+	if n.PatternValues == nil {
+		n.PatternValues = make([]NodeValue[T], 0)
+	}
+	for i, v := range n.PatternValues {
+		if v.Val == filter {
+			if data != nil {
+				if v.Data == nil {
+					v.Data = make([]T, 0)
+				}
+				v.Data = append(v.Data, *data)
+				n.PatternValues[i] = v
+			}
+			return v.Tree, nil
+		}
+	}
+
+	t := NewTrie[T]()
+	err := t.Insert(filter, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	newNodeValue := NewNodeValue[T](filter, t, data)
+	n.PatternValues = append(n.PatternValues, newNodeValue)
+
+	return newNodeValue.Tree, nil
+}
+
+func NewNodeValue[T any](val string, patternTrie *Trie[T], data *T) NodeValue[T] {
+	t := &Tree[T]{
+		Nodes: make([]*node[T], 0),
+	}
+
+	v := NodeValue[T]{
+		Val:         val,
+		PatternTrie: patternTrie,
+		Tree:        t,
+		Data:        nil,
+	}
+
+	if data != nil {
+		if v.Data == nil {
+			v.Data = make([]T, 0)
+		}
+		v.Data = append(v.Data, *data)
+	}
+
+	return v
+}
+
+func addNode[T any](t *Tree[T], tags []Tag, idx int, data T) error {
+	if idx >= len(tags) {
+		return nil
+	}
+
+	tag := tags[idx]
+	nodeIdx := -1
+	for i, t := range t.Nodes {
+		if t.Name == tag.Name {
+			nodeIdx = i
+			break
+		}
+	}
+	if nodeIdx == -1 {
+		t.Nodes = append(t.Nodes, &node[T]{
+			Name: tag.Name,
+		})
+		nodeIdx = len(t.Nodes) - 1
+	}
+	node := t.Nodes[nodeIdx]
+
+	// Add the data to the childTree if this is the last tag.
+	var dataToAdd *T
+	if idx == len(tags)-1 {
+		dataToAdd = &data
+	}
+
+	childTree, err := node.addValue(tag.Val, dataToAdd)
+	if err != nil {
+		return err
+	}
+
+	// Recurse to the next tag.
+	if err := addNode(childTree, tags, idx+1, data); err != nil {
+		// TODO: perform cleanup to avoid partially added nodes.
+		return err
+	}
+
+	return nil
+}
+
+// Match returns the data for the given tags.
+func (t *Tree[T]) Match(tags map[string]string, data *[]T) (bool, error) {
+	isMatchAny := false
+	if data == nil || *data == nil {
+		isMatchAny = true
+	}
+	return match(t, tags, data, isMatchAny)
+
+}
+
+func match[T any](
+	t *Tree[T],
+	tags map[string]string,
+	data *[]T,
+	isMatchAny bool,
+) (bool, error) {
+	if len(tags) == 0 || t == nil {
+		return false, nil
+	}
+
+	for _, node := range t.Nodes {
+		name := node.Name
+		negate := false
+		if IsMatchNoneTag(name) {
+			name = name[1:]
+			negate = true
+		}
+		tagValue, tagNameFound := tags[name]
+		absVal, absValFound := node.AbsoluteValues[tagValue]
+		if tagNameFound && absValFound {
+			if data != nil && *data != nil {
+				*data = append(*data, absVal.Data...)
+			}
+			if isMatchAny && len(absVal.Data) > 0 {
+				return true, nil
+			}
+
+			matched, err := match(absVal.Tree, tags, data, isMatchAny)
+			if err != nil {
+				return false, err
+			}
+			if isMatchAny && matched {
+				return true, nil
+			}
+		}
+		if tagNameFound != negate {
+			for _, v := range node.PatternValues {
+				matched, err := v.PatternTrie.Match(tagValue, nil)
+				if err != nil {
+					return false, err
+				}
+				if matched {
+					if data != nil && *data != nil {
+						*data = append(*data, v.Data...)
+					}
+					if isMatchAny && len(v.Data) > 0 {
+						return true, nil
+					}
+					matched, err := match(v.Tree, tags, data, isMatchAny)
+					if err != nil {
+						return false, err
+					}
+					if isMatchAny && matched {
+						return true, nil
+					}
+				}
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// TagsFromTagFilter creates tags from a tag filter.
+// The tag values can be of the format:
+// "foo" OR "{foo,bar,baz}" OR "{{Variable}}"
+// There cannot be a mix of value formats like "simpleValue, {foo,bar}" etc.
+func TagsFromTagFilter(tf string) ([]Tag, error) {
+	tags := make([]Tag, 0)
+	tfSanitized := strings.TrimSpace(tf)
+	tagValuePairs := strings.Split(tfSanitized, " ")
+	for _, tagValuePair := range tagValuePairs {
+		tagAndValue := strings.Split(tagValuePair, ":")
+		if len(tagAndValue) != 2 {
+			return nil, fmt.Errorf("invalid tag filter: %s", tf)
+		}
+		tag := tagAndValue[0]
+		val := tagAndValue[1]
+		if len(tag) == 0 || len(val) == 0 {
+			return nil, fmt.Errorf("invalid tag filter: %s", tf)
+		}
+
+		varName := ""
+		if IsVarTagValue(val) {
+			varName = val
+			val = _matchall
+		}
+		if val == _matchNone {
+			tag = "!" + tag
+			val = _matchall
+		}
+
+		tags = append(tags, Tag{
+			Name: tag,
+			Val:  val,
+			Var:  varName,
+		})
+	}
+
+	return tags, nil
+}
+
+func IsVarTagValue(value string) bool {
+	if len(value) < 4 {
+		return false
+	}
+
+	for i := 0; i < len(value); i++ {
+		if value[i] == '{' {
+			if i+1 < len(value) && value[i+1] == '{' {
+				if strings.Contains(value[i+1:], "}}") {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func IsMatchNoneTag(tagName string) bool {
+	if len(tagName) == 0 {
+		return false
+	}
+	return tagName[0] == '!'
+}
+
+func IsAbsoluteValue(val string) bool {
+	return !strings.ContainsAny(val, "{!*[")
+}
+
+/*
+tag1:value1 tag2:value2 tag3:value3
+tag1:foo1 tag4:* tag8:val*
+
+tag1 -> value1 ---->
+			tag2 -> value2 ---->
+						tag3 -> value3 D-> R1
+        foo1 ---->
+			tag4 -> * ---->
+						tag8 -> val* D-> R2
+
+input:
+	tag1:foo1 tag4:foobar tag8:value8
+*/

--- a/src/metrics/tagfiltertree/tag_filter_tree_benchmark_test.go
+++ b/src/metrics/tagfiltertree/tag_filter_tree_benchmark_test.go
@@ -1,0 +1,110 @@
+package tagfiltertree
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/pkg/testing/assert"
+)
+
+const (
+	_numFilters = 100
+)
+
+// Predefined tag names and values for benchmarks
+var tags = []string{"tag1", "tag2", "tag3", "tag4", "tag5", "tag6", "tag7", "tag8", "tag9", "tag10"}
+var values = []string{"value1", "value2", "value3", "value4", "value5"}
+
+// Filter Types
+const (
+	ABSOLUTE  = 0
+	WILDCARD  = 1
+	NEGATION  = 2
+	COMPOSITE = 3
+)
+
+/*
+* Benchmark results:
+* BenchmarkTagFilterTreeMatch/MatchAll-10      673851	      1561 ns/op	     190 B/op	       0 allocs/op
+* BenchmarkTagFilterTreeMatch/MatchAny-10     4203621	       256.0 ns/op	       0 B/op	       0 allocs/op
+ */
+func BenchmarkTagFilterTreeMatch(b *testing.B) {
+	// Generate a benchmark set of tag filters with varying complexity
+	filters := make([]string, 0)
+	for i := 0; i < _numFilters; i++ {
+		filters = append(filters, generateTagFilter(1+rnd.Intn(len(tags)-1))) // 10 filters in the string
+	}
+	input := map[string]string{
+		"tag1": "value1",
+		"tag2": "value2",
+		"tag3": "value3",
+		"tag4": "value4",
+		"tag5": "value5",
+	}
+	tree := New[*Rule]()
+	data := &Rule{}
+
+	for _, f := range filters {
+		err := tree.AddTagFilter(f, data)
+		assert.NoError(b, err)
+	}
+
+	b.ResetTimer()
+	b.Run("MatchAll", func(b *testing.B) {
+		resultData := make([]*Rule, 0, 10)
+		for i := 0; i < b.N; i++ {
+			_, _ = tree.Match(input, &resultData)
+		}
+	})
+
+	b.ResetTimer()
+	b.Run("MatchAny", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = tree.Match(input, nil)
+		}
+	})
+}
+
+// Seeded random number generator for deterministic results
+var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// Generate a single random tag filter based on type
+func generateTagValuePair(idx int, tagType int) string {
+	tag := tags[idx]
+	switch tagType {
+	case ABSOLUTE:
+		value := values[rnd.Intn(len(values))]
+		return fmt.Sprintf("%s:%s", tag, value)
+	case WILDCARD:
+		return fmt.Sprintf("%s:*", tag)
+	case NEGATION:
+		if rnd.Intn(2) == 0 {
+			return fmt.Sprintf("%s:!*", tag) // tag should not exist
+		} else {
+			value := values[rnd.Intn(len(values))]
+			return fmt.Sprintf("%s:!%s", tag, value) // tag should not have this value
+		}
+	case COMPOSITE:
+		value1 := values[rnd.Intn(len(values))]
+		value2 := values[rnd.Intn(len(values))]
+		return fmt.Sprintf("%s:{%s,%s}", tag, value1, value2) // matches either value1 or value2
+	default:
+		return ""
+	}
+}
+
+// Generate a tag filter with the specified number of tags.
+func generateTagFilter(numTags int) string {
+	var filter []string
+
+	idxs := rnd.Perm(len(tags))
+	for i := 0; i < numTags; i++ {
+		tagType := rnd.Intn(4) // Randomly choose from ABSOLUTE, WILDCARD, NEGATION, COMPOSITE
+		pair := generateTagValuePair(idxs[i], tagType)
+		filter = append(filter, pair)
+	}
+	return strings.Join(filter, " ")
+}

--- a/src/metrics/tagfiltertree/tag_filter_tree_test.go
+++ b/src/metrics/tagfiltertree/tag_filter_tree_test.go
@@ -1,0 +1,530 @@
+package tagfiltertree
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+)
+
+type Rule struct {
+	TagFilters []string
+	Namespace  string
+}
+
+func (r *Rule) Resolve(inputTags map[string]string) (string, error) {
+	if !IsVarTagValue(r.Namespace) {
+		return r.Namespace, nil
+	}
+
+	varMap := make(map[string]string)
+	for _, tagFilter := range r.TagFilters {
+		tags, err := TagsFromTagFilter(tagFilter)
+		if err != nil {
+			return "", err
+		}
+		for _, tag := range tags {
+			if tag.Var != "" {
+				// is var tag
+				inputTagValue, ok := inputTags[tag.Name]
+				if !ok {
+					return "", errors.New("tag not found")
+				}
+				varMap[tag.Var] = inputTagValue
+			}
+		}
+	}
+
+	ns := r.Namespace
+	for varName, varValue := range varMap {
+		ns = strings.ReplaceAll(ns, varName, varValue)
+	}
+	return ns, nil
+}
+
+func TestTreeGetData(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputTags map[string]string
+		rules     []Rule
+		expected  []string
+	}{
+		{
+			name: "multiple input tags, multiple filters, multiple rules, match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "value3",
+				"tag4": "value4",
+				"tag5": "value5",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2",
+					},
+					Namespace: "namespace1",
+				},
+				{
+					TagFilters: []string{
+						"tag4:value4 tag5:value5",
+					},
+					Namespace: "namespace2",
+				},
+				{
+					TagFilters: []string{
+						"tag5:*",
+					},
+					Namespace: "namespace3",
+				},
+				{
+					TagFilters: []string{
+						"tag8:value8 tag9:value9",
+						"tag5:value5 tag6:value6",
+					},
+					Namespace: "namespace4",
+				},
+			},
+			expected: []string{"namespace1", "namespace2", "namespace3"},
+		},
+		{
+			name: "multiple input tags, common prefix tags, match one",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "apple",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2 tag3:apple",
+					},
+					Namespace: "namespace1",
+				},
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2 tag3:banana",
+					},
+					Namespace: "namespace2",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+		{
+			name: "multiple input tags, common prefix tags, existing value, match one",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "apple",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2 tag3:apple tag4:banana",
+					},
+					Namespace: "namespace1",
+				},
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2 tag3:apple",
+					},
+					Namespace: "namespace2",
+				},
+			},
+			expected: []string{"namespace2"},
+		},
+		{
+			name: "multiple input tags, common prefix tags, existing value with wildcard, match one",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "apple",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2 tag3:* tag4:banana",
+					},
+					Namespace: "namespace1",
+				},
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2 tag3:*",
+					},
+					Namespace: "namespace2",
+				},
+			},
+			expected: []string{"namespace2"},
+		},
+		{
+			name: "multiple input tags, multiple filters, multiple rules, multiple values, match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "value3",
+				"tag4": "value4",
+				"tag5": "value5",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2",
+					},
+					Namespace: "namespace1",
+				},
+				{
+					TagFilters: []string{
+						"tag1:val1 tag4:value4 tag5:value5",
+					},
+					Namespace: "namespaceA",
+				},
+				{
+					TagFilters: []string{
+						"tag1:val* tag4:value4 tag5:value5",
+					},
+					Namespace: "namespace2",
+				},
+				{
+					TagFilters: []string{
+						"tag5:*",
+					},
+					Namespace: "namespace3",
+				},
+				{
+					TagFilters: []string{
+						"tag8:value8 tag9:value9",
+						"tag5:value5 tag6:value6",
+					},
+					Namespace: "namespace4",
+				},
+			},
+			expected: []string{"namespace1", "namespace2", "namespace3"},
+		},
+		{
+			name: "single rule, all negation, match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag4": "value4",
+				"tag5": "value5",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag3:!*",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+		{
+			name: "single rule, all negation, no match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag4": "value4",
+				"tag5": "value5",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag2:!*",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: []string{},
+		},
+		{
+			name: "single rule, negation, match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "value3",
+				"tag4": "value4",
+				"tag5": "value5",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag3:!{value1,value2}",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+		{
+			name: "multiple rules, negation, single match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "value3",
+				"tag4": "value4",
+				"tag5": "value5",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:!* tag2:value2",
+					},
+					Namespace: "namespace1",
+				},
+				{
+					TagFilters: []string{
+						"tag1:value1 tag6:!*",
+					},
+					Namespace: "namespace2",
+				},
+			},
+			expected: []string{"namespace2"},
+		},
+		{
+			name: "single input tag, single filter, match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+		{
+			name: "multiple input tags, single filter, match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "value3",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+		{
+			name: "single input tag, multiple filters, match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1",
+						"tag2:value2",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+		{
+			name: "single input tag, multiple filters, no match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag3:value1",
+						"tag2:value2",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "multiple input tags, multiple filters, match",
+			inputTags: map[string]string{
+				"tag1": "value1",
+				"tag2": "value2",
+				"tag3": "value3",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2",
+						"tag4:value2 tag5:value2",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+		{
+			name: "multiple input tags, multiple filters, no match",
+			inputTags: map[string]string{
+				"tag3": "value3",
+				"tag4": "value4",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag1:value1 tag2:value2",
+						"tag5:value5 tag6:value6",
+					},
+					Namespace: "namespace1",
+				},
+				{
+					TagFilters: []string{
+						"tag7:*",
+					},
+					Namespace: "namespace2",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "multiple input tags, composite tag value, match",
+			inputTags: map[string]string{
+				"tag3": "apple",
+				"tag4": "banana",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag3:{value3,apple} tag4:{value4,banana}",
+						"tag5:value5 tag6:value6",
+					},
+					Namespace: "namespace1",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+		{
+			name: "multiple input tags, var tag value, single rule match",
+			inputTags: map[string]string{
+				"tag3": "apple",
+				"tag4": "banana",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag3:{{VAR1}} tag4:{{VAR2}}",
+						"tag5:value5 tag6:value6",
+					},
+					Namespace: "{{VAR1}}_{{VAR2}}",
+				},
+			},
+			expected: []string{"apple_banana"},
+		},
+		{
+			name: "multiple input tags, var tag value, multi rule match",
+			inputTags: map[string]string{
+				"tag3": "apple",
+				"tag4": "banana",
+				"tag5": "train",
+				"tag6": "car",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag3:{{VAR1}} tag4:{{VAR2}}",
+						"tag5:value5 tag6:value6",
+					},
+					Namespace: "namespace1_{{VAR1}}_{{VAR2}}",
+				},
+				{
+					TagFilters: []string{
+						"tag4:{{VAR5}} tag5:{{VAR6}} tag6:{{VAR2}}",
+						"tag5:value5 tag7:value7",
+					},
+					Namespace: "{{VAR6}}_{{VAR6}}_{{VAR2}}_{{VAR5}}",
+				},
+			},
+			expected: []string{
+				"namespace1_apple_banana",
+				"train_train_car_banana",
+			},
+		},
+		{
+			name: "multiple input tags, wildcard tag value, multi rule match",
+			inputTags: map[string]string{
+				"tag3": "apple",
+				"tag4": "banana",
+				"tag5": "train",
+				"tag6": "car",
+			},
+			rules: []Rule{
+				{
+					TagFilters: []string{
+						"tag3:app* tag4:ban*",
+						"tag5:train tag6:value6",
+					},
+					Namespace: "namespace1",
+				},
+				{
+					TagFilters: []string{
+						"tag4:bag* tag5:* tag6:c*",
+						"tag5:value5 tag7:value7",
+					},
+					Namespace: "namespace2",
+				},
+			},
+			expected: []string{"namespace1"},
+		},
+	}
+
+	less := func(a, b string) bool { return a < b }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := New[*Rule]()
+			for _, rule := range tt.rules {
+				for _, tagFilter := range rule.TagFilters {
+					err := tree.AddTagFilter(tagFilter, &rule)
+					require.NoError(t, err)
+				}
+			}
+
+			// check all match
+			actual := make([]*Rule, 0, len(tt.expected))
+			_, err := tree.Match(tt.inputTags, &actual)
+			resolved := make([]string, 0, len(actual))
+			for _, r := range actual {
+				ns, err := r.Resolve(tt.inputTags)
+				require.NoError(t, err)
+				resolved = append(resolved, ns)
+			}
+
+			require.NoError(t, err)
+			if len(tt.expected) == 0 {
+				require.Empty(t, actual)
+				return
+			}
+
+			actualNamespaces := uniqueNamespaces(resolved)
+			require.Equal(t, "", cmp.Diff(tt.expected, actualNamespaces, cmpopts.SortSlices(less)))
+
+			// check any match
+			anyMatched, err := tree.Match(tt.inputTags, nil)
+			require.Equal(t, len(tt.expected) > 0, anyMatched)
+		})
+	}
+}
+
+func uniqueNamespaces(input []string) []string {
+	unique := make(map[string]struct{})
+	for _, r := range input {
+		unique[r] = struct{}{}
+	}
+
+	output := make([]string, 0, len(unique))
+	for ns, _ := range unique {
+		output = append(output, ns)
+	}
+	return output
+}

--- a/src/metrics/tagfiltertree/trie_char.go
+++ b/src/metrics/tagfiltertree/trie_char.go
@@ -1,0 +1,23 @@
+package tagfiltertree
+
+type trieChar struct {
+	ch byte
+}
+
+func (c *trieChar) SetEnd() {
+	c.ch |= 0x01
+}
+
+func (c *trieChar) IsEnd() bool {
+	return c.ch&0x01 == 0x01
+}
+
+func NewTrieChar(ch byte) trieChar {
+	return trieChar{
+		ch: ch << 1,
+	}
+}
+
+func (c *trieChar) Char() byte {
+	return c.ch >> 1
+}

--- a/src/metrics/tagfiltertree/trie_children.go
+++ b/src/metrics/tagfiltertree/trie_children.go
@@ -1,0 +1,50 @@
+package tagfiltertree
+
+import "fmt"
+
+type trieChildren[T any] struct {
+	children   []*T
+	pointerSet PointerSet
+}
+
+func newTrieChildren[T any]() trieChildren[T] {
+	return trieChildren[T]{
+		children: nil,
+	}
+}
+
+func (tc *trieChildren[T]) Insert(ch byte, data *T) error {
+	if tc.pointerSet.IsSet(ch) {
+		return fmt.Errorf("character already exists")
+	}
+
+	newIdx := tc.pointerSet.CountSetBitsUntil(ch)
+
+	// make room for the new child.
+	tc.children = append(tc.children, nil)
+
+	for i := len(tc.children) - 1; i > newIdx; i-- {
+		tc.children[i] = tc.children[i-1]
+	}
+
+	// set the new data in the correct idx.
+	tc.children[newIdx] = data
+
+	// set the idx of the new child.
+	tc.pointerSet.Set(ch)
+
+	return nil
+}
+
+func (tc *trieChildren[T]) Get(ch byte) *T {
+	if !tc.pointerSet.IsSet(ch) {
+		return nil
+	}
+
+	childIdx := tc.pointerSet.CountSetBitsUntil(ch) - 1
+	return tc.children[childIdx]
+}
+
+func (tc *trieChildren[T]) Exists(ch byte) bool {
+	return tc.pointerSet.IsSet(ch)
+}

--- a/src/metrics/tagfiltertree/trie_children_test.go
+++ b/src/metrics/tagfiltertree/trie_children_test.go
@@ -1,0 +1,31 @@
+package tagfiltertree
+
+import (
+	"testing"
+)
+
+func TestTrieChildrenGet(t *testing.T) {
+	tc := newTrieChildren[int]()
+
+	// Insert a child.
+	data := 42
+	err := tc.Insert('a', &data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Get the child.
+	got := tc.Get('a')
+	if got == nil {
+		t.Fatalf("expected child to exist")
+	}
+	if *got != data {
+		t.Fatalf("unexpected data: got %v, want %v", *got, data)
+	}
+
+	// Get a non-existing child.
+	got = tc.Get('b')
+	if got != nil {
+		t.Fatalf("unexpected child: got %v, want nil", *got)
+	}
+}

--- a/src/metrics/tagfiltertree/trie_test.go
+++ b/src/metrics/tagfiltertree/trie_test.go
@@ -1,0 +1,416 @@
+package tagfiltertree
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type Pattern struct {
+	pattern string
+	data    string
+}
+
+func TestTrieMatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		patterns      []Pattern
+		input         string
+		expectedMatch bool
+		expectedData  []string
+		isDisabled    bool
+	}{
+		{
+			name: "suffix wildcard minimum match",
+			patterns: []Pattern{
+				{
+					pattern: "foo*",
+					data:    "data1",
+				},
+			},
+			input:         "foo",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "suffix wildcard match",
+			patterns: []Pattern{
+				{
+					pattern: "foo*",
+					data:    "data1",
+				},
+			},
+			input:         "foo123",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "suffix wildcard suffix match",
+			patterns: []Pattern{
+				{
+					pattern: "foo*",
+					data:    "data1",
+				},
+			},
+			input:         "foofoofoofoo",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "suffix wildcard no match",
+			patterns: []Pattern{
+				{
+					pattern: "foo*",
+					data:    "data1",
+				},
+			},
+			input:         "fobar",
+			expectedMatch: false,
+			expectedData:  []string{},
+		},
+		{
+			name: "prefix wildcard minimum match",
+			patterns: []Pattern{
+				{
+					pattern: "*foo",
+					data:    "data1",
+				},
+			},
+			input:         "foo",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "prefix wildcard prefix match",
+			patterns: []Pattern{
+				{
+					pattern: "*foo",
+					data:    "data1",
+				},
+			},
+			input:         "fofofofoo",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "prefix wildcard no match",
+			patterns: []Pattern{
+				{
+					pattern: "*foo",
+					data:    "data1",
+				},
+			},
+			input:         "barfobo",
+			expectedMatch: false,
+			expectedData:  []string{},
+		},
+		{
+			name: "single exact match",
+			patterns: []Pattern{
+				{
+					pattern: "foobar",
+					data:    "data1",
+				},
+			},
+			input:         "foobar",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "single suffix and prefix wildcard match",
+			patterns: []Pattern{
+				{
+					pattern: "*foo*",
+					data:    "data1",
+				},
+			},
+			input:         "barfoobar",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "single negation match",
+			patterns: []Pattern{
+				{
+					pattern: "!foo",
+					data:    "data1",
+				},
+			},
+			input:         "bar",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "single negation with wildcard match",
+			patterns: []Pattern{
+				{
+					pattern: "!*foo*",
+					data:    "data1",
+				},
+			},
+			input:         "fofobar",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "composite, absolute match, single match",
+			patterns: []Pattern{
+				{
+					pattern: "{foo,bar}",
+					data:    "data1",
+				},
+			},
+			input:         "bar",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "composite starting middle, wildcards, single match",
+			patterns: []Pattern{
+				{
+					pattern: "*choco{*foo*,*bar*}late*",
+					data:    "data1",
+				},
+			},
+			input:         "123chocobarlate456",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "char range, wildcards, single match",
+			patterns: []Pattern{
+				{
+					pattern: "[a-d]*",
+					data:    "data1",
+				},
+			},
+			input:         "chocolate",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "composite, wildcard match, single match",
+			patterns: []Pattern{
+				{
+					pattern: "{*foo*,*bar*}",
+					data:    "data1",
+				},
+			},
+			input:         "bar",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "single negative composite, wildcards, no match",
+			patterns: []Pattern{
+				{
+					pattern: "!{*foo*,*bar*}",
+					data:    "data1",
+				},
+			},
+			input:         "bar",
+			expectedMatch: false,
+			expectedData:  []string{},
+		},
+		{
+			name: "composite, char range, wildcards, single match",
+			patterns: []Pattern{
+				{
+					pattern: "{abc, [1-4]*, *foo*}",
+					data:    "data1",
+				},
+			},
+			input:         "30000000",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "char range without dash, wildcards, no match",
+			patterns: []Pattern{
+				{
+					pattern: "[14]*",
+					data:    "data1",
+				},
+			},
+			input:         "30000000",
+			expectedMatch: false,
+			expectedData:  []string{},
+		},
+		{
+			name: "char range without dash, wildcards, match",
+			patterns: []Pattern{
+				{
+					pattern: "[14]*",
+					data:    "data1",
+				},
+			},
+			input:         "40000000",
+			expectedMatch: true,
+			expectedData:  []string{"data1"},
+		},
+		{
+			name: "multiple composite, wildcard and absolute match, single match",
+			patterns: []Pattern{
+				{
+					pattern: "{*foo*,*bal*,batbaz}",
+					data:    "data1",
+				},
+				{
+					pattern: "*batbaz",
+					data:    "data2",
+				},
+			},
+			input:         "batbaz",
+			expectedMatch: true,
+			expectedData:  []string{"data1", "data2"},
+		},
+		{
+			name: "multiple intersecting composite, wildcard and absolute match, all match",
+			patterns: []Pattern{
+				{
+					pattern: "!{*foo*,*bal*}",
+					data:    "data1",
+				},
+				{
+					pattern: "!{*bal*,gaz*}",
+					data:    "data2",
+				},
+			},
+			input:         "batbaz",
+			expectedMatch: true,
+			expectedData:  []string{"data1", "data2"},
+			// disable test since we don't support multiple negative composite filters at the moment.
+			isDisabled: true,
+		},
+		{
+			name: "multiple intersecting composite, wildcard and absolute match, single match",
+			patterns: []Pattern{
+				{
+					pattern: "!{*foo*,*bal*}",
+					data:    "data1",
+				},
+				{
+					pattern: "!{*bal*,gaz*}",
+					data:    "data2",
+				},
+			},
+			input:         "foo",
+			expectedMatch: true,
+			expectedData:  []string{"data2"},
+			// disable test since we don't support multiple negative composite filters at the moment.
+			isDisabled: true,
+		},
+		{
+			name: "multiple intersecting composite, wildcard and absolute match, no match",
+			patterns: []Pattern{
+				{
+					pattern: "!{*foo*,*bal*}",
+					data:    "data1",
+				},
+				{
+					pattern: "!{*bal*,gaz*}",
+					data:    "data2",
+				},
+			},
+			input:         "banbalabal",
+			expectedMatch: false,
+			expectedData:  []string{},
+			// disable test since we don't support multiple negative composite filters at the moment.
+			isDisabled: true,
+		},
+		{
+			name: "multiple negations with wildcard, single match",
+			patterns: []Pattern{
+				{
+					pattern: "!*foo*",
+					data:    "data1",
+				},
+				{
+					pattern: "!*bar*",
+					data:    "data2",
+				},
+				{
+					pattern: "!*baz*",
+					data:    "data3",
+				},
+			},
+			input:         "fofoobar",
+			expectedMatch: true,
+			expectedData:  []string{"data3"},
+			// disable test since we don't support multiple negative composite filters at the moment.
+			isDisabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		runTest := func(withData bool) {
+			if tt.isDisabled {
+				return
+			}
+			trie := NewTrie[string]()
+			for _, rule := range tt.patterns {
+				var data *string
+				if withData {
+					data = &rule.data
+				}
+				trie.Insert(rule.pattern, data)
+			}
+
+			var data []string
+			if withData {
+				data = make([]string, 0)
+			}
+			matched, err := trie.Match(tt.input, &data)
+			require.NoError(t, err)
+
+			// check match.
+			require.Equal(t, tt.expectedMatch, matched)
+
+			if !withData {
+				for i := range data {
+					require.Empty(t, data[i])
+				}
+				return
+			}
+
+			if len(tt.expectedData) == 0 {
+				require.Empty(t, data)
+				return
+			}
+
+			// dedup data.
+			data = deduplicateData(data)
+
+			// check data.
+			sort.Slice(data, func(i, j int) bool {
+				return data[i] < data[j]
+			})
+			sort.Slice(tt.expectedData, func(i, j int) bool {
+				return tt.expectedData[i] < tt.expectedData[j]
+			})
+
+			require.Equal(t, true, reflect.DeepEqual(data, tt.expectedData))
+		}
+
+		t.Run(tt.name+"_with_data", func(t *testing.T) {
+			runTest(true)
+		})
+		t.Run(tt.name+"_without_data", func(t *testing.T) {
+			runTest(false)
+		})
+	}
+}
+
+func deduplicateData(data []string) []string {
+	dataMap := make(map[string]struct{})
+	for i := range data {
+		dataMap[data[i]] = struct{}{}
+	}
+	data = make([]string, 0, len(dataMap))
+	for k := range dataMap {
+		data = append(data, k)
+	}
+	return data
+}


### PR DESCRIPTION
This PR introduces a new data structure which we call "tagfiltertree". 
A query consists of several tag filters. A tag filter is nothing but a tag and value pair where the value is a pattern much like a regex. For instance, "service:*foo*" is a valid tag filter. A query is nothing but a list of such tag filters that need to be matched with Conjunction within an incoming metricID.

The key observation behind creating a tree structure is that the presence of a tag in a metricID and a query has the potential to drastically prune the search space of the possible queries going forward. So much so that within a couple comparisons we expect an incoming metricID to output the entire list of matched queries.

This package optimizes CPU and memory for match time as opposed to creation of the tree itself. It is not thread-safe so make sure to protect the tree appropriately if it is going to be used in a multithreaded context.

Refer to the README.md for more details.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
Use this data structure when you want to quickly match an input metricID to a list of queries.
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
