### PR TITLE
[aggregator] Add read timeout for aggregator client

### DIFF
--- a/src/aggregator/client/config.go
+++ b/src/aggregator/client/config.go
@@ -235,6 +235,7 @@ func (c *TLSConfiguration) NewTLSOptions() xtls.Options {
 type ConnectionConfiguration struct {
 	ConnectionTimeout            time.Duration        `yaml:"connectionTimeout"`
 	ConnectionKeepAlive          *bool                `yaml:"connectionKeepAlive"`
+	ReadTimeout                  time.Duration        `yaml:"readTimeout"`
 	WriteTimeout                 time.Duration        `yaml:"writeTimeout"`
 	InitReconnectThreshold       int                  `yaml:"initReconnectThreshold"`
 	MaxReconnectThreshold        int                  `yaml:"maxReconnectThreshold"`
@@ -253,6 +254,9 @@ func (c *ConnectionConfiguration) NewConnectionOptions(scope tally.Scope) Connec
 	}
 	if c.ConnectionKeepAlive != nil {
 		opts = opts.SetConnectionKeepAlive(*c.ConnectionKeepAlive)
+	}
+	if c.ReadTimeout != 0 {
+		opts = opts.SetReadTimeout(c.ReadTimeout)
 	}
 	if c.WriteTimeout != 0 {
 		opts = opts.SetWriteTimeout(c.WriteTimeout)

--- a/src/aggregator/client/config_test.go
+++ b/src/aggregator/client/config_test.go
@@ -70,6 +70,7 @@ queueDropType: oldest
 connection:
   connectionTimeout: 1s
   connectionKeepAlive: true
+  readTimeout: 1s
   writeTimeout: 1s
   initReconnectThreshold: 2
   maxReconnectThreshold: 5000
@@ -117,6 +118,7 @@ func TestConfigUnmarshal(t *testing.T) {
 	require.Equal(t, DropOldest, *cfg.QueueDropType)
 	require.Equal(t, time.Second, cfg.Connection.ConnectionTimeout)
 	require.Equal(t, true, *cfg.Connection.ConnectionKeepAlive)
+	require.Equal(t, time.Second, cfg.Connection.ReadTimeout)
 	require.Equal(t, time.Second, cfg.Connection.WriteTimeout)
 	require.Equal(t, 2, cfg.Connection.InitReconnectThreshold)
 	require.Equal(t, 5000, cfg.Connection.MaxReconnectThreshold)

--- a/src/aggregator/client/conn_options.go
+++ b/src/aggregator/client/conn_options.go
@@ -34,6 +34,7 @@ import (
 const (
 	defaultConnectionTimeout            = 1 * time.Second
 	defaultConnectionKeepAlive          = true
+	defaultReadTimeout                  = 15 * time.Second
 	defaultWriteTimeout                 = 15 * time.Second
 	defaultInitReconnectThreshold       = 1
 	defaultMaxReconnectThreshold        = 4
@@ -71,6 +72,12 @@ type ConnectionOptions interface {
 
 	// ConnectionKeepAlive returns the keepAlive for the connection.
 	ConnectionKeepAlive() bool
+
+	// SetReadTimeout sets the timeout for reading data.
+	SetReadTimeout(value time.Duration) ConnectionOptions
+
+	// ReadTimeout returns the timeout for reading data.
+	ReadTimeout() time.Duration
 
 	// SetWriteTimeout sets the timeout for writing data.
 	SetWriteTimeout(value time.Duration) ConnectionOptions
@@ -138,6 +145,7 @@ type connectionOptions struct {
 	writeRetryOpts retry.Options
 	rwOpts         xio.Options
 	connTimeout    time.Duration
+	readTimeout    time.Duration
 	writeTimeout   time.Duration
 	maxDuration    time.Duration
 	initThreshold  int
@@ -161,6 +169,7 @@ func NewConnectionOptions() ConnectionOptions {
 		instrumentOpts: instrument.NewOptions(),
 		connTimeout:    defaultConnectionTimeout,
 		connKeepAlive:  defaultConnectionKeepAlive,
+		readTimeout:    defaultReadTimeout,
 		writeTimeout:   defaultWriteTimeout,
 		initThreshold:  defaultInitReconnectThreshold,
 		maxThreshold:   defaultMaxReconnectThreshold,
@@ -211,6 +220,16 @@ func (o *connectionOptions) SetConnectionKeepAlive(value bool) ConnectionOptions
 
 func (o *connectionOptions) ConnectionKeepAlive() bool {
 	return o.connKeepAlive
+}
+
+func (o *connectionOptions) SetReadTimeout(value time.Duration) ConnectionOptions {
+	opts := *o
+	opts.readTimeout = value
+	return &opts
+}
+
+func (o *connectionOptions) ReadTimeout() time.Duration {
+	return o.readTimeout
 }
 
 func (o *connectionOptions) SetWriteTimeout(value time.Duration) ConnectionOptions {

--- a/src/aggregator/client/conn_test.go
+++ b/src/aggregator/client/conn_test.go
@@ -338,6 +338,7 @@ func TestConnectWithCustomDialer(t *testing.T) {
 		mockConn := NewMockConn(ctrl)
 
 		mockConn.EXPECT().Write(testData)
+		mockConn.EXPECT().SetReadDeadline(gomock.Any())
 		mockConn.EXPECT().SetWriteDeadline(gomock.Any())
 		testWithConn(t, mockConn)
 	})
@@ -347,6 +348,7 @@ func TestConnectWithCustomDialer(t *testing.T) {
 		mockConn := NewMockConn(ctrl)
 
 		mockConn.EXPECT().Write(testData)
+		mockConn.EXPECT().SetReadDeadline(gomock.Any())
 		mockConn.EXPECT().SetWriteDeadline(gomock.Any())
 
 		mockKeepAlivable := NewMockkeepAlivable(ctrl)
@@ -489,7 +491,8 @@ func testConnectionOptions() ConnectionOptions {
 		SetInitReconnectThreshold(2).
 		SetMaxReconnectThreshold(6).
 		SetReconnectThresholdMultiplier(2).
-		SetWriteTimeout(100 * time.Millisecond)
+		SetWriteTimeout(100 * time.Millisecond).
+		SetReadTimeout(100 * time.Millisecond)
 }
 
 func testTLSConnectionOptions() ConnectionOptions {


### PR DESCRIPTION
**What this PR does / why we need it**:
After support for TLS was introduced, the aggregator client not only sends data to the aggregator server but also receives data (during the TLS handshake). If, for some reason, the server is unable to respond to the client, the client will be stuck because it doesn't have a timeout for reading data. This PR adds support for read timeout.