### PR TITLE
Concurrently write ConsumerWriters on error

### DIFF
--- a/src/msg/producer/writer/consumer_writer.go
+++ b/src/msg/producer/writer/consumer_writer.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -45,6 +46,7 @@ const (
 
 var (
 	errInvalidConnection = errors.New("connection is invalid")
+	errWriteInProgress   = errors.New("write in progress")
 	u                    uninitializedReadWriter
 )
 
@@ -107,10 +109,13 @@ type consumerWriterImpl struct {
 	connRetrier retry.Retrier
 	logger      *zap.Logger
 
-	resetCh chan struct{}
-	doneCh  chan struct{}
-	wg      sync.WaitGroup
-	m       consumerWriterMetrics
+	resetCh           chan struct{}
+	doneCh            chan struct{}
+	wg                sync.WaitGroup
+	m                 consumerWriterMetrics
+	isActive          int32
+	activeWriteDoneCh chan error
+	activeWriteTimer  *time.Timer
 
 	nowFn     clock.NowFn
 	connectFn connectFn
@@ -150,17 +155,20 @@ func newConsumerWriter(
 
 	connOpts := opts.ConnectionOptions()
 	w := &consumerWriterImpl{
-		addr:        addr,
-		router:      router,
-		opts:        opts,
-		connOpts:    connOpts,
-		ackRetrier:  retry.NewRetrier(opts.AckErrorRetryOptions()),
-		connRetrier: retry.NewRetrier(connOpts.RetryOptions().SetForever(defaultRetryForever)),
-		logger:      opts.InstrumentOptions().Logger(),
-		resetCh:     make(chan struct{}, 1),
-		doneCh:      make(chan struct{}),
-		m:           m,
-		nowFn:       time.Now,
+		addr:              addr,
+		router:            router,
+		opts:              opts,
+		connOpts:          connOpts,
+		ackRetrier:        retry.NewRetrier(opts.AckErrorRetryOptions()),
+		connRetrier:       retry.NewRetrier(connOpts.RetryOptions().SetForever(defaultRetryForever)),
+		logger:            opts.InstrumentOptions().Logger(),
+		resetCh:           make(chan struct{}, 1),
+		activeWriteDoneCh: make(chan error, 1),
+		activeWriteTimer:  time.NewTimer(200 * time.Millisecond),
+		isActive:          0,
+		doneCh:            make(chan struct{}),
+		m:                 m,
+		nowFn:             time.Now,
 	}
 	w.connectFn = w.connectNoRetry
 
@@ -195,6 +203,38 @@ func (w *consumerWriterImpl) Address() string {
 // Write should fail fast so that the write could be tried on other
 // consumer writers that are sharing the message queue.
 func (w *consumerWriterImpl) Write(connIndex int, b []byte) error {
+	// mark as active if not already active.
+	if !atomic.CompareAndSwapInt32(&w.isActive, 0, 1) {
+		return errWriteInProgress
+	}
+
+	// start the timer and write in a goroutine.
+	w.activeWriteTimer.Reset(200 * time.Millisecond)
+	go func() {
+		// write and notify done.
+		// make it non-blocking by dropping the returned err.
+		select {
+		case w.activeWriteDoneCh <- w.write(connIndex, b):
+		default:
+			<-w.activeWriteDoneCh
+		}
+
+		// stop the timer.
+		w.activeWriteTimer.Stop()
+
+		// mark the write as inactive.
+		atomic.CompareAndSwapInt32(&w.isActive, 1, 0)
+	}()
+
+	select {
+	case err := <-w.activeWriteDoneCh:
+		return err
+	case <-w.activeWriteTimer.C:
+		return errWriteInProgress
+	}
+}
+
+func (w *consumerWriterImpl) write(connIndex int, b []byte) error {
 	w.writeState.RLock()
 	if !w.writeState.validConns || len(w.writeState.conns) == 0 {
 		w.writeState.RUnlock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
When writing to a ConsumerService, m3msg producer randomly picks a ConsumerWriter that writes to a replica. It will block until there is a success or an error. In certain cases such as deployment of the ConsumerService, the error path induces an very high latency (25s+). This creates a huge backlog in the m3aggregator message queue and drastically increases the consume latency of the messages. In order to minimize the impact of these errors, this PR waits for a configurable amount of time on a write to return. If it doesn't then it opportunistically starts writing the message to another random replica concurrently. If this succeeds and the message is acked, the subsequent writes will detect that the stalled ConsumerWriter is still active and will skip over it to go straight to another ConsumerWriter. As soon as the connection stability returns, the m3msg producer will go back to writing to one replica. 
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
