### PR TITLE
[aggregator] Close Aggregator client connection asynchronously

### DIFF
--- a/src/aggregator/client/conn.go
+++ b/src/aggregator/client/conn.go
@@ -216,10 +216,6 @@ func (c *connection) connectWithLock() error {
 		conn = securedConn
 	}
 
-	if c.conn != nil {
-		c.conn.Close() // nolint: errcheck
-	}
-
 	c.conn = conn
 	c.writer.Reset(conn)
 	return nil
@@ -294,7 +290,15 @@ func (c *connection) resetWithLock() {
 
 func (c *connection) closeWithLock() {
 	if c.conn != nil {
-		c.conn.Close() // nolint: errcheck
+		// Reference: https://github.com/golang/go/blob/8fd0f83552d3ef9ca38c031bec93a36b189e3e11/src/crypto/tls/conn.go#L1361
+		//
+		// tls.Conn.Close() sets a 5-second write timeout before sending a "close notify" alert.
+		// If the connection is half-open and the send queue is full, "close notify" will be delayed
+		// by this timeout before returning an error. Currently, there is no way to configure this timeout
+		// at the application level (see: https://github.com/golang/go/issues/45162).
+		//
+		// At this point, the lock should be acquired, and we can safely close the connection asynchronously.
+		go c.conn.Close() // nolint: errcheck
 	}
 	c.conn = nil
 }

--- a/src/aggregator/client/conn.go
+++ b/src/aggregator/client/conn.go
@@ -216,6 +216,7 @@ func (c *connection) connectWithLock() error {
 		conn = securedConn
 	}
 
+	// c.conn is always nil at this point, so closing the previous connection is unnecessary
 	c.conn = conn
 	c.writer.Reset(conn)
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
`crypto/tls.Conn.Close()` takes 5 seconds to execute in cases where the connection is half-open, and the send queue (sendq) is full.

To avoid blocking while waiting for this timeout, this PR introduces an asynchronous closure workaround that allows flushing to continue without being delayed.

**References**:
Write deadline in `crypto/tls`: [[link](https://github.com/golang/go/blob/8fd0f83552d3ef9ca38c031bec93a36b189e3e11/src/crypto/tls/conn.go#L1361)]
GitHub issue for this problem: [[link](https://github.com/golang/go/issues/45162)]

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:

```
NONE
```

**Does this PR require updating code package or user-facing documentation?**:

```
NONE
```
