### PR TITLE
Fix m3msg producer Close operation

### DIFF
--- a/src/msg/producer/writer/consumer_writer.go
+++ b/src/msg/producer/writer/consumer_writer.go
@@ -522,15 +522,15 @@ func (w *consumerWriterImpl) connectNoRetryWithTimeout(addr string) (readWriterW
 		// by default we set SO_LINGER off because:
 		// 1. these connections are meant to be always open.
 		// 2. if we are closing the connection, it means that
-		//    either
-		// 	  a. the server terminated/rebooted
-		//    b. we are are terminating/rebooting.
+		//    either:
+		//    a. the server terminated/rebooted.
+		//    b. producer itself is terminating/rebooting.
 		//    c. there was a change in consumers of the topic
 		//       or placement change.
-		//    In any case, we don't want care about the data
+		//    In any case, we don't care about the data
 		//    held up in the sendbuf.
 		// 3. We don't want to hang on to the connection until
-		// .  all the data is flushed out.
+		//    all the data is flushed out.
 		w.logger.Warn("could not set linger off", zap.Error(err))
 	}
 

--- a/src/msg/producer/writer/consumer_writer.go
+++ b/src/msg/producer/writer/consumer_writer.go
@@ -511,29 +511,6 @@ func (w *consumerWriterImpl) connectNoRetryWithTimeout(addr string) (readWriterW
 	if err = tcpConn.SetKeepAlivePeriod(keepAlivePeriod); err != nil {
 		w.m.setKeepAlivePeriodError.Inc(1)
 	}
-	c, ok := conn.(*net.TCPConn)
-	if !ok {
-		w.logger.Warn("could not get TCPConn from dialer")
-		return newReadWriterWithTimeout(conn, w.connOpts.WriteTimeout(), w.nowFn), nil
-	}
-
-	// set linger off to avoid hanging on close
-	if err = c.SetLinger(0); err != nil {
-		// by default we set SO_LINGER off because:
-		// 1. these connections are meant to be always open.
-		// 2. if we are closing the connection, it means that
-		//    either:
-		//    a. the server terminated/rebooted.
-		//    b. producer itself is terminating/rebooting.
-		//    c. there was a change in consumers of the topic
-		//       or placement change.
-		//    In any case, we don't care about the data
-		//    held up in the sendbuf.
-		// 3. We don't want to hang on to the connection until
-		//    all the data is flushed out.
-		w.logger.Warn("could not set linger off", zap.Error(err))
-	}
-
 	return newReadWriterWithTimeout(conn, w.connOpts.WriteTimeout(), w.nowFn), nil
 }
 

--- a/src/msg/producer/writer/consumer_writer.go
+++ b/src/msg/producer/writer/consumer_writer.go
@@ -356,7 +356,7 @@ func (w *consumerWriterImpl) resetWithConnectFn(fn connectAllFn) error {
 	}
 	w.reset(resetOptions{
 		connections: conns,
-		at:          time.Time{},
+		at:          w.nowFn(),
 		validConns:  true,
 	})
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
Each MessageWriter within the m3msg Producer has multiple ConsumerWriters depending on the number of replicas configured. The MessageWriter writes a message to its internal queue and a goroutine reads from this queue and writes it serially to the consumerWriters. If any consumerWriter gets stuck then the whole message queue is blocked. This creates a huge backup of messages in the aggregator that instantiates said m3msg producer. 
This PR aims to unblock a stuck Write() within the ConsumerWriter.
Why does the Write() get stuck?
When the consuming service (via m3msg consumer) terminates, it issues a Close() on its listen socket. On seeing this the client as it stands today will first try and re-connect to the same consuming service only to be rejected over and over again and only when it is successful it will close the existing connection. It therefore never closes its existing connection which makes the existing connection block on a write() / flush(). 
This PR changes the order of event such that it first issues a Close() on the socket and then proceeds to retry connects. 

<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
