### PR TITLE
[aggregator] Adding cardinality by source metrics

### DIFF
--- a/src/aggregator/aggregator/extract_source.go
+++ b/src/aggregator/aggregator/extract_source.go
@@ -1,0 +1,39 @@
+package aggregator
+
+import "strings"
+
+const (
+	_tagPairSplitter     = ","
+	_tagPairSplitterByte = ','
+	_tagNameSplitter     = "="
+)
+
+func ExtractSourceTag(id string, sourceTag string) (string, bool) {
+	var (
+		sourceTagAssign     = _tagPairSplitter + sourceTag + _tagNameSplitter
+		minimumSourceTagLen = len(sourceTagAssign) + 1
+	)
+	idlen := len(id)
+	if idlen < minimumSourceTagLen {
+		return "", false
+	}
+
+	idx := strings.Index(id, sourceTagAssign)
+	if idx < 0 {
+		return "", false
+	}
+
+	// The front of the ID is now the tag value, along with the remainder of the
+	// ID's tags. Find the next tag splitter, if any.
+	id = id[idx+len(sourceTagAssign):]
+	idx = strings.IndexByte(id, _tagPairSplitterByte)
+
+	switch idx {
+	case -1: // delimiter not found; remainder of ID is the service name
+		return id, len(id) > 0
+	case 0: // id[0] = ',' - i.e., no tag value
+		return "", false
+	default: // id[:idx] == tag value
+		return id[:idx], true
+	}
+}

--- a/src/aggregator/aggregator/extract_source_test.go
+++ b/src/aggregator/aggregator/extract_source_test.go
@@ -1,0 +1,65 @@
+package aggregator
+
+import (
+	"testing"
+)
+
+func TestExtractSourceTag(t *testing.T) {
+	sourceTag := "service"
+	tests := []struct {
+		name   string
+		id     string
+		want   string
+		wantOk bool
+	}{
+		{
+			name:   "valid source tag with more tags",
+			id:     "metricname,service=myservice,env=test",
+			want:   "myservice",
+			wantOk: true,
+		},
+		{
+			name:   "valid source tag at end",
+			id:     "metricname,service=myservice",
+			want:   "myservice",
+			wantOk: true,
+		},
+		{
+			name:   "service tag not found",
+			id:     "metricname,env=test",
+			want:   "",
+			wantOk: false,
+		},
+		{
+			name:   "empty service tag value",
+			id:     "metricname,service=",
+			want:   "",
+			wantOk: false,
+		},
+		{
+			name:   "empty ID",
+			id:     "",
+			want:   "",
+			wantOk: false,
+		},
+		{
+			name:   "ID shorter than minimum length",
+			id:     "s",
+			want:   "",
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ExtractSourceTag(tt.id, sourceTag)
+			if ok != tt.wantOk {
+				t.Errorf("ExtractSourceTag() ok = %v, want %v", ok, tt.wantOk)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ExtractSourceTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -65,6 +65,11 @@ var (
 	// are issues with the instances taking over the shards and as such we need to switch
 	// the traffic back to the previous owner of the shards immediately.
 	defaultBufferDurationAfterShardCutoff = time.Hour
+
+	// By default the cardinality metrics are disabled.
+	defaultCardinalityMetricsEnabled = false
+	// By default the source tag is "service".
+	defaultSourceTag = "service"
 )
 
 // MaxAllowedForwardingDelayFn returns the maximum allowed forwarding delay given
@@ -347,6 +352,18 @@ type Options interface {
 	// SetWritesIgnoreCutoffCutover sets a flag controlling whether cutoff/cutover timestamps
 	// are ignored for incoming writes.
 	SetWritesIgnoreCutoffCutover(value bool) Options
+
+	// CardinalityMetricsEnabled enables the emission of cardinality metrics.
+	CardinalityMetricsEnabled() bool
+
+	// SetCardinalityMetricsEnabled sets the cardinality metrics enabled.
+	SetCardinalityMetricsEnabled(value bool) Options
+
+	// SetSourceTag sets the source tag.
+	SetSourceTag(value string) Options
+
+	// SourceTag returns the source tag.
+	SourceTag() string
 }
 
 type options struct {
@@ -392,7 +409,9 @@ type options struct {
 	timedMetricsFlushOffsetEnabled   bool
 	featureFlagBundlesParsed         []FeatureFlagBundleParsed
 	writesIgnoreCutoffCutover        bool
-
+	cardinalityMetricsEnabled        bool
+	sourceTag                        string
+	
 	// Derived options.
 	fullCounterPrefix []byte
 	fullTimerPrefix   []byte
@@ -434,6 +453,8 @@ func NewOptions(clockOpts clock.Options) Options {
 		maxNumCachedSourceSets:           defaultMaxNumCachedSourceSets,
 		discardNaNAggregatedValues:       defaultDiscardNaNAggregatedValues,
 		verboseErrors:                    defaultVerboseErrors,
+		cardinalityMetricsEnabled:        defaultCardinalityMetricsEnabled,
+		sourceTag:                        defaultSourceTag,
 	}
 
 	// Initialize pools.
@@ -929,6 +950,26 @@ func (o *options) SetWritesIgnoreCutoffCutover(value bool) Options {
 	opts := *o
 	opts.writesIgnoreCutoffCutover = value
 	return &opts
+}
+
+func (o *options) CardinalityMetricsEnabled() bool {
+	return o.cardinalityMetricsEnabled
+}
+
+func (o *options) SetCardinalityMetricsEnabled(value bool) Options {
+	opts := *o
+	opts.cardinalityMetricsEnabled = value
+	return &opts
+}
+
+func (o *options) SetSourceTag(value string) Options {
+	opts := *o
+	opts.sourceTag = value
+	return &opts
+}
+
+func (o *options) SourceTag() string {
+	return o.sourceTag
 }
 
 func defaultMaxAllowedForwardingDelayFn(

--- a/src/aggregator/aggregator/options.go
+++ b/src/aggregator/aggregator/options.go
@@ -359,11 +359,11 @@ type Options interface {
 	// SetCardinalityMetricsEnabled sets the cardinality metrics enabled.
 	SetCardinalityMetricsEnabled(value bool) Options
 
-	// SetSourceTag sets the source tag.
-	SetSourceTag(value string) Options
-
 	// SourceTag returns the source tag.
 	SourceTag() string
+
+	// SetSourceTag sets the source tag.
+	SetSourceTag(value string) Options
 }
 
 type options struct {
@@ -411,7 +411,7 @@ type options struct {
 	writesIgnoreCutoffCutover        bool
 	cardinalityMetricsEnabled        bool
 	sourceTag                        string
-	
+
 	// Derived options.
 	fullCounterPrefix []byte
 	fullTimerPrefix   []byte
@@ -962,14 +962,14 @@ func (o *options) SetCardinalityMetricsEnabled(value bool) Options {
 	return &opts
 }
 
+func (o *options) SourceTag() string {
+	return o.sourceTag
+}
+
 func (o *options) SetSourceTag(value string) Options {
 	opts := *o
 	opts.sourceTag = value
 	return &opts
-}
-
-func (o *options) SourceTag() string {
-	return o.sourceTag
 }
 
 func defaultMaxAllowedForwardingDelayFn(

--- a/src/aggregator/aggregator/tick_result.go
+++ b/src/aggregator/aggregator/tick_result.go
@@ -51,16 +51,22 @@ func (r *tickResultForMetricCategory) merge(
 }
 
 type tickResult struct {
-	standard  tickResultForMetricCategory
-	forwarded tickResultForMetricCategory
-	timed     tickResultForMetricCategory
+	standard            tickResultForMetricCategory
+	forwarded           tickResultForMetricCategory
+	timed               tickResultForMetricCategory
+	cardinalityBySource map[string]int
 }
 
 // merge merges two results. Both input results may become invalid after merge is called.
 func (r *tickResult) merge(other tickResult) tickResult {
-	return tickResult{
-		standard:  r.standard.merge(other.standard),
-		forwarded: r.forwarded.merge(other.forwarded),
-		timed:     r.timed.merge(other.timed),
+	res := tickResult{
+		standard:            r.standard.merge(other.standard),
+		forwarded:           r.forwarded.merge(other.forwarded),
+		timed:               r.timed.merge(other.timed),
+		cardinalityBySource: r.cardinalityBySource,
 	}
+	for k, v := range other.cardinalityBySource {
+		res.cardinalityBySource[k] += v
+	}
+	return res
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We want cardinality metrics coming from aggregator, this is done at the ticker and the metrics get pushed when the flush happens.

I added possibility to disable the metrics and option to set your own source tag (by default source will be collected from the service tag)

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
Add per flush cardinality metrics
```
