### PR TITLE
Support ETCD Prefix KV Retrievals and Watches

### DIFF
--- a/src/cluster/kv/etcd/store.go
+++ b/src/cluster/kv/etcd/store.go
@@ -50,40 +50,13 @@ var (
 	errNilPutResponse        = errors.New("nil put response from etcd")
 )
 
-// NewStore creates a kv store based on etcd
+// NewStore creates a kv store based on etcd and watches single keys.
 func NewStore(etcdKV *clientv3.Client, opts Options) (kv.TxnStore, error) {
-	scope := opts.InstrumentsOptions().MetricsScope()
-
-	store := &client{
-		opts:           opts,
-		kv:             etcdKV,
-		watchables:     map[string]kv.ValueWatchable{},
-		retrier:        retry.NewRetrier(opts.RetryOptions()),
-		logger:         opts.InstrumentsOptions().Logger(),
-		cacheFile:      opts.CacheFileFn()(opts.Prefix()),
-		cache:          newCache(),
-		cacheUpdatedCh: make(chan struct{}, 1),
-		m: clientMetrics{
-			etcdGetError:   scope.Counter("etcd-get-error"),
-			etcdPutError:   scope.Counter("etcd-put-error"),
-			etcdTnxError:   scope.Counter("etcd-tnx-error"),
-			diskWriteError: scope.Counter("disk-write-error"),
-			diskReadError:  scope.Counter("disk-read-error"),
-		},
+	store, err := newStore[kv.Value, kv.ValueWatch](etcdKV, opts)
+	if err != nil {
+		return nil, err
 	}
-
-	clientWatchOpts := []clientv3.OpOption{
-		// periodically (appx every 10 mins) checks for the latest data
-		// with or without any update notification
-		clientv3.WithProgressNotify(),
-		// receive initial notification once the watch channel is created
-		clientv3.WithCreatedNotify(),
-	}
-
-	if rev := opts.WatchWithRevision(); rev > 0 {
-		clientWatchOpts = append(clientWatchOpts, clientv3.WithRev(rev))
-	}
-
+	clientWatchOpts := newClientWatchOptions(opts)
 	wOpts := watchmanager.NewOptions().
 		SetClient(etcdKV).
 		SetUpdateFn(store.update).
@@ -100,6 +73,63 @@ func NewStore(etcdKV *clientv3.Client, opts Options) (kv.TxnStore, error) {
 	}
 
 	store.wm = wm
+	return store, nil
+}
+
+// NewPrefixStore creates a kv store based on etcd and watches all keys with a given prefix.
+func NewPrefixStore(etcdKV *clientv3.Client, opts Options) (kv.PrefixStore, error) {
+	store, err := newStore[map[string]kv.Value, kv.PrefixWatch](
+		etcdKV,
+		opts,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	clientWatchOpts := newClientWatchOptions(opts)
+	clientWatchOpts = append(clientWatchOpts, []clientv3.OpOption{clientv3.WithPrefix()}...)
+	wOpts := watchmanager.NewOptions().
+		SetClient(etcdKV).
+		SetUpdateFn(store.updateForPrefix).
+		SetTickAndStopFn(store.tickAndStop).
+		SetWatchOptions(clientWatchOpts).
+		SetWatchChanCheckInterval(opts.WatchChanCheckInterval()).
+		SetWatchChanInitTimeout(opts.WatchChanInitTimeout()).
+		SetWatchChanResetInterval(opts.WatchChanResetInterval()).
+		SetInstrumentsOptions(opts.InstrumentsOptions())
+
+	wm, err := watchmanager.NewWatchManager(wOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	store.wm = wm
+	return store, nil
+}
+
+func newStore[ValueType any, ValueWatchType any](
+	etcdKV *clientv3.Client,
+	opts Options,
+) (*client[ValueType, ValueWatchType], error) {
+	scope := opts.InstrumentsOptions().MetricsScope()
+
+	store := &client[ValueType, ValueWatchType]{
+		opts:           opts,
+		kv:             etcdKV,
+		watchables:     map[string]kv.Watchable[ValueType, ValueWatchType]{},
+		retrier:        retry.NewRetrier(opts.RetryOptions()),
+		logger:         opts.InstrumentsOptions().Logger(),
+		cacheFile:      opts.CacheFileFn()(opts.Prefix()),
+		cache:          newCache(),
+		cacheUpdatedCh: make(chan struct{}, 1),
+		m: clientMetrics{
+			etcdGetError:   scope.Counter("etcd-get-error"),
+			etcdPutError:   scope.Counter("etcd-put-error"),
+			etcdTnxError:   scope.Counter("etcd-tnx-error"),
+			diskWriteError: scope.Counter("disk-write-error"),
+			diskReadError:  scope.Counter("disk-read-error"),
+		},
+	}
 
 	if store.cacheFile != "" {
 		if err := store.initCache(opts.NewDirectoryMode()); err != nil {
@@ -119,12 +149,28 @@ func NewStore(etcdKV *clientv3.Client, opts Options) (kv.TxnStore, error) {
 	return store, nil
 }
 
-type client struct {
+func newClientWatchOptions(opts Options) []clientv3.OpOption {
+	clientWatchOpts := []clientv3.OpOption{
+		// periodically (appx every 10 mins) checks for the latest data
+		// with or without any update notification
+		clientv3.WithProgressNotify(),
+		// receive initial notification once the watch channel is created
+		clientv3.WithCreatedNotify(),
+	}
+
+	if rev := opts.WatchWithRevision(); rev > 0 {
+		clientWatchOpts = append(clientWatchOpts, clientv3.WithRev(rev))
+	}
+
+	return clientWatchOpts
+}
+
+type client[ValueType any, ValueWatchType any] struct {
 	sync.RWMutex
 
 	opts           Options
 	kv             *clientv3.Client
-	watchables     map[string]kv.ValueWatchable
+	watchables     map[string]kv.Watchable[ValueType, ValueWatchType]
 	retrier        retry.Retrier
 	logger         *zap.Logger
 	m              clientMetrics
@@ -145,11 +191,11 @@ type clientMetrics struct {
 
 // Get returns the latest value from etcd store and only fall back to
 // in-memory cache if the remote store is unavailable
-func (c *client) Get(key string) (kv.Value, error) {
+func (c *client[ValueType, ValueWatchType]) Get(key string) (kv.Value, error) {
 	return c.get(c.opts.ApplyPrefix(key))
 }
 
-func (c *client) get(key string) (kv.Value, error) {
+func (c *client[ValueType, ValueWatchType]) get(key string) (kv.Value, error) {
 	ctx, cancel := c.context()
 	defer cancel()
 
@@ -179,7 +225,35 @@ func (c *client) get(key string) (kv.Value, error) {
 	return v, nil
 }
 
-func (c *client) History(key string, from, to int) ([]kv.Value, error) {
+func (c *client[ValueType, ValueWatchType]) GetForPrefix(prefix string) (map[string]kv.Value, error) {
+	ctx, cancel := c.context()
+	defer cancel()
+	prefix = c.opts.ApplyPrefix(prefix)
+
+	var opts []clientv3.OpOption
+	if c.opts.EnableFastGets() {
+		opts = append(opts, clientv3.WithSerializable())
+	}
+	opts = append(opts, clientv3.WithPrefix())
+	r, err := c.kv.Get(ctx, prefix, opts...)
+	if err != nil {
+		c.m.etcdGetError.Inc(1)
+		return nil, err
+	}
+
+	if r.Count == 0 {
+		return nil, kv.ErrNotFound
+	}
+
+	values := make(map[string]kv.Value)
+	for _, kv := range r.Kvs {
+		values[string(kv.Key)] = newValue(kv.Value, kv.Version, kv.ModRevision)
+	}
+
+	return values, nil
+}
+
+func (c *client[ValueType, ValueWatchType]) History(key string, from, to int) ([]kv.Value, error) {
 	if from > to || from < 0 || to < 0 {
 		return nil, errInvalidHistoryVersion
 	}
@@ -250,7 +324,7 @@ func (c *client) History(key string, from, to int) ([]kv.Value, error) {
 	return res, nil
 }
 
-func (c *client) processCondition(condition kv.Condition) (clientv3.Cmp, error) {
+func (c *client[ValueType, ValueWatchType]) processCondition(condition kv.Condition) (clientv3.Cmp, error) {
 	var cmp clientv3.Cmp
 	switch condition.TargetType() {
 	case kv.TargetVersion:
@@ -270,7 +344,7 @@ func (c *client) processCondition(condition kv.Condition) (clientv3.Cmp, error) 
 	return clientv3.Compare(cmp, compareStr, condition.Value()), nil
 }
 
-func (c *client) processOp(op kv.Op) (clientv3.Op, error) {
+func (c *client[ValueType, ValueWatchType]) processOp(op kv.Op) (clientv3.Op, error) {
 	switch op.Type() {
 	case kv.OpSet:
 		opSet := op.(kv.SetOp)
@@ -290,7 +364,7 @@ func (c *client) processOp(op kv.Op) (clientv3.Op, error) {
 	}
 }
 
-func (c *client) Commit(conditions []kv.Condition, ops []kv.Op) (kv.Response, error) {
+func (c *client[ValueType, ValueWatchType]) Commit(conditions []kv.Condition, ops []kv.Op) (kv.Response, error) {
 	ctx, cancel := c.context()
 	defer cancel()
 
@@ -353,23 +427,41 @@ func (c *client) Commit(conditions []kv.Condition, ops []kv.Op) (kv.Response, er
 	return kv.NewResponse().SetResponses(opResponses), nil
 }
 
-func (c *client) Watch(key string) (kv.ValueWatch, error) {
+func (c *client[ValueType, ValueWatchType]) Watch(key string) (ValueWatchType, error) {
 	newKey := c.opts.ApplyPrefix(key)
 	c.Lock()
-	watchable, ok := c.watchables[newKey]
+	w, ok := c.watchables[newKey]
 	if !ok {
-		watchable = kv.NewValueWatchable()
-		c.watchables[newKey] = watchable
+		watchable := kv.NewValueWatchable()
+		w = watchable.(kv.Watchable[ValueType, ValueWatchType])
+		c.watchables[newKey] = w
 
 		go c.wm.Watch(newKey)
 
 	}
 	c.Unlock()
-	_, w, err := watchable.Watch()
-	return w, err
+	_, watch, err := w.Watch()
+	return watch, err
 }
 
-func (c *client) getFromKVStore(key string) (kv.Value, error) {
+func (c *client[ValueType, ValueWatchType]) WatchForPrefix(prefix string) (ValueWatchType, error) {
+	newKey := c.opts.ApplyPrefix(prefix)
+	c.Lock()
+	w, ok := c.watchables[newKey]
+	if !ok {
+		watchable := kv.NewPrefixWatchable()
+		w = watchable.(kv.Watchable[ValueType, ValueWatchType])
+		c.watchables[newKey] = w
+		go c.wm.Watch(newKey)
+	}
+
+	c.Unlock()
+
+	_, watch, err := w.Watch()
+	return watch, err
+}
+
+func (c *client[ValueType, ValueWatchType]) getFromKVStore(key string) (kv.Value, error) {
 	var (
 		nv  kv.Value
 		err error
@@ -388,7 +480,7 @@ func (c *client) getFromKVStore(key string) (kv.Value, error) {
 	return nv, nil
 }
 
-func (c *client) getFromEtcdEvents(key string, events []*clientv3.Event) kv.Value {
+func (c *client[ValueType, ValueWatchType]) getFromEtcdEvents(key string, events []*clientv3.Event) kv.Value {
 	lastEvent := events[len(events)-1]
 	if lastEvent.Type == clientv3.EventTypeDelete {
 		c.deleteCache(key)
@@ -400,7 +492,26 @@ func (c *client) getFromEtcdEvents(key string, events []*clientv3.Event) kv.Valu
 	return nv
 }
 
-func (c *client) update(key string, events []*clientv3.Event) error {
+func (c *client[ValueType, ValueWatchType]) getFromEtcdEventsForPrefix(
+	prefix string,
+	events []*clientv3.Event,
+) (map[string]kv.Value, []string) {
+	toDelete := []string{}
+
+	values := make(map[string]kv.Value)
+	for _, e := range events {
+		if e.Type == clientv3.EventTypeDelete {
+			toDelete = append(toDelete, string(e.Kv.Key))
+			continue
+		}
+
+		values[string(e.Kv.Key)] = newValue(e.Kv.Value, e.Kv.Version, e.Kv.ModRevision)
+	}
+
+	return values, toDelete
+}
+
+func (c *client[ValueType, ValueWatchType]) update(key string, events []*clientv3.Event) error {
 	var nv kv.Value
 	if len(events) == 0 {
 		var err error
@@ -419,7 +530,12 @@ func (c *client) update(key string, events []*clientv3.Event) error {
 		return fmt.Errorf("unexpected: no watchable found for key: %s", key)
 	}
 
-	curValue := w.Get()
+	watchable, ok := any(w).(kv.ValueWatchable)
+	if !ok {
+		return fmt.Errorf("unexpected: value watchable not found for key: %s", key)
+	}
+
+	curValue := watchable.Get()
 
 	// Both current and new are nil.
 	if curValue == nil && nv == nil {
@@ -428,17 +544,65 @@ func (c *client) update(key string, events []*clientv3.Event) error {
 
 	if nv == nil {
 		// At deletion, just update the watch to nil.
-		return w.Update(nil)
+		return watchable.Update(nil)
 	}
 
 	if curValue == nil || nv.IsNewer(curValue) {
-		return w.Update(nv)
+		return watchable.Update(nv)
 	}
 
 	return nil
 }
 
-func (c *client) tickAndStop(key string) bool {
+func (c *client[ValueType, ValueWatchType]) updateForPrefix(prefix string, events []*clientv3.Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	values, toDelete := c.getFromEtcdEventsForPrefix(prefix, events)
+
+	c.RLock()
+	w, ok := c.watchables[prefix]
+	c.RUnlock()
+	if !ok {
+		return fmt.Errorf("unexpected: no watchable found for key: %s", prefix)
+	}
+
+	watchable, ok := any(w).(kv.PrefixWatchable)
+	if !ok {
+		return fmt.Errorf("unexpected: prefix watchable not found for path: %s", prefix)
+	}
+
+	curValue := watchable.Get()
+
+	// Both current and new are empty.
+	if len(curValue) == 0 && len(values) == 0 {
+		return nil
+	}
+
+	if len(values) == 0 {
+		// At deletion, just update the watch to nil.
+		return watchable.Update(nil)
+	}
+
+	// combine the current and new values
+	combinedValues := make(map[string]kv.Value)
+	for k, v := range curValue {
+		combinedValues[k] = v
+	}
+	for k, v := range values {
+		combinedValues[k] = v
+	}
+
+	// delete the keys that are no longer present
+	for _, k := range toDelete {
+		delete(combinedValues, k)
+	}
+
+	return watchable.Update(combinedValues)
+}
+
+func (c *client[ValueType, ValueWatchType]) tickAndStop(key string) bool {
 	// fast path
 	c.RLock()
 	watchable, ok := c.watchables[key]
@@ -472,7 +636,7 @@ func (c *client) tickAndStop(key string) bool {
 	return true
 }
 
-func (c *client) Set(key string, v proto.Message) (int, error) {
+func (c *client[ValueType, ValueWatchType]) Set(key string, v proto.Message) (int, error) {
 	ctx, cancel := c.context()
 	defer cancel()
 
@@ -495,7 +659,7 @@ func (c *client) Set(key string, v proto.Message) (int, error) {
 	return int(r.PrevKv.Version + 1), nil
 }
 
-func (c *client) SetIfNotExists(key string, v proto.Message) (int, error) {
+func (c *client[ValueType, ValueWatchType]) SetIfNotExists(key string, v proto.Message) (int, error) {
 	version, err := c.CheckAndSet(key, etcdVersionZero, v)
 	if err == kv.ErrVersionMismatch {
 		err = kv.ErrAlreadyExists
@@ -503,7 +667,7 @@ func (c *client) SetIfNotExists(key string, v proto.Message) (int, error) {
 	return version, err
 }
 
-func (c *client) CheckAndSet(key string, version int, v proto.Message) (int, error) {
+func (c *client[ValueType, ValueWatchType]) CheckAndSet(key string, version int, v proto.Message) (int, error) {
 	ctx, cancel := c.context()
 	defer cancel()
 
@@ -528,7 +692,7 @@ func (c *client) CheckAndSet(key string, version int, v proto.Message) (int, err
 	return version + 1, nil
 }
 
-func (c *client) Delete(key string) (kv.Value, error) {
+func (c *client[ValueType, ValueWatchType]) Delete(key string) (kv.Value, error) {
 	ctx, cancel := c.context()
 	defer cancel()
 
@@ -550,7 +714,7 @@ func (c *client) Delete(key string) (kv.Value, error) {
 	return prevKV, nil
 }
 
-func (c *client) deleteCache(key string) {
+func (c *client[ValueType, ValueWatchType]) deleteCache(key string) {
 	c.cache.Lock()
 	defer c.cache.Unlock()
 
@@ -564,7 +728,7 @@ func (c *client) deleteCache(key string) {
 	c.notifyCacheUpdate()
 }
 
-func (c *client) getCache(key string) (kv.Value, bool) {
+func (c *client[ValueType, ValueWatchType]) getCache(key string) (kv.Value, bool) {
 	c.cache.RLock()
 	v, ok := c.cache.Values[key]
 	c.cache.RUnlock()
@@ -572,7 +736,7 @@ func (c *client) getCache(key string) (kv.Value, bool) {
 	return v, ok
 }
 
-func (c *client) mergeCache(key string, v *value) {
+func (c *client[ValueType, ValueWatchType]) mergeCache(key string, v *value) {
 	c.cache.Lock()
 
 	cur, ok := c.cache.Values[key]
@@ -584,7 +748,7 @@ func (c *client) mergeCache(key string, v *value) {
 	c.cache.Unlock()
 }
 
-func (c *client) notifyCacheUpdate() {
+func (c *client[ValueType, ValueWatchType]) notifyCacheUpdate() {
 	// notify that cached data is updated
 	select {
 	case c.cacheUpdatedCh <- struct{}{}:
@@ -592,7 +756,7 @@ func (c *client) notifyCacheUpdate() {
 	}
 }
 
-func (c *client) writeCacheToFile() error {
+func (c *client[ValueType, ValueWatchType]) writeCacheToFile() error {
 	file, err := os.Create(c.cacheFile)
 	if err != nil {
 		c.m.diskWriteError.Inc(1)
@@ -619,7 +783,7 @@ func (c *client) writeCacheToFile() error {
 	return nil
 }
 
-func (c *client) createCacheDir(fm os.FileMode) error {
+func (c *client[ValueType, ValueWatchType]) createCacheDir(fm os.FileMode) error {
 	path := path.Dir(c.opts.CacheFileFn()(c.opts.Prefix()))
 	if err := os.MkdirAll(path, fm); err != nil {
 		c.m.diskWriteError.Inc(1)
@@ -638,7 +802,7 @@ func (c *client) createCacheDir(fm os.FileMode) error {
 	return nil
 }
 
-func (c *client) initCache(fm os.FileMode) error {
+func (c *client[ValueType, ValueWatchType]) initCache(fm os.FileMode) error {
 	if err := c.createCacheDir(fm); err != nil {
 		c.m.diskWriteError.Inc(1)
 		return fmt.Errorf("error creating cache directory: %s", err)
@@ -660,7 +824,7 @@ func (c *client) initCache(fm os.FileMode) error {
 	return nil
 }
 
-func (c *client) context() (context.Context, context.CancelFunc) {
+func (c *client[ValueType, ValueWatchType]) context() (context.Context, context.CancelFunc) {
 	ctx := context.Background()
 	cancel := noopCancel
 	if c.opts.RequestTimeout() > 0 {

--- a/src/cluster/kv/etcd/store_test.go
+++ b/src/cluster/kv/etcd/store_test.go
@@ -87,8 +87,9 @@ func TestNoCache(t *testing.T) {
 	ec, opts, closeFn := testStore(t)
 
 	store, err := NewStore(ec, opts)
+	s := store.(*client[kv.Value, kv.ValueWatch])
 	require.NoError(t, err)
-	require.Equal(t, 0, len(store.(*client).cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cacheUpdatedCh))
 
 	version, err := store.Set("foo", genProto("bar1"))
 	require.NoError(t, err)
@@ -99,7 +100,7 @@ func TestNoCache(t *testing.T) {
 	verifyValue(t, value, "bar1", 1)
 	// the will send a notification but won't trigger a sync
 	// because no cache file is set
-	require.Equal(t, 1, len(store.(*client).cacheUpdatedCh))
+	require.Equal(t, 1, len(s.cacheUpdatedCh))
 
 	closeFn()
 
@@ -110,6 +111,7 @@ func TestNoCache(t *testing.T) {
 
 	// new store but no cache file set
 	store, err = NewStore(ec, opts)
+	s = store.(*client[kv.Value, kv.ValueWatch])
 	require.NoError(t, err)
 
 	_, err = store.Set("foo", genProto("bar1"))
@@ -117,7 +119,7 @@ func TestNoCache(t *testing.T) {
 
 	_, err = store.Get("foo")
 	require.Error(t, err)
-	require.Equal(t, 0, len(store.(*client).cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cacheUpdatedCh))
 }
 
 func TestCacheDirCreation(t *testing.T) {
@@ -134,6 +136,7 @@ func TestCacheDirCreation(t *testing.T) {
 	})
 
 	store, err := NewStore(ec, opts)
+	s := store.(*client[kv.Value, kv.ValueWatch])
 	require.NoError(t, err)
 
 	info, err := os.Stat(cdir)
@@ -146,7 +149,7 @@ func TestCacheDirCreation(t *testing.T) {
 	value, err := store.Get("foo")
 	require.NoError(t, err)
 	verifyValue(t, value, "bar", 1)
-	require.Equal(t, 0, len(store.(*client).cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cacheUpdatedCh))
 }
 
 func TestCache(t *testing.T) {
@@ -160,8 +163,9 @@ func TestCache(t *testing.T) {
 	})
 
 	store, err := NewStore(ec, opts)
+	s := store.(*client[kv.Value, kv.ValueWatch])
 	require.NoError(t, err)
-	require.Equal(t, 0, len(store.(*client).cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cacheUpdatedCh))
 
 	version, err := store.Set("foo", genProto("bar1"))
 	require.NoError(t, err)
@@ -172,7 +176,7 @@ func TestCache(t *testing.T) {
 	verifyValue(t, value, "bar1", 1)
 	for {
 		// the notification should be picked up and trigger a sync
-		if len(store.(*client).cacheUpdatedCh) == 0 {
+		if len(s.cacheUpdatedCh) == 0 {
 			break
 		}
 	}
@@ -182,10 +186,11 @@ func TestCache(t *testing.T) {
 	value, err = store.Get("foo")
 	require.NoError(t, err)
 	verifyValue(t, value, "bar1", 1)
-	require.Equal(t, 0, len(store.(*client).cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cacheUpdatedCh))
 
 	// new store but with cache file
 	store, err = NewStore(ec, opts)
+	s = store.(*client[kv.Value, kv.ValueWatch])
 	require.NoError(t, err)
 
 	_, err = store.Set("key", genProto("bar1"))
@@ -193,12 +198,12 @@ func TestCache(t *testing.T) {
 
 	_, err = store.Get("key")
 	require.Error(t, err)
-	require.Equal(t, 0, len(store.(*client).cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cacheUpdatedCh))
 
 	value, err = store.Get("foo")
 	require.NoError(t, err)
 	verifyValue(t, value, "bar1", 1)
-	require.Equal(t, 0, len(store.(*client).cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cacheUpdatedCh))
 }
 
 func TestSetIfNotExist(t *testing.T) {
@@ -260,8 +265,8 @@ func TestWatchClose(t *testing.T) {
 	<-w1.C()
 	verifyValue(t, w1.Get(), "bar1", 1)
 
-	c := store.(*client)
-	_, ok := c.watchables["test/foo"]
+	s := store.(*client[kv.Value, kv.ValueWatch])
+	_, ok := s.watchables["test/foo"]
 	require.True(t, ok)
 
 	// closing w1 will close the go routine for the watch updates
@@ -269,9 +274,9 @@ func TestWatchClose(t *testing.T) {
 
 	// waits until the original watchable is cleaned up
 	for {
-		c.RLock()
-		_, ok = c.watchables["test/foo"]
-		c.RUnlock()
+		s.RLock()
+		_, ok = s.watchables["test/foo"]
+		s.RUnlock()
 		if !ok {
 			break
 		}
@@ -408,11 +413,11 @@ func TestGetFromKvNotFound(t *testing.T) {
 	defer closeFn()
 	store, err := NewStore(ec, opts)
 	require.NoError(t, err)
-	c := store.(*client)
-	_, err = c.Set("foo", genProto("bar1"))
+	s := store.(*client[kv.Value, kv.ValueWatch])
+	_, err = s.Set("foo", genProto("bar1"))
 	require.NoError(t, err)
 
-	val, err := c.getFromKVStore("foo2")
+	val, err := s.getFromKVStore("foo2")
 	require.NoError(t, err)
 	require.Nil(t, val)
 }
@@ -519,14 +524,14 @@ func TestWatchNonBlocking(t *testing.T) {
 
 	store, err := NewStore(ec, opts)
 	require.NoError(t, err)
-	c := store.(*client)
+	s := store.(*client[kv.Value, kv.ValueWatch])
 
-	_, err = c.Set("foo", genProto("bar1"))
+	_, err = s.Set("foo", genProto("bar1"))
 	require.NoError(t, err)
 
 	before := time.Now()
 	ecluster.Members[0].Bridge().Blackhole()
-	w1, err := c.Watch("foo")
+	w1, err := s.Watch("foo")
 	require.WithinDuration(t, time.Now(), before, 100*time.Millisecond)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(w1.C()))
@@ -642,26 +647,26 @@ func TestDelete_UpdateCache(t *testing.T) {
 	c, err := NewStore(ec, opts)
 	require.NoError(t, err)
 
-	store := c.(*client)
-	version, err := store.Set("foo", genProto("bar1"))
+	s := c.(*client[kv.Value, kv.ValueWatch])
+	version, err := s.Set("foo", genProto("bar1"))
 	require.NoError(t, err)
 	require.Equal(t, 1, version)
 
-	v, err := store.Get("foo")
+	v, err := s.Get("foo")
 	require.NoError(t, err)
 	verifyValue(t, v, "bar1", 1)
-	require.Equal(t, 1, len(store.cache.Values))
-	require.Equal(t, 1, len(store.cacheUpdatedCh))
+	require.Equal(t, 1, len(s.cache.Values))
+	require.Equal(t, 1, len(s.cacheUpdatedCh))
 
 	// drain the notification
-	<-store.cacheUpdatedCh
+	<-s.cacheUpdatedCh
 
-	v, err = store.Delete("foo")
+	v, err = s.Delete("foo")
 	require.NoError(t, err)
 	verifyValue(t, v, "bar1", 1)
 	// make sure the cache is cleaned up
-	require.Equal(t, 0, len(store.cache.Values))
-	require.Equal(t, 1, len(store.cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cache.Values))
+	require.Equal(t, 1, len(s.cacheUpdatedCh))
 }
 
 func TestDelete_UpdateWatcherCache(t *testing.T) {
@@ -671,19 +676,19 @@ func TestDelete_UpdateWatcherCache(t *testing.T) {
 	setStore, err := NewStore(ec, opts)
 	require.NoError(t, err)
 
-	setClient := setStore.(*client)
-	version, err := setClient.Set("foo", genProto("bar1"))
+	s := setStore.(*client[kv.Value, kv.ValueWatch])
+	version, err := s.Set("foo", genProto("bar1"))
 	require.NoError(t, err)
 	require.Equal(t, 1, version)
 
-	setV, err := setClient.Get("foo")
+	setV, err := s.Get("foo")
 	require.NoError(t, err)
 	verifyValue(t, setV, "bar1", 1)
-	require.Equal(t, 1, len(setClient.cache.Values))
-	require.Equal(t, 1, len(setClient.cacheUpdatedCh))
+	require.Equal(t, 1, len(s.cache.Values))
+	require.Equal(t, 1, len(s.cacheUpdatedCh))
 
 	// drain the notification to ensure set received update
-	<-setClient.cacheUpdatedCh
+	<-s.cacheUpdatedCh
 
 	// make a custom cache path for the get client
 	clientCachePath, err := ioutil.TempDir("", "client-cache-dir")
@@ -695,7 +700,7 @@ func TestDelete_UpdateWatcherCache(t *testing.T) {
 		return nsFile
 	}))
 	require.NoError(t, err)
-	getClient := getStore.(*client)
+	getClient := getStore.(*client[kv.Value, kv.ValueWatch])
 
 	getW, err := getClient.Watch("foo")
 	require.NoError(t, err)
@@ -715,13 +720,13 @@ func TestDelete_UpdateWatcherCache(t *testing.T) {
 		return err == nil
 	}, time.Minute))
 
-	setV, err = setClient.Delete("foo")
+	setV, err = s.Delete("foo")
 	require.NoError(t, err)
 	verifyValue(t, setV, "bar1", 1)
 
 	// make sure the cache is cleaned up on set client
-	require.Equal(t, 0, len(setClient.cache.Values))
-	require.Equal(t, 1, len(setClient.cacheUpdatedCh))
+	require.Equal(t, 0, len(s.cache.Values))
+	require.Equal(t, 1, len(s.cacheUpdatedCh))
 
 	// make sure the cache is cleaned up on get client (mem and disk)
 	var (
@@ -795,15 +800,15 @@ func TestStaleDelete__FromGet(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	setClient := setStore.(*client)
-	version, err := setClient.Set("foo", genProto("bar1"))
+	s := setStore.(*client[kv.Value, kv.ValueWatch])
+	version, err := s.Set("foo", genProto("bar1"))
 	require.NoError(t, err)
 	require.Equal(t, 1, version)
 
-	setV, err := setClient.Get("foo")
+	setV, err := s.Get("foo")
 	require.NoError(t, err)
 	verifyValue(t, setV, "bar1", 1)
-	require.Equal(t, 1, len(setClient.cache.Values))
+	require.Equal(t, 1, len(s.cache.Values))
 
 	// drain the notification to ensure set received update
 	var (
@@ -843,7 +848,7 @@ func TestStaleDelete__FromGet(t *testing.T) {
 		return nsFile
 	}))
 	require.NoError(t, err)
-	getClient := getStore.(*client)
+	getClient := getStore.(*client[kv.Value, kv.ValueWatch])
 
 	require.True(t, xclock.WaitUntil(func() bool {
 		getClient.cache.RLock()
@@ -878,15 +883,15 @@ func TestStaleDelete__FromWatch(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	setClient := setStore.(*client)
-	version, err := setClient.Set("foo", genProto("bar1"))
+	s := setStore.(*client[kv.Value, kv.ValueWatch])
+	version, err := s.Set("foo", genProto("bar1"))
 	require.NoError(t, err)
 	require.Equal(t, 1, version)
 
-	setV, err := setClient.Get("foo")
+	setV, err := s.Get("foo")
 	require.NoError(t, err)
 	verifyValue(t, setV, "bar1", 1)
-	require.Equal(t, 1, len(setClient.cache.Values))
+	require.Equal(t, 1, len(s.cache.Values))
 
 	// drain the notification to ensure set received update
 	var (
@@ -928,7 +933,7 @@ func TestStaleDelete__FromWatch(t *testing.T) {
 		return nsFile
 	}))
 	require.NoError(t, err)
-	getClient := getStore.(*client)
+	getClient := getStore.(*client[kv.Value, kv.ValueWatch])
 
 	require.True(t, xclock.WaitUntil(func() bool {
 		getClient.cache.RLock()
@@ -1108,7 +1113,7 @@ func TestWatchWithStartRevision(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			cl := store.(*client).kv
+			cl := store.(*client[kv.Value, kv.ValueWatch]).kv
 
 			resp, err := cl.Get(context.Background(), "foo")
 			require.NoError(t, err)

--- a/src/cluster/kv/store.go
+++ b/src/cluster/kv/store.go
@@ -99,6 +99,73 @@ func valueFromWatch(value interface{}) Value {
 	return nil
 }
 
+type prefixWatch struct {
+	w xwatch.Watch
+}
+
+// newValueWatch creates a new ValueWatch
+func newPrefixWatch(w xwatch.Watch) PrefixWatch {
+	return &prefixWatch{w: w}
+}
+
+func (v *prefixWatch) Close() {
+	v.w.Close()
+}
+
+func (v *prefixWatch) C() <-chan struct{} {
+	return v.w.C()
+}
+
+func (v *prefixWatch) Get() map[string]Value {
+	return v.w.Get().(map[string]Value)
+}
+
+type prefixWatchable struct {
+	w xwatch.Watchable
+}
+
+// NewPrefixWatchable creates a new PrefixWatchable
+func NewPrefixWatchable() PrefixWatchable {
+	return &prefixWatchable{w: xwatch.NewPrefixWatchable()}
+}
+
+func (w *prefixWatchable) Get() map[string]Value {
+	return valueFromPrefixWatch(w.w.Get())
+}
+
+func (w *prefixWatchable) Watch() (map[string]Value, PrefixWatch, error) {
+	value, watch, err := w.w.Watch()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return valueFromPrefixWatch(value), newPrefixWatch(watch), nil
+}
+
+func (w *prefixWatchable) NumWatches() int {
+	return w.w.NumWatches()
+}
+
+func (w *prefixWatchable) Update(v map[string]Value) error {
+	return w.w.Update(v)
+}
+
+func (w *prefixWatchable) Close() {
+	w.w.Close()
+}
+
+func (w *prefixWatchable) IsClosed() bool {
+	return w.w.IsClosed()
+}
+
+func valueFromPrefixWatch(value interface{}) map[string]Value {
+	if value != nil {
+		return value.(map[string]Value)
+	}
+
+	return nil
+}
+
 type overrideOptions struct {
 	zone      string
 	env       string

--- a/src/cluster/kv/types.go
+++ b/src/cluster/kv/types.go
@@ -80,20 +80,10 @@ type ValueWatch interface {
 }
 
 // ValueWatchable can be watched for Value changes
-type ValueWatchable interface {
-	// Get returns the latest Value
-	Get() Value
-	// Watch returns the Value and a ValueWatch that will be notified on updates
-	Watch() (Value, ValueWatch, error)
-	// NumWatches returns the number of watches on the Watchable
-	NumWatches() int
-	// Update sets the Value and notify Watches
-	Update(Value) error
-	// IsClosed returns true if the Watchable is closed
-	IsClosed() bool
-	// Close stops watching for value updates
-	Close()
-}
+type ValueWatchable = Watchable[Value, ValueWatch]
+
+// PrefixWatchable can be watched for Prefix changes
+type PrefixWatchable = Watchable[map[string]Value, PrefixWatch]
 
 // OverrideOptions provides a set of options to override the default configurations of a KV store.
 type OverrideOptions interface {
@@ -230,4 +220,34 @@ type TxnStore interface {
 	Store
 
 	Commit([]Condition, []Op) (Response, error)
+}
+
+// PrefixStore is a multi-key store that supports prefix-based operations.
+// It exposes a Get() method that fetches all the values under the particular
+// prefix. It supports watching a prefix path and returns the current state
+// of the entire list of keys that are covered by the prefix.
+// It only supports read-only operations at the moment.
+type PrefixStore interface {
+	GetForPrefix(prefix string) (map[string]Value, error)
+	WatchForPrefix(prefix string) (PrefixWatch, error)
+}
+
+type PrefixWatch interface {
+	C() <-chan struct{}
+	Get() map[string]Value
+	Close()
+}
+
+type Watchable[ValueType any, ValueWatchType any] interface {
+	Get() ValueType
+	// Watch returns the PrefixWatch that will be notified on updates
+	Watch() (ValueType, ValueWatchType, error)
+	// NumWatches returns the number of watches on the Watchable
+	NumWatches() int
+	// Update notifies the registered Watches
+	Update(ValueType) error
+	// IsClosed returns true if the Watchable is closed
+	IsClosed() bool
+	// Close stops watching for updates to the prefix path.
+	Close()
 }

--- a/src/x/watch/watch.go
+++ b/src/x/watch/watch.go
@@ -69,6 +69,11 @@ func NewWatchable() Watchable {
 	return &watchable{}
 }
 
+// NewPrefixWatchable returns a PrefixWatchable
+func NewPrefixWatchable() Watchable {
+	return &prefixWatchable{values: make(map[string]interface{})}
+}
+
 type watchable struct {
 	sync.RWMutex
 
@@ -179,6 +184,45 @@ func (w *watchable) closeFunc(c chan struct{}) closer {
 			}
 		}
 	}
+}
+
+type prefixWatchable struct {
+	watchable
+	values map[string]interface{}
+}
+
+func (w *prefixWatchable) Update(v interface{}) error {
+	w.Lock()
+	defer w.Unlock()
+
+	if w.closed {
+		return errClosed
+	}
+
+	// add v into the values map.
+	vMap, ok := v.(map[string]interface{})
+	if !ok {
+		return errors.New("invalid value for prefix watch")
+	}
+	for k, val := range vMap {
+		w.values[k] = val
+	}
+
+	for _, s := range w.active {
+		select {
+		case s <- struct{}{}:
+		default:
+		}
+	}
+
+	return nil
+}
+
+func (w *prefixWatchable) Get() interface{} {
+	w.RLock()
+	v := w.values
+	w.RUnlock()
+	return v
 }
 
 type watch struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
At the moment we can only watch absolute paths individually in ETCD KV store. With this change, we create a PrefixStore that can retrieve and watch a prefix path.
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note
NONE
```
