### PR TITLE
Added method to validate the weights of instances and scan current load

### DIFF
--- a/src/cluster/placement/algo/subclustered.go
+++ b/src/cluster/placement/algo/subclustered.go
@@ -11,6 +11,10 @@ var (
 	errIncompatibleWithSubclusteredAlgo = errors.New("could not apply subclustered algo on the placement")
 )
 
+const (
+	uninitializedSubClusterID = 0
+)
+
 type subclusteredPlacementAlgorithm struct {
 	opts placement.Options
 }
@@ -20,6 +24,10 @@ func newSubclusteredAlgorithm(opts placement.Options) placement.Algorithm {
 }
 
 func (a subclusteredPlacementAlgorithm) IsCompatibleWith(p placement.Placement) error {
+	if p == nil {
+		return fmt.Errorf("placement is nil")
+	}
+
 	if !p.IsSharded() {
 		return errIncompatibleWithSubclusteredAlgo
 	}
@@ -35,19 +43,37 @@ func (a subclusteredPlacementAlgorithm) InitialPlacement(
 	shards []uint32,
 	rf int,
 ) (placement.Placement, error) {
-	// TODO: Implement subclustered initial placement logic
-	return nil, fmt.Errorf("subclustered initial placement not yet implemented")
-}
+	instancesPerSubcluster := a.opts.InstancesPerSubCluster()
+	if instancesPerSubcluster <= 0 {
+		return nil, fmt.Errorf("instances per subcluster is not set")
+	}
+	if instancesPerSubcluster%rf != 0 {
+		return nil, fmt.Errorf("instances per subcluster is not a multiple of replica factor")
+	}
+	if len(instances)%instancesPerSubcluster != 0 {
+		return nil, fmt.Errorf("number of instances is not a multiple of instances per subcluster")
+	}
 
-func (a subclusteredPlacementAlgorithm) AddReplica(p placement.Placement) (placement.Placement, error) {
-	if err := a.IsCompatibleWith(p); err != nil {
+	ph, err := newSubclusteredInitHelper(instances, shards, a.opts, rf)
+	if err != nil {
 		return nil, err
 	}
 
-	// TODO: Implement subclustered add replica logic
-	return nil, fmt.Errorf("subclustered add replica not yet implemented")
+	for i := 0; i < rf; i++ {
+		err := ph.placeShards(newShards(shards), nil, ph.Instances())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ph.generatePlacement(), nil
 }
 
+func (a subclusteredPlacementAlgorithm) AddReplica(p placement.Placement) (placement.Placement, error) {
+	return nil, fmt.Errorf("AddReplica is not supported for subclustered placement")
+}
+
+// nolint:dupl
 func (a subclusteredPlacementAlgorithm) RemoveInstances(
 	p placement.Placement,
 	instanceIDs []string,
@@ -56,10 +82,28 @@ func (a subclusteredPlacementAlgorithm) RemoveInstances(
 		return nil, err
 	}
 
-	// TODO: Implement subclustered remove instances logic
-	return nil, fmt.Errorf("subclustered remove instances not yet implemented")
+	p = p.Clone()
+	for _, instanceID := range instanceIDs {
+		ph, leavingInstance, err := newubclusteredRemoveInstanceHelper(p, instanceID, a.opts)
+		if err != nil {
+			return nil, err
+		}
+		if err := ph.placeShards(leavingInstance.Shards().All(), leavingInstance, ph.Instances()); err != nil {
+			return nil, err
+		}
+
+		if err := ph.optimize(safe); err != nil {
+			return nil, err
+		}
+
+		if p, _, err = addInstanceToPlacement(ph.generatePlacement(), leavingInstance, withShards); err != nil {
+			return nil, err
+		}
+	}
+	return tryCleanupShardState(p, a.opts)
 }
 
+// nolint:dupl
 func (a subclusteredPlacementAlgorithm) AddInstances(
 	p placement.Placement,
 	instances []placement.Instance,
@@ -68,8 +112,21 @@ func (a subclusteredPlacementAlgorithm) AddInstances(
 		return nil, err
 	}
 
-	// TODO: Implement subclustered add instances logic
-	return nil, fmt.Errorf("subclustered add instances not yet implemented")
+	p = p.Clone()
+	for _, instance := range instances {
+		ph, addingInstance, err := newubclusteredAddInstanceHelper(p, instance, a.opts, withLeavingShardsOnly)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := ph.addInstance(addingInstance); err != nil {
+			return nil, err
+		}
+
+		p = ph.generatePlacement()
+	}
+
+	return tryCleanupShardState(p, a.opts)
 }
 
 func (a subclusteredPlacementAlgorithm) ReplaceInstances(
@@ -81,8 +138,32 @@ func (a subclusteredPlacementAlgorithm) ReplaceInstances(
 		return nil, err
 	}
 
-	// TODO: Implement subclustered replace instances logic
-	return nil, fmt.Errorf("subclustered replace instances not yet implemented")
+	p = p.Clone()
+	ph, leavingInstances, addingInstances, err := newubclusteredReplaceInstanceHelper(p,
+		leavingInstanceIDs, addingInstances, a.opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, leavingInstance := range leavingInstances {
+		err = ph.placeShards(leavingInstance.Shards().All(), leavingInstance, []placement.Instance{addingInstances[i]})
+		if err != nil {
+			return nil, err
+		}
+		load := loadOnInstance(leavingInstance)
+		if load != 0 {
+			return nil, fmt.Errorf("could not fully replace all shards from %s, %d shards left unassigned",
+				leavingInstance.ID(), load)
+		}
+	}
+
+	p = ph.generatePlacement()
+	for _, leavingInstance := range leavingInstances {
+		if p, _, err = addInstanceToPlacement(p, leavingInstance, withShards); err != nil {
+			return nil, err
+		}
+	}
+	return tryCleanupShardState(p, a.opts)
 }
 
 func (a subclusteredPlacementAlgorithm) MarkShardsAvailable(
@@ -94,8 +175,7 @@ func (a subclusteredPlacementAlgorithm) MarkShardsAvailable(
 		return nil, err
 	}
 
-	// TODO: Implement subclustered mark shards available logic
-	return nil, fmt.Errorf("subclustered mark shards available not yet implemented")
+	return markShardsAvailable(p.Clone(), instanceID, shardIDs, a.opts)
 }
 
 func (a subclusteredPlacementAlgorithm) MarkAllShardsAvailable(
@@ -105,8 +185,7 @@ func (a subclusteredPlacementAlgorithm) MarkAllShardsAvailable(
 		return nil, false, err
 	}
 
-	// TODO: Implement subclustered mark all shards available logic
-	return nil, false, fmt.Errorf("subclustered mark all shards available not yet implemented")
+	return markAllShardsAvailable(p, a.opts)
 }
 
 func (a subclusteredPlacementAlgorithm) BalanceShards(
@@ -115,7 +194,17 @@ func (a subclusteredPlacementAlgorithm) BalanceShards(
 	if err := a.IsCompatibleWith(p); err != nil {
 		return nil, err
 	}
+	ph, err := newSubclusteredHelper(p, a.opts, uninitializedSubClusterID)
+	if err != nil {
+		return nil, err
+	}
+	err = ph.validatePartialSubclusters(uninitializedSubClusterID, validationOpBalance)
+	if err != nil {
+		return nil, err
+	}
+	if err := ph.optimize(unsafe); err != nil {
+		return nil, fmt.Errorf("shard balance optimization failed: %w", err)
+	}
 
-	// TODO: Implement subclustered balance shards logic
-	return nil, fmt.Errorf("subclustered balance shards not yet implemented")
+	return tryCleanupShardState(ph.generatePlacement(), a.opts)
 }

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -82,7 +82,7 @@ func newSubclusteredHelper(p placement.Placement, targetRF int, opts placement.O
 		return nil, err
 	}
 
-	ph.scanCurrentLoad()
+	ph.scanCurrentLoad(subClusterToExclude)
 
 	err = ph.validateSubclusterDistribution()
 	if err != nil {
@@ -122,8 +122,8 @@ func (ph *subclusteredHelper) validateInstanceWeight() error {
 	return nil
 }
 
-// nolint: unused
-func (ph *subclusteredHelper) scanCurrentLoad() {
+// nolint
+func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 	ph.shardToInstanceMap = make(map[uint32]map[placement.Instance]struct{}, len(ph.uniqueShards))
 	ph.groupToInstancesMap = make(map[string]map[placement.Instance]struct{})
 	ph.groupToWeightMap = make(map[string]uint32)
@@ -148,6 +148,7 @@ func (ph *subclusteredHelper) scanCurrentLoad() {
 				instanceShardCounts: make(map[string]int),
 			}
 		}
+
 		// if we are checking that all instance weight is same than we can simply the calculation by assuming it as 1
 		ph.groupToWeightMap[instance.IsolationGroup()]++
 		totalWeight++

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -135,10 +135,12 @@ func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 			continue
 		}
 
-		if _, exist := ph.groupToInstancesMap[instance.IsolationGroup()]; !exist {
-			ph.groupToInstancesMap[instance.IsolationGroup()] = make(map[placement.Instance]struct{})
+		ig := instance.IsolationGroup()
+
+		if _, exist := ph.groupToInstancesMap[ig]; !exist {
+			ph.groupToInstancesMap[ig] = make(map[placement.Instance]struct{})
 		}
-		ph.groupToInstancesMap[instance.IsolationGroup()][instance] = struct{}{}
+		ph.groupToInstancesMap[ig][instance] = struct{}{}
 
 		subClusterID := instance.SubClusterID()
 		if _, exist := ph.subClusters[subClusterID]; !exist {
@@ -150,8 +152,8 @@ func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 			}
 		}
 
-		// if we are checking that all instance weight is same than we can simply the calculation by assuming it as 1
-		ph.groupToWeightMap[instance.IsolationGroup()]++
+		// if we are checking that all instance weight is same than we can simplify the calculation by assuming it as 1.
+		ph.groupToWeightMap[ig]++
 		totalWeight++
 		ph.subClusters[subClusterID].instances[instance.ID()] = instance
 

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -21,8 +21,12 @@
 package algo
 
 import (
-	"errors"
+	"container/heap"
 	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -30,12 +34,14 @@ import (
 	"github.com/m3db/m3/src/cluster/shard"
 )
 
-var (
-	// nolint: unused
-	errSubclusteredHelperNotImplemented = errors.New("subclustered helper methods not yet implemented")
+type validationOperation int
+
+const (
+	validationOpRemoval validationOperation = iota
+	validationOpAddition
+	validationOpBalance
 )
 
-// nolint
 type subclusteredHelper struct {
 	targetLoad             map[string]int
 	shardToInstanceMap     map[uint32]map[placement.Instance]struct{}
@@ -52,7 +58,6 @@ type subclusteredHelper struct {
 }
 
 // subcluster is a subcluster in the placement.
-// nolint
 type subcluster struct {
 	id                  uint32
 	targetShardCount    int
@@ -61,10 +66,157 @@ type subcluster struct {
 	instanceShardCounts map[string]int
 }
 
-// nolint
-func newSubclusteredHelper(p placement.Placement, targetRF int, opts placement.Options, subClusterToExclude uint32) (placementHelper, error) {
+func newSubclusteredInitHelper(
+	instances []placement.Instance,
+	ids []uint32,
+	opts placement.Options,
+	rf int,
+) (placementHelper, error) {
+	err := assignSubClusterIDs(instances, nil, opts.InstancesPerSubCluster())
+	if err != nil {
+		return nil, err
+	}
+	emptyPlacement := placement.NewPlacement().
+		SetInstances(instances).
+		SetShards(ids).
+		SetReplicaFactor(rf).
+		SetIsSharded(true).
+		SetIsSubclustered(true).
+		SetInstancesPerSubCluster(opts.InstancesPerSubCluster()).
+		SetCutoverNanos(opts.PlacementCutoverNanosFn()())
+	ph, err := newSubclusteredHelper(emptyPlacement, opts, uninitializedSubClusterID)
+	if err != nil {
+		return nil, err
+	}
+	return ph, nil
+}
+
+func newubclusteredAddInstanceHelper(
+	p placement.Placement,
+	instance placement.Instance,
+	opts placement.Options,
+	t instanceType,
+) (placementHelper, placement.Instance, error) {
+	instanceInPlacement, exist := p.Instance(instance.ID())
+	if !exist {
+		if err := assignSubClusterIDs([]placement.Instance{instance}, p, opts.InstancesPerSubCluster()); err != nil {
+			return nil, nil, err
+		}
+		ph, err := newSubclusteredHelper(p.SetInstances(append(p.Instances(), instance)), opts, uninitializedSubClusterID)
+		if err != nil {
+			return nil, nil, err
+		}
+		err = ph.validatePartialSubclusters(instance.SubClusterID(), validationOpAddition)
+		if err != nil {
+			return nil, nil, err
+		}
+		return ph, instance, nil
+	}
+
+	switch t {
+	case withLeavingShardsOnly:
+		if !instanceInPlacement.IsLeaving() {
+			return nil, nil, errInstanceContainsNonLeavingShards
+		}
+	case withAvailableOrLeavingShardsOnly:
+		shards := instanceInPlacement.Shards()
+		if shards.NumShards() != shards.NumShardsForState(shard.Available)+shards.NumShardsForState(shard.Leaving) {
+			return nil, nil, errInstanceContainsInitializingShards
+		}
+	default:
+		return nil, nil, fmt.Errorf("unexpected type %v", t)
+	}
+
+	ph, err := newSubclusteredHelper(p, opts, uninitializedSubClusterID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ph, instanceInPlacement, nil
+}
+
+func newubclusteredRemoveInstanceHelper(
+	p placement.Placement,
+	instanceID string,
+	opts placement.Options,
+) (placementHelper, placement.Instance, error) {
+	p, leavingInstance, err := removeInstanceFromPlacement(p, instanceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	subclusterInstances := getSubClusterInstances(p.Instances(), leavingInstance.SubClusterID())
+	// if the number of instances after removing the leaving instance is still greater than or equal to
+	// instancesPerSubcluster, we can safely assume that there were multiple replace operations going on
+	// in the cluster. In that case we don't need to exclude the subcluster from the calculation of
+	// targetShardCount.
+	if len(subclusterInstances) >= opts.InstancesPerSubCluster() {
+		ph, err := newSubclusteredHelper(p, opts, uninitializedSubClusterID)
+		if err != nil {
+			return nil, nil, err
+		}
+		return ph, leavingInstance, nil
+	}
+	// if the number of instances after removing the leaving instance is less than instancesPerSubcluster,
+	// we need to exclude the subcluster from the calculation of targetShardCount.
+	// Basically we are considering this operation equivalent to removeSubcluster.
+	ph, err := newSubclusteredHelper(p, opts, leavingInstance.SubClusterID())
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ph.validatePartialSubclusters(leavingInstance.SubClusterID(), validationOpRemoval)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ph, leavingInstance, nil
+}
+
+func newubclusteredReplaceInstanceHelper(
+	p placement.Placement,
+	instanceIDs []string,
+	addingInstances []placement.Instance,
+	opts placement.Options,
+) (placementHelper, []placement.Instance, []placement.Instance, error) {
+	var (
+		leavingInstances = make([]placement.Instance, len(instanceIDs))
+		err              error
+	)
+	for i, instanceID := range instanceIDs {
+		p, leavingInstances[i], err = removeInstanceFromPlacement(p, instanceID)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	newAddingInstances := make([]placement.Instance, len(addingInstances))
+	for i, instance := range addingInstances {
+		p, newAddingInstances[i], err = addInstanceToPlacement(p, instance, anyType)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	if len(newAddingInstances) != len(leavingInstances) {
+		return nil, nil, nil, fmt.Errorf("number of adding instances (%d) does not match number of leaving instances (%d)",
+			len(newAddingInstances), len(leavingInstances))
+	}
+
+	// Match adding instances with leaving instances
+	for i, addingInstance := range newAddingInstances {
+		addingInstance.SetSubClusterID(leavingInstances[i].SubClusterID())
+	}
+	ph, err := newSubclusteredHelper(p, opts, uninitializedSubClusterID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return ph, leavingInstances, newAddingInstances, nil
+}
+
+func newSubclusteredHelper(
+	p placement.Placement,
+	opts placement.Options,
+	subClusterToExclude uint32,
+) (*subclusteredHelper, error) {
 	ph := &subclusteredHelper{
-		rf:                     targetRF,
+		rf:                     p.ReplicaFactor(),
 		instances:              make(map[string]placement.Instance, p.NumInstances()),
 		uniqueShards:           p.Shards(),
 		log:                    opts.InstrumentOptions().Logger(),
@@ -89,13 +241,13 @@ func newSubclusteredHelper(p placement.Placement, targetRF int, opts placement.O
 		return nil, err
 	}
 
-	// TODO: Implement subclustered helper logic build target load.
+	ph.buildTargetLoad(subClusterToExclude)
+	ph.buildTargetSubclusterLoad(subClusterToExclude)
 
 	return ph, nil
 }
 
 // validateInstanceWeight validates that all instances have the same weight.
-// nolint: unused
 func (ph *subclusteredHelper) validateInstanceWeight() error {
 	if len(ph.instances) == 0 {
 		return nil
@@ -123,7 +275,6 @@ func (ph *subclusteredHelper) validateInstanceWeight() error {
 	return nil
 }
 
-// nolint
 func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 	ph.shardToInstanceMap = make(map[uint32]map[placement.Instance]struct{}, len(ph.uniqueShards))
 	ph.groupToInstancesMap = make(map[string]map[placement.Instance]struct{})
@@ -152,9 +303,14 @@ func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 			}
 		}
 
-		// if we are checking that all instance weight is same than we can simplify the calculation by assuming it as 1.
-		ph.groupToWeightMap[ig]++
-		totalWeight++
+		// if we are excluding the subcluster, we don't need to consider the weight of the instances for
+		// targetload calculation.
+		if subClusterID != subClusterToExclude {
+			// if we are checking that all instance weight is same than we can simplify the calculation by assuming it as 1.
+			ph.groupToWeightMap[ig]++
+			totalWeight++
+		}
+
 		ph.subClusters[subClusterID].instances[instance.ID()] = instance
 
 		for _, s := range instance.Shards().All() {
@@ -168,8 +324,98 @@ func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 	ph.totalWeight = totalWeight
 }
 
+// buildTargetLoad builds the target load for the instances in the placement.
+// The target load is the number of shards that each instance should have.
+// The target load is calculated based on the total weight of the instances and the replica factor.
+// This method implements a weighted load balancing algorithm that handles both normal and
+// over-weighted isolation groups. Over-weighted groups are those that have more instances
+// than the replica factor allows, which requires special handling to ensure proper distribution.
+func (ph *subclusteredHelper) buildTargetLoad(subClusterToExclude uint32) {
+	// Step 1: Identify over-weighted isolation groups
+	// Over-weighted groups are those where the number of instances exceeds the replica factor.
+	// These groups need special handling as they can't follow the standard distribution formula.
+	overWeightedGroups := 0
+	overWeight := uint32(0)
+	for _, weight := range ph.groupToWeightMap {
+		if isOverWeighted(weight, ph.totalWeight, ph.rf) {
+			overWeightedGroups++
+			overWeight += weight
+		}
+	}
+
+	// Step 2: Calculate target load for each instance
+	// The target load determines how many shards each instance should ideally have.
+	targetLoad := make(map[string]int, len(ph.instances))
+	for _, instance := range ph.instances {
+		// Skip instances that are leaving the cluster
+		if instance.IsLeaving() {
+			continue
+		}
+		if instance.SubClusterID() == subClusterToExclude {
+			continue
+		}
+		igWeight := ph.groupToWeightMap[instance.IsolationGroup()]
+
+		if isOverWeighted(igWeight, ph.totalWeight, ph.rf) {
+			// For over-weighted isolation groups:
+			// Distribute shards proportionally within the group based on instance weight.
+			// Use ceiling to ensure we don't under-allocate shards.
+			targetLoad[instance.ID()] = int(math.Ceil(float64(ph.getShardLen()) *
+				float64(instance.Weight()) / float64(igWeight)))
+		} else {
+			// For normal isolation groups:
+			// Use the standard formula that accounts for over-weighted groups.
+			// The formula ensures that the total shard count across all instances
+			// equals totalShards * replicaFactor, while respecting instance weights.
+			targetLoad[instance.ID()] = ph.getShardLen() * (ph.rf - overWeightedGroups) *
+				int(instance.Weight()) / int(ph.totalWeight-overWeight)
+		}
+	}
+	ph.targetLoad = targetLoad
+}
+
+// buildTargetSubclusterLoad builds the target load for the subclusters.
+// This method distributes the total number of shards evenly across all active subclusters,
+// ensuring that each subcluster gets approximately the same number of shards to manage.
+// Any remaining shards (due to integer division) are distributed one by one to subclusters
+// in a deterministic order to ensure consistent placement.
+func (ph *subclusteredHelper) buildTargetSubclusterLoad(subClusterToExclude uint32) {
+	totalShards := len(ph.uniqueShards)
+	subClusters := ph.getSubclusterIds(subClusterToExclude)
+	sort.Slice(subClusters, func(i, j int) bool { return subClusters[i] <= subClusters[j] })
+	totalDivided := 0
+	for _, subClusterID := range subClusters {
+		ph.subClusters[subClusterID].targetShardCount = int(math.Floor(float64(totalShards) / float64(len(subClusters))))
+		totalDivided += ph.subClusters[subClusterID].targetShardCount
+	}
+	diff := totalShards - totalDivided
+	for _, curr := range subClusters {
+		if diff == 0 {
+			break
+		}
+		ph.subClusters[curr].targetShardCount++
+		diff--
+	}
+}
+
+// getSubclusterIds gets the subcluster ids slice.
+func (ph *subclusteredHelper) getSubclusterIds(subClusterToExclude uint32) []uint32 {
+	subClusterIds := make([]uint32, 0, len(ph.subClusters))
+	for k := range ph.subClusters {
+		if k == subClusterToExclude {
+			continue
+		}
+		subClusterIds = append(subClusterIds, k)
+	}
+	return subClusterIds
+}
+
+// getShardLen gets the shard length.
+func (ph *subclusteredHelper) getShardLen() int {
+	return len(ph.uniqueShards)
+}
+
 // assignShardToInstance assigns a shard to an instance.
-// nolint: unused
 func (ph *subclusteredHelper) assignShardToInstance(s shard.Shard, to placement.Instance) {
 	to.Shards().Add(s)
 
@@ -181,71 +427,597 @@ func (ph *subclusteredHelper) assignShardToInstance(s shard.Shard, to placement.
 	ph.subClusters[to.SubClusterID()].instanceShardCounts[to.ID()]++
 }
 
-// nolint
 // Instances returns the list of instances managed by the PlacementHelper.
 func (ph *subclusteredHelper) Instances() []placement.Instance {
-	// TODO: Implement subclustered instances logic
-	return nil
+	res := make([]placement.Instance, 0, len(ph.instances))
+	for _, instance := range ph.instances {
+		res = append(res, instance)
+	}
+	return res
+}
+
+// moveShard tries to move a shard from the from instance to the to instance.
+// If the shard is not assignable to the to instance, it returns false.
+func (ph *subclusteredHelper) moveShard(candidateShard shard.Shard, from, to placement.Instance) bool {
+	shardID := candidateShard.ID()
+	if !ph.canAssignInstance(shardID, from, to) {
+		return false
+	}
+
+	if candidateShard.State() == shard.Leaving {
+		return false
+	}
+
+	newShard := shard.NewShard(shardID)
+	if from != nil {
+		// nolint: exhaustive
+		switch candidateShard.State() {
+		case shard.Unknown, shard.Initializing:
+			from.Shards().Remove(shardID)
+			newShard.SetSourceID(candidateShard.SourceID())
+		case shard.Available:
+			candidateShard.
+				SetState(shard.Leaving).
+				SetCutoffNanos(ph.opts.ShardCutoffNanosFn()())
+			newShard.SetSourceID(from.ID())
+		}
+		ph.removeShardFromInstance(shardID, from)
+	}
+	curShard, ok := to.Shards().Shard(shardID)
+	if ok && curShard.State() == shard.Leaving {
+		newShard = shard.NewShard(shardID).SetState(shard.Available)
+		instances := ph.shardToInstanceMap[shardID]
+		for instance := range instances {
+			shards := instance.Shards()
+			initShard, ok := shards.Shard(shardID)
+			if ok && initShard.SourceID() == to.ID() {
+				initShard.SetSourceID("")
+			}
+		}
+
+	}
+
+	ph.assignShardToInstance(newShard, to)
+	return true
+}
+
+func (ph *subclusteredHelper) removeShardFromInstance(shardID uint32, from placement.Instance) {
+	delete(ph.shardToInstanceMap[shardID], from)
+	if fromsubcluster, exist := ph.subClusters[from.SubClusterID()]; exist {
+		fromsubcluster.shardMap[shardID]--
+		if fromsubcluster.shardMap[shardID] == 0 {
+			delete(fromsubcluster.shardMap, shardID)
+		}
+		fromsubcluster.instanceShardCounts[from.ID()]--
+		if fromsubcluster.instanceShardCounts[from.ID()] == 0 {
+			delete(fromsubcluster.instanceShardCounts, from.ID())
+		}
+	}
+}
+
+func (ph *subclusteredHelper) canAssignInstance(shardID uint32, from, to placement.Instance) bool {
+	s, ok := to.Shards().Shard(shardID)
+	if ok && s.State() != shard.Leaving {
+		return false
+	}
+	tosubcluster := ph.subClusters[to.SubClusterID()]
+	// the targetshardCount is 0 when we are removing the subcluster.
+	// In this case we don't want to assign shard to any other instance in the the leaving subcluster.
+	// As eventually these shards will be assigned to the new subcluster.
+	if tosubcluster.targetShardCount == 0 {
+		return false
+	}
+	// if the subcluster is full, the shard should be already assigned to the subcluster
+	// if the shard is not assigned to the subcluster, return false
+	if len(tosubcluster.shardMap) == tosubcluster.targetShardCount {
+		if _, exists := tosubcluster.shardMap[shardID]; !exists {
+			return false
+		}
+	}
+
+	if from != nil {
+		fromSubcluster, exists := ph.subClusters[from.SubClusterID()]
+		// In case of removing an instance/subcluster. the targetShardCount will be 0.
+		// If it is the last instance in the subcluster, the subcluster should not be present in the helper
+		if !exists || fromSubcluster.targetShardCount == 0 {
+			// In case of removing a subcluster we only need to check if all the replicas of a shard has been
+			// assigned to the same subcluster.
+			for instance := range ph.shardToInstanceMap[shardID] {
+				if instance.SubClusterID() == from.SubClusterID() {
+					continue
+				}
+				if instance.SubClusterID() != to.SubClusterID() {
+					return false
+				}
+			}
+			return ph.CanMoveShard(shardID, from, to.IsolationGroup())
+		}
+		// Case 1(add-instance): If we are moving the shard within the same subcluster, we just need to check
+		// if the if the shard cnn be moved to the to IsolationGroup.
+		if from.SubClusterID() == to.SubClusterID() {
+			return ph.CanMoveShard(shardID, from, to.IsolationGroup())
+		}
+		// Case 2(add-instance): If we are moving the shard across subclusters.
+		// Case 2.1(add-instance): Check if the from instance's subcluster can give the shards, i.e.
+		// if the number of shards in the from instance's subcluster has reached to its targetShardCount
+		// in that case we cannot take any shard from this instance's subcluster.
+		if exists && len(fromSubcluster.shardMap) == fromSubcluster.targetShardCount {
+			return false
+		}
+		// Case 2.2(add-instance): If we can take shards from the from instance's subcluster, we need to check
+		// if the from subcluster has given all the shards only the replicas of the shards is left
+		// in the from subcluster. IF that is the case then we need to make sure the replica is only going
+		// to the subcluster which already has one or more replica of the shard. To find this we will
+		// take intersection of the shards in froma d to subcluster and if the shard doesn'y exist in
+		// intersection and len(intersection) == (len(fromsubcluster.shardMap)-fromsubcluster.targetShardCount)
+		// we will return false. (This case will be viable when the targetShardCount of to subcluster hasn't reached but
+		// the from subcluster has given all the shards.)
+		if exists && len(fromSubcluster.shardMap) > fromSubcluster.targetShardCount {
+			intersection := ph.findMapKeyIntersection(tosubcluster.shardMap, fromSubcluster.shardMap)
+			if _, exist := intersection[shardID]; !exist &&
+				len(intersection) == (len(fromSubcluster.shardMap)-fromSubcluster.targetShardCount) {
+				return false
+			}
+		}
+		// Case 2.3(add-instance): If the from subcluster hasn't given all the shards,
+		// we just need to check for isolation group movement
+	}
+	return ph.CanMoveShard(shardID, from, to.IsolationGroup())
+}
+
+// findMapKeyIntersection returns a map containing keys that exist in both input maps
+func (ph *subclusteredHelper) findMapKeyIntersection(map1, map2 map[uint32]int) map[uint32]struct{} {
+	// Create a map to store keys from the first map
+	keys := make(map[uint32]struct{})
+	for k := range map1 {
+		keys[k] = struct{}{}
+	}
+
+	// Create result map for intersection
+	intersection := make(map[uint32]struct{})
+
+	// Find intersection by checking which keys from map1 exist in map2
+	for k := range map2 {
+		if _, exists := keys[k]; exists {
+			intersection[k] = struct{}{}
+		}
+	}
+
+	return intersection
 }
 
 // CanMoveShard checks if the shard can be moved from the instance to the target isolation group.
-// nolint: unused
 func (ph *subclusteredHelper) CanMoveShard(shard uint32, from placement.Instance, toIsolationGroup string) bool {
-	// TODO: Implement subclustered shard movement logic
-	return false
+	if from != nil {
+		if from.IsolationGroup() == toIsolationGroup {
+			return true
+		}
+	}
+	for instance := range ph.shardToInstanceMap[shard] {
+		if instance.IsolationGroup() == toIsolationGroup {
+			return false
+		}
+	}
+	return true
 }
 
 // placeShards distributes shards to the instances in the helper, with aware of where are the shards coming from.
-// nolint: unused
+// nolint: dupl
 func (ph *subclusteredHelper) placeShards(
 	shards []shard.Shard,
 	from placement.Instance,
 	candidates []placement.Instance,
 ) error {
-	// TODO: Implement subclustered shard placement logic
-	return fmt.Errorf("subclustered placeShards not yet implemented: %w",
-		errSubclusteredHelperNotImplemented)
+	shardSet := getShardMap(shards)
+	if from != nil {
+		ph.returnInitializingShardsToSource(shardSet, from, candidates)
+	}
+
+	instanceHeap, err := ph.buildInstanceHeap(nonLeavingInstances(candidates), true)
+	if err != nil {
+		return err
+	}
+	// if there are shards left to be assigned, distribute them evenly
+	var triedInstances []placement.Instance
+	for _, s := range shardSet {
+		if s.State() == shard.Leaving {
+			continue
+		}
+		moved := false
+		for instanceHeap.Len() > 0 {
+			tryInstance := heap.Pop(instanceHeap).(placement.Instance)
+			triedInstances = append(triedInstances, tryInstance)
+			if ph.moveShard(s, from, tryInstance) {
+				moved = true
+				break
+			}
+		}
+		if !moved {
+			return errNotEnoughIsolationGroups
+		}
+		for _, triedInstance := range triedInstances {
+			heap.Push(instanceHeap, triedInstance)
+		}
+		triedInstances = triedInstances[:0]
+	}
+	return nil
 }
 
 // addInstance adds an instance to the placement.
-// nolint: unused
 func (ph *subclusteredHelper) addInstance(addingInstance placement.Instance) error {
-	// TODO: Implement subclustered add instance logic
-	return fmt.Errorf("subclustered addInstance not yet implemented: %w", errSubclusteredHelperNotImplemented)
+	ph.reclaimLeavingShards(addingInstance)
+	return ph.assignLoadToInstanceUnsafe(addingInstance)
+}
+
+func (ph *subclusteredHelper) assignLoadToInstanceSafe(addingInstance placement.Instance) error {
+	return ph.assignTargetLoad(addingInstance, func(from, to placement.Instance) bool {
+		return ph.moveOneShardInState(from, to, shard.Unknown)
+	})
+}
+
+func (ph *subclusteredHelper) assignLoadToInstanceUnsafe(addingInstance placement.Instance) error {
+	return ph.assignTargetLoad(addingInstance, func(from, to placement.Instance) bool {
+		return ph.moveOneShard(from, to)
+	})
+}
+
+func (ph *subclusteredHelper) assignTargetLoad(
+	targetInstance placement.Instance,
+	moveOneShardFn func(from, to placement.Instance) bool,
+) error {
+
+	targetLoad := ph.targetLoadForInstance(targetInstance.ID())
+	// First try to move shards from other subclusters
+
+	instanceHeap, err := ph.buildInstanceHeap(ph.removeSubClusterInstances(targetInstance.SubClusterID()), false)
+	if err != nil {
+		return err
+	}
+	for targetInstance.Shards().NumShards() < targetLoad && instanceHeap.Len() > 0 {
+		fromInstance := heap.Pop(instanceHeap).(placement.Instance)
+		if moved := moveOneShardFn(fromInstance, targetInstance); moved {
+			heap.Push(instanceHeap, fromInstance)
+		}
+	}
+	// Then try to move shards from the same subcluster
+	instanceHeap, err = ph.buildInstanceHeap(ph.getSubClusterInstances(targetInstance.SubClusterID()), false)
+	if err != nil {
+		return err
+	}
+	for targetInstance.Shards().NumShards() < targetLoad && instanceHeap.Len() > 0 {
+		fromInstance := heap.Pop(instanceHeap).(placement.Instance)
+		if moved := moveOneShardFn(fromInstance, targetInstance); moved {
+			heap.Push(instanceHeap, fromInstance)
+		}
+	}
+	return nil
+}
+
+func (ph *subclusteredHelper) targetLoadForInstance(id string) int {
+	return ph.targetLoad[id]
+}
+
+func (ph *subclusteredHelper) moveOneShard(from, to placement.Instance) bool {
+	return ph.moveOneShardInState(from, to, shard.Unknown) ||
+		ph.moveOneShardInState(from, to, shard.Initializing) ||
+		ph.moveOneShardInState(from, to, shard.Available)
+}
+
+func (ph *subclusteredHelper) moveOneShardInState(from, to placement.Instance, state shard.State) bool {
+	shards := from.Shards().ShardsForState(state)
+	toSubcluster := ph.subClusters[to.SubClusterID()]
+	// we are randomly shuffling the shards to minimize the shard sharing percentage between
+	// the replica sets within a subcluster
+	if to.SubClusterID() == from.SubClusterID() || len(toSubcluster.shardMap) == toSubcluster.targetShardCount {
+		shards = ph.randomShuffle(shards)
+	} else {
+		// we are greedy shuffling the shards to minimize the skew in the existing subclusters
+		// when moving the shards to new subcluster. We sort the shards by the amount of skew it
+		// will cause in the subcluster if all the shard replicas will be removed. We then take the
+		// shard which will cause the least skew and move it to the new subcluster.
+		shards = ph.greedyShuffle(shards, from)
+	}
+	for _, s := range shards {
+		if ph.moveShard(s, from, to) {
+			return true
+		}
+	}
+	return false
+}
+
+func (ph *subclusteredHelper) randomShuffle(shards []shard.Shard) []shard.Shard {
+	if len(shards) <= 1 {
+		return shards
+	}
+
+	result := make([]shard.Shard, len(shards))
+	copy(result, shards)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := len(result) - 1; i > 0; i-- {
+		j := rng.Intn(i + 1)
+		result[i], result[j] = result[j], result[i]
+	}
+
+	return result
+}
+
+func (ph *subclusteredHelper) greedyShuffle(shards []shard.Shard, fromInstance placement.Instance) []shard.Shard {
+	if len(shards) == 0 {
+		return shards
+	}
+	// Focus optimization specifically on minimizing skew within this subcluster
+	return ph.optimizeForSubclusterBalance(shards, fromInstance)
+}
+
+// calculateSubclusterSkew computes the skew (max - min shard count) within a subcluster
+func (ph *subclusteredHelper) calculateSubclusterSkew(instanceCounts map[string]int) int {
+	if len(instanceCounts) == 0 {
+		return 0
+	}
+	minCount := math.MaxInt32
+	maxCount := 0
+	for _, count := range instanceCounts {
+		if count < minCount {
+			minCount = count
+		}
+		if count > maxCount {
+			maxCount = count
+		}
+	}
+
+	return maxCount - minCount
+}
+
+// optimizeForSubclusterBalance orders shards to minimize subcluster skew during removal process
+// Calculate actual skew after removal of each shard and sort by that for optimal ordering
+func (ph *subclusteredHelper) optimizeForSubclusterBalance(
+	shards []shard.Shard,
+	fromInstance placement.Instance,
+) []shard.Shard {
+	if len(shards) <= 1 {
+		// No optimization needed for single shard
+		return shards
+	}
+
+	type shardSkewScore struct {
+		shard            shard.Shard
+		skewAfterRemoval int
+	}
+
+	shardScores := make([]shardSkewScore, 0, len(shards))
+	fromSubcluster := ph.subClusters[fromInstance.SubClusterID()]
+	instanceCounts := fromSubcluster.instanceShardCounts
+	countAfterReplicaRemoval := make(map[string]int)
+	for id, count := range instanceCounts {
+		countAfterReplicaRemoval[id] = count
+	}
+
+	// Remove the count for the shards in the from instance whose one or more replicas have
+	// already been moved to the new subcluster. These shard counts should not be counted in
+	// skew calculation as they will be moved to the new subcluster.
+	for s, count := range fromSubcluster.shardMap {
+		if count == ph.rf {
+			continue
+		}
+		for instance := range ph.shardToInstanceMap[s] {
+			if instance.SubClusterID() == fromInstance.SubClusterID() {
+				countAfterReplicaRemoval[instance.ID()]--
+				if countAfterReplicaRemoval[instance.ID()] == 0 {
+					delete(countAfterReplicaRemoval, instance.ID())
+				}
+			}
+		}
+	}
+
+	for _, s := range shards {
+		shardID := s.ID()
+
+		if count, exists := fromSubcluster.shardMap[shardID]; exists && count < ph.rf {
+			// if some of the replicas of the shards have been moved then that shard should be moved at last
+			// we priopitize moving new shards  to the subcluster first until the target subcluster count
+			// hasn't been reached.
+			shardScores = append(shardScores, shardSkewScore{
+				shard:            s,
+				skewAfterRemoval: math.MaxInt32 - count,
+			})
+			continue
+		}
+
+		// Track which instances we modified so we can restore them
+		modifiedInstances := make(map[string]int)
+
+		// Find all instances in the subcluster that currently hold this shard and remove it
+		if instancesWithShard, exists := ph.shardToInstanceMap[shardID]; exists {
+			for instance := range instancesWithShard {
+				instanceID := instance.ID()
+				// Only consider instances in the same subcluster to remove shard replicas count from.
+				if instance.SubClusterID() == fromInstance.SubClusterID() && countAfterReplicaRemoval[instanceID] > 0 {
+					modifiedInstances[instanceID] = countAfterReplicaRemoval[instanceID]
+					countAfterReplicaRemoval[instanceID]-- // Remove one replica from this instance
+				}
+			}
+		}
+
+		// Calculate resulting skew within the subcluster after removing all replicas of this shard
+		skewAfterRemoval := ph.calculateSubclusterSkew(countAfterReplicaRemoval)
+		shardScores = append(shardScores, shardSkewScore{
+			shard:            s,
+			skewAfterRemoval: skewAfterRemoval,
+		})
+
+		// Restore the original counts for the next iteration
+		for instanceID, originalCount := range modifiedInstances {
+			countAfterReplicaRemoval[instanceID] = originalCount
+		}
+	}
+
+	// Sort by skewAfterRemoval (ascending) - prioritize shards that result in lowest skew when removed
+	// For shards with the same skew, randomize their order to avoid deterministic bias
+	sort.Slice(shardScores, func(i, j int) bool {
+		if shardScores[i].skewAfterRemoval == shardScores[j].skewAfterRemoval {
+			// Randomly shuffle equal skew shards for non-deterministic ordering
+			return rand.Float64() < 0.5
+		}
+		return shardScores[i].skewAfterRemoval < shardScores[j].skewAfterRemoval
+	})
+
+	// Extract sorted shards
+	result := make([]shard.Shard, len(shards))
+	for i, score := range shardScores {
+		result[i] = score.shard
+	}
+
+	return result
+}
+
+// nolint: dupl
+func (ph *subclusteredHelper) mostUnderLoadedInstance() (placement.Instance, bool) {
+	var (
+		res              placement.Instance
+		maxLoadGap       int
+		totalLoadSurplus int
+	)
+	// nolint: dupl
+	for id, instance := range ph.instances {
+		if ph.targetLoad[id] == 0 {
+			// only the instances with target load > 0 are considered for load balancing
+			continue
+		}
+		loadGap := ph.targetLoad[id] - loadOnInstance(instance)
+		if loadGap > maxLoadGap {
+			maxLoadGap = loadGap
+			res = instance
+		}
+		if loadGap == maxLoadGap && res != nil && res.ID() > id {
+			res = instance
+		}
+		if loadGap < 0 {
+			totalLoadSurplus -= loadGap
+		}
+	}
+	if maxLoadGap > 0 && totalLoadSurplus != 0 {
+		return res, true
+	}
+	return nil, false
 }
 
 // optimize rebalances the load distribution in the cluster.
-// nolint: unused
+// nolint: dupl
 func (ph *subclusteredHelper) optimize(t optimizeType) error {
-	// TODO: Implement subclustered optimization logic
-	return fmt.Errorf("subclustered optimize not yet implemented: %w", errSubclusteredHelperNotImplemented)
+	var fn assignLoadFn
+	switch t {
+	case safe:
+		fn = ph.assignLoadToInstanceSafe
+	case unsafe:
+		fn = ph.assignLoadToInstanceUnsafe
+	}
+	uniq := make(map[string]struct{}, len(ph.instances))
+	for {
+		ins, ok := ph.mostUnderLoadedInstance()
+		if !ok {
+			return nil
+		}
+		if _, exist := uniq[ins.ID()]; exist {
+			return nil
+		}
+
+		uniq[ins.ID()] = struct{}{}
+		if err := fn(ins); err != nil {
+			return err
+		}
+	}
 }
 
 // generatePlacement generates a placement.
-// nolint: unused
 func (ph *subclusteredHelper) generatePlacement() placement.Placement {
-	// TODO: Implement subclustered placement generation logic
-	return nil
+	var instances = make([]placement.Instance, 0, len(ph.instances))
+
+	for _, instance := range ph.instances {
+		if instance.Shards().NumShards() > 0 {
+			instances = append(instances, instance)
+		}
+	}
+
+	for _, instance := range instances {
+		shards := instance.Shards()
+		for _, s := range shards.ShardsForState(shard.Unknown) {
+			shards.Add(shard.NewShard(s.ID()).
+				SetSourceID(s.SourceID()).
+				SetState(shard.Initializing).
+				SetCutoverNanos(ph.opts.ShardCutoverNanosFn()()))
+		}
+	}
+
+	return placement.NewPlacement().
+		SetInstances(instances).
+		SetShards(ph.uniqueShards).
+		SetReplicaFactor(ph.rf).
+		SetIsSharded(true).
+		SetIsSubclustered(true).
+		SetInstancesPerSubCluster(ph.instancesPerSubcluster).
+		SetIsMirrored(ph.opts.IsMirrored()).
+		SetCutoverNanos(ph.opts.PlacementCutoverNanosFn()())
 }
 
 // reclaimLeavingShards reclaims all the leaving shards on the given instance
 // by pulling them back from the rest of the cluster.
-// nolint: unused
 func (ph *subclusteredHelper) reclaimLeavingShards(instance placement.Instance) {
-	// TODO: Implement subclustered reclaim leaving shards logic
+	if instance.Shards().NumShardsForState(shard.Leaving) == 0 {
+		// Shortcut if there is nothing to be reclaimed.
+		return
+	}
+	id := instance.ID()
+	for _, i := range ph.instances {
+		for _, s := range i.Shards().ShardsForState(shard.Initializing) {
+			if s.SourceID() == id {
+				ph.moveShard(s, i, instance)
+			}
+		}
+	}
 }
 
 // returnInitializingShards returns all the initializing shards on the given instance
 // by returning them back to the original owners.
-// nolint: unused
 func (ph *subclusteredHelper) returnInitializingShards(instance placement.Instance) {
-	// TODO: Implement subclustered return initializing shards logic
+	shardSet := getShardMap(instance.Shards().All())
+	ph.returnInitializingShardsToSource(shardSet, instance, ph.Instances())
+}
+
+// nolint: dupl
+func (ph *subclusteredHelper) returnInitializingShardsToSource(
+	shardSet map[uint32]shard.Shard,
+	from placement.Instance,
+	candidates []placement.Instance,
+) {
+	candidateMap := make(map[string]placement.Instance, len(candidates))
+	for _, candidate := range candidates {
+		candidateMap[candidate.ID()] = candidate
+	}
+	for _, s := range shardSet {
+		if s.State() != shard.Initializing {
+			continue
+		}
+		sourceID := s.SourceID()
+		if sourceID == "" {
+			continue
+		}
+		sourceInstance, ok := candidateMap[sourceID]
+		if !ok {
+			continue
+		}
+		if sourceInstance.IsLeaving() {
+			continue
+		}
+		if ph.moveShard(s, from, sourceInstance) {
+			delete(shardSet, s.ID())
+		}
+	}
 }
 
 // validateSubclusterDistribution validates that:
 // 1. Number of isolation groups equals replica factor (rf)
 // 2. For complete subclusters, nodes per isolation group = instancesPerSubcluster / rf
-// nolint: unused
 func (ph *subclusteredHelper) validateSubclusterDistribution() error {
 	if len(ph.instances) == 0 {
 		return nil
@@ -280,6 +1052,151 @@ func (ph *subclusteredHelper) validateSubclusterDistribution() error {
 				return fmt.Errorf("subcluster %d isolation group %s has %d instances, expected 0",
 					subclusterID, isolationGroup, count)
 			}
+		}
+	}
+
+	return nil
+}
+
+func (ph *subclusteredHelper) buildInstanceHeap(
+	instances []placement.Instance,
+	availableCapacityAscending bool,
+) (heap.Interface, error) {
+	return newHeap(instances, availableCapacityAscending, ph.targetLoad, ph.groupToWeightMap, true)
+}
+
+// removeSubClusterInstances returns instances that are not in the specified subcluster
+func (ph *subclusteredHelper) removeSubClusterInstances(subclusterID uint32) []placement.Instance {
+	var instances = nonLeavingInstances(ph.Instances())
+	var result = make([]placement.Instance, 0, len(instances))
+	for _, instance := range instances {
+		if instance.SubClusterID() != subclusterID {
+			result = append(result, instance)
+		}
+	}
+	return result
+}
+
+// getSubClusterInstances returns instances that are in the specified subcluster
+func (ph *subclusteredHelper) getSubClusterInstances(subclusterID uint32) []placement.Instance {
+	currSubcluster := ph.subClusters[subclusterID]
+	var instances = make([]placement.Instance, 0, len(currSubcluster.instances))
+	for _, instance := range currSubcluster.instances {
+		if instance.IsLeaving() {
+			continue
+		}
+		instances = append(instances, instance)
+	}
+	return instances
+}
+
+func (ph *subclusteredHelper) validatePartialSubclusters(excludeSubclusterID uint32, op validationOperation) error {
+	for subclusterID, subcluster := range ph.subClusters {
+		if subclusterID == excludeSubclusterID {
+			continue
+		}
+		if len(subcluster.instances) < ph.instancesPerSubcluster {
+			var operation string
+			switch op {
+			case validationOpRemoval:
+				operation = "removed"
+			case validationOpAddition:
+				operation = "added"
+			case validationOpBalance:
+				operation = "balanced"
+			}
+			return fmt.Errorf("partial subcluster %d is present with %d instances, while a subcluster %d is being %s",
+				subclusterID, len(subcluster.instances), excludeSubclusterID, operation)
+		}
+	}
+	return nil
+}
+
+// getSubClusterInstances returns instances that are in the specified subcluster
+func getSubClusterInstances(instances []placement.Instance, subclusterID uint32) []placement.Instance {
+	var result []placement.Instance
+	for _, instance := range instances {
+		if instance.SubClusterID() == subclusterID {
+			result = append(result, instance)
+		}
+	}
+	return result
+}
+
+func assignSubClusterIDs(
+	instances []placement.Instance,
+	currPlacement placement.Placement,
+	instancesPerSubcluster int,
+) error {
+	if instancesPerSubcluster <= 0 {
+		return fmt.Errorf("instances per subcluster is not set")
+	}
+
+	// Track subcluster counts and find incomplete subclusters
+	subclusterCounts := make(map[uint32]int)
+	var incompleteSubclusters []uint32
+	maxSubclusterID := uint32(0)
+
+	if currPlacement != nil {
+		currInstances := currPlacement.Instances()
+
+		// Count instances in each subcluster
+		for _, instance := range currInstances {
+			if instance.IsLeaving() {
+				continue
+			}
+			subClusterID := instance.SubClusterID()
+			subclusterCounts[subClusterID]++
+			if subClusterID > maxSubclusterID {
+				maxSubclusterID = subClusterID
+			}
+		}
+
+		// Find incomplete subclusters (those with fewer than instancesPerSubcluster instances)
+		for subClusterID, count := range subclusterCounts {
+			if count < instancesPerSubcluster {
+				incompleteSubclusters = append(incompleteSubclusters, subClusterID)
+			}
+		}
+
+		// Sort incomplete subclusters by ID in ascending order
+		sort.Slice(incompleteSubclusters, func(i, j int) bool {
+			return incompleteSubclusters[i] < incompleteSubclusters[j]
+		})
+	}
+
+	// Assign subcluster IDs to new instances
+	// First, fill incomplete subclusters in order of increasing ID
+	// Then, create new subclusters as needed
+	nextIncompleteIndex := 0
+	currentSubclusterID := uint32(0)
+	currentSubclusterCount := 0
+
+	for _, instance := range instances {
+		// Try to fill incomplete subclusters first
+		if nextIncompleteIndex < len(incompleteSubclusters) {
+			currentSubclusterID = incompleteSubclusters[nextIncompleteIndex]
+			currentSubclusterCount = subclusterCounts[currentSubclusterID]
+		} else if currentSubclusterCount == instancesPerSubcluster || currentSubclusterCount == 0 {
+			// No more incomplete subclusters, create a new one
+			maxSubclusterID++
+			currentSubclusterID = maxSubclusterID
+			currentSubclusterCount = 0
+		}
+
+		// Assign the instance to the current subcluster
+		instance.SetSubClusterID(currentSubclusterID)
+		currentSubclusterCount++
+
+		// Update tracking
+		subclusterCounts[currentSubclusterID] = currentSubclusterCount
+
+		// If we've filled this subcluster, move to the next incomplete one
+		if currentSubclusterCount == instancesPerSubcluster {
+			if nextIncompleteIndex < len(incompleteSubclusters) {
+				nextIncompleteIndex++
+			}
+			currentSubclusterCount = 0
 		}
 	}
 

--- a/src/cluster/placement/algo/subclustered_helper_test.go
+++ b/src/cluster/placement/algo/subclustered_helper_test.go
@@ -47,16 +47,7 @@ func TestValidateInstanceWeight(t *testing.T) {
 				placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 2),
 			},
 			expectError: true,
-			errorMsg:    "inconsistent instance weights: instance i2 has weight 2, expected 1",
-		},
-		{
-			name: "multiple instances with different weights - first instance has higher weight",
-			instances: []placement.Instance{
-				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 3),
-				placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1),
-			},
-			expectError: true,
-			errorMsg:    "inconsistent instance weights: instance i2 has weight 1, expected 3",
+			errorMsg:    "inconsistent instance weights:",
 		},
 	}
 

--- a/src/cluster/placement/algo/subclustered_helper_test.go
+++ b/src/cluster/placement/algo/subclustered_helper_test.go
@@ -1,0 +1,467 @@
+package algo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/m3db/m3/src/cluster/placement"
+	"github.com/m3db/m3/src/cluster/shard"
+	"github.com/m3db/m3/src/x/instrument"
+)
+
+func TestValidateInstanceWeight(t *testing.T) {
+	tests := []struct {
+		name        string
+		instances   []placement.Instance
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "empty instances",
+			instances:   []placement.Instance{},
+			expectError: false,
+		},
+		{
+			name: "single instance",
+			instances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple instances with same weight",
+			instances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+				placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1),
+				placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1),
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple instances with different weights",
+			instances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+				placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 2),
+			},
+			expectError: true,
+			errorMsg:    "inconsistent instance weights: instance i2 has weight 2, expected 1",
+		},
+		{
+			name: "multiple instances with different weights - first instance has higher weight",
+			instances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 3),
+				placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1),
+			},
+			expectError: true,
+			errorMsg:    "inconsistent instance weights: instance i2 has weight 1, expected 3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ph := &subclusteredHelper{
+				instances: make(map[string]placement.Instance),
+			}
+
+			for _, instance := range tt.instances {
+				ph.instances[instance.ID()] = instance
+			}
+
+			err := ph.validateInstanceWeight()
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewSubclusteredHelper(t *testing.T) {
+	tests := []struct {
+		name                string
+		placement           placement.Placement
+		targetRF            int
+		opts                placement.Options
+		subClusterToExclude uint32
+		expectError         bool
+		errorMsg            string
+	}{
+		{
+			name: "valid placement with consistent weights",
+			placement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1).SetSubClusterID(1),
+				}).
+				SetShards([]uint32{1, 2, 3}).
+				SetReplicaFactor(3).
+				SetInstancesPerSubCluster(3).
+				SetHasSubClusters(true),
+			targetRF:            3,
+			opts:                placement.NewOptions().SetInstancesPerSubCluster(3).SetHasSubClusters(true),
+			subClusterToExclude: 0,
+			expectError:         false,
+		},
+		{
+			name: "placement with inconsistent weights",
+			placement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 2).SetSubClusterID(1),
+				}).
+				SetShards([]uint32{1, 2}).
+				SetReplicaFactor(2).
+				SetInstancesPerSubCluster(2).
+				SetHasSubClusters(true),
+			targetRF:            2,
+			opts:                placement.NewOptions().SetInstancesPerSubCluster(2).SetHasSubClusters(true),
+			subClusterToExclude: 0,
+			expectError:         true,
+			errorMsg:            "inconsistent instance weights",
+		},
+		{
+			name: "valid placement with multiple subclusters",
+			placement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					// Subcluster 1
+					placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1).SetSubClusterID(1),
+					// Subcluster 2
+					placement.NewEmptyInstance("i4", "r1", "z1", "endpoint", 1).SetSubClusterID(2),
+					placement.NewEmptyInstance("i5", "r2", "z1", "endpoint", 1).SetSubClusterID(2),
+					placement.NewEmptyInstance("i6", "r3", "z1", "endpoint", 1).SetSubClusterID(2),
+				}).
+				SetShards([]uint32{1, 2, 3, 4, 5, 6}).
+				SetReplicaFactor(3).
+				SetInstancesPerSubCluster(3).
+				SetHasSubClusters(true),
+			targetRF:            3,
+			opts:                placement.NewOptions().SetInstancesPerSubCluster(3).SetHasSubClusters(true),
+			subClusterToExclude: 0,
+			expectError:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper, err := newSubclusteredHelper(tt.placement, tt.targetRF, tt.opts, tt.subClusterToExclude)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+				assert.Nil(t, helper)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, helper)
+
+				// Verify helper properties
+				sh := helper.(*subclusteredHelper)
+				assert.Equal(t, tt.targetRF, sh.rf)
+				assert.Equal(t, tt.placement.InstancesPerSubCluster(), sh.instancesPerSubcluster)
+				assert.Equal(t, len(tt.placement.Instances()), len(sh.instances))
+				assert.Equal(t, len(tt.placement.Shards()), len(sh.uniqueShards))
+			}
+		})
+	}
+}
+
+func TestValidateSubclusterDistribution(t *testing.T) {
+	tests := []struct {
+		name        string
+		ph          *subclusteredHelper
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "empty instances",
+			ph: &subclusteredHelper{
+				instances: make(map[string]placement.Instance),
+				opts:      placement.NewOptions().SetInstancesPerSubCluster(3),
+			},
+			expectError: false,
+		},
+		{
+			name: "instances per subcluster not set",
+			ph: &subclusteredHelper{
+				instances: map[string]placement.Instance{
+					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+				},
+				opts: placement.NewOptions().SetInstancesPerSubCluster(0),
+			},
+			expectError: true,
+			errorMsg:    "instances per subcluster is not set",
+		},
+		{
+			name: "number of isolation groups matches replica factor",
+			ph: &subclusteredHelper{
+				instances: map[string]placement.Instance{
+					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i2": placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i3": placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1).SetSubClusterID(1),
+				},
+				rf:                     3,
+				instancesPerSubcluster: 3,
+				opts:                   placement.NewOptions().SetInstancesPerSubCluster(3),
+				groupToInstancesMap: map[string]map[placement.Instance]struct{}{
+					"r1": {placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1): {}},
+					"r2": {placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1): {}},
+					"r3": {placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1): {}},
+				},
+				subClusters: map[uint32]*subcluster{
+					1: {
+						id: 1,
+						instances: map[string]placement.Instance{
+							"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+							"i2": placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1),
+							"i3": placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "number of isolation groups does not match replica factor",
+			ph: &subclusteredHelper{
+				instances: map[string]placement.Instance{
+					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i2": placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1).SetSubClusterID(1),
+				},
+				rf:                     3,
+				instancesPerSubcluster: 2,
+				opts:                   placement.NewOptions().SetInstancesPerSubCluster(2),
+				groupToInstancesMap: map[string]map[placement.Instance]struct{}{
+					"r1": {placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1): {}},
+					"r2": {placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1): {}},
+				},
+				subClusters: map[uint32]*subcluster{
+					1: {
+						id: 1,
+						instances: map[string]placement.Instance{
+							"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+							"i2": placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1),
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "number of isolation groups (2) does not match replica factor (3)",
+		},
+		{
+			name: "complete subcluster with incorrect distribution",
+			ph: &subclusteredHelper{
+				instances: map[string]placement.Instance{
+					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i2": placement.NewEmptyInstance("i2", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i3": placement.NewEmptyInstance("i3", "r2", "z1", "endpoint", 1).SetSubClusterID(1),
+				},
+				rf:                     2,
+				instancesPerSubcluster: 3,
+				opts:                   placement.NewOptions().SetInstancesPerSubCluster(3),
+				groupToInstancesMap: map[string]map[placement.Instance]struct{}{
+					"r1": {
+						placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1): {},
+						placement.NewEmptyInstance("i2", "r1", "z1", "endpoint", 1): {},
+					},
+					"r2": {placement.NewEmptyInstance("i3", "r2", "z1", "endpoint", 1): {}},
+				},
+				subClusters: map[uint32]*subcluster{
+					1: {
+						id: 1,
+						instances: map[string]placement.Instance{
+							"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+							"i2": placement.NewEmptyInstance("i2", "r1", "z1", "endpoint", 1),
+							"i3": placement.NewEmptyInstance("i3", "r2", "z1", "endpoint", 1),
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "subcluster 1 isolation group r1 has 2 instances, expected 1",
+		},
+		{
+			name: "incomplete subcluster with too many instances in group",
+			ph: &subclusteredHelper{
+				instances: map[string]placement.Instance{
+					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i2": placement.NewEmptyInstance("i2", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+				},
+				rf:                     2,
+				instancesPerSubcluster: 3,
+				opts:                   placement.NewOptions().SetInstancesPerSubCluster(3),
+				groupToInstancesMap: map[string]map[placement.Instance]struct{}{
+					"r1": {
+						placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1): {},
+						placement.NewEmptyInstance("i2", "r1", "z1", "endpoint", 1): {},
+					},
+				},
+				subClusters: map[uint32]*subcluster{
+					1: {
+						id: 1,
+						instances: map[string]placement.Instance{
+							"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+							"i2": placement.NewEmptyInstance("i2", "r1", "z1", "endpoint", 1),
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "number of isolation groups (1) does not match replica factor (2)",
+		},
+		{
+			name: "incomplete subcluster with correct distribution",
+			ph: &subclusteredHelper{
+				instances: map[string]placement.Instance{
+					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i2": placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1).SetSubClusterID(1),
+				},
+				rf:                     2,
+				instancesPerSubcluster: 3,
+				opts:                   placement.NewOptions().SetInstancesPerSubCluster(3),
+				groupToInstancesMap: map[string]map[placement.Instance]struct{}{
+					"r1": {placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1): {}},
+					"r2": {placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1): {}},
+				},
+				subClusters: map[uint32]*subcluster{
+					1: {
+						id: 1,
+						instances: map[string]placement.Instance{
+							"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+							"i2": placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple subclusters with correct distribution",
+			ph: &subclusteredHelper{
+				instances: map[string]placement.Instance{
+					// Subcluster 1
+					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i2": placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1).SetSubClusterID(1),
+					"i3": placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1).SetSubClusterID(1),
+					// Subcluster 2
+					"i4": placement.NewEmptyInstance("i4", "r1", "z1", "endpoint", 1).SetSubClusterID(2),
+					"i5": placement.NewEmptyInstance("i5", "r2", "z1", "endpoint", 1).SetSubClusterID(2),
+					"i6": placement.NewEmptyInstance("i6", "r3", "z1", "endpoint", 1).SetSubClusterID(2),
+				},
+				rf:                     3,
+				instancesPerSubcluster: 3,
+				opts:                   placement.NewOptions().SetInstancesPerSubCluster(3),
+				groupToInstancesMap: map[string]map[placement.Instance]struct{}{
+					"r1": {
+						placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1): {},
+						placement.NewEmptyInstance("i4", "r1", "z1", "endpoint", 1): {},
+					},
+					"r2": {
+						placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1): {},
+						placement.NewEmptyInstance("i5", "r2", "z1", "endpoint", 1): {},
+					},
+					"r3": {
+						placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1): {},
+						placement.NewEmptyInstance("i6", "r3", "z1", "endpoint", 1): {},
+					},
+				},
+				subClusters: map[uint32]*subcluster{
+					1: {
+						id: 1,
+						instances: map[string]placement.Instance{
+							"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+							"i2": placement.NewEmptyInstance("i2", "r2", "z1", "endpoint", 1),
+							"i3": placement.NewEmptyInstance("i3", "r3", "z1", "endpoint", 1),
+						},
+					},
+					2: {
+						id: 2,
+						instances: map[string]placement.Instance{
+							"i4": placement.NewEmptyInstance("i4", "r1", "z1", "endpoint", 1),
+							"i5": placement.NewEmptyInstance("i5", "r2", "z1", "endpoint", 1),
+							"i6": placement.NewEmptyInstance("i6", "r3", "z1", "endpoint", 1),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.ph.validateSubclusterDistribution()
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Helper function to create a test placement with instances
+func createTestPlacement(instances []placement.Instance, shards []uint32, rf int, instancesPerSubcluster int) placement.Placement {
+	return placement.NewPlacement().
+		SetInstances(instances).
+		SetShards(shards).
+		SetReplicaFactor(rf).
+		SetInstancesPerSubCluster(instancesPerSubcluster).
+		SetHasSubClusters(true)
+}
+
+// Helper function to create test options
+func createTestOptions(instancesPerSubcluster int) placement.Options {
+	return placement.NewOptions().
+		SetInstancesPerSubCluster(instancesPerSubcluster).
+		SetHasSubClusters(true).
+		SetInstrumentOptions(instrument.NewOptions().SetLogger(zap.NewNop()))
+}
+
+func TestNewSubclusteredHelperIntegration(t *testing.T) {
+	instances := []placement.Instance{
+		placement.NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1),
+		placement.NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1),
+		placement.NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1).SetSubClusterID(1),
+	}
+
+	placement := createTestPlacement(instances, []uint32{1, 2, 3}, 3, 3)
+	opts := createTestOptions(3)
+
+	helper, err := newSubclusteredHelper(placement, 3, opts, 0)
+	require.NoError(t, err)
+	require.NotNil(t, helper)
+
+	sh := helper.(*subclusteredHelper)
+	assert.Equal(t, 3, sh.rf)
+	assert.Equal(t, 3, sh.instancesPerSubcluster)
+	assert.Equal(t, 3, len(sh.instances))
+	assert.Equal(t, 3, len(sh.uniqueShards))
+	assert.Equal(t, 3, len(sh.groupToInstancesMap))
+	assert.Equal(t, 1, len(sh.subClusters))
+}
+
+func TestValidateInstanceWeightIntegration(t *testing.T) {
+	instance1 := placement.NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1)
+	instance1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+	instance1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+	instance2 := placement.NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1)
+	instance2.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+	ph := &subclusteredHelper{
+		instances: map[string]placement.Instance{
+			"i1": instance1,
+			"i2": instance2,
+		},
+	}
+
+	err := ph.validateInstanceWeight()
+	assert.NoError(t, err)
+}

--- a/src/cluster/placement/algo/subclustered_helper_test.go
+++ b/src/cluster/placement/algo/subclustered_helper_test.go
@@ -142,7 +142,7 @@ func TestNewSubclusteredHelper(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			helper, err := newSubclusteredHelper(tt.placement, tt.targetRF, tt.opts, tt.subClusterToExclude)
+			helper, err := newSubclusteredHelper(tt.placement, tt.opts, tt.subClusterToExclude)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
@@ -152,11 +152,10 @@ func TestNewSubclusteredHelper(t *testing.T) {
 				assert.NotNil(t, helper)
 
 				// Verify helper properties
-				sh := helper.(*subclusteredHelper)
-				assert.Equal(t, tt.targetRF, sh.rf)
-				assert.Equal(t, tt.placement.InstancesPerSubCluster(), sh.instancesPerSubcluster)
-				assert.Equal(t, len(tt.placement.Instances()), len(sh.instances))
-				assert.Equal(t, len(tt.placement.Shards()), len(sh.uniqueShards))
+				assert.Equal(t, tt.targetRF, helper.rf)
+				assert.Equal(t, tt.placement.InstancesPerSubCluster(), helper.instancesPerSubcluster)
+				assert.Equal(t, len(tt.placement.Instances()), len(helper.instances))
+				assert.Equal(t, len(tt.placement.Shards()), len(helper.uniqueShards))
 			}
 		})
 	}
@@ -443,17 +442,16 @@ func TestNewSubclusteredHelperIntegration(t *testing.T) {
 	placement := createTestPlacement(instances, []uint32{1, 2, 3}, 3, 3)
 	opts := createTestOptions(3)
 
-	helper, err := newSubclusteredHelper(placement, 3, opts, 0)
+	helper, err := newSubclusteredHelper(placement, opts, 0)
 	require.NoError(t, err)
 	require.NotNil(t, helper)
 
-	sh := helper.(*subclusteredHelper)
-	assert.Equal(t, 3, sh.rf)
-	assert.Equal(t, 3, sh.instancesPerSubcluster)
-	assert.Equal(t, 3, len(sh.instances))
-	assert.Equal(t, 3, len(sh.uniqueShards))
-	assert.Equal(t, 3, len(sh.groupToInstancesMap))
-	assert.Equal(t, 1, len(sh.subClusters))
+	assert.Equal(t, 3, helper.rf)
+	assert.Equal(t, 3, helper.instancesPerSubcluster)
+	assert.Equal(t, 3, len(helper.instances))
+	assert.Equal(t, 3, len(helper.uniqueShards))
+	assert.Equal(t, 3, len(helper.groupToInstancesMap))
+	assert.Equal(t, 1, len(helper.subClusters))
 }
 
 func TestValidateInstanceWeightIntegration(t *testing.T) {
@@ -473,4 +471,237 @@ func TestValidateInstanceWeightIntegration(t *testing.T) {
 
 	err := ph.validateInstanceWeight()
 	assert.NoError(t, err)
+}
+
+func TestAssignSubClusterIDs(t *testing.T) {
+	tests := []struct {
+		name                   string
+		instancesPerSubcluster int
+		currentPlacement       placement.Placement
+		newInstances           []placement.Instance
+		expectedSubclusterIDs  []uint32
+		expectError            bool
+		errorMessage           string
+	}{
+		{
+			name:                   "no current placement, 3 instances per subcluster",
+			instancesPerSubcluster: 3,
+			currentPlacement:       nil,
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1),
+				placement.NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1),
+				placement.NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1),
+				placement.NewEmptyInstance("i4", "r4", "z1", "endpoint4", 1),
+				placement.NewEmptyInstance("i5", "r5", "z1", "endpoint5", 1),
+			},
+			expectedSubclusterIDs: []uint32{1, 1, 1, 2, 2},
+			expectError:           false,
+		},
+		{
+			name:                   "empty new instances",
+			instancesPerSubcluster: 3,
+			currentPlacement:       nil,
+			newInstances:           []placement.Instance{},
+			expectedSubclusterIDs:  []uint32{},
+			expectError:            false,
+		},
+		{
+			name:                   "exactly fill one subcluster",
+			instancesPerSubcluster: 3,
+			currentPlacement:       nil,
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1),
+				placement.NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1),
+				placement.NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1),
+			},
+			expectedSubclusterIDs: []uint32{1, 1, 1},
+			expectError:           false,
+		},
+		{
+			name:                   "fill multiple subclusters exactly",
+			instancesPerSubcluster: 2,
+			currentPlacement:       nil,
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1),
+				placement.NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1),
+				placement.NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1),
+				placement.NewEmptyInstance("i4", "r4", "z1", "endpoint4", 1),
+				placement.NewEmptyInstance("i5", "r5", "z1", "endpoint5", 1),
+				placement.NewEmptyInstance("i6", "r6", "z1", "endpoint6", 1),
+			},
+			expectedSubclusterIDs: []uint32{1, 1, 2, 2, 3, 3},
+			expectError:           false,
+		},
+		{
+			name:                   "invalid instances per subcluster - zero",
+			instancesPerSubcluster: 0,
+			currentPlacement:       nil,
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1),
+			},
+			expectedSubclusterIDs: []uint32{},
+			expectError:           true,
+			errorMessage:          "instances per subcluster is not set",
+		},
+		{
+			name:                   "invalid instances per subcluster - negative",
+			instancesPerSubcluster: -1,
+			currentPlacement:       nil,
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1),
+			},
+			expectedSubclusterIDs: []uint32{},
+			expectError:           true,
+			errorMessage:          "instances per subcluster is not set",
+		},
+		{
+			name:                   "fill incomplete subclusters in order of increasing ID",
+			instancesPerSubcluster: 3,
+			currentPlacement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					// Subcluster 1: 2 instances (incomplete)
+					placement.NewEmptyInstance("existing1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("existing2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1),
+					// Subcluster 3: 1 instance (incomplete)
+					placement.NewEmptyInstance("existing3", "r3", "z1", "endpoint3", 1).SetSubClusterID(3),
+					// Subcluster 5: 2 instances (incomplete)
+					placement.NewEmptyInstance("existing4", "r4", "z1", "endpoint4", 1).SetSubClusterID(5),
+					placement.NewEmptyInstance("existing5", "r5", "z1", "endpoint5", 1).SetSubClusterID(5),
+				}).
+				SetIsSharded(true).
+				SetIsSubclustered(true),
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("new1", "r6", "z1", "endpoint6", 1),
+				placement.NewEmptyInstance("new2", "r7", "z1", "endpoint7", 1),
+				placement.NewEmptyInstance("new3", "r8", "z1", "endpoint8", 1),
+				placement.NewEmptyInstance("new4", "r9", "z1", "endpoint9", 1),
+				placement.NewEmptyInstance("new5", "r10", "z1", "endpoint10", 1),
+			},
+			expectedSubclusterIDs: []uint32{1, 3, 3, 5, 6}, // Fill 1, then 3, then 5, then create 6
+			expectError:           false,
+		},
+		{
+			name:                   "current placement with leaving instances",
+			instancesPerSubcluster: 3,
+			currentPlacement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					placement.NewEmptyInstance("existing1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("existing2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("leaving1", "r3", "z1", "endpoint3", 1).
+						SetSubClusterID(1).
+						SetShards(shard.NewShards([]shard.Shard{shard.NewShard(1).SetState(shard.Leaving)})),
+					placement.NewEmptyInstance("existing3", "r4", "z1", "endpoint4", 1).SetSubClusterID(2),
+				}).
+				SetIsSharded(true).
+				SetIsSubclustered(true),
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("new1", "r5", "z1", "endpoint5", 1),
+				placement.NewEmptyInstance("new2", "r6", "z1", "endpoint6", 1),
+				placement.NewEmptyInstance("new3", "r7", "z1", "endpoint7", 1),
+			},
+			expectedSubclusterIDs: []uint32{1, 2, 2}, // Fill subcluster 1 (2 non-leaving), then 2
+			expectError:           false,
+		},
+		{
+			name:                   "single instance fills incomplete subcluster",
+			instancesPerSubcluster: 3,
+			currentPlacement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					placement.NewEmptyInstance("existing1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("existing2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("existing3", "r3", "z1", "endpoint3", 1).SetSubClusterID(2),
+				}).
+				SetIsSharded(true).
+				SetIsSubclustered(true),
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("new1", "r4", "z1", "endpoint4", 1),
+			},
+			expectedSubclusterIDs: []uint32{1}, // Fill subcluster 1 (smaller ID)
+			expectError:           false,
+		},
+		{
+			name:                   "multiple incomplete subclusters with same count",
+			instancesPerSubcluster: 4,
+			currentPlacement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					// Subcluster 5: 2 instances
+					placement.NewEmptyInstance("existing1", "r1", "z1", "endpoint1", 1).SetSubClusterID(5),
+					placement.NewEmptyInstance("existing2", "r2", "z1", "endpoint2", 1).SetSubClusterID(5),
+					// Subcluster 2: 2 instances
+					placement.NewEmptyInstance("existing3", "r3", "z1", "endpoint3", 1).SetSubClusterID(2),
+					placement.NewEmptyInstance("existing4", "r4", "z1", "endpoint4", 1).SetSubClusterID(2),
+					// Subcluster 7: 2 instances
+					placement.NewEmptyInstance("existing5", "r5", "z1", "endpoint5", 1).SetSubClusterID(7),
+					placement.NewEmptyInstance("existing6", "r6", "z1", "endpoint6", 1).SetSubClusterID(7),
+				}).
+				SetIsSharded(true).
+				SetIsSubclustered(true),
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("new1", "r7", "z1", "endpoint7", 1),
+				placement.NewEmptyInstance("new2", "r8", "z1", "endpoint8", 1),
+				placement.NewEmptyInstance("new3", "r9", "z1", "endpoint9", 1),
+				placement.NewEmptyInstance("new4", "r10", "z1", "endpoint10", 1),
+			},
+			expectedSubclusterIDs: []uint32{2, 2, 5, 5}, // Fill in order: 2, 5, 7 (by ID)
+			expectError:           false,
+		},
+		{
+			name:                   "all subclusters full, create new ones",
+			instancesPerSubcluster: 2,
+			currentPlacement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					placement.NewEmptyInstance("existing1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("existing2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1), // subcluster 1 full
+					placement.NewEmptyInstance("existing3", "r3", "z1", "endpoint3", 1).SetSubClusterID(3),
+					placement.NewEmptyInstance("existing4", "r4", "z1", "endpoint4", 1).SetSubClusterID(3), // subcluster 3 full
+				}).
+				SetIsSharded(true).
+				SetIsSubclustered(true),
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("new1", "r5", "z1", "endpoint5", 1),
+				placement.NewEmptyInstance("new2", "r6", "z1", "endpoint6", 1),
+				placement.NewEmptyInstance("new3", "r7", "z1", "endpoint7", 1),
+			},
+			expectedSubclusterIDs: []uint32{4, 4, 5}, // Create new subclusters 4 and 5
+			expectError:           false,
+		},
+		{
+			name:                   "edge case: exactly one instance needed to complete subcluster",
+			instancesPerSubcluster: 3,
+			currentPlacement: placement.NewPlacement().
+				SetInstances([]placement.Instance{
+					placement.NewEmptyInstance("existing1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("existing2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1),
+					placement.NewEmptyInstance("existing3", "r3", "z1", "endpoint3", 1).SetSubClusterID(2),
+					placement.NewEmptyInstance("existing4", "r4", "z1", "endpoint4", 1).SetSubClusterID(2),
+				}).
+				SetIsSharded(true).
+				SetIsSubclustered(true),
+			newInstances: []placement.Instance{
+				placement.NewEmptyInstance("new1", "r5", "z1", "endpoint5", 1),
+				placement.NewEmptyInstance("new2", "r6", "z1", "endpoint6", 1),
+			},
+			expectedSubclusterIDs: []uint32{1, 2}, // Complete subcluster 1, then 2
+			expectError:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := assignSubClusterIDs(tt.newInstances, tt.currentPlacement, tt.instancesPerSubcluster)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errorMessage, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, len(tt.expectedSubclusterIDs), len(tt.newInstances))
+
+				for i, expectedID := range tt.expectedSubclusterIDs {
+					assert.Equal(t, expectedID, tt.newInstances[i].SubClusterID(),
+						"Instance %d (ID: %s) should be in subcluster %d",
+						i, tt.newInstances[i].ID(), expectedID)
+				}
+			}
+		})
+	}
 }

--- a/src/cluster/placement/algo/subclustered_helper_test.go
+++ b/src/cluster/placement/algo/subclustered_helper_test.go
@@ -407,7 +407,12 @@ func TestValidateSubclusterDistribution(t *testing.T) {
 }
 
 // Helper function to create a test placement with instances
-func createTestPlacement(instances []placement.Instance, shards []uint32, rf int, instancesPerSubcluster int) placement.Placement {
+func createTestPlacement(
+	instances []placement.Instance,
+	shards []uint32,
+	rf int,
+	instancesPerSubcluster int,
+) placement.Placement {
 	return placement.NewPlacement().
 		SetInstances(instances).
 		SetShards(shards).

--- a/src/cluster/placement/algo/subclustered_helper_test.go
+++ b/src/cluster/placement/algo/subclustered_helper_test.go
@@ -93,9 +93,9 @@ func TestNewSubclusteredHelper(t *testing.T) {
 				SetShards([]uint32{1, 2, 3}).
 				SetReplicaFactor(3).
 				SetInstancesPerSubCluster(3).
-				SetHasSubClusters(true),
+				SetIsSubclustered(true),
 			targetRF:            3,
-			opts:                placement.NewOptions().SetInstancesPerSubCluster(3).SetHasSubClusters(true),
+			opts:                placement.NewOptions().SetInstancesPerSubCluster(3).SetIsSubclustered(true),
 			subClusterToExclude: 0,
 			expectError:         false,
 		},
@@ -109,9 +109,9 @@ func TestNewSubclusteredHelper(t *testing.T) {
 				SetShards([]uint32{1, 2}).
 				SetReplicaFactor(2).
 				SetInstancesPerSubCluster(2).
-				SetHasSubClusters(true),
+				SetIsSubclustered(true),
 			targetRF:            2,
-			opts:                placement.NewOptions().SetInstancesPerSubCluster(2).SetHasSubClusters(true),
+			opts:                placement.NewOptions().SetInstancesPerSubCluster(2).SetIsSubclustered(true),
 			subClusterToExclude: 0,
 			expectError:         true,
 			errorMsg:            "inconsistent instance weights",
@@ -132,9 +132,9 @@ func TestNewSubclusteredHelper(t *testing.T) {
 				SetShards([]uint32{1, 2, 3, 4, 5, 6}).
 				SetReplicaFactor(3).
 				SetInstancesPerSubCluster(3).
-				SetHasSubClusters(true),
+				SetIsSubclustered(true),
 			targetRF:            3,
-			opts:                placement.NewOptions().SetInstancesPerSubCluster(3).SetHasSubClusters(true),
+			opts:                placement.NewOptions().SetInstancesPerSubCluster(3).SetIsSubclustered(true),
 			subClusterToExclude: 0,
 			expectError:         false,
 		},
@@ -409,14 +409,14 @@ func createTestPlacement(
 		SetShards(shards).
 		SetReplicaFactor(rf).
 		SetInstancesPerSubCluster(instancesPerSubcluster).
-		SetHasSubClusters(true)
+		SetIsSubclustered(true)
 }
 
 // Helper function to create test options
 func createTestOptions(instancesPerSubcluster int) placement.Options {
 	return placement.NewOptions().
 		SetInstancesPerSubCluster(instancesPerSubcluster).
-		SetHasSubClusters(true).
+		SetIsSubclustered(true).
 		SetInstrumentOptions(instrument.NewOptions().SetLogger(zap.NewNop()))
 }
 

--- a/src/cluster/placement/algo/subclustered_helper_test.go
+++ b/src/cluster/placement/algo/subclustered_helper_test.go
@@ -178,12 +178,25 @@ func TestValidateSubclusterDistribution(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "replica factor not set",
+			ph: &subclusteredHelper{
+				instances: map[string]placement.Instance{
+					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
+				},
+				opts: placement.NewOptions().SetInstancesPerSubCluster(3),
+				rf:   0,
+			},
+			expectError: true,
+			errorMsg:    "replica factor should be greater than 0",
+		},
+		{
 			name: "instances per subcluster not set",
 			ph: &subclusteredHelper{
 				instances: map[string]placement.Instance{
 					"i1": placement.NewEmptyInstance("i1", "r1", "z1", "endpoint", 1),
 				},
 				opts: placement.NewOptions().SetInstancesPerSubCluster(0),
+				rf:   3,
 			},
 			expectError: true,
 			errorMsg:    "instances per subcluster is not set",

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -1,0 +1,1620 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package algo
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/m3db/m3/src/cluster/placement"
+	"github.com/m3db/m3/src/cluster/shard"
+)
+
+// getRandomSubclusterIDs randomly selects the specified number of subcluster IDs from the placement
+func getRandomSubclusterIDs(p placement.Placement, numToRemove int) []uint32 {
+	subclusterMap := make(map[uint32]struct{})
+	for _, instance := range p.Instances() {
+		subclusterMap[instance.SubClusterID()] = struct{}{}
+	}
+
+	subclusterIDs := make([]uint32, 0, len(subclusterMap))
+	for subclusterID := range subclusterMap {
+		subclusterIDs = append(subclusterIDs, subclusterID)
+	}
+
+	// Randomly shuffle and select the first numToRemove
+	rand.Shuffle(len(subclusterIDs), func(i, j int) {
+		subclusterIDs[i], subclusterIDs[j] = subclusterIDs[j], subclusterIDs[i]
+	})
+
+	if numToRemove > len(subclusterIDs) {
+		numToRemove = len(subclusterIDs)
+	}
+
+	return subclusterIDs[:numToRemove]
+}
+
+func TestSubclusteredAlgorithm_IsCompatibleWith(t *testing.T) {
+	algo := newSubclusteredAlgorithm(placement.NewOptions())
+
+	tests := []struct {
+		name        string
+		placement   placement.Placement
+		expectError bool
+	}{
+		{
+			name:        "nil placement",
+			placement:   nil,
+			expectError: true,
+		},
+		{
+			name: "not sharded placement",
+			placement: placement.NewPlacement().
+				SetIsSharded(false).
+				SetIsSubclustered(true),
+			expectError: true,
+		},
+		{
+			name: "no subclusters placement",
+			placement: placement.NewPlacement().
+				SetIsSharded(true).
+				SetIsSubclustered(false),
+			expectError: true,
+		},
+		{
+			name: "compatible placement",
+			placement: placement.NewPlacement().
+				SetIsSharded(true).
+				SetIsSubclustered(true),
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := algo.IsCompatibleWith(tt.placement)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInitialPlacement(t *testing.T) {
+	tests := []struct {
+		name                   string
+		instancesPerSubcluster int
+		instances              []placement.Instance
+		shards                 int
+		replicaFactor          int
+		expectError            bool
+		errorMessage           string
+	}{
+		{
+			name:                   "instances per subcluster not multiple of replica factor",
+			instancesPerSubcluster: 5,
+			shards:                 5,
+			replicaFactor:          3,
+			expectError:            true,
+			errorMessage:           "instances per subcluster is not a multiple of replica factor",
+		},
+		{
+			name:                   "instances per subcluster is not set",
+			instancesPerSubcluster: 0,
+			shards:                 5,
+			replicaFactor:          3,
+			expectError:            true,
+			errorMessage:           "instances per subcluster is not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster)
+			algo := newSubclusteredAlgorithm(opts)
+
+			// Clone instances to avoid modifying the original test data
+			instances := make([]placement.Instance, len(tt.instances))
+			for i, instance := range tt.instances {
+				instances[i] = instance.Clone()
+			}
+
+			// Clone shards to avoid modifying the original test data
+			shards := make([]uint32, tt.shards)
+			for i := range shards {
+				shards[i] = uint32(i)
+			}
+
+			result, err := algo.InitialPlacement(instances, shards, tt.replicaFactor)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errorMessage, err.Error())
+				assert.Nil(t, result)
+			} else {
+				// For now, the method returns nil, nil when successful
+				// This will need to be updated when the implementation is complete
+				assert.NoError(t, err)
+				assert.Nil(t, result) // Current implementation returns nil
+			}
+
+			// Verify that instances were assigned subcluster IDs correctly
+			if !tt.expectError && len(instances) > 0 {
+				// Check that all instances have valid subcluster IDs
+				for i, instance := range instances {
+					assert.True(t, instance.SubClusterID() > 0,
+						"Instance %d (ID: %s) should have a valid subcluster ID",
+						i, instance.ID())
+				}
+
+				// Verify subcluster assignment logic
+				expectedSubclusters := make(map[uint32]int)
+				for _, instance := range instances {
+					expectedSubclusters[instance.SubClusterID()]++
+				}
+
+				// Each subcluster should not exceed the configured limit
+				for subclusterID, count := range expectedSubclusters {
+					assert.True(t, count <= tt.instancesPerSubcluster,
+						"Subcluster %d should not exceed %d instances, got %d",
+						subclusterID, tt.instancesPerSubcluster, count)
+				}
+			}
+		})
+	}
+}
+
+func TestSubclusteredAlgorithm_InitialPlacement(t *testing.T) {
+	tests := []struct {
+		name                   string
+		instancesPerSubcluster int
+		replicaFactor          int
+		totalInstances         int
+		totalShards            int
+		expectError            bool
+		errorMessage           string
+		expectedSubclusters    int
+	}{
+		{
+			name:                   "valid configuration - rf=2, instancesPerSubcluster=6",
+			instancesPerSubcluster: 6,
+			replicaFactor:          2,
+			totalInstances:         12,
+			totalShards:            64,
+			expectError:            false,
+			expectedSubclusters:    2,
+		},
+		{
+			name:                   "valid configuration - rf=3, instancesPerSubcluster=9",
+			instancesPerSubcluster: 9,
+			replicaFactor:          3,
+			totalInstances:         27,
+			totalShards:            1024,
+			expectError:            false,
+			expectedSubclusters:    3,
+		},
+		{
+			name:                   "valid configuration - rf=1, instancesPerSubcluster=4",
+			instancesPerSubcluster: 4,
+			replicaFactor:          1,
+			totalInstances:         4,
+			totalShards:            16,
+			expectError:            false,
+			expectedSubclusters:    1,
+		},
+		{
+			name:                   "valid configuration - rf=4, instancesPerSubcluster=8",
+			instancesPerSubcluster: 8,
+			replicaFactor:          4,
+			totalInstances:         16,
+			totalShards:            512,
+			expectError:            false,
+			expectedSubclusters:    2,
+		},
+		{
+			name:                   "valid configuration - multiple subclusters",
+			instancesPerSubcluster: 3,
+			replicaFactor:          1,
+			totalInstances:         6,
+			totalShards:            6,
+			expectError:            false,
+			expectedSubclusters:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster)
+			algo := newSubclusteredAlgorithm(opts)
+
+			// Generate instances dynamically
+			instances := make([]placement.Instance, tt.totalInstances)
+			for i := 0; i < tt.totalInstances; i++ {
+				instances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Generate shards dynamically
+			shards := make([]uint32, tt.totalShards)
+			for i := 0; i < tt.totalShards; i++ {
+				shards[i] = uint32(i)
+			}
+
+			result, err := algo.InitialPlacement(instances, shards, tt.replicaFactor)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, tt.errorMessage, err.Error())
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				subclusterMap := make(map[uint32]struct{})
+
+				instances := result.Instances()
+				for _, instance := range instances {
+					subclusterMap[instance.SubClusterID()] = struct{}{}
+				}
+
+				// Verify subcluster assignments
+				assert.Equal(t, tt.expectedSubclusters, len(subclusterMap))
+
+				// Verify placement properties
+				assert.Equal(t, tt.replicaFactor, result.ReplicaFactor())
+				assert.True(t, result.IsSharded())
+				assert.True(t, result.IsSubclustered())
+				assert.NoError(t, placement.Validate(result))
+				assert.Equal(t, tt.instancesPerSubcluster, result.InstancesPerSubCluster())
+			}
+		})
+	}
+}
+
+func TestSubclusteredAlgorithm_InitialPlacement_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name                   string
+		instancesPerSubcluster int
+		replicaFactor          int
+		totalInstances         int
+		totalShards            int
+		expectError            bool
+		errorMessage           string
+	}{
+		{
+			name:                   "instances per subcluster not multiple of replica factor - rf=2, instancesPerSubcluster=5",
+			instancesPerSubcluster: 5,
+			replicaFactor:          2,
+			totalInstances:         5,
+			totalShards:            5,
+			expectError:            true,
+			errorMessage:           "instances per subcluster is not a multiple of replica factor",
+		},
+		{
+			name:                   "instances per subcluster not multiple of replica factor - rf=3, instancesPerSubcluster=8",
+			instancesPerSubcluster: 8,
+			replicaFactor:          3,
+			totalInstances:         8,
+			totalShards:            8,
+			expectError:            true,
+			errorMessage:           "instances per subcluster is not a multiple of replica factor",
+		},
+		{
+			name:                   "replica factor greater than instances per subcluster",
+			instancesPerSubcluster: 2,
+			replicaFactor:          3,
+			totalInstances:         2,
+			totalShards:            2,
+			expectError:            true,
+			errorMessage:           "instances per subcluster is not a multiple of replica factor",
+		},
+		{
+			name:                   "instances per subcluster not set",
+			instancesPerSubcluster: 0,
+			replicaFactor:          1,
+			totalInstances:         1,
+			totalShards:            1,
+			expectError:            true,
+			errorMessage:           "instances per subcluster is not set",
+		},
+		{
+			name:                   "negative instances per subcluster",
+			instancesPerSubcluster: -1,
+			replicaFactor:          1,
+			totalInstances:         1,
+			totalShards:            1,
+			expectError:            true,
+			errorMessage:           "instances per subcluster is not set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster)
+			algo := subclusteredPlacementAlgorithm{opts: opts}
+			// Generate instances dynamically
+			instances := make([]placement.Instance, tt.totalInstances)
+			for i := 0; i < tt.totalInstances; i++ {
+				instances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Generate shards dynamically
+			shards := make([]uint32, tt.totalShards)
+			for i := 0; i < tt.totalShards; i++ {
+				shards[i] = uint32(i)
+			}
+
+			result, err := algo.InitialPlacement(instances, shards, tt.replicaFactor)
+
+			assert.Error(t, err)
+			assert.Equal(t, tt.errorMessage, err.Error())
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestAddInstancesValidCases(t *testing.T) {
+	tests := []struct {
+		name                   string
+		instancesPerSubcluster int
+		replicaFactor          int
+		instancesToAdd         int
+		totalShards            int
+	}{
+		{
+			name:                   "valid configuration - rf=3, instancesPerSubcluster=6",
+			instancesPerSubcluster: 6,
+			replicaFactor:          3,
+			instancesToAdd:         12,
+			totalShards:            128,
+		},
+		{
+			name:                   "valid configuration - rf=3, instancesPerSubcluster=9",
+			instancesPerSubcluster: 9,
+			replicaFactor:          3,
+			instancesToAdd:         27,
+			totalShards:            128,
+		},
+		{
+			name:                   "valid configuration - rf=4, instancesPerSubcluster=8",
+			instancesPerSubcluster: 8,
+			replicaFactor:          4,
+			instancesToAdd:         16,
+			totalShards:            128,
+		},
+		{
+			name:                   "valid configuration - rf=2, instancesPerSubcluster=6`",
+			instancesPerSubcluster: 8,
+			replicaFactor:          2,
+			instancesToAdd:         16,
+			totalShards:            128,
+		},
+		{
+			name:                   "partial subcluster configuration - rf=3, instancesPerSubcluster=6",
+			instancesPerSubcluster: 6,
+			replicaFactor:          3,
+			instancesToAdd:         10,
+			totalShards:            128,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster)
+			algo := subclusteredPlacementAlgorithm{opts: opts}
+
+			initialInstances := make([]placement.Instance, tt.instancesPerSubcluster)
+			for i := 0; i < tt.instancesPerSubcluster; i++ {
+				initialInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			initialShards := make([]uint32, tt.totalShards)
+			for i := 0; i < tt.totalShards; i++ {
+				initialShards[i] = uint32(i)
+			}
+
+			result, err := algo.InitialPlacement(initialInstances, initialShards, tt.replicaFactor)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.NoError(t, placement.Validate(result))
+
+			instancesToAdd := make([]placement.Instance, tt.instancesToAdd)
+			for i := 0; i < tt.instancesToAdd; i++ {
+				instancesToAdd[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", tt.instancesPerSubcluster+i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", tt.instancesPerSubcluster+i)).
+					SetShards(shard.NewShards(nil))
+			}
+			currentPlacement := result.Clone()
+			for i := 0; i < tt.instancesToAdd; i++ {
+				instance := instancesToAdd[i]
+				newPlacement, err := algo.AddInstances(currentPlacement, []placement.Instance{instance})
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				assert.Equal(t, tt.instancesPerSubcluster+i+1, len(newPlacement.Instances()))
+				assert.NoError(t, placement.Validate(newPlacement))
+
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
+				assert.NoError(t, err)
+				assert.True(t, marked2)
+				assert.NoError(t, placement.Validate(newPlacement))
+
+				currentPlacement = newPlacement
+			}
+			assert.NoError(t, placement.Validate(currentPlacement))
+		})
+	}
+}
+
+func TestAddInstancesErrorCases(t *testing.T) {
+	tests := []struct {
+		name                   string
+		replicaFactor          int
+		instancesPerSubcluster int
+		instancesToAdd         []placement.Instance
+		expectError            bool
+	}{
+		{
+			name:                   "number of isolation groups is not equal to replica factor",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			instancesToAdd: []placement.Instance{
+				placement.NewEmptyInstance("I7", "R8", "R8", "E0", 1),
+			},
+			expectError: true,
+		},
+		{
+			name:                   "instances per isolation group != instancesPerSubcluster/replicaFactor",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			instancesToAdd: []placement.Instance{
+				placement.NewEmptyInstance("I9", "R0", "R0", "E0", 1),
+				placement.NewEmptyInstance("I10", "R0", "R0", "E1", 1),
+				placement.NewEmptyInstance("I11", "R0", "R0", "E2", 1),
+			},
+			expectError: true,
+		},
+		{
+			name:                   "instances per isolation group != instancesPerSubcluster/replicaFacto (full subcluster)",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			instancesToAdd: []placement.Instance{
+				placement.NewEmptyInstance("I9", "R0", "R0", "E0", 1),
+				placement.NewEmptyInstance("I10", "R1", "R1", "E1", 1),
+				placement.NewEmptyInstance("I11", "R2", "R2", "E2", 1),
+				placement.NewEmptyInstance("I12", "R0", "R0", "E0", 1),
+				placement.NewEmptyInstance("I13", "R1", "R1", "E1", 1),
+				placement.NewEmptyInstance("I14", "R0", "R0", "E2", 1),
+			},
+			expectError: true,
+		},
+		{
+			name:                   "instances do not have same weight",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			instancesToAdd: []placement.Instance{
+				placement.NewEmptyInstance("I15", "R0", "R0", "E0", 10),
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster)
+			algo := subclusteredPlacementAlgorithm{opts: opts}
+
+			initialInstances := make([]placement.Instance, tt.instancesPerSubcluster)
+			for i := 0; i < tt.instancesPerSubcluster; i++ {
+				initialInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			totalShards := 128
+			shards := make([]uint32, totalShards)
+			for i := 0; i < totalShards; i++ {
+				shards[i] = uint32(i)
+			}
+
+			result, err := algo.InitialPlacement(initialInstances, shards, tt.replicaFactor)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.NoError(t, placement.Validate(result))
+
+			newPlacement, err := algo.AddInstances(result, tt.instancesToAdd)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, newPlacement)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				assert.NoError(t, placement.Validate(newPlacement))
+			}
+		})
+	}
+}
+
+func TestRemoveInstancesValidCases(t *testing.T) {
+	tests := []struct {
+		name                   string
+		replicaFactor          int
+		initialSubClusters     int
+		instancesPerSubcluster int
+		subClustersToRemove    int
+		totalShards            int
+	}{
+		{
+			name:                   "valid configuration - rf=3, instancesPerSubcluster=6",
+			replicaFactor:          3,
+			initialSubClusters:     4,
+			instancesPerSubcluster: 6,
+			subClustersToRemove:    1,
+			totalShards:            128,
+		},
+		{
+			name:                   "valid configuration - rf=3, instancesPerSubcluster=9",
+			replicaFactor:          3,
+			initialSubClusters:     10,
+			instancesPerSubcluster: 9,
+			subClustersToRemove:    5,
+			totalShards:            1024,
+		},
+		{
+			name:                   "valid configuration - rf=4, instancesPerSubcluster=8",
+			replicaFactor:          4,
+			initialSubClusters:     10,
+			instancesPerSubcluster: 8,
+			subClustersToRemove:    4,
+			totalShards:            1024,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster).
+				SetIsSubclustered(true)
+			algo := subclusteredPlacementAlgorithm{opts}
+
+			initialInstances := make([]placement.Instance, tt.instancesPerSubcluster*tt.initialSubClusters)
+			for i := 0; i < tt.instancesPerSubcluster*tt.initialSubClusters; i++ {
+				initialInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			initialShards := make([]uint32, tt.totalShards)
+			for i := 0; i < tt.totalShards; i++ {
+				initialShards[i] = uint32(i)
+			}
+
+			result, err := algo.InitialPlacement(initialInstances, initialShards, tt.replicaFactor)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.NoError(t, placement.Validate(result))
+
+			// Randomly select subclusters to remove
+			subclustersToRemove := getRandomSubclusterIDs(result, tt.subClustersToRemove)
+
+			// Get all instances from the selected subclusters
+			var instancesToRemove []string
+			for _, subclusterID := range subclustersToRemove {
+				for _, instance := range placement.BySubClusterIDThenInstanceID(result.Instances()) {
+					if instance.SubClusterID() == subclusterID {
+						instancesToRemove = append(instancesToRemove, instance.ID())
+					}
+				}
+			}
+
+			// Remove the instances
+			newPlacement, err := algo.RemoveInstances(result, instancesToRemove)
+			assert.NoError(t, err)
+			assert.NotNil(t, newPlacement)
+			assert.NoError(t, placement.Validate(newPlacement))
+
+			// Verify that the expected number of instances were removed
+			expectedRemainingInstances := tt.instancesPerSubcluster * (tt.initialSubClusters - tt.subClustersToRemove)
+			assert.Equal(t, expectedRemainingInstances, len(newPlacement.Instances()))
+		})
+	}
+}
+
+func TestPartialSubclustersRemoveOperation(t *testing.T) {
+	tests := []struct {
+		name                   string
+		replicaFactor          int
+		instancesPerSubcluster int
+		instancesToAdd         int
+		totalShards            int
+		subClustersToRemove    int
+	}{
+		{
+			name:                   "remove subcluster while removal of subcluster is going on",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			instancesToAdd:         18,
+			totalShards:            128,
+			subClustersToRemove:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster)
+			algo := subclusteredPlacementAlgorithm{opts: opts}
+
+			initialInstances := make([]placement.Instance, tt.instancesPerSubcluster)
+			for i := 0; i < tt.instancesPerSubcluster; i++ {
+				initialInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			initialShards := make([]uint32, tt.totalShards)
+			for i := 0; i < tt.totalShards; i++ {
+				initialShards[i] = uint32(i)
+			}
+
+			result, err := algo.InitialPlacement(initialInstances, initialShards, tt.replicaFactor)
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.NoError(t, placement.Validate(result))
+
+			currentPlacement, marked, err := algo.MarkAllShardsAvailable(result)
+			assert.NoError(t, err)
+			assert.True(t, marked)
+			assert.NoError(t, placement.Validate(currentPlacement))
+
+			instancesToAdd := make([]placement.Instance, tt.instancesToAdd)
+			for i := 0; i < tt.instancesToAdd; i++ {
+				instancesToAdd[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", tt.instancesPerSubcluster+i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", tt.instancesPerSubcluster+i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			for i := 0; i < tt.instancesToAdd; i++ {
+				instance := instancesToAdd[i]
+				newPlacement, err := algo.AddInstances(currentPlacement, []placement.Instance{instance})
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				assert.NoError(t, placement.Validate(newPlacement))
+
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
+				assert.NoError(t, err)
+				assert.True(t, marked2)
+				assert.NoError(t, placement.Validate(newPlacement))
+
+				currentPlacement = newPlacement
+			}
+			// Randomly select subclusters to remove
+			subclustersToRemove := getRandomSubclusterIDs(currentPlacement, tt.subClustersToRemove)
+			if tt.instancesToAdd%tt.instancesPerSubcluster != 0 {
+				subclustersToRemove = []uint32{1}
+			}
+
+			// Get all instances from the selected subclusters
+			var instancesToRemove []string
+			for _, subclusterID := range subclustersToRemove {
+				for _, instance := range currentPlacement.Instances() {
+					if instance.SubClusterID() == subclusterID {
+						instancesToRemove = append(instancesToRemove, instance.ID())
+					}
+				}
+			}
+
+			if tt.subClustersToRemove > 1 {
+				instancesToRemove[0], instancesToRemove[tt.instancesPerSubcluster] =
+					instancesToRemove[tt.instancesPerSubcluster], instancesToRemove[0]
+			}
+
+			// Remove the instances
+			newPlacement, err := algo.RemoveInstances(currentPlacement, instancesToRemove)
+			assert.Error(t, err)
+			assert.Nil(t, newPlacement)
+		})
+	}
+}
+
+func TestPartialSubclustersAddOperation(t *testing.T) {
+	shards := make([]uint32, 1024)
+	for i := 0; i < 1024; i++ {
+		shards[i] = uint32(i)
+	}
+
+	instancesPerSubCluster := 9
+	replicaFactor := 3
+	subclustersToAdd := 5
+	subclusterIDToRemove := uint32(3)
+
+	initialInstances := make([]placement.Instance, instancesPerSubCluster*subclustersToAdd)
+	for i := 0; i < len(initialInstances); i++ {
+		subclusterID := uint32(i/instancesPerSubCluster + 1)
+		initialInstances[i] = placement.NewInstance().
+			SetID(fmt.Sprintf("I%d", i)).
+			SetIsolationGroup(fmt.Sprintf("R%d", i%replicaFactor)).
+			SetWeight(1).
+			SetEndpoint(fmt.Sprintf("E%d", i)).
+			SetSubClusterID(subclusterID).
+			SetShards(shard.NewShards(nil))
+	}
+	opts := placement.NewOptions().SetInstancesPerSubCluster(instancesPerSubCluster).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	result, err := algo.InitialPlacement(initialInstances, shards, replicaFactor)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.NoError(t, placement.Validate(result))
+
+	currentPlacement, marked, err := algo.MarkAllShardsAvailable(result)
+	assert.NoError(t, err)
+	assert.True(t, marked)
+	assert.NoError(t, placement.Validate(currentPlacement))
+
+	instanceToRemove := ""
+	for _, instance := range currentPlacement.Instances() {
+		if instance.SubClusterID() == subclusterIDToRemove {
+			instanceToRemove = instance.ID()
+			break
+		}
+	}
+
+	newPlacement, err := algo.RemoveInstances(currentPlacement, []string{instanceToRemove})
+	assert.NoError(t, err)
+	assert.NotNil(t, newPlacement)
+	assert.NoError(t, placement.Validate(newPlacement))
+
+	instanceToAdd := placement.NewInstance().
+		SetID("RI0").
+		SetIsolationGroup("R0").
+		SetWeight(1).
+		SetEndpoint("E0").
+		SetShards(shard.NewShards(nil))
+
+	newPlacement, err = algo.AddInstances(newPlacement, []placement.Instance{instanceToAdd})
+	assert.NoError(t, err)
+	assert.NotNil(t, newPlacement)
+	assert.NoError(t, placement.Validate(newPlacement))
+}
+
+func TestReplaceInstancesValidCases(t *testing.T) {
+	tests := []struct {
+		name                        string
+		rf                          int
+		instancesPerSub             int
+		totalInstances              int
+		shards                      int
+		instancesToAddBeforeReplace int
+	}{
+		{
+			name:                        "RF=3, 6 instance/subcluster, add 5 instances (not multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             6,
+			totalInstances:              12,
+			shards:                      256,
+			instancesToAddBeforeReplace: 5,
+		},
+		{
+			name:                        "RF=3, 6 instance/subcluster, add 12 instances (multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             6,
+			totalInstances:              6,
+			shards:                      256,
+			instancesToAddBeforeReplace: 12,
+		},
+		{
+			name:                        "RF=3, 9 instance/subcluster, add 7 instances (not multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             9,
+			totalInstances:              9,
+			shards:                      256,
+			instancesToAddBeforeReplace: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create initial test instances
+			instances := make([]placement.Instance, tt.totalInstances)
+			for i := 0; i < tt.totalInstances; i++ {
+				instances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.rf)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Generate shard IDs from 0 to shards-1
+			shardIDs := make([]uint32, tt.shards)
+			for i := 0; i < tt.shards; i++ {
+				shardIDs[i] = uint32(i)
+			}
+
+			// Create algorithm
+			opts := placement.NewOptions().
+				SetValidZone("zone1").
+				SetIsSharded(true).
+				SetInstancesPerSubCluster(tt.instancesPerSub).
+				SetIsSubclustered(true)
+			algo := newSubclusteredAlgorithm(opts)
+
+			// Perform initial placement
+			p, err := algo.InitialPlacement(instances, shardIDs, tt.rf)
+			assert.NoError(t, err)
+			assert.NotNil(t, p)
+			assert.NoError(t, placement.Validate(p))
+
+			// Verify initial placement
+			currentPlacement, marked, err := algo.MarkAllShardsAvailable(p)
+			assert.NoError(t, err)
+			assert.True(t, marked)
+			assert.NoError(t, placement.Validate(currentPlacement))
+
+			// Create new instances to add
+			totalInstances := tt.instancesToAddBeforeReplace + tt.instancesPerSub -
+				(tt.instancesToAddBeforeReplace % tt.instancesPerSub)
+			newInstances := make([]placement.Instance, totalInstances)
+			for i := range totalInstances {
+				newInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", tt.totalInstances+i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.rf)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", tt.totalInstances+i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Add new instances
+			j := 0
+			for _, instance := range newInstances {
+				if j == tt.instancesToAddBeforeReplace {
+					break
+				}
+				newPlacement, err := algo.AddInstances(currentPlacement, []placement.Instance{instance})
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
+				assert.NoError(t, err)
+				assert.True(t, marked2)
+				assert.NoError(t, placement.Validate(newPlacement))
+				currentPlacement = newPlacement
+				j++
+			}
+
+			// Get instances to replace (one from each subcluster)
+			instancesToReplace := make([]string, 0)
+			subClusterMap := make(map[uint32][]string)
+			for _, instance := range currentPlacement.Instances() {
+				subClusterMap[instance.SubClusterID()] = append(subClusterMap[instance.SubClusterID()], instance.ID())
+			}
+
+			// Select one instance from each subcluster for replacement
+			for _, instances := range subClusterMap {
+				if len(instances) > 0 {
+					instancesToReplace = append(instancesToReplace, instances[0])
+				}
+			}
+
+			// Create replacement instances with same isolation groups
+			replacementInstances := make([]placement.Instance, len(instancesToReplace))
+			for i, instanceID := range instancesToReplace {
+				instance, _ := currentPlacement.Instance(instanceID)
+				replacementInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("R%d", i)).
+					SetIsolationGroup(instance.IsolationGroup()).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("RE%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Perform replacement
+			newPlacement, err := algo.ReplaceInstances(currentPlacement, instancesToReplace, replacementInstances)
+			assert.NoError(t, err)
+			assert.NotNil(t, newPlacement)
+			newPlacement, marked3, err := algo.MarkAllShardsAvailable(newPlacement)
+			assert.NoError(t, err)
+			assert.True(t, marked3)
+
+			// Verify final placement
+			assert.NoError(t, placement.Validate(newPlacement))
+			if j < totalInstances {
+				// Add remaining instances
+				finalPlacement, err := algo.AddInstances(newPlacement, newInstances[j:])
+				assert.NoError(t, err)
+				assert.NotNil(t, finalPlacement)
+				assert.NoError(t, placement.Validate(finalPlacement))
+				finalPlacement, marked4, err := algo.MarkAllShardsAvailable(finalPlacement)
+				assert.NoError(t, err)
+				assert.True(t, marked4)
+				assert.NoError(t, placement.Validate(finalPlacement))
+				newPlacement = finalPlacement
+			}
+
+			// Verify that replaced instances are gone and new ones are present
+			for _, instanceID := range instancesToReplace {
+				_, exists := newPlacement.Instance(instanceID)
+				assert.False(t, exists, "Replaced instance should not exist in final placement")
+			}
+
+			for _, instance := range replacementInstances {
+				_, exists := newPlacement.Instance(instance.ID())
+				assert.True(t, exists, "Replacement instance should exist in final placement")
+			}
+		})
+	}
+}
+
+func TestRemoveInstancesErrorCases(t *testing.T) {
+	tests := []struct {
+		name                   string
+		replicaFactor          int
+		instancesPerSubcluster int
+		initialSubClusters     int
+		instanceIDsToRemove    []string
+		expectError            bool
+		errorContains          string
+		setupPlacement         func() placement.Placement
+	}{
+		{
+			name:                   "nil placement",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "placement is nil",
+			setupPlacement:         func() placement.Placement { return nil },
+		},
+		{
+			name:                   "non-sharded placement",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "could not apply subclustered algo on the placement",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				instances := make([]placement.Instance, 6)
+				for i := 0; i < 6; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(1).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Create a non-sharded placement by cloning and modifying
+				nonShardedInstances := make([]placement.Instance, len(p.Instances()))
+				for i, instance := range p.Instances() {
+					nonShardedInstances[i] = placement.NewInstance().
+						SetID(instance.ID()).
+						SetIsolationGroup(instance.IsolationGroup()).
+						SetWeight(instance.Weight()).
+						SetEndpoint(instance.Endpoint()).
+						SetShards(instance.Shards())
+				}
+
+				return placement.NewPlacement().
+					SetInstances(nonShardedInstances).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(false).
+					SetIsSubclustered(true).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster())
+			},
+		},
+		{
+			name:                   "placement without subclusters",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "could not apply subclustered algo on the placement",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := newSubclusteredAlgorithm(opts)
+
+				instances := make([]placement.Instance, 6)
+				for i := 0; i < 6; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Create a placement without subclusters
+				return placement.NewPlacement().
+					SetInstances(p.Instances()).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(true).
+					SetIsSubclustered(false).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster())
+			},
+		},
+		{
+			name:                   "instance does not exist",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"non-existent-instance"},
+			expectError:            true,
+			errorContains:          "instance non-existent-instance does not exist in placement",
+			// nolint: dupl
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := newSubclusteredAlgorithm(opts)
+
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name:                   "removing instance from partial subcluster",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "partial subcluster",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				// Create instances with one subcluster having fewer instances than instancesPerSubcluster
+				instances := make([]placement.Instance, 6)
+				for i := 0; i < 6; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				instances = make([]placement.Instance, 3)
+				for i := 0; i < 3; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i+6)).
+						SetIsolationGroup(fmt.Sprintf("R%d", (i+6)%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i+6)).
+						SetShards(shard.NewShards(nil))
+				}
+				p, err = algo.AddInstances(p, instances)
+				if err != nil {
+					t.Fatalf("Failed to add instances: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name:                   "inconsistent instance weights",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "inconsistent instance weights",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				// Create instances with consistent weights first
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Now modify one instance to have a different weight
+				modifiedInstances := make([]placement.Instance, len(p.Instances()))
+				for i, instance := range p.Instances() {
+					if instance.ID() == "I1" {
+						modifiedInstances[i] = placement.NewInstance().
+							SetID(instance.ID()).
+							SetIsolationGroup(instance.IsolationGroup()).
+							SetWeight(2). // Different weight
+							SetEndpoint(instance.Endpoint()).
+							SetSubClusterID(instance.SubClusterID()).
+							SetShards(instance.Shards())
+					} else {
+						modifiedInstances[i] = instance
+					}
+				}
+
+				return placement.NewPlacement().
+					SetInstances(modifiedInstances).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(true).
+					SetIsSubclustered(true).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster()).
+					SetIsMirrored(p.IsMirrored())
+			},
+		},
+		{
+			name:                   "valid removal - should not error",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            false,
+			// nolint: dupl
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+				return p
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster).SetIsSubclustered(true)
+			algo := subclusteredPlacementAlgorithm{opts: opts}
+
+			p := tt.setupPlacement()
+			if p == nil && !tt.expectError {
+				t.Fatal("Setup placement returned nil but test doesn't expect error")
+			}
+
+			// Skip the test if placement is nil and we expect an error
+			if p == nil && tt.expectError {
+				return
+			}
+
+			newPlacement, err := algo.RemoveInstances(p, tt.instanceIDsToRemove)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, newPlacement)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				assert.NoError(t, placement.Validate(newPlacement))
+
+				// Verify that the expected number of instances were removed
+				expectedRemainingInstances := len(p.Instances()) - len(tt.instanceIDsToRemove)
+				assert.Equal(t, expectedRemainingInstances, len(newPlacement.Instances()))
+			}
+		})
+	}
+}
+
+func TestReclaimLeavingInstance(t *testing.T) {
+	opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+	algo := newSubclusteredAlgorithm(opts)
+
+	instances := make([]placement.Instance, 12)
+	for i := 0; i < 12; i++ {
+		instances[i] = placement.NewInstance().
+			SetID(fmt.Sprintf("I%d", i)).
+			SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+			SetWeight(1).
+			SetEndpoint(fmt.Sprintf("E%d", i)).
+			SetShards(shard.NewShards(nil))
+	}
+
+	shards := make([]uint32, 32)
+	for i := 0; i < 32; i++ {
+		shards[i] = uint32(i)
+	}
+
+	p, err := algo.InitialPlacement(instances, shards, 3)
+	assert.NoError(t, err)
+
+	currentPlacement, marked, err := algo.MarkAllShardsAvailable(p)
+	assert.NoError(t, err)
+	assert.True(t, marked)
+	assert.NoError(t, placement.Validate(currentPlacement))
+
+	instanceToRemove := "I0"
+	newPlacement, err := algo.RemoveInstances(currentPlacement, []string{instanceToRemove})
+	assert.NoError(t, err)
+	assert.NotNil(t, newPlacement)
+	assert.NoError(t, placement.Validate(newPlacement))
+
+	// Add the removed instance again to the placement
+	addingInstance, exists := newPlacement.Instance(instanceToRemove)
+	assert.True(t, exists)
+
+	finalPlacement, err := algo.AddInstances(newPlacement, []placement.Instance{addingInstance})
+	assert.NoError(t, err)
+	assert.NotNil(t, finalPlacement)
+	assert.NoError(t, placement.Validate(finalPlacement))
+
+	// check if the removed instance is still present and has all shards in AVAILABLE state in the same subcluster
+	instance, exists := finalPlacement.Instance(instanceToRemove)
+	assert.True(t, exists)
+	assert.False(t, instance.IsLeaving())
+}
+
+func newSubclusteredTestInstance(id string) placement.Instance {
+	return placement.NewInstance().
+		SetID(id).
+		SetIsolationGroup("rack-" + id).
+		SetEndpoint("endpoint-" + id).
+		SetWeight(1)
+}
+
+func TestSubclusteredAlgorithm_BalanceShards_WhenBalanced(t *testing.T) {
+	// Create instances for 2 subclusters, each with 3 instances (6 total)
+	// Replica factor 3, so we need 3 isolation groups
+	// With 2 shards and RF=3, we should have 6 total shard replicas distributed across instances
+	i1 := newSubclusteredTestInstance("i1").
+		SetIsolationGroup("rack-0").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+		}))
+	i2 := newSubclusteredTestInstance("i2").
+		SetIsolationGroup("rack-1").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+		}))
+	i3 := newSubclusteredTestInstance("i3").
+		SetIsolationGroup("rack-2").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+		}))
+	i4 := newSubclusteredTestInstance("i4").
+		SetIsolationGroup("rack-0").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(1).SetState(shard.Available),
+		}))
+	i5 := newSubclusteredTestInstance("i5").
+		SetIsolationGroup("rack-1").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(1).SetState(shard.Available),
+		}))
+	i6 := newSubclusteredTestInstance("i6").
+		SetIsolationGroup("rack-2").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(1).SetState(shard.Available),
+		}))
+
+	initialPlacement := placement.NewPlacement().
+		SetReplicaFactor(3).
+		SetShards([]uint32{0, 1}).
+		SetInstances([]placement.Instance{i1, i2, i3, i4, i5, i6}).
+		SetIsSharded(true).
+		SetIsSubclustered(true).
+		SetInstancesPerSubCluster(3)
+
+	expectedPlacement := initialPlacement.Clone()
+
+	opts := placement.NewOptions().
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	balancedPlacement, err := algo.BalanceShards(initialPlacement)
+	assert.NoError(t, err)
+
+	// Verify the placement is valid
+	assert.NoError(t, placement.Validate(balancedPlacement))
+
+	// Verify subcluster properties are maintained
+	assert.True(t, balancedPlacement.IsSubclustered())
+	assert.Equal(t, 3, balancedPlacement.InstancesPerSubCluster())
+	assert.Equal(t, 3, balancedPlacement.ReplicaFactor())
+
+	// Verify instance count is preserved
+	assert.Equal(t, len(expectedPlacement.Instances()), len(balancedPlacement.Instances()))
+
+	// Verify total shard count is preserved
+	originalShardCount := 0
+	balancedShardCount := 0
+	for _, instance := range initialPlacement.Instances() {
+		originalShardCount += instance.Shards().NumShards()
+	}
+	for _, instance := range balancedPlacement.Instances() {
+		balancedShardCount += instance.Shards().NumShards()
+	}
+	assert.Equal(t, originalShardCount, balancedShardCount)
+}
+
+func TestSubclusteredAlgorithm_BalanceShards_WhenImbalanced(t *testing.T) {
+	// Create an imbalanced placement where some instances have more shards
+	// With 3 shards and RF=3, we should have 9 total shard replicas distributed across instances
+	i1 := newSubclusteredTestInstance("i1").
+		SetIsolationGroup("rack-0").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+			shard.NewShard(1).SetState(shard.Available),
+			shard.NewShard(2).SetState(shard.Available),
+		}))
+	i2 := newSubclusteredTestInstance("i2").
+		SetIsolationGroup("rack-1").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+			shard.NewShard(1).SetState(shard.Available),
+			shard.NewShard(2).SetState(shard.Available),
+		}))
+	i3 := newSubclusteredTestInstance("i3").
+		SetIsolationGroup("rack-2").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+			shard.NewShard(1).SetState(shard.Available),
+			shard.NewShard(2).SetState(shard.Available),
+		}))
+	i4 := newSubclusteredTestInstance("i4").
+		SetIsolationGroup("rack-0").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{}))
+	i5 := newSubclusteredTestInstance("i5").
+		SetIsolationGroup("rack-1").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{}))
+	i6 := newSubclusteredTestInstance("i6").
+		SetIsolationGroup("rack-2").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{}))
+
+	p := placement.NewPlacement().
+		SetReplicaFactor(3).
+		SetShards([]uint32{0, 1, 2}).
+		SetInstances([]placement.Instance{i1, i2, i3, i4, i5, i6}).
+		SetIsSharded(true).
+		SetIsSubclustered(true).
+		SetInstancesPerSubCluster(3)
+
+	opts := placement.NewOptions().
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	balancedPlacement, err := algo.BalanceShards(p)
+	assert.NoError(t, err)
+
+	// Verify the placement is valid
+	assert.NoError(t, placement.Validate(balancedPlacement))
+
+	// Verify subcluster properties are maintained
+	assert.True(t, balancedPlacement.IsSubclustered())
+	assert.Equal(t, 3, balancedPlacement.InstancesPerSubCluster())
+	assert.Equal(t, 3, balancedPlacement.ReplicaFactor())
+
+	// Verify instance count is preserved
+	assert.Equal(t, len(p.Instances()), len(balancedPlacement.Instances()))
+
+	// Verify total shard count is preserved
+	originalShardCount := 0
+	balancedShardCount := 0
+	for _, instance := range p.Instances() {
+		originalShardCount += instance.Shards().NumShards()
+	}
+	for _, instance := range balancedPlacement.Instances() {
+		balancedShardCount += instance.Shards().NumShards()
+	}
+	assert.Equal(t, originalShardCount, balancedShardCount)
+
+	// Verify all instances are in the correct subclusters
+	for _, instance := range balancedPlacement.Instances() {
+		expectedSubcluster := uint32(1)
+		if instance.ID() >= "i4" {
+			expectedSubcluster = 2
+		}
+		assert.Equal(t, expectedSubcluster, instance.SubClusterID())
+	}
+}
+
+func TestSubclusteredAlgorithm_BalanceShards_ErrorCases(t *testing.T) {
+	opts := placement.NewOptions().
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	tests := []struct {
+		name          string
+		placement     placement.Placement
+		errorContains string
+	}{
+		{
+			name:          "nil placement",
+			placement:     nil,
+			errorContains: "placement is nil",
+		},
+		{
+			name: "not sharded placement",
+			placement: placement.NewPlacement().
+				SetIsSharded(false).
+				SetIsSubclustered(true),
+			errorContains: "could not apply subclustered algo on the placement",
+		},
+		{
+			name: "not subclustered placement",
+			placement: placement.NewPlacement().
+				SetIsSharded(true).
+				SetIsSubclustered(false),
+			errorContains: "could not apply subclustered algo on the placement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			balancedPlacement, err := algo.BalanceShards(tt.placement)
+			assert.Error(t, err)
+			assert.Nil(t, balancedPlacement)
+			assert.Contains(t, err.Error(), tt.errorContains)
+		})
+	}
+}
+
+// TestSubclusteredAlgorithm_BalanceShards_EmptyPlacement tests balancing empty placements
+func TestSubclusteredAlgorithm_BalanceShards_EmptyPlacement(t *testing.T) {
+	opts := placement.NewOptions().
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	emptyPlacement := placement.NewPlacement().
+		SetInstances([]placement.Instance{}).
+		SetShards([]uint32{}).
+		SetReplicaFactor(3).
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true).
+		SetIsSharded(true)
+
+	balancedPlacement, err := algo.BalanceShards(emptyPlacement)
+	assert.NoError(t, err)
+	assert.NotNil(t, balancedPlacement)
+	assert.NoError(t, placement.Validate(balancedPlacement))
+	assert.Equal(t, 0, len(balancedPlacement.Instances()))
+}

--- a/src/cluster/placement/placement_test.go
+++ b/src/cluster/placement/placement_test.go
@@ -160,6 +160,20 @@ func TestValidateMirrorButNotSharded(t *testing.T) {
 	assert.Equal(t, errMirrorNotSharded.Error(), err.Error())
 }
 
+func TestValidateSubclusteredButNotSharded(t *testing.T) {
+	p := NewPlacement().SetIsSubclustered(true)
+	err := Validate(p)
+	require.Error(t, err)
+	assert.Equal(t, errSubclusteredNotSharded.Error(), err.Error())
+}
+
+func TestValidateInstanceWithSubclusterIDInNonSubclusteredPlacement(t *testing.T) {
+	i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint", 1).SetSubClusterID(1)
+	p := NewPlacement().SetInstances([]Instance{i1}).SetShards([]uint32{1}).SetReplicaFactor(1)
+	err := Validate(p)
+	require.Error(t, err)
+}
+
 func TestValidateMissingShard(t *testing.T) {
 	i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint", 1)
 	i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
@@ -765,4 +779,442 @@ func getProtoShards(ids []uint32) []*placementpb.Shard {
 		}
 	}
 	return r
+}
+
+func TestValidateSubclusteredPlacement(t *testing.T) {
+	tests := []struct {
+		name                   string
+		instancesPerSubcluster int
+		replicaFactor          int
+		instances              []Instance
+		shards                 []uint32
+		expectError            bool
+	}{
+		{
+			name:                   "valid subclustered placement - single subcluster",
+			instancesPerSubcluster: 6,
+			replicaFactor:          2,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r1", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(5).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(6).SetState(shard.Available))
+
+				i3 := NewEmptyInstance("i3", "r2", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(5).SetState(shard.Available))
+
+				i4 := NewEmptyInstance("i4", "r2", "z1", "endpoint4", 1).SetSubClusterID(1)
+				i4.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i4.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+				i4.Shards().Add(shard.NewShard(6).SetState(shard.Available))
+
+				return []Instance{i1, i2, i3, i4}
+			}(),
+			shards:      []uint32{1, 2, 3, 4, 5, 6},
+			expectError: false,
+		},
+		{
+			name:                   "valid subclustered placement - multiple subclusters",
+			instancesPerSubcluster: 3,
+			replicaFactor:          1,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+
+				i3 := NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(5).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(6).SetState(shard.Available))
+
+				i4 := NewEmptyInstance("i4", "r1", "z1", "endpoint4", 1).SetSubClusterID(2)
+				i4.Shards().Add(shard.NewShard(7).SetState(shard.Available))
+				i4.Shards().Add(shard.NewShard(8).SetState(shard.Available))
+
+				i5 := NewEmptyInstance("i5", "r2", "z1", "endpoint5", 1).SetSubClusterID(2)
+				i5.Shards().Add(shard.NewShard(9).SetState(shard.Available))
+				i5.Shards().Add(shard.NewShard(10).SetState(shard.Available))
+
+				i6 := NewEmptyInstance("i6", "r3", "z1", "endpoint6", 1).SetSubClusterID(2)
+				i6.Shards().Add(shard.NewShard(11).SetState(shard.Available))
+				i6.Shards().Add(shard.NewShard(12).SetState(shard.Available))
+
+				return []Instance{i1, i2, i3, i4, i5, i6}
+			}(),
+			shards:      []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+			expectError: false,
+		},
+		// nolint: dupl
+		{
+			name:                   "shard with wrong isolation group count",
+			instancesPerSubcluster: 6,
+			replicaFactor:          2,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "IG1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i2 := NewEmptyInstance("i2", "IG1", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+				return []Instance{i1, i2}
+			}(),
+			shards:      []uint32{1, 2},
+			expectError: true,
+		},
+		{
+			name:                   "instance with uninitialized subcluster ID",
+			instancesPerSubcluster: 3,
+			replicaFactor:          1,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+				// This instance has uninitialized subcluster ID
+				i3 := NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1)
+				i3.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				return []Instance{i1, i2, i3}
+			}(),
+			shards:      []uint32{1, 2, 3},
+			expectError: true,
+		},
+		{
+			name:                   "valid subclustered placement with leaving instances",
+			instancesPerSubcluster: 4,
+			replicaFactor:          2,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+
+				// Leaving instance - should be ignored in subcluster validation
+				i3 := NewEmptyInstance("i3", "r2", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(2).SetState(shard.Leaving))
+				i3.Shards().Add(shard.NewShard(3).SetState(shard.Leaving))
+
+				i4 := NewEmptyInstance("i4", "r1", "z1", "endpoint4", 1).SetSubClusterID(1)
+				i4.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i4.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+
+				i5 := NewEmptyInstance("i5", "r2", "z1", "endpoint5", 1).SetSubClusterID(1)
+				i5.Shards().Add(shard.NewShard(2).SetState(shard.Initializing).SetSourceID("i3"))
+				i5.Shards().Add(shard.NewShard(3).SetState(shard.Initializing).SetSourceID("i3"))
+
+				return []Instance{i1, i2, i3, i4, i5}
+			}(),
+			shards:      []uint32{1, 2, 3, 4},
+			expectError: false,
+		},
+		{
+			name:                   "shard with leaving state ignored in validation",
+			instancesPerSubcluster: 3,
+			replicaFactor:          1,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r1", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(5).SetState(shard.Available))
+
+				// This shard is leaving, so it should be ignored in isolation group validation
+				i3 := NewEmptyInstance("i3", "r1", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(3).SetState(shard.Leaving))
+				i3.Shards().Add(shard.NewShard(6).SetState(shard.Available))
+
+				i4 := NewEmptyInstance("i4", "r1", "z1", "endpoint4", 1).SetSubClusterID(2)
+				i4.Shards().Add(shard.NewShard(3).SetState(shard.Initializing).SetSourceID("i3"))
+
+				return []Instance{i1, i2, i3, i4}
+			}(),
+			shards:      []uint32{1, 2, 3, 4, 5, 6},
+			expectError: false,
+		},
+		{
+			name:                   "shards are shared among multiple complete subclusters",
+			instancesPerSubcluster: 3,
+			replicaFactor:          3,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i3 := NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i4 := NewEmptyInstance("i4", "r1", "z1", "endpoint4", 1).SetSubClusterID(2)
+				i4.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i4.Shards().Add(shard.NewShard(5).SetState(shard.Available))
+				i4.Shards().Add(shard.NewShard(6).SetState(shard.Available))
+
+				i5 := NewEmptyInstance("i5", "r2", "z1", "endpoint5", 1).SetSubClusterID(2)
+				i5.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+				i5.Shards().Add(shard.NewShard(5).SetState(shard.Available))
+				i5.Shards().Add(shard.NewShard(6).SetState(shard.Available))
+
+				i6 := NewEmptyInstance("i6", "r3", "z1", "endpoint6", 1).SetSubClusterID(2)
+				i6.Shards().Add(shard.NewShard(4).SetState(shard.Available))
+				i6.Shards().Add(shard.NewShard(5).SetState(shard.Available))
+				i6.Shards().Add(shard.NewShard(6).SetState(shard.Available))
+
+				return []Instance{i1, i2, i3, i4, i5, i6}
+			}(),
+			shards:      []uint32{1, 2, 3, 4, 5, 6},
+			expectError: true,
+		},
+		{
+			name:                   "shards in transitionary state while moving to another subcluster",
+			instancesPerSubcluster: 3,
+			replicaFactor:          3,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(3).SetState(shard.Leaving))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i3 := NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i4 := NewEmptyInstance("i4", "r1", "z1", "endpoint4", 1).SetSubClusterID(2)
+				i4.Shards().Add(shard.NewShard(3).SetState(shard.Initializing).SetSourceID("i1"))
+
+				return []Instance{i1, i2, i3, i4}
+			}(),
+			shards:      []uint32{1, 2, 3},
+			expectError: false,
+		},
+		{
+			name:                   "shards in transitionary state - belongs to > 2 subclusters",
+			instancesPerSubcluster: 3,
+			replicaFactor:          3,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				i3 := NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i4 := NewEmptyInstance("i4", "r1", "z1", "endpoint4", 1).SetSubClusterID(2)
+				i4.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+				i5 := NewEmptyInstance("i5", "r2", "z1", "endpoint5", 1).SetSubClusterID(2)
+				i5.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i5.Shards().Add(shard.NewShard(3).SetState(shard.Initializing).SetSourceID("i8"))
+
+				i6 := NewEmptyInstance("i6", "r3", "z1", "endpoint6", 1).SetSubClusterID(2)
+				i6.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+				i7 := NewEmptyInstance("i7", "r1", "z1", "endpoint7", 1).SetSubClusterID(3)
+				i7.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i8 := NewEmptyInstance("i8", "r2", "z1", "endpoint8", 1).SetSubClusterID(3)
+				i8.Shards().Add(shard.NewShard(3).SetState(shard.Leaving))
+
+				return []Instance{i1, i2, i3, i4, i5, i6, i7, i8}
+			}(),
+			shards:      []uint32{1, 2, 3},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPlacement().
+				SetInstances(tt.instances).
+				SetShards(tt.shards).
+				SetReplicaFactor(tt.replicaFactor).
+				SetIsSharded(true).
+				SetIsSubclustered(true).
+				SetInstancesPerSubCluster(tt.instancesPerSubcluster)
+
+			err := Validate(p)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateSubclusteredPlacementEdgeCases(t *testing.T) {
+	tests := []struct {
+		name                   string
+		instancesPerSubcluster int
+		replicaFactor          int
+		instances              []Instance
+		shards                 []uint32
+		expectError            bool
+		errorMessage           string
+	}{
+		{
+			name:                   "empty placement",
+			instancesPerSubcluster: 3,
+			replicaFactor:          1,
+			instances:              []Instance{},
+			shards:                 []uint32{},
+			expectError:            false,
+		},
+		{
+			name:                   "single instance placement",
+			instancesPerSubcluster: 3,
+			replicaFactor:          1,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				return []Instance{i1}
+			}(),
+			shards:      []uint32{1},
+			expectError: false,
+		},
+		// nolint: dupl
+		{
+			name:                   "incomplete subcluster - should not fail validation",
+			instancesPerSubcluster: 4,
+			replicaFactor:          2,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+				// Only 2 instances in subcluster, but instancesPerSubcluster is 4
+				// This should still be valid as the subcluster is not full
+				return []Instance{i1, i2}
+			}(),
+			shards:      []uint32{1, 2},
+			expectError: false,
+		},
+		{
+			name:                   "multiple isolation groups per shard",
+			instancesPerSubcluster: 6,
+			replicaFactor:          3,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				i3 := NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				return []Instance{i1, i2, i3}
+			}(),
+			shards:      []uint32{1},
+			expectError: false,
+		},
+		{
+			name:                   "shard with insufficient isolation groups",
+			instancesPerSubcluster: 6,
+			replicaFactor:          3,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r1", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				i3 := NewEmptyInstance("i3", "r2", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+
+				// Only 2 instances from same isolation group, but replica factor is 3
+				return []Instance{i1, i2, i3}
+			}(),
+			shards:       []uint32{1},
+			expectError:  true,
+			errorMessage: "invalid shard 1, expected 3 isolation groups, actual 2",
+		},
+		{
+			name:                   "subcluster with more instances than instancesPerSubcluster",
+			instancesPerSubcluster: 3,
+			replicaFactor:          3,
+			instances: func() []Instance {
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i1.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i2 := NewEmptyInstance("i2", "r2", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+				i2.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				i3 := NewEmptyInstance("i3", "r3", "z1", "endpoint3", 1).SetSubClusterID(1)
+				i3.Shards().Add(shard.NewShard(1).SetState(shard.Available))
+				i3.Shards().Add(shard.NewShard(2).SetState(shard.Available))
+
+				i4 := NewEmptyInstance("i4", "r3", "z1", "endpoint4", 1).SetSubClusterID(1)
+				i4.Shards().Add(shard.NewShard(3).SetState(shard.Available))
+
+				return []Instance{i1, i2, i3, i4}
+			}(),
+			shards:       []uint32{1, 2, 3},
+			expectError:  true,
+			errorMessage: "invalid subcluster 1, expected at most 3 instances, actual 4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPlacement().
+				SetInstances(tt.instances).
+				SetShards(tt.shards).
+				SetReplicaFactor(tt.replicaFactor).
+				SetIsSharded(true).
+				SetIsSubclustered(true).
+				SetInstancesPerSubCluster(tt.instancesPerSubcluster)
+
+			err := Validate(p)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Equal(t, tt.errorMessage, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR adds the initial validations while creating the subcluster helper and scan the current load on the instances  which means the current number of shards assigned to the instances.
The following validations have been added:

- validateInstanceWeight - validates that each instance in the subcluster has the same weight. This ensures that each instance in the subcluster has same number of shards assigned.
- validateSubclusterDistribution -
    - validates if the number of isolation groups are exactly equal to the number of replicas.
    - the number of instances in a subclusters should never exceed `instancesPerSubcluster/replicaFactor`. For example: If  `instancesPerSubcluster` value is **6** and `replicaFator` is **3** each isolation group can have at most **2** instances in each subcluster.