### PR TITLE
Added code to move shards from the existing instances to new instances maintaining subcluster property

### DIFF
--- a/src/cluster/placement/algo/subclustered_helper_test.go
+++ b/src/cluster/placement/algo/subclustered_helper_test.go
@@ -152,11 +152,10 @@ func TestNewSubclusteredHelper(t *testing.T) {
 				assert.NotNil(t, helper)
 
 				// Verify helper properties
-				sh := helper.(*subclusteredHelper)
-				assert.Equal(t, tt.targetRF, sh.rf)
-				assert.Equal(t, tt.placement.InstancesPerSubCluster(), sh.instancesPerSubcluster)
-				assert.Equal(t, len(tt.placement.Instances()), len(sh.instances))
-				assert.Equal(t, len(tt.placement.Shards()), len(sh.uniqueShards))
+				assert.Equal(t, tt.targetRF, helper.rf)
+				assert.Equal(t, tt.placement.InstancesPerSubCluster(), helper.instancesPerSubcluster)
+				assert.Equal(t, len(tt.placement.Instances()), len(helper.instances))
+				assert.Equal(t, len(tt.placement.Shards()), len(helper.uniqueShards))
 			}
 		})
 	}
@@ -447,13 +446,12 @@ func TestNewSubclusteredHelperIntegration(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, helper)
 
-	sh := helper.(*subclusteredHelper)
-	assert.Equal(t, 3, sh.rf)
-	assert.Equal(t, 3, sh.instancesPerSubcluster)
-	assert.Equal(t, 3, len(sh.instances))
-	assert.Equal(t, 3, len(sh.uniqueShards))
-	assert.Equal(t, 3, len(sh.groupToInstancesMap))
-	assert.Equal(t, 1, len(sh.subClusters))
+	assert.Equal(t, 3, helper.rf)
+	assert.Equal(t, 3, helper.instancesPerSubcluster)
+	assert.Equal(t, 3, len(helper.instances))
+	assert.Equal(t, 3, len(helper.uniqueShards))
+	assert.Equal(t, 3, len(helper.groupToInstancesMap))
+	assert.Equal(t, 1, len(helper.subClusters))
 }
 
 func TestValidateInstanceWeightIntegration(t *testing.T) {

--- a/src/cluster/placement/placement_test.go
+++ b/src/cluster/placement/placement_test.go
@@ -863,7 +863,6 @@ func TestValidateSubclusteredPlacement(t *testing.T) {
 				i1 := NewEmptyInstance("i1", "IG1", "z1", "endpoint1", 1).SetSubClusterID(1)
 				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
 				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
-
 				i2 := NewEmptyInstance("i2", "IG1", "z1", "endpoint2", 1).SetSubClusterID(1)
 				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
 				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))


### PR DESCRIPTION
Added code to move shards from the existing instances to new instances maintaining subcluster property

Added code to move shards from the existing instances to new instances maintaining subcluster property

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
After the shards have been chosen greedily we have to make sure that all the replicas of the shards go to the new subcluster. For this we add conditions to the canAssignInstance method when from instance is not nil. The conditions are described below:

- If we are moving the shard within the same subcluster, to.subclusterID == from.subclusterID, we just need to check if the if the shard can be moved to the to IsolationGroup.
- If we are moving the shard across subclusters,
  - Check if the from instance's subcluster can give the shards, i.e., if the number of shards in the from instance's subcluster has reached to its targetShardCount in that case we cannot take any shard from this instance's subcluster.
  - If we can take shards from the from instance's subcluster, we need to check if the from subcluster has given all the shards only the replicas of the shards is left in the from subcluster. If that is the case then we need to make sure the replica is only going to the new subcluster which already has one or more replica of the shard. To find this we will take intersection of the shards in from and to subcluster and if the shard doesn't exist in intersection and len(intersection) == (len(fromsubcluster.shardMap)-fromsubcluster.targetShardCount) we will return false. (This case will be viable when the targetShardCount of to subcluster hasn't reached but the from subcluster has given all the shards.)
  - If the from subcluster hasn't given all the shards, we just need to check for isolation group movement