### PR TITLE
Added code to remove instances/subcluster from the placement

### DIFF
--- a/src/cluster/placement/algo/subclustered.go
+++ b/src/cluster/placement/algo/subclustered.go
@@ -77,8 +77,25 @@ func (a subclusteredPlacementAlgorithm) RemoveInstances(
 		return nil, err
 	}
 
-	// TODO: Implement subclustered remove instances logic
-	return nil, fmt.Errorf("subclustered remove instances not yet implemented")
+	p = p.Clone()
+	for _, instanceID := range instanceIDs {
+		ph, leavingInstance, err := newubclusteredRemoveInstanceHelper(p, instanceID, a.opts)
+		if err != nil {
+			return nil, err
+		}
+		if err := ph.placeShards(leavingInstance.Shards().All(), leavingInstance, ph.Instances()); err != nil {
+			return nil, err
+		}
+
+		// if err := ph.optimize(safe); err != nil {
+		// 	return nil, err
+		// }
+
+		if p, _, err = addInstanceToPlacement(ph.generatePlacement(), leavingInstance, withShards); err != nil {
+			return nil, err
+		}
+	}
+	return tryCleanupShardState(p, a.opts)
 }
 
 // nolint:dupl

--- a/src/cluster/placement/algo/subclustered.go
+++ b/src/cluster/placement/algo/subclustered.go
@@ -11,6 +11,10 @@ var (
 	errIncompatibleWithSubclusteredAlgo = errors.New("could not apply subclustered algo on the placement")
 )
 
+const (
+	uninitializedSubClusterID = 0
+)
+
 type subclusteredPlacementAlgorithm struct {
 	opts placement.Options
 }
@@ -69,6 +73,7 @@ func (a subclusteredPlacementAlgorithm) AddReplica(p placement.Placement) (place
 	return nil, fmt.Errorf("AddReplica is not supported for subclustered placement")
 }
 
+// nolint:dupl
 func (a subclusteredPlacementAlgorithm) RemoveInstances(
 	p placement.Placement,
 	instanceIDs []string,
@@ -87,9 +92,9 @@ func (a subclusteredPlacementAlgorithm) RemoveInstances(
 			return nil, err
 		}
 
-		// if err := ph.optimize(safe); err != nil {
-		// 	return nil, err
-		// }
+		if err := ph.optimize(safe); err != nil {
+			return nil, err
+		}
 
 		if p, _, err = addInstanceToPlacement(ph.generatePlacement(), leavingInstance, withShards); err != nil {
 			return nil, err
@@ -133,8 +138,32 @@ func (a subclusteredPlacementAlgorithm) ReplaceInstances(
 		return nil, err
 	}
 
-	// TODO: Implement subclustered replace instances logic
-	return nil, fmt.Errorf("subclustered replace instances not yet implemented")
+	p = p.Clone()
+	ph, leavingInstances, addingInstances, err := newubclusteredReplaceInstanceHelper(p,
+		leavingInstanceIDs, addingInstances, a.opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, leavingInstance := range leavingInstances {
+		err = ph.placeShards(leavingInstance.Shards().All(), leavingInstance, []placement.Instance{addingInstances[i]})
+		if err != nil {
+			return nil, err
+		}
+		load := loadOnInstance(leavingInstance)
+		if load != 0 {
+			return nil, fmt.Errorf("could not fully replace all shards from %s, %d shards left unassigned",
+				leavingInstance.ID(), load)
+		}
+	}
+
+	p = ph.generatePlacement()
+	for _, leavingInstance := range leavingInstances {
+		if p, _, err = addInstanceToPlacement(p, leavingInstance, withShards); err != nil {
+			return nil, err
+		}
+	}
+	return tryCleanupShardState(p, a.opts)
 }
 
 func (a subclusteredPlacementAlgorithm) MarkShardsAvailable(
@@ -165,7 +194,17 @@ func (a subclusteredPlacementAlgorithm) BalanceShards(
 	if err := a.IsCompatibleWith(p); err != nil {
 		return nil, err
 	}
+	ph, err := newSubclusteredHelper(p, a.opts, uninitializedSubClusterID)
+	if err != nil {
+		return nil, err
+	}
+	err = ph.validatePartialSubclusters(uninitializedSubClusterID, validationOpBalance)
+	if err != nil {
+		return nil, err
+	}
+	if err := ph.optimize(unsafe); err != nil {
+		return nil, fmt.Errorf("shard balance optimization failed: %w", err)
+	}
 
-	// TODO: Implement subclustered balance shards logic
-	return nil, fmt.Errorf("subclustered balance shards not yet implemented")
+	return tryCleanupShardState(ph.generatePlacement(), a.opts)
 }

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -522,7 +522,8 @@ func (ph *subclusteredHelper) canAssignInstance(shardID uint32, from, to placeme
 				return false
 			}
 		}
-		// Case 2.3(add-instance): If the from subcluster hasn't given all the shards, we just need to check for isolation group movement
+		// Case 2.3(add-instance): If the from subcluster hasn't given all the shards,
+		// we just need to check for isolation group movement
 	}
 	return ph.CanMoveShard(shardID, from, to.IsolationGroup())
 }
@@ -1001,7 +1002,8 @@ func (ph *subclusteredHelper) validatePartialSubclusters(excludeSubclusterID uin
 			case validationOpAddition:
 				operation = "added"
 			}
-			return fmt.Errorf("partial subcluster %d is present with %d instances, while a subcluster %d is being %s", subclusterID, len(subcluster.instances), excludeSubclusterID, operation)
+			return fmt.Errorf("partial subcluster %d is present with %d instances, while a subcluster %d is being %s",
+				subclusterID, len(subcluster.instances), excludeSubclusterID, operation)
 		}
 	}
 	return nil

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -40,6 +40,13 @@ var (
 	errSubclusteredHelperNotImplemented = errors.New("subclustered helper methods not yet implemented")
 )
 
+type validationOperation int
+
+const (
+	validationOpRemoval validationOperation = iota
+	validationOpAddition
+)
+
 // nolint
 type subclusteredHelper struct {
 	targetLoad             map[string]int
@@ -106,6 +113,10 @@ func newubclusteredAddInstanceHelper(
 		if err != nil {
 			return nil, nil, err
 		}
+		err = ph.validatePartialSubclusters(instance.SubClusterID(), validationOpAddition)
+		if err != nil {
+			return nil, nil, err
+		}
 		return ph, instance, nil
 	}
 
@@ -130,11 +141,45 @@ func newubclusteredAddInstanceHelper(
 	return ph, instanceInPlacement, nil
 }
 
+func newubclusteredRemoveInstanceHelper(
+	p placement.Placement,
+	instanceID string,
+	opts placement.Options,
+) (placementHelper, placement.Instance, error) {
+	p, leavingInstance, err := removeInstanceFromPlacement(p, instanceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	subclusterInstances := getSubClusterInstances(p.Instances(), leavingInstance.SubClusterID())
+	// if the number of instances after removing the leaving instance is still equal to instancesPerSubcluster,
+	// we can safely assume that there was a replace operation going on in the cluster.
+	// In that case we don't need to exclude the subcluster from the calculation of targetShardCount.
+	if len(subclusterInstances) == opts.InstancesPerSubCluster() {
+		ph, err := newSubclusteredHelper(p, opts, 0)
+		if err != nil {
+			return nil, nil, err
+		}
+		return ph, leavingInstance, nil
+	}
+	// if the number of instances after removing the leaving instance is not equal to instancesPerSubcluster,
+	// we need to exclude the subcluster from the calculation of targetShardCount.
+	// Basically we are considering this operation equivalent to removeSubcluster.
+	ph, err := newSubclusteredHelper(p, opts, leavingInstance.SubClusterID())
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ph.validatePartialSubclusters(leavingInstance.SubClusterID(), validationOpRemoval)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ph, leavingInstance, nil
+}
+
 func newSubclusteredHelper(
 	p placement.Placement,
 	opts placement.Options,
 	subClusterToExclude uint32,
-) (placementHelper, error) {
+) (*subclusteredHelper, error) {
 	ph := &subclusteredHelper{
 		rf:                     p.ReplicaFactor(),
 		instances:              make(map[string]placement.Instance, p.NumInstances()),
@@ -419,6 +464,12 @@ func (ph *subclusteredHelper) canAssignInstance(shardID uint32, from, to placeme
 		return false
 	}
 	tosubcluster := ph.subClusters[to.SubClusterID()]
+	// the targetshardCount is 0 when we are removing the subcluster.
+	// In this case we don't want to assign shard to any other instance in the the leaving subcluster.
+	// As eventually these shards will be assigned to the new subcluster.
+	if tosubcluster.targetShardCount == 0 {
+		return false
+	}
 	// if the subcluster is full, the shard should be already assigned to the subcluster
 	// if the shard is not assigned to the subcluster, return false
 	if len(tosubcluster.shardMap) == tosubcluster.targetShardCount {
@@ -428,20 +479,35 @@ func (ph *subclusteredHelper) canAssignInstance(shardID uint32, from, to placeme
 	}
 
 	if from != nil {
-		// Case 1: If we are moving the shard within the same subcluster, we just need to check
+		fromSubcluster, exists := ph.subClusters[from.SubClusterID()]
+		// In case of removing an instance/subcluster. the targetShardCount will be 0.
+		// If it is the last instance in the subcluster, the subcluster should not be present in the helper
+		if !exists || fromSubcluster.targetShardCount == 0 {
+			// In case of removing a subcluster we only need to check if all the replicas of a shard has been
+			// assigned to the same subcluster.
+			for instance := range ph.shardToInstanceMap[shardID] {
+				if instance.SubClusterID() == from.SubClusterID() {
+					continue
+				}
+				if instance.SubClusterID() != to.SubClusterID() {
+					return false
+				}
+			}
+			return ph.CanMoveShard(shardID, from, to.IsolationGroup())
+		}
+		// Case 1(add-instance): If we are moving the shard within the same subcluster, we just need to check
 		// if the if the shard cnn be moved to the to IsolationGroup.
 		if from.SubClusterID() == to.SubClusterID() {
 			return ph.CanMoveShard(shardID, from, to.IsolationGroup())
 		}
-		// Case 2: If we are moving the shard across subclusters.
-		// Case 2.1: Check if the from instance's subcluster can give the shards, i.e.
+		// Case 2(add-instance): If we are moving the shard across subclusters.
+		// Case 2.1(add-instance): Check if the from instance's subcluster can give the shards, i.e.
 		// if the number of shards in the from instance's subcluster has reached to its targetShardCount
 		// in that case we cannot take any shard from this instance's subcluster.
-		fromSubcluster, exists := ph.subClusters[from.SubClusterID()]
 		if exists && len(fromSubcluster.shardMap) == fromSubcluster.targetShardCount {
 			return false
 		}
-		// Case 2.2: If we can take shards from the from instance's subcluster, we need to check
+		// Case 2.2(add-instance): If we can take shards from the from instance's subcluster, we need to check
 		// if the from subcluster has given all the shards only the replicas of the shards is left
 		// in the from subcluster. IF that is the case then we need to make sure the replica is only going
 		// to the subcluster which already has one or more replica of the shard. To find this we will
@@ -456,7 +522,7 @@ func (ph *subclusteredHelper) canAssignInstance(shardID uint32, from, to placeme
 				return false
 			}
 		}
-		// Case 2.3: If the from subcluster hasn't given all the shards, we just need to check for isolation group movement
+		// Case 2.3(add-instance): If the from subcluster hasn't given all the shards, we just need to check for isolation group movement
 	}
 	return ph.CanMoveShard(shardID, from, to.IsolationGroup())
 }
@@ -890,6 +956,68 @@ func (ph *subclusteredHelper) validateSubclusterDistribution() error {
 	return nil
 }
 
+func (ph *subclusteredHelper) buildInstanceHeap(
+	instances []placement.Instance,
+	availableCapacityAscending bool,
+) (heap.Interface, error) {
+	return newHeap(instances, availableCapacityAscending, ph.targetLoad, ph.groupToWeightMap, true)
+}
+
+// removeSubClusterInstances returns instances that are not in the specified subcluster
+func (ph *subclusteredHelper) removeSubClusterInstances(subclusterID uint32) []placement.Instance {
+	var instances = nonLeavingInstances(ph.Instances())
+	var result = make([]placement.Instance, 0, len(instances))
+	for _, instance := range instances {
+		if instance.SubClusterID() != subclusterID {
+			result = append(result, instance)
+		}
+	}
+	return result
+}
+
+// getSubClusterInstances returns instances that are in the specified subcluster
+func (ph *subclusteredHelper) getSubClusterInstances(subclusterID uint32) []placement.Instance {
+	currSubcluster := ph.subClusters[subclusterID]
+	var instances = make([]placement.Instance, 0, len(currSubcluster.instances))
+	for _, instance := range currSubcluster.instances {
+		if instance.IsLeaving() {
+			continue
+		}
+		instances = append(instances, instance)
+	}
+	return instances
+}
+
+func (ph *subclusteredHelper) validatePartialSubclusters(excludeSubclusterID uint32, op validationOperation) error {
+	for subclusterID, subcluster := range ph.subClusters {
+		if subclusterID == excludeSubclusterID {
+			continue
+		}
+		if len(subcluster.instances) < ph.instancesPerSubcluster {
+			var operation string
+			switch op {
+			case validationOpRemoval:
+				operation = "removed"
+			case validationOpAddition:
+				operation = "added"
+			}
+			return fmt.Errorf("partial subcluster %d is present with %d instances, while a subcluster %d is being %s", subclusterID, len(subcluster.instances), excludeSubclusterID, operation)
+		}
+	}
+	return nil
+}
+
+// getSubClusterInstances returns instances that are in the specified subcluster
+func getSubClusterInstances(instances []placement.Instance, subclusterID uint32) []placement.Instance {
+	var result []placement.Instance
+	for _, instance := range instances {
+		if instance.SubClusterID() == subclusterID {
+			result = append(result, instance)
+		}
+	}
+	return result
+}
+
 func assignSubClusterIDs(
 	instances []placement.Instance,
 	currPlacement placement.Placement,
@@ -968,36 +1096,4 @@ func assignSubClusterIDs(
 	}
 
 	return nil
-}
-
-func (ph *subclusteredHelper) buildInstanceHeap(
-	instances []placement.Instance,
-	availableCapacityAscending bool,
-) (heap.Interface, error) {
-	return newHeap(instances, availableCapacityAscending, ph.targetLoad, ph.groupToWeightMap, true)
-}
-
-// removeSubClusterInstances returns instances that are not in the specified subcluster
-func (ph *subclusteredHelper) removeSubClusterInstances(subclusterID uint32) []placement.Instance {
-	var instances = nonLeavingInstances(ph.Instances())
-	var result = make([]placement.Instance, 0, len(instances))
-	for _, instance := range instances {
-		if instance.SubClusterID() != subclusterID {
-			result = append(result, instance)
-		}
-	}
-	return result
-}
-
-// getSubClusterInstances returns instances that are in the specified subcluster
-func (ph *subclusteredHelper) getSubClusterInstances(subclusterID uint32) []placement.Instance {
-	currSubcluster := ph.subClusters[subclusterID]
-	var instances = make([]placement.Instance, 0, len(currSubcluster.instances))
-	for _, instance := range currSubcluster.instances {
-		if instance.IsLeaving() {
-			continue
-		}
-		instances = append(instances, instance)
-	}
-	return instances
 }

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -151,17 +151,18 @@ func newubclusteredRemoveInstanceHelper(
 		return nil, nil, err
 	}
 	subclusterInstances := getSubClusterInstances(p.Instances(), leavingInstance.SubClusterID())
-	// if the number of instances after removing the leaving instance is still equal to instancesPerSubcluster,
-	// we can safely assume that there was a replace operation going on in the cluster.
-	// In that case we don't need to exclude the subcluster from the calculation of targetShardCount.
-	if len(subclusterInstances) == opts.InstancesPerSubCluster() {
+	// if the number of instances after removing the leaving instance is still greater than or equal to
+	// instancesPerSubcluster, we can safely assume that there were multiple replace operations going on
+	// in the cluster. In that case we don't need to exclude the subcluster from the calculation of
+	// targetShardCount.
+	if len(subclusterInstances) >= opts.InstancesPerSubCluster() {
 		ph, err := newSubclusteredHelper(p, opts, 0)
 		if err != nil {
 			return nil, nil, err
 		}
 		return ph, leavingInstance, nil
 	}
-	// if the number of instances after removing the leaving instance is not equal to instancesPerSubcluster,
+	// if the number of instances after removing the leaving instance is less than instancesPerSubcluster,
 	// we need to exclude the subcluster from the calculation of targetShardCount.
 	// Basically we are considering this operation equivalent to removeSubcluster.
 	ph, err := newSubclusteredHelper(p, opts, leavingInstance.SubClusterID())
@@ -240,7 +241,6 @@ func (ph *subclusteredHelper) validateInstanceWeight() error {
 	return nil
 }
 
-// nolint
 func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 	ph.shardToInstanceMap = make(map[uint32]map[placement.Instance]struct{}, len(ph.uniqueShards))
 	ph.groupToInstancesMap = make(map[string]map[placement.Instance]struct{})
@@ -269,9 +269,14 @@ func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 			}
 		}
 
-		// if we are checking that all instance weight is same than we can simplify the calculation by assuming it as 1.
-		ph.groupToWeightMap[ig]++
-		totalWeight++
+		// if we are excluding the subcluster, we don't need to consider the weight of the instances for
+		// targetload calculation.
+		if subClusterID != subClusterToExclude {
+			// if we are checking that all instance weight is same than we can simplify the calculation by assuming it as 1.
+			ph.groupToWeightMap[ig]++
+			totalWeight++
+		}
+
 		ph.subClusters[subClusterID].instances[instance.ID()] = instance
 
 		for _, s := range instance.Shards().All() {
@@ -313,8 +318,9 @@ func (ph *subclusteredHelper) buildTargetLoad(subClusterToExclude uint32) {
 		if instance.IsLeaving() {
 			continue
 		}
-
-		// Get the weight of the instance's isolation group
+		if instance.SubClusterID() == subClusterToExclude {
+			continue
+		}
 		igWeight := ph.groupToWeightMap[instance.IsolationGroup()]
 
 		if isOverWeighted(igWeight, ph.totalWeight, ph.rf) {

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -22,7 +22,6 @@ package algo
 
 import (
 	"container/heap"
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -35,19 +34,14 @@ import (
 	"github.com/m3db/m3/src/cluster/shard"
 )
 
-var (
-	// nolint: unused
-	errSubclusteredHelperNotImplemented = errors.New("subclustered helper methods not yet implemented")
-)
-
 type validationOperation int
 
 const (
 	validationOpRemoval validationOperation = iota
 	validationOpAddition
+	validationOpBalance
 )
 
-// nolint
 type subclusteredHelper struct {
 	targetLoad             map[string]int
 	shardToInstanceMap     map[uint32]map[placement.Instance]struct{}
@@ -64,7 +58,6 @@ type subclusteredHelper struct {
 }
 
 // subcluster is a subcluster in the placement.
-// nolint
 type subcluster struct {
 	id                  uint32
 	targetShardCount    int
@@ -91,7 +84,7 @@ func newSubclusteredInitHelper(
 		SetIsSubclustered(true).
 		SetInstancesPerSubCluster(opts.InstancesPerSubCluster()).
 		SetCutoverNanos(opts.PlacementCutoverNanosFn()())
-	ph, err := newSubclusteredHelper(emptyPlacement, opts, 0)
+	ph, err := newSubclusteredHelper(emptyPlacement, opts, uninitializedSubClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +102,7 @@ func newubclusteredAddInstanceHelper(
 		if err := assignSubClusterIDs([]placement.Instance{instance}, p, opts.InstancesPerSubCluster()); err != nil {
 			return nil, nil, err
 		}
-		ph, err := newSubclusteredHelper(p.SetInstances(append(p.Instances(), instance)), opts, 0)
+		ph, err := newSubclusteredHelper(p.SetInstances(append(p.Instances(), instance)), opts, uninitializedSubClusterID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -134,7 +127,7 @@ func newubclusteredAddInstanceHelper(
 		return nil, nil, fmt.Errorf("unexpected type %v", t)
 	}
 
-	ph, err := newSubclusteredHelper(p, opts, 0)
+	ph, err := newSubclusteredHelper(p, opts, uninitializedSubClusterID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -156,7 +149,7 @@ func newubclusteredRemoveInstanceHelper(
 	// in the cluster. In that case we don't need to exclude the subcluster from the calculation of
 	// targetShardCount.
 	if len(subclusterInstances) >= opts.InstancesPerSubCluster() {
-		ph, err := newSubclusteredHelper(p, opts, 0)
+		ph, err := newSubclusteredHelper(p, opts, uninitializedSubClusterID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -174,6 +167,47 @@ func newubclusteredRemoveInstanceHelper(
 		return nil, nil, err
 	}
 	return ph, leavingInstance, nil
+}
+
+func newubclusteredReplaceInstanceHelper(
+	p placement.Placement,
+	instanceIDs []string,
+	addingInstances []placement.Instance,
+	opts placement.Options,
+) (placementHelper, []placement.Instance, []placement.Instance, error) {
+	var (
+		leavingInstances = make([]placement.Instance, len(instanceIDs))
+		err              error
+	)
+	for i, instanceID := range instanceIDs {
+		p, leavingInstances[i], err = removeInstanceFromPlacement(p, instanceID)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	newAddingInstances := make([]placement.Instance, len(addingInstances))
+	for i, instance := range addingInstances {
+		p, newAddingInstances[i], err = addInstanceToPlacement(p, instance, anyType)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	if len(newAddingInstances) != len(leavingInstances) {
+		return nil, nil, nil, fmt.Errorf("number of adding instances (%d) does not match number of leaving instances (%d)",
+			len(newAddingInstances), len(leavingInstances))
+	}
+
+	// Match adding instances with leaving instances
+	for i, addingInstance := range newAddingInstances {
+		addingInstance.SetSubClusterID(leavingInstances[i].SubClusterID())
+	}
+	ph, err := newSubclusteredHelper(p, opts, uninitializedSubClusterID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return ph, leavingInstances, newAddingInstances, nil
 }
 
 func newSubclusteredHelper(
@@ -296,7 +330,6 @@ func (ph *subclusteredHelper) scanCurrentLoad(subClusterToExclude uint32) {
 // This method implements a weighted load balancing algorithm that handles both normal and
 // over-weighted isolation groups. Over-weighted groups are those that have more instances
 // than the replica factor allows, which requires special handling to ensure proper distribution.
-// nolint
 func (ph *subclusteredHelper) buildTargetLoad(subClusterToExclude uint32) {
 	// Step 1: Identify over-weighted isolation groups
 	// Over-weighted groups are those where the number of instances exceeds the replica factor.
@@ -383,7 +416,6 @@ func (ph *subclusteredHelper) getShardLen() int {
 }
 
 // assignShardToInstance assigns a shard to an instance.
-// nolint: unused
 func (ph *subclusteredHelper) assignShardToInstance(s shard.Shard, to placement.Instance) {
 	to.Shards().Add(s)
 
@@ -395,7 +427,6 @@ func (ph *subclusteredHelper) assignShardToInstance(s shard.Shard, to placement.
 	ph.subClusters[to.SubClusterID()].instanceShardCounts[to.ID()]++
 }
 
-// nolint
 // Instances returns the list of instances managed by the PlacementHelper.
 func (ph *subclusteredHelper) Instances() []placement.Instance {
 	res := make([]placement.Instance, 0, len(ph.instances))
@@ -556,7 +587,6 @@ func (ph *subclusteredHelper) findMapKeyIntersection(map1, map2 map[uint32]int) 
 }
 
 // CanMoveShard checks if the shard can be moved from the instance to the target isolation group.
-// nolint: unused
 func (ph *subclusteredHelper) CanMoveShard(shard uint32, from placement.Instance, toIsolationGroup string) bool {
 	if from != nil {
 		if from.IsolationGroup() == toIsolationGroup {
@@ -614,10 +644,15 @@ func (ph *subclusteredHelper) placeShards(
 }
 
 // addInstance adds an instance to the placement.
-// nolint: unused
 func (ph *subclusteredHelper) addInstance(addingInstance placement.Instance) error {
 	ph.reclaimLeavingShards(addingInstance)
 	return ph.assignLoadToInstanceUnsafe(addingInstance)
+}
+
+func (ph *subclusteredHelper) assignLoadToInstanceSafe(addingInstance placement.Instance) error {
+	return ph.assignTargetLoad(addingInstance, func(from, to placement.Instance) bool {
+		return ph.moveOneShardInState(from, to, shard.Unknown)
+	})
 }
 
 func (ph *subclusteredHelper) assignLoadToInstanceUnsafe(addingInstance placement.Instance) error {
@@ -633,6 +668,7 @@ func (ph *subclusteredHelper) assignTargetLoad(
 
 	targetLoad := ph.targetLoadForInstance(targetInstance.ID())
 	// First try to move shards from other subclusters
+
 	instanceHeap, err := ph.buildInstanceHeap(ph.removeSubClusterInstances(targetInstance.SubClusterID()), false)
 	if err != nil {
 		return err
@@ -773,6 +809,7 @@ func (ph *subclusteredHelper) optimizeForSubclusterBalance(
 			}
 		}
 	}
+
 	for _, s := range shards {
 		shardID := s.ID()
 
@@ -782,7 +819,7 @@ func (ph *subclusteredHelper) optimizeForSubclusterBalance(
 			// hasn't been reached.
 			shardScores = append(shardScores, shardSkewScore{
 				shard:            s,
-				skewAfterRemoval: math.MaxInt32,
+				skewAfterRemoval: math.MaxInt32 - count,
 			})
 			continue
 		}
@@ -834,15 +871,65 @@ func (ph *subclusteredHelper) optimizeForSubclusterBalance(
 	return result
 }
 
+// nolint: dupl
+func (ph *subclusteredHelper) mostUnderLoadedInstance() (placement.Instance, bool) {
+	var (
+		res              placement.Instance
+		maxLoadGap       int
+		totalLoadSurplus int
+	)
+	// nolint: dupl
+	for id, instance := range ph.instances {
+		if ph.targetLoad[id] == 0 {
+			// only the instances with target load > 0 are considered for load balancing
+			continue
+		}
+		loadGap := ph.targetLoad[id] - loadOnInstance(instance)
+		if loadGap > maxLoadGap {
+			maxLoadGap = loadGap
+			res = instance
+		}
+		if loadGap == maxLoadGap && res != nil && res.ID() > id {
+			res = instance
+		}
+		if loadGap < 0 {
+			totalLoadSurplus -= loadGap
+		}
+	}
+	if maxLoadGap > 0 && totalLoadSurplus != 0 {
+		return res, true
+	}
+	return nil, false
+}
+
 // optimize rebalances the load distribution in the cluster.
-// nolint: unused
+// nolint: dupl
 func (ph *subclusteredHelper) optimize(t optimizeType) error {
-	// TODO: Implement subclustered optimization logic
-	return fmt.Errorf("subclustered optimize not yet implemented: %w", errSubclusteredHelperNotImplemented)
+	var fn assignLoadFn
+	switch t {
+	case safe:
+		fn = ph.assignLoadToInstanceSafe
+	case unsafe:
+		fn = ph.assignLoadToInstanceUnsafe
+	}
+	uniq := make(map[string]struct{}, len(ph.instances))
+	for {
+		ins, ok := ph.mostUnderLoadedInstance()
+		if !ok {
+			return nil
+		}
+		if _, exist := uniq[ins.ID()]; exist {
+			return nil
+		}
+
+		uniq[ins.ID()] = struct{}{}
+		if err := fn(ins); err != nil {
+			return err
+		}
+	}
 }
 
 // generatePlacement generates a placement.
-// nolint: unused
 func (ph *subclusteredHelper) generatePlacement() placement.Placement {
 	var instances = make([]placement.Instance, 0, len(ph.instances))
 
@@ -875,14 +962,23 @@ func (ph *subclusteredHelper) generatePlacement() placement.Placement {
 
 // reclaimLeavingShards reclaims all the leaving shards on the given instance
 // by pulling them back from the rest of the cluster.
-// nolint: unused
 func (ph *subclusteredHelper) reclaimLeavingShards(instance placement.Instance) {
-	// TODO: Implement subclustered reclaim leaving shards logic
+	if instance.Shards().NumShardsForState(shard.Leaving) == 0 {
+		// Shortcut if there is nothing to be reclaimed.
+		return
+	}
+	id := instance.ID()
+	for _, i := range ph.instances {
+		for _, s := range i.Shards().ShardsForState(shard.Initializing) {
+			if s.SourceID() == id {
+				ph.moveShard(s, i, instance)
+			}
+		}
+	}
 }
 
 // returnInitializingShards returns all the initializing shards on the given instance
 // by returning them back to the original owners.
-// nolint: unused
 func (ph *subclusteredHelper) returnInitializingShards(instance placement.Instance) {
 	shardSet := getShardMap(instance.Shards().All())
 	ph.returnInitializingShardsToSource(shardSet, instance, ph.Instances())
@@ -922,7 +1018,6 @@ func (ph *subclusteredHelper) returnInitializingShardsToSource(
 // validateSubclusterDistribution validates that:
 // 1. Number of isolation groups equals replica factor (rf)
 // 2. For complete subclusters, nodes per isolation group = instancesPerSubcluster / rf
-// nolint: unused
 func (ph *subclusteredHelper) validateSubclusterDistribution() error {
 	if len(ph.instances) == 0 {
 		return nil
@@ -1007,6 +1102,8 @@ func (ph *subclusteredHelper) validatePartialSubclusters(excludeSubclusterID uin
 				operation = "removed"
 			case validationOpAddition:
 				operation = "added"
+			case validationOpBalance:
+				operation = "balanced"
 			}
 			return fmt.Errorf("partial subcluster %d is present with %d instances, while a subcluster %d is being %s",
 				subclusterID, len(subcluster.instances), excludeSubclusterID, operation)

--- a/src/cluster/placement/algo/subclustered_helper_test.go
+++ b/src/cluster/placement/algo/subclustered_helper_test.go
@@ -152,11 +152,10 @@ func TestNewSubclusteredHelper(t *testing.T) {
 				assert.NotNil(t, helper)
 
 				// Verify helper properties
-				sh := helper.(*subclusteredHelper)
-				assert.Equal(t, tt.targetRF, sh.rf)
-				assert.Equal(t, tt.placement.InstancesPerSubCluster(), sh.instancesPerSubcluster)
-				assert.Equal(t, len(tt.placement.Instances()), len(sh.instances))
-				assert.Equal(t, len(tt.placement.Shards()), len(sh.uniqueShards))
+				assert.Equal(t, tt.targetRF, helper.rf)
+				assert.Equal(t, tt.placement.InstancesPerSubCluster(), helper.instancesPerSubcluster)
+				assert.Equal(t, len(tt.placement.Instances()), len(helper.instances))
+				assert.Equal(t, len(tt.placement.Shards()), len(helper.uniqueShards))
 			}
 		})
 	}
@@ -447,13 +446,12 @@ func TestNewSubclusteredHelperIntegration(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, helper)
 
-	sh := helper.(*subclusteredHelper)
-	assert.Equal(t, 3, sh.rf)
-	assert.Equal(t, 3, sh.instancesPerSubcluster)
-	assert.Equal(t, 3, len(sh.instances))
-	assert.Equal(t, 3, len(sh.uniqueShards))
-	assert.Equal(t, 3, len(sh.groupToInstancesMap))
-	assert.Equal(t, 1, len(sh.subClusters))
+	assert.Equal(t, 3, helper.rf)
+	assert.Equal(t, 3, helper.instancesPerSubcluster)
+	assert.Equal(t, 3, len(helper.instances))
+	assert.Equal(t, 3, len(helper.uniqueShards))
+	assert.Equal(t, 3, len(helper.groupToInstancesMap))
+	assert.Equal(t, 1, len(helper.subClusters))
 }
 
 func TestValidateInstanceWeightIntegration(t *testing.T) {

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -612,7 +612,7 @@ func TestRemoveInstancesValidCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster).
-				SetHasSubClusters(true)
+				SetIsSubclustered(true)
 			algo := subclusteredPlacementAlgorithm{opts: opts}
 
 			initialInstances := make([]placement.Instance, tt.instancesPerSubcluster*tt.initialSubClusters)
@@ -794,7 +794,7 @@ func TestPartialSubclustersAddOperation(t *testing.T) {
 			SetShards(shard.NewShards(nil))
 	}
 	opts := placement.NewOptions().SetInstancesPerSubCluster(instancesPerSubCluster).
-		SetHasSubClusters(true)
+		SetIsSubclustered(true)
 	algo := subclusteredPlacementAlgorithm{opts: opts}
 
 	result, err := algo.InitialPlacement(initialInstances, shards, replicaFactor)

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -746,6 +746,9 @@ func TestPartialSubclustersRemoveOperation(t *testing.T) {
 			}
 			// Randomly select subclusters to remove
 			subclustersToRemove := getRandomSubclusterIDs(currentPlacement, tt.subClustersToRemove)
+			if tt.instancesToAdd%tt.instancesPerSubcluster != 0 {
+				subclustersToRemove = []uint32{1}
+			}
 
 			// Get all instances from the selected subclusters
 			var instancesToRemove []string
@@ -758,9 +761,7 @@ func TestPartialSubclustersRemoveOperation(t *testing.T) {
 			}
 
 			if tt.subClustersToRemove > 1 {
-				rand.Shuffle(len(instancesToRemove), func(i, j int) {
-					instancesToRemove[i], instancesToRemove[j] = instancesToRemove[j], instancesToRemove[i]
-				})
+				instancesToRemove[0], instancesToRemove[tt.instancesPerSubcluster] = instancesToRemove[tt.instancesPerSubcluster], instancesToRemove[0]
 			}
 
 			// Remove the instances
@@ -828,6 +829,7 @@ func TestPartialSubclustersAddOperation(t *testing.T) {
 		SetShards(shard.NewShards(nil))
 
 	newPlacement, err = algo.AddInstances(newPlacement, []placement.Instance{instanceToAdd})
-	assert.Error(t, err)
-	assert.Nil(t, newPlacement)
+	assert.NoError(t, err)
+	assert.NotNil(t, newPlacement)
+	assert.NoError(t, placement.Validate(newPlacement))
 }

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -470,9 +470,9 @@ func TestAddInstancesValidCases(t *testing.T) {
 				assert.Equal(t, tt.instancesPerSubcluster+i+1, len(newPlacement.Instances()))
 				assert.NoError(t, placement.Validate(newPlacement))
 
-				newPlacement, marked, err := algo.MarkAllShardsAvailable(newPlacement)
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
 				assert.NoError(t, err)
-				assert.True(t, marked)
+				assert.True(t, marked2)
 				assert.NoError(t, placement.Validate(newPlacement))
 
 				currentPlacement = newPlacement
@@ -594,7 +594,7 @@ func TestRemoveInstancesValidCases(t *testing.T) {
 		{
 			name:                   "valid configuration - rf=3, instancesPerSubcluster=9",
 			replicaFactor:          3,
-			initialSubClusters:     24,
+			initialSubClusters:     10,
 			instancesPerSubcluster: 9,
 			subClustersToRemove:    5,
 			totalShards:            1024,
@@ -613,17 +613,15 @@ func TestRemoveInstancesValidCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster).
 				SetIsSubclustered(true)
-			algo := subclusteredPlacementAlgorithm{opts: opts}
+			algo := subclusteredPlacementAlgorithm{opts}
 
 			initialInstances := make([]placement.Instance, tt.instancesPerSubcluster*tt.initialSubClusters)
 			for i := 0; i < tt.instancesPerSubcluster*tt.initialSubClusters; i++ {
-				subclusterID := uint32(i/tt.instancesPerSubcluster + 1)
 				initialInstances[i] = placement.NewInstance().
 					SetID(fmt.Sprintf("I%d", i)).
 					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.replicaFactor)).
 					SetWeight(1).
 					SetEndpoint(fmt.Sprintf("E%d", i)).
-					SetSubClusterID(subclusterID).
 					SetShards(shard.NewShards(nil))
 			}
 
@@ -643,7 +641,7 @@ func TestRemoveInstancesValidCases(t *testing.T) {
 			// Get all instances from the selected subclusters
 			var instancesToRemove []string
 			for _, subclusterID := range subclustersToRemove {
-				for _, instance := range result.Instances() {
+				for _, instance := range placement.BySubClusterIDThenInstanceID(result.Instances()) {
 					if instance.SubClusterID() == subclusterID {
 						instancesToRemove = append(instancesToRemove, instance.ID())
 					}
@@ -672,14 +670,6 @@ func TestPartialSubclustersRemoveOperation(t *testing.T) {
 		totalShards            int
 		subClustersToRemove    int
 	}{
-		{
-			name:                   "remove subcluster while addition of subcluster is going on",
-			replicaFactor:          3,
-			instancesPerSubcluster: 6,
-			instancesToAdd:         14,
-			totalShards:            128,
-			subClustersToRemove:    1,
-		},
 		{
 			name:                   "remove subcluster while removal of subcluster is going on",
 			replicaFactor:          3,
@@ -737,9 +727,9 @@ func TestPartialSubclustersRemoveOperation(t *testing.T) {
 				assert.NotNil(t, newPlacement)
 				assert.NoError(t, placement.Validate(newPlacement))
 
-				newPlacement, marked, err = algo.MarkAllShardsAvailable(newPlacement)
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
 				assert.NoError(t, err)
-				assert.True(t, marked)
+				assert.True(t, marked2)
 				assert.NoError(t, placement.Validate(newPlacement))
 
 				currentPlacement = newPlacement
@@ -833,4 +823,798 @@ func TestPartialSubclustersAddOperation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, newPlacement)
 	assert.NoError(t, placement.Validate(newPlacement))
+}
+
+func TestReplaceInstancesValidCases(t *testing.T) {
+	tests := []struct {
+		name                        string
+		rf                          int
+		instancesPerSub             int
+		totalInstances              int
+		shards                      int
+		instancesToAddBeforeReplace int
+	}{
+		{
+			name:                        "RF=3, 6 instance/subcluster, add 5 instances (not multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             6,
+			totalInstances:              12,
+			shards:                      256,
+			instancesToAddBeforeReplace: 5,
+		},
+		{
+			name:                        "RF=3, 6 instance/subcluster, add 12 instances (multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             6,
+			totalInstances:              6,
+			shards:                      256,
+			instancesToAddBeforeReplace: 12,
+		},
+		{
+			name:                        "RF=3, 9 instance/subcluster, add 7 instances (not multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             9,
+			totalInstances:              9,
+			shards:                      256,
+			instancesToAddBeforeReplace: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create initial test instances
+			instances := make([]placement.Instance, tt.totalInstances)
+			for i := 0; i < tt.totalInstances; i++ {
+				instances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.rf)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Generate shard IDs from 0 to shards-1
+			shardIDs := make([]uint32, tt.shards)
+			for i := 0; i < tt.shards; i++ {
+				shardIDs[i] = uint32(i)
+			}
+
+			// Create algorithm
+			opts := placement.NewOptions().
+				SetValidZone("zone1").
+				SetIsSharded(true).
+				SetInstancesPerSubCluster(tt.instancesPerSub).
+				SetIsSubclustered(true)
+			algo := newSubclusteredAlgorithm(opts)
+
+			// Perform initial placement
+			p, err := algo.InitialPlacement(instances, shardIDs, tt.rf)
+			assert.NoError(t, err)
+			assert.NotNil(t, p)
+			assert.NoError(t, placement.Validate(p))
+
+			// Verify initial placement
+			currentPlacement, marked, err := algo.MarkAllShardsAvailable(p)
+			assert.NoError(t, err)
+			assert.True(t, marked)
+			assert.NoError(t, placement.Validate(currentPlacement))
+
+			// Create new instances to add
+			totalInstances := tt.instancesToAddBeforeReplace + tt.instancesPerSub -
+				(tt.instancesToAddBeforeReplace % tt.instancesPerSub)
+			newInstances := make([]placement.Instance, totalInstances)
+			for i := range totalInstances {
+				newInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", tt.totalInstances+i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.rf)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", tt.totalInstances+i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Add new instances
+			j := 0
+			for _, instance := range newInstances {
+				if j == tt.instancesToAddBeforeReplace {
+					break
+				}
+				newPlacement, err := algo.AddInstances(currentPlacement, []placement.Instance{instance})
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
+				assert.NoError(t, err)
+				assert.True(t, marked2)
+				assert.NoError(t, placement.Validate(newPlacement))
+				currentPlacement = newPlacement
+				j++
+			}
+
+			// Get instances to replace (one from each subcluster)
+			instancesToReplace := make([]string, 0)
+			subClusterMap := make(map[uint32][]string)
+			for _, instance := range currentPlacement.Instances() {
+				subClusterMap[instance.SubClusterID()] = append(subClusterMap[instance.SubClusterID()], instance.ID())
+			}
+
+			// Select one instance from each subcluster for replacement
+			for _, instances := range subClusterMap {
+				if len(instances) > 0 {
+					instancesToReplace = append(instancesToReplace, instances[0])
+				}
+			}
+
+			// Create replacement instances with same isolation groups
+			replacementInstances := make([]placement.Instance, len(instancesToReplace))
+			for i, instanceID := range instancesToReplace {
+				instance, _ := currentPlacement.Instance(instanceID)
+				replacementInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("R%d", i)).
+					SetIsolationGroup(instance.IsolationGroup()).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("RE%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Perform replacement
+			newPlacement, err := algo.ReplaceInstances(currentPlacement, instancesToReplace, replacementInstances)
+			assert.NoError(t, err)
+			assert.NotNil(t, newPlacement)
+			newPlacement, marked3, err := algo.MarkAllShardsAvailable(newPlacement)
+			assert.NoError(t, err)
+			assert.True(t, marked3)
+
+			// Verify final placement
+			assert.NoError(t, placement.Validate(newPlacement))
+			if j < totalInstances {
+				// Add remaining instances
+				finalPlacement, err := algo.AddInstances(newPlacement, newInstances[j:])
+				assert.NoError(t, err)
+				assert.NotNil(t, finalPlacement)
+				assert.NoError(t, placement.Validate(finalPlacement))
+				finalPlacement, marked4, err := algo.MarkAllShardsAvailable(finalPlacement)
+				assert.NoError(t, err)
+				assert.True(t, marked4)
+				assert.NoError(t, placement.Validate(finalPlacement))
+				newPlacement = finalPlacement
+			}
+
+			// Verify that replaced instances are gone and new ones are present
+			for _, instanceID := range instancesToReplace {
+				_, exists := newPlacement.Instance(instanceID)
+				assert.False(t, exists, "Replaced instance should not exist in final placement")
+			}
+
+			for _, instance := range replacementInstances {
+				_, exists := newPlacement.Instance(instance.ID())
+				assert.True(t, exists, "Replacement instance should exist in final placement")
+			}
+		})
+	}
+}
+
+func TestRemoveInstancesErrorCases(t *testing.T) {
+	tests := []struct {
+		name                   string
+		replicaFactor          int
+		instancesPerSubcluster int
+		initialSubClusters     int
+		instanceIDsToRemove    []string
+		expectError            bool
+		errorContains          string
+		setupPlacement         func() placement.Placement
+	}{
+		{
+			name:                   "nil placement",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "placement is nil",
+			setupPlacement:         func() placement.Placement { return nil },
+		},
+		{
+			name:                   "non-sharded placement",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "could not apply subclustered algo on the placement",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				instances := make([]placement.Instance, 6)
+				for i := 0; i < 6; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(1).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Create a non-sharded placement by cloning and modifying
+				nonShardedInstances := make([]placement.Instance, len(p.Instances()))
+				for i, instance := range p.Instances() {
+					nonShardedInstances[i] = placement.NewInstance().
+						SetID(instance.ID()).
+						SetIsolationGroup(instance.IsolationGroup()).
+						SetWeight(instance.Weight()).
+						SetEndpoint(instance.Endpoint()).
+						SetShards(instance.Shards())
+				}
+
+				return placement.NewPlacement().
+					SetInstances(nonShardedInstances).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(false).
+					SetIsSubclustered(true).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster())
+			},
+		},
+		{
+			name:                   "placement without subclusters",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "could not apply subclustered algo on the placement",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := newSubclusteredAlgorithm(opts)
+
+				instances := make([]placement.Instance, 6)
+				for i := 0; i < 6; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Create a placement without subclusters
+				return placement.NewPlacement().
+					SetInstances(p.Instances()).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(true).
+					SetIsSubclustered(false).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster())
+			},
+		},
+		{
+			name:                   "instance does not exist",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"non-existent-instance"},
+			expectError:            true,
+			errorContains:          "instance non-existent-instance does not exist in placement",
+			// nolint: dupl
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := newSubclusteredAlgorithm(opts)
+
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name:                   "removing instance from partial subcluster",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "partial subcluster",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				// Create instances with one subcluster having fewer instances than instancesPerSubcluster
+				instances := make([]placement.Instance, 6)
+				for i := 0; i < 6; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				instances = make([]placement.Instance, 3)
+				for i := 0; i < 3; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i+6)).
+						SetIsolationGroup(fmt.Sprintf("R%d", (i+6)%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i+6)).
+						SetShards(shard.NewShards(nil))
+				}
+				p, err = algo.AddInstances(p, instances)
+				if err != nil {
+					t.Fatalf("Failed to add instances: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name:                   "inconsistent instance weights",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "inconsistent instance weights",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				// Create instances with consistent weights first
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Now modify one instance to have a different weight
+				modifiedInstances := make([]placement.Instance, len(p.Instances()))
+				for i, instance := range p.Instances() {
+					if instance.ID() == "I1" {
+						modifiedInstances[i] = placement.NewInstance().
+							SetID(instance.ID()).
+							SetIsolationGroup(instance.IsolationGroup()).
+							SetWeight(2). // Different weight
+							SetEndpoint(instance.Endpoint()).
+							SetSubClusterID(instance.SubClusterID()).
+							SetShards(instance.Shards())
+					} else {
+						modifiedInstances[i] = instance
+					}
+				}
+
+				return placement.NewPlacement().
+					SetInstances(modifiedInstances).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(true).
+					SetIsSubclustered(true).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster()).
+					SetIsMirrored(p.IsMirrored())
+			},
+		},
+		{
+			name:                   "valid removal - should not error",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            false,
+			// nolint: dupl
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+				return p
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster).SetIsSubclustered(true)
+			algo := subclusteredPlacementAlgorithm{opts: opts}
+
+			p := tt.setupPlacement()
+			if p == nil && !tt.expectError {
+				t.Fatal("Setup placement returned nil but test doesn't expect error")
+			}
+
+			// Skip the test if placement is nil and we expect an error
+			if p == nil && tt.expectError {
+				return
+			}
+
+			newPlacement, err := algo.RemoveInstances(p, tt.instanceIDsToRemove)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, newPlacement)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				assert.NoError(t, placement.Validate(newPlacement))
+
+				// Verify that the expected number of instances were removed
+				expectedRemainingInstances := len(p.Instances()) - len(tt.instanceIDsToRemove)
+				assert.Equal(t, expectedRemainingInstances, len(newPlacement.Instances()))
+			}
+		})
+	}
+}
+
+func TestReclaimLeavingInstance(t *testing.T) {
+	opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetIsSubclustered(true)
+	algo := newSubclusteredAlgorithm(opts)
+
+	instances := make([]placement.Instance, 12)
+	for i := 0; i < 12; i++ {
+		instances[i] = placement.NewInstance().
+			SetID(fmt.Sprintf("I%d", i)).
+			SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+			SetWeight(1).
+			SetEndpoint(fmt.Sprintf("E%d", i)).
+			SetShards(shard.NewShards(nil))
+	}
+
+	shards := make([]uint32, 32)
+	for i := 0; i < 32; i++ {
+		shards[i] = uint32(i)
+	}
+
+	p, err := algo.InitialPlacement(instances, shards, 3)
+	assert.NoError(t, err)
+
+	currentPlacement, marked, err := algo.MarkAllShardsAvailable(p)
+	assert.NoError(t, err)
+	assert.True(t, marked)
+	assert.NoError(t, placement.Validate(currentPlacement))
+
+	instanceToRemove := "I0"
+	newPlacement, err := algo.RemoveInstances(currentPlacement, []string{instanceToRemove})
+	assert.NoError(t, err)
+	assert.NotNil(t, newPlacement)
+	assert.NoError(t, placement.Validate(newPlacement))
+
+	// Add the removed instance again to the placement
+	addingInstance, exists := newPlacement.Instance(instanceToRemove)
+	assert.True(t, exists)
+
+	finalPlacement, err := algo.AddInstances(newPlacement, []placement.Instance{addingInstance})
+	assert.NoError(t, err)
+	assert.NotNil(t, finalPlacement)
+	assert.NoError(t, placement.Validate(finalPlacement))
+
+	// check if the removed instance is still present and has all shards in AVAILABLE state in the same subcluster
+	instance, exists := finalPlacement.Instance(instanceToRemove)
+	assert.True(t, exists)
+	assert.False(t, instance.IsLeaving())
+}
+
+func newSubclusteredTestInstance(id string) placement.Instance {
+	return placement.NewInstance().
+		SetID(id).
+		SetIsolationGroup("rack-" + id).
+		SetEndpoint("endpoint-" + id).
+		SetWeight(1)
+}
+
+func TestSubclusteredAlgorithm_BalanceShards_WhenBalanced(t *testing.T) {
+	// Create instances for 2 subclusters, each with 3 instances (6 total)
+	// Replica factor 3, so we need 3 isolation groups
+	// With 2 shards and RF=3, we should have 6 total shard replicas distributed across instances
+	i1 := newSubclusteredTestInstance("i1").
+		SetIsolationGroup("rack-0").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+		}))
+	i2 := newSubclusteredTestInstance("i2").
+		SetIsolationGroup("rack-1").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+		}))
+	i3 := newSubclusteredTestInstance("i3").
+		SetIsolationGroup("rack-2").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+		}))
+	i4 := newSubclusteredTestInstance("i4").
+		SetIsolationGroup("rack-0").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(1).SetState(shard.Available),
+		}))
+	i5 := newSubclusteredTestInstance("i5").
+		SetIsolationGroup("rack-1").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(1).SetState(shard.Available),
+		}))
+	i6 := newSubclusteredTestInstance("i6").
+		SetIsolationGroup("rack-2").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(1).SetState(shard.Available),
+		}))
+
+	initialPlacement := placement.NewPlacement().
+		SetReplicaFactor(3).
+		SetShards([]uint32{0, 1}).
+		SetInstances([]placement.Instance{i1, i2, i3, i4, i5, i6}).
+		SetIsSharded(true).
+		SetIsSubclustered(true).
+		SetInstancesPerSubCluster(3)
+
+	expectedPlacement := initialPlacement.Clone()
+
+	opts := placement.NewOptions().
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	balancedPlacement, err := algo.BalanceShards(initialPlacement)
+	assert.NoError(t, err)
+
+	// Verify the placement is valid
+	assert.NoError(t, placement.Validate(balancedPlacement))
+
+	// Verify subcluster properties are maintained
+	assert.True(t, balancedPlacement.IsSubclustered())
+	assert.Equal(t, 3, balancedPlacement.InstancesPerSubCluster())
+	assert.Equal(t, 3, balancedPlacement.ReplicaFactor())
+
+	// Verify instance count is preserved
+	assert.Equal(t, len(expectedPlacement.Instances()), len(balancedPlacement.Instances()))
+
+	// Verify total shard count is preserved
+	originalShardCount := 0
+	balancedShardCount := 0
+	for _, instance := range initialPlacement.Instances() {
+		originalShardCount += instance.Shards().NumShards()
+	}
+	for _, instance := range balancedPlacement.Instances() {
+		balancedShardCount += instance.Shards().NumShards()
+	}
+	assert.Equal(t, originalShardCount, balancedShardCount)
+}
+
+func TestSubclusteredAlgorithm_BalanceShards_WhenImbalanced(t *testing.T) {
+	// Create an imbalanced placement where some instances have more shards
+	// With 3 shards and RF=3, we should have 9 total shard replicas distributed across instances
+	i1 := newSubclusteredTestInstance("i1").
+		SetIsolationGroup("rack-0").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+			shard.NewShard(1).SetState(shard.Available),
+			shard.NewShard(2).SetState(shard.Available),
+		}))
+	i2 := newSubclusteredTestInstance("i2").
+		SetIsolationGroup("rack-1").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+			shard.NewShard(1).SetState(shard.Available),
+			shard.NewShard(2).SetState(shard.Available),
+		}))
+	i3 := newSubclusteredTestInstance("i3").
+		SetIsolationGroup("rack-2").
+		SetSubClusterID(1).
+		SetShards(shard.NewShards([]shard.Shard{
+			shard.NewShard(0).SetState(shard.Available),
+			shard.NewShard(1).SetState(shard.Available),
+			shard.NewShard(2).SetState(shard.Available),
+		}))
+	i4 := newSubclusteredTestInstance("i4").
+		SetIsolationGroup("rack-0").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{}))
+	i5 := newSubclusteredTestInstance("i5").
+		SetIsolationGroup("rack-1").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{}))
+	i6 := newSubclusteredTestInstance("i6").
+		SetIsolationGroup("rack-2").
+		SetSubClusterID(2).
+		SetShards(shard.NewShards([]shard.Shard{}))
+
+	p := placement.NewPlacement().
+		SetReplicaFactor(3).
+		SetShards([]uint32{0, 1, 2}).
+		SetInstances([]placement.Instance{i1, i2, i3, i4, i5, i6}).
+		SetIsSharded(true).
+		SetIsSubclustered(true).
+		SetInstancesPerSubCluster(3)
+
+	opts := placement.NewOptions().
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	balancedPlacement, err := algo.BalanceShards(p)
+	assert.NoError(t, err)
+
+	// Verify the placement is valid
+	assert.NoError(t, placement.Validate(balancedPlacement))
+
+	// Verify subcluster properties are maintained
+	assert.True(t, balancedPlacement.IsSubclustered())
+	assert.Equal(t, 3, balancedPlacement.InstancesPerSubCluster())
+	assert.Equal(t, 3, balancedPlacement.ReplicaFactor())
+
+	// Verify instance count is preserved
+	assert.Equal(t, len(p.Instances()), len(balancedPlacement.Instances()))
+
+	// Verify total shard count is preserved
+	originalShardCount := 0
+	balancedShardCount := 0
+	for _, instance := range p.Instances() {
+		originalShardCount += instance.Shards().NumShards()
+	}
+	for _, instance := range balancedPlacement.Instances() {
+		balancedShardCount += instance.Shards().NumShards()
+	}
+	assert.Equal(t, originalShardCount, balancedShardCount)
+
+	// Verify all instances are in the correct subclusters
+	for _, instance := range balancedPlacement.Instances() {
+		expectedSubcluster := uint32(1)
+		if instance.ID() >= "i4" {
+			expectedSubcluster = 2
+		}
+		assert.Equal(t, expectedSubcluster, instance.SubClusterID())
+	}
+}
+
+func TestSubclusteredAlgorithm_BalanceShards_ErrorCases(t *testing.T) {
+	opts := placement.NewOptions().
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	tests := []struct {
+		name          string
+		placement     placement.Placement
+		errorContains string
+	}{
+		{
+			name:          "nil placement",
+			placement:     nil,
+			errorContains: "placement is nil",
+		},
+		{
+			name: "not sharded placement",
+			placement: placement.NewPlacement().
+				SetIsSharded(false).
+				SetIsSubclustered(true),
+			errorContains: "could not apply subclustered algo on the placement",
+		},
+		{
+			name: "not subclustered placement",
+			placement: placement.NewPlacement().
+				SetIsSharded(true).
+				SetIsSubclustered(false),
+			errorContains: "could not apply subclustered algo on the placement",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			balancedPlacement, err := algo.BalanceShards(tt.placement)
+			assert.Error(t, err)
+			assert.Nil(t, balancedPlacement)
+			assert.Contains(t, err.Error(), tt.errorContains)
+		})
+	}
+}
+
+// TestSubclusteredAlgorithm_BalanceShards_EmptyPlacement tests balancing empty placements
+func TestSubclusteredAlgorithm_BalanceShards_EmptyPlacement(t *testing.T) {
+	opts := placement.NewOptions().
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true)
+	algo := subclusteredPlacementAlgorithm{opts: opts}
+
+	emptyPlacement := placement.NewPlacement().
+		SetInstances([]placement.Instance{}).
+		SetShards([]uint32{}).
+		SetReplicaFactor(3).
+		SetInstancesPerSubCluster(3).
+		SetIsSubclustered(true).
+		SetIsSharded(true)
+
+	balancedPlacement, err := algo.BalanceShards(emptyPlacement)
+	assert.NoError(t, err)
+	assert.NotNil(t, balancedPlacement)
+	assert.NoError(t, placement.Validate(balancedPlacement))
+	assert.Equal(t, 0, len(balancedPlacement.Instances()))
 }

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -761,7 +761,8 @@ func TestPartialSubclustersRemoveOperation(t *testing.T) {
 			}
 
 			if tt.subClustersToRemove > 1 {
-				instancesToRemove[0], instancesToRemove[tt.instancesPerSubcluster] = instancesToRemove[tt.instancesPerSubcluster], instancesToRemove[0]
+				instancesToRemove[0], instancesToRemove[tt.instancesPerSubcluster] =
+					instancesToRemove[tt.instancesPerSubcluster], instancesToRemove[0]
 			}
 
 			// Remove the instances

--- a/src/cluster/placement/placement_test.go
+++ b/src/cluster/placement/placement_test.go
@@ -863,7 +863,6 @@ func TestValidateSubclusteredPlacement(t *testing.T) {
 				i1 := NewEmptyInstance("i1", "IG1", "z1", "endpoint1", 1).SetSubClusterID(1)
 				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
 				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
-
 				i2 := NewEmptyInstance("i2", "IG1", "z1", "endpoint2", 1).SetSubClusterID(1)
 				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
 				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Added code to removeInstances from the subclustered placement.

- The method to removeInstance from the subcluster is same as what is present in sharded algorithm.
- During the removal of instance it is assumed that all the instances of the subclusters will be removed eventually, because the agnostic in the subclustered placement is to remove subcluster or add subcluster. 
- To make sure there is no target load assigned to the instance of the removing subcluster we do not include their weight while scanning current load and we skip these instances while building targetLoad.
- Keeping the assumption in mind while removing an instance the we calculate the shard count on the subclusters by excluding the subcluster of removing instance.
- This also give rise to a problem of removing more than one subcluster at the time. To prevent this a validation has been added that while removing an instance if there is a partial subcluster, other than the removing subcluster the algorithm will throw an error. 
- Similar validation has been added for AddInstance that while adding instances if there are multiple partial subcluster present in the placement the addInstance operation will fail.
- There can be a case when we are removing a instance which was added to the placement after replace. To facilitate that we have added a validation that if after removing an instance we still have `instancesPerSubcluster` instances in the subcluster we do not remove the removing instance suvcluster ID from target shard calculation.
