### PR TITLE
Added code to replace instances in subclustered placement

### DIFF
--- a/src/cluster/placement/algo/subclustered.go
+++ b/src/cluster/placement/algo/subclustered.go
@@ -169,3 +169,11 @@ func (a subclusteredPlacementAlgorithm) BalanceShards(
 	// TODO: Implement subclustered balance shards logic
 	return nil, fmt.Errorf("subclustered balance shards not yet implemented")
 }
+
+func (a subclusteredPlacementAlgorithm) validateRemoveInstances(p placement.Placement, instanceIDs []string) error {
+	if err := a.IsCompatibleWith(p); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -926,12 +926,6 @@ func (ph *subclusteredHelper) reclaimLeavingShards(instance placement.Instance) 
 	for _, i := range ph.instances {
 		for _, s := range i.Shards().ShardsForState(shard.Initializing) {
 			if s.SourceID() == id {
-				// NB(cw) in very rare case, the leaving shards could not be taken back.
-				// For example: in a RF=2 case, instance a and b on ig1, instance c on ig2,
-				// c took shard1 from instance a, before we tried to assign shard1 back to instance a,
-				// b got assigned shard1, now if we try to add instance a back to the topology, a can
-				// no longer take shard1 back.
-				// But it's fine, the algo will fil up those load with other shards from the cluster
 				ph.moveShard(s, i, instance)
 			}
 		}

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -1105,9 +1105,3 @@ func assignSubClusterIDs(
 
 	return nil
 }
-
-func (ph *subclusteredHelper) buildInstanceHeap(
-	instances []placement.Instance,
-	availableCapacityAscending bool) (heap.Interface, error) {
-	return newHeap(instances, availableCapacityAscending, ph.targetLoad, ph.groupToWeightMap, true)
-}

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -117,6 +117,7 @@ func newubclusteredAddInstanceHelper(
 		if err != nil {
 			return nil, nil, err
 		}
+
 		return ph, instance, nil
 	}
 

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -210,7 +210,7 @@ func newubclusteredReplaceInstanceHelper(
 	for i, addingInstance := range newAddingInstances {
 		addingInstance.SetSubClusterID(leavingInstances[i].SubClusterID())
 	}
-	ph, err := newSubclusteredHelper(p, p.ReplicaFactor(), opts, 0)
+	ph, err := newSubclusteredHelper(p, opts, 0)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -117,7 +117,6 @@ func newubclusteredAddInstanceHelper(
 		if err != nil {
 			return nil, nil, err
 		}
-
 		return ph, instance, nil
 	}
 

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -476,6 +476,7 @@ func (ph *subclusteredHelper) canAssignInstance(shardID uint32, from, to placeme
 	if tosubcluster.targetShardCount == 0 {
 		return false
 	}
+
 	// if the subcluster is full, the shard should be already assigned to the subcluster
 	// if the shard is not assigned to the subcluster, return false
 	if len(tosubcluster.shardMap) == tosubcluster.targetShardCount {
@@ -1104,4 +1105,10 @@ func assignSubClusterIDs(
 	}
 
 	return nil
+}
+
+func (ph *subclusteredHelper) buildInstanceHeap(
+	instances []placement.Instance,
+	availableCapacityAscending bool) (heap.Interface, error) {
+	return newHeap(instances, availableCapacityAscending, ph.targetLoad, ph.groupToWeightMap, true)
 }

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -176,6 +176,47 @@ func newubclusteredRemoveInstanceHelper(
 	return ph, leavingInstance, nil
 }
 
+func newubclusteredReplaceInstanceHelper(
+	p placement.Placement,
+	instanceIDs []string,
+	addingInstances []placement.Instance,
+	opts placement.Options,
+) (placementHelper, []placement.Instance, []placement.Instance, error) {
+	var (
+		leavingInstances = make([]placement.Instance, len(instanceIDs))
+		err              error
+	)
+	for i, instanceID := range instanceIDs {
+		p, leavingInstances[i], err = removeInstanceFromPlacement(p, instanceID)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	newAddingInstances := make([]placement.Instance, len(addingInstances))
+	for i, instance := range addingInstances {
+		p, newAddingInstances[i], err = addInstanceToPlacement(p, instance, anyType)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	if len(newAddingInstances) != len(leavingInstances) {
+		return nil, nil, nil, fmt.Errorf("number of adding instances (%d) does not match number of leaving instances (%d)",
+			len(newAddingInstances), len(leavingInstances))
+	}
+
+	// Match adding instances with leaving instances
+	for i, addingInstance := range newAddingInstances {
+		addingInstance.SetSubClusterID(leavingInstances[i].SubClusterID())
+	}
+	ph, err := newSubclusteredHelper(p, p.ReplicaFactor(), opts, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return ph, leavingInstances, newAddingInstances, nil
+}
+
 func newSubclusteredHelper(
 	p placement.Placement,
 	opts placement.Options,
@@ -877,7 +918,24 @@ func (ph *subclusteredHelper) generatePlacement() placement.Placement {
 // by pulling them back from the rest of the cluster.
 // nolint: unused
 func (ph *subclusteredHelper) reclaimLeavingShards(instance placement.Instance) {
-	// TODO: Implement subclustered reclaim leaving shards logic
+	if instance.Shards().NumShardsForState(shard.Leaving) == 0 {
+		// Shortcut if there is nothing to be reclaimed.
+		return
+	}
+	id := instance.ID()
+	for _, i := range ph.instances {
+		for _, s := range i.Shards().ShardsForState(shard.Initializing) {
+			if s.SourceID() == id {
+				// NB(cw) in very rare case, the leaving shards could not be taken back.
+				// For example: in a RF=2 case, instance a and b on ig1, instance c on ig2,
+				// c took shard1 from instance a, before we tried to assign shard1 back to instance a,
+				// b got assigned shard1, now if we try to add instance a back to the topology, a can
+				// no longer take shard1 back.
+				// But it's fine, the algo will fil up those load with other shards from the cluster
+				ph.moveShard(s, i, instance)
+			}
+		}
+	}
 }
 
 // returnInitializingShards returns all the initializing shards on the given instance

--- a/src/cluster/placement/algo/subclustered_helper.go
+++ b/src/cluster/placement/algo/subclustered_helper.go
@@ -476,7 +476,6 @@ func (ph *subclusteredHelper) canAssignInstance(shardID uint32, from, to placeme
 	if tosubcluster.targetShardCount == 0 {
 		return false
 	}
-
 	// if the subcluster is full, the shard should be already assigned to the subcluster
 	// if the shard is not assigned to the subcluster, return false
 	if len(tosubcluster.shardMap) == tosubcluster.targetShardCount {

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -283,7 +283,6 @@ func TestSubclusteredAlgorithm_InitialPlacement(t *testing.T) {
 
 				// Verify subcluster assignments
 				assert.Equal(t, tt.expectedSubclusters, len(subclusterMap))
-
 				// Verify placement properties
 				assert.Equal(t, tt.replicaFactor, result.ReplicaFactor())
 				assert.True(t, result.IsSharded())

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -356,7 +356,6 @@ func TestSubclusteredAlgorithm_InitialPlacement_ErrorCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster)
 			algo := subclusteredPlacementAlgorithm{opts: opts}
-
 			// Generate instances dynamically
 			instances := make([]placement.Instance, tt.totalInstances)
 			for i := 0; i < tt.totalInstances; i++ {

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -672,14 +672,6 @@ func TestPartialSubclustersRemoveOperation(t *testing.T) {
 		subClustersToRemove    int
 	}{
 		{
-			name:                   "remove subcluster while addition of subcluster is going on",
-			replicaFactor:          3,
-			instancesPerSubcluster: 6,
-			instancesToAdd:         14,
-			totalShards:            128,
-			subClustersToRemove:    1,
-		},
-		{
 			name:                   "remove subcluster while removal of subcluster is going on",
 			replicaFactor:          3,
 			instancesPerSubcluster: 6,

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -469,9 +469,9 @@ func TestAddInstancesValidCases(t *testing.T) {
 				assert.Equal(t, tt.instancesPerSubcluster+i+1, len(newPlacement.Instances()))
 				assert.NoError(t, placement.Validate(newPlacement))
 
-				newPlacement, marked, err := algo.MarkAllShardsAvailable(newPlacement)
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
 				assert.NoError(t, err)
-				assert.True(t, marked)
+				assert.True(t, marked2)
 				assert.NoError(t, placement.Validate(newPlacement))
 
 				currentPlacement = newPlacement
@@ -736,9 +736,9 @@ func TestPartialSubclustersRemoveOperation(t *testing.T) {
 				assert.NotNil(t, newPlacement)
 				assert.NoError(t, placement.Validate(newPlacement))
 
-				newPlacement, marked, err = algo.MarkAllShardsAvailable(newPlacement)
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
 				assert.NoError(t, err)
-				assert.True(t, marked)
+				assert.True(t, marked2)
 				assert.NoError(t, placement.Validate(newPlacement))
 
 				currentPlacement = newPlacement
@@ -832,4 +832,548 @@ func TestPartialSubclustersAddOperation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, newPlacement)
 	assert.NoError(t, placement.Validate(newPlacement))
+}
+
+func TestReplaceInstancesValidCases(t *testing.T) {
+	tests := []struct {
+		name                        string
+		rf                          int
+		instancesPerSub             int
+		totalInstances              int
+		shards                      int
+		instancesToAddBeforeReplace int
+	}{
+		{
+			name:                        "RF=3, 6 instance/subcluster, add 5 instances (not multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             6,
+			totalInstances:              12,
+			shards:                      256,
+			instancesToAddBeforeReplace: 5,
+		},
+		{
+			name:                        "RF=3, 6 instance/subcluster, add 12 instances (multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             6,
+			totalInstances:              6,
+			shards:                      256,
+			instancesToAddBeforeReplace: 12,
+		},
+		{
+			name:                        "RF=3, 9 instance/subcluster, add 7 instances (not multiple of instancesPerSubcluster)",
+			rf:                          3,
+			instancesPerSub:             9,
+			totalInstances:              9,
+			shards:                      256,
+			instancesToAddBeforeReplace: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create initial test instances
+			instances := make([]placement.Instance, tt.totalInstances)
+			for i := 0; i < tt.totalInstances; i++ {
+				instances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.rf)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Generate shard IDs from 0 to shards-1
+			shardIDs := make([]uint32, tt.shards)
+			for i := 0; i < tt.shards; i++ {
+				shardIDs[i] = uint32(i)
+			}
+
+			// Create algorithm
+			opts := placement.NewOptions().
+				SetValidZone("zone1").
+				SetIsSharded(true).
+				SetInstancesPerSubCluster(tt.instancesPerSub).
+				SetHasSubClusters(true)
+			algo := newSubclusteredAlgorithm(opts)
+
+			// Perform initial placement
+			p, err := algo.InitialPlacement(instances, shardIDs, tt.rf)
+			assert.NoError(t, err)
+			assert.NotNil(t, p)
+			assert.NoError(t, placement.Validate(p))
+
+			// Verify initial placement
+			currentPlacement, marked, err := algo.MarkAllShardsAvailable(p)
+			assert.NoError(t, err)
+			assert.True(t, marked)
+			assert.NoError(t, placement.Validate(currentPlacement))
+
+			// Create new instances to add
+			totalInstances := tt.instancesToAddBeforeReplace + tt.instancesPerSub -
+				(tt.instancesToAddBeforeReplace % tt.instancesPerSub)
+			newInstances := make([]placement.Instance, totalInstances)
+			for i := range totalInstances {
+				newInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("I%d", tt.totalInstances+i)).
+					SetIsolationGroup(fmt.Sprintf("R%d", i%tt.rf)).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("E%d", tt.totalInstances+i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Add new instances
+			j := 0
+			for _, instance := range newInstances {
+				if j == tt.instancesToAddBeforeReplace {
+					break
+				}
+				newPlacement, err := algo.AddInstances(currentPlacement, []placement.Instance{instance})
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				newPlacement, marked2, err := algo.MarkAllShardsAvailable(newPlacement)
+				assert.NoError(t, err)
+				assert.True(t, marked2)
+				assert.NoError(t, placement.Validate(newPlacement))
+				currentPlacement = newPlacement
+				j++
+			}
+
+			// Get instances to replace (one from each subcluster)
+			instancesToReplace := make([]string, 0)
+			subClusterMap := make(map[uint32][]string)
+			for _, instance := range currentPlacement.Instances() {
+				subClusterMap[instance.SubClusterID()] = append(subClusterMap[instance.SubClusterID()], instance.ID())
+			}
+
+			// Select one instance from each subcluster for replacement
+			for _, instances := range subClusterMap {
+				if len(instances) > 0 {
+					instancesToReplace = append(instancesToReplace, instances[0])
+				}
+			}
+
+			// Create replacement instances with same isolation groups
+			replacementInstances := make([]placement.Instance, len(instancesToReplace))
+			for i, instanceID := range instancesToReplace {
+				instance, _ := currentPlacement.Instance(instanceID)
+				replacementInstances[i] = placement.NewInstance().
+					SetID(fmt.Sprintf("R%d", i)).
+					SetIsolationGroup(instance.IsolationGroup()).
+					SetWeight(1).
+					SetEndpoint(fmt.Sprintf("RE%d", i)).
+					SetShards(shard.NewShards(nil))
+			}
+
+			// Perform replacement
+			newPlacement, err := algo.ReplaceInstances(currentPlacement, instancesToReplace, replacementInstances)
+			assert.NoError(t, err)
+			assert.NotNil(t, newPlacement)
+			newPlacement, marked3, err := algo.MarkAllShardsAvailable(newPlacement)
+			assert.NoError(t, err)
+			assert.True(t, marked3)
+
+			// Verify final placement
+			assert.NoError(t, placement.Validate(newPlacement))
+			if j < totalInstances {
+				// Add remaining instances
+				finalPlacement, err := algo.AddInstances(newPlacement, newInstances[j:])
+				assert.NoError(t, err)
+				assert.NotNil(t, finalPlacement)
+				assert.NoError(t, placement.Validate(finalPlacement))
+				finalPlacement, marked4, err := algo.MarkAllShardsAvailable(finalPlacement)
+				assert.NoError(t, err)
+				assert.True(t, marked4)
+				assert.NoError(t, placement.Validate(finalPlacement))
+				newPlacement = finalPlacement
+			}
+
+			// Verify that replaced instances are gone and new ones are present
+			for _, instanceID := range instancesToReplace {
+				_, exists := newPlacement.Instance(instanceID)
+				assert.False(t, exists, "Replaced instance should not exist in final placement")
+			}
+
+			for _, instance := range replacementInstances {
+				_, exists := newPlacement.Instance(instance.ID())
+				assert.True(t, exists, "Replacement instance should exist in final placement")
+			}
+		})
+	}
+}
+
+func TestRemoveInstancesErrorCases(t *testing.T) {
+	tests := []struct {
+		name                   string
+		replicaFactor          int
+		instancesPerSubcluster int
+		initialSubClusters     int
+		instanceIDsToRemove    []string
+		expectError            bool
+		errorContains          string
+		setupPlacement         func() placement.Placement
+	}{
+		{
+			name:                   "nil placement",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "placement is nil",
+			setupPlacement:         func() placement.Placement { return nil },
+		},
+		{
+			name:                   "non-sharded placement",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "could not apply subclustered algo on the placement",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetHasSubClusters(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				instances := make([]placement.Instance, 6)
+				for i := 0; i < 6; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(1).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Create a non-sharded placement by cloning and modifying
+				nonShardedInstances := make([]placement.Instance, len(p.Instances()))
+				for i, instance := range p.Instances() {
+					nonShardedInstances[i] = placement.NewInstance().
+						SetID(instance.ID()).
+						SetIsolationGroup(instance.IsolationGroup()).
+						SetWeight(instance.Weight()).
+						SetEndpoint(instance.Endpoint()).
+						SetShards(instance.Shards())
+				}
+
+				return placement.NewPlacement().
+					SetInstances(nonShardedInstances).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(false).
+					SetHasSubClusters(true).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster())
+			},
+		},
+		{
+			name:                   "placement without subclusters",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "could not apply subclustered algo on the placement",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetHasSubClusters(true)
+				algo := newSubclusteredAlgorithm(opts)
+
+				instances := make([]placement.Instance, 6)
+				for i := 0; i < 6; i++ {
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Create a placement without subclusters
+				return placement.NewPlacement().
+					SetInstances(p.Instances()).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(true).
+					SetHasSubClusters(false).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster())
+			},
+		},
+		{
+			name:                   "instance does not exist",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"non-existent-instance"},
+			expectError:            true,
+			errorContains:          "instance non-existent-instance does not exist in placement",
+			// nolint: dupl
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetHasSubClusters(true)
+				algo := newSubclusteredAlgorithm(opts)
+
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name:                   "removing instance from partial subcluster",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "partial subcluster",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetHasSubClusters(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				// Create instances with one subcluster having fewer instances than instancesPerSubcluster
+				instances := make([]placement.Instance, 9) // 6 + 3 instead of 6 + 6
+				for i := 0; i < 9; i++ {
+					subclusterID := uint32(1)
+					if i >= 6 {
+						subclusterID = 2
+					}
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+				return p
+			},
+		},
+		{
+			name:                   "inconsistent instance weights",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            true,
+			errorContains:          "inconsistent instance weights",
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetHasSubClusters(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				// Create instances with consistent weights first
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+
+				// Now modify one instance to have a different weight
+				modifiedInstances := make([]placement.Instance, len(p.Instances()))
+				for i, instance := range p.Instances() {
+					if instance.ID() == "I1" {
+						modifiedInstances[i] = placement.NewInstance().
+							SetID(instance.ID()).
+							SetIsolationGroup(instance.IsolationGroup()).
+							SetWeight(2). // Different weight
+							SetEndpoint(instance.Endpoint()).
+							SetSubClusterID(instance.SubClusterID()).
+							SetShards(instance.Shards())
+					} else {
+						modifiedInstances[i] = instance
+					}
+				}
+
+				return placement.NewPlacement().
+					SetInstances(modifiedInstances).
+					SetShards(p.Shards()).
+					SetReplicaFactor(p.ReplicaFactor()).
+					SetIsSharded(true).
+					SetHasSubClusters(true).
+					SetInstancesPerSubCluster(p.InstancesPerSubCluster()).
+					SetIsMirrored(p.IsMirrored())
+			},
+		},
+		{
+			name:                   "valid removal - should not error",
+			replicaFactor:          3,
+			instancesPerSubcluster: 6,
+			initialSubClusters:     2,
+			instanceIDsToRemove:    []string{"I0"},
+			expectError:            false,
+			// nolint: dupl
+			setupPlacement: func() placement.Placement {
+				opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetHasSubClusters(true)
+				algo := subclusteredPlacementAlgorithm{opts: opts}
+
+				instances := make([]placement.Instance, 12)
+				for i := 0; i < 12; i++ {
+					subclusterID := uint32(i/6 + 1)
+					instances[i] = placement.NewInstance().
+						SetID(fmt.Sprintf("I%d", i)).
+						SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+						SetWeight(1).
+						SetEndpoint(fmt.Sprintf("E%d", i)).
+						SetSubClusterID(subclusterID).
+						SetShards(shard.NewShards(nil))
+				}
+
+				shards := make([]uint32, 128)
+				for i := 0; i < 128; i++ {
+					shards[i] = uint32(i)
+				}
+
+				p, err := algo.InitialPlacement(instances, shards, 3)
+				if err != nil {
+					t.Fatalf("Failed to create placement: %v", err)
+				}
+				return p
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster).SetHasSubClusters(true)
+			algo := subclusteredPlacementAlgorithm{opts: opts}
+
+			p := tt.setupPlacement()
+			if p == nil && !tt.expectError {
+				t.Fatal("Setup placement returned nil but test doesn't expect error")
+			}
+
+			// Skip the test if placement is nil and we expect an error
+			if p == nil && tt.expectError {
+				return
+			}
+
+			newPlacement, err := algo.RemoveInstances(p, tt.instanceIDsToRemove)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, newPlacement)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, newPlacement)
+				assert.NoError(t, placement.Validate(newPlacement))
+
+				// Verify that the expected number of instances were removed
+				expectedRemainingInstances := len(p.Instances()) - len(tt.instanceIDsToRemove)
+				assert.Equal(t, expectedRemainingInstances, len(newPlacement.Instances()))
+			}
+		})
+	}
+}
+
+func TestReclaimLeavingInstance(t *testing.T) {
+	opts := placement.NewOptions().SetInstancesPerSubCluster(6).SetHasSubClusters(true)
+	algo := newSubclusteredAlgorithm(opts)
+
+	instances := make([]placement.Instance, 12)
+	for i := 0; i < 12; i++ {
+		instances[i] = placement.NewInstance().
+			SetID(fmt.Sprintf("I%d", i)).
+			SetIsolationGroup(fmt.Sprintf("R%d", i%3)).
+			SetWeight(1).
+			SetEndpoint(fmt.Sprintf("E%d", i)).
+			SetShards(shard.NewShards(nil))
+	}
+
+	shards := make([]uint32, 32)
+	for i := 0; i < 32; i++ {
+		shards[i] = uint32(i)
+	}
+
+	p, err := algo.InitialPlacement(instances, shards, 3)
+	assert.NoError(t, err)
+
+	currentPlacement, marked, err := algo.MarkAllShardsAvailable(p)
+	assert.NoError(t, err)
+	assert.True(t, marked)
+	assert.NoError(t, placement.Validate(currentPlacement))
+
+	instanceToRemove := "I0"
+	newPlacement, err := algo.RemoveInstances(currentPlacement, []string{instanceToRemove})
+	assert.NoError(t, err)
+	assert.NotNil(t, newPlacement)
+	assert.NoError(t, placement.Validate(newPlacement))
+
+	// Add the removed instance again to the placement
+	addingInstance, exists := newPlacement.Instance(instanceToRemove)
+	assert.True(t, exists)
+
+	finalPlacement, err := algo.AddInstances(newPlacement, []placement.Instance{addingInstance})
+	assert.NoError(t, err)
+	assert.NotNil(t, finalPlacement)
+	assert.NoError(t, placement.Validate(finalPlacement))
+
+	// check if the removed instance is still present and has all shards in AVAILABLE state in the same subcluster
+	instance, exists := finalPlacement.Instance(instanceToRemove)
+	assert.True(t, exists)
+	assert.False(t, instance.IsLeaving())
+
 }

--- a/src/cluster/placement/algo/subclustered_test.go
+++ b/src/cluster/placement/algo/subclustered_test.go
@@ -356,6 +356,7 @@ func TestSubclusteredAlgorithm_InitialPlacement_ErrorCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := placement.NewOptions().SetInstancesPerSubCluster(tt.instancesPerSubcluster)
 			algo := subclusteredPlacementAlgorithm{opts: opts}
+
 			// Generate instances dynamically
 			instances := make([]placement.Instance, tt.totalInstances)
 			for i := 0; i < tt.totalInstances; i++ {

--- a/src/cluster/placement/placement_test.go
+++ b/src/cluster/placement/placement_test.go
@@ -860,10 +860,10 @@ func TestValidateSubclusteredPlacement(t *testing.T) {
 			instancesPerSubcluster: 6,
 			replicaFactor:          2,
 			instances: func() []Instance {
-				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1 := NewEmptyInstance("i1", "IG1", "z1", "endpoint1", 1).SetSubClusterID(1)
 				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
 				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
-				i2 := NewEmptyInstance("i2", "r1", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2 := NewEmptyInstance("i2", "IG1", "z1", "endpoint2", 1).SetSubClusterID(1)
 				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
 				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
 

--- a/src/cluster/placement/placement_test.go
+++ b/src/cluster/placement/placement_test.go
@@ -860,10 +860,10 @@ func TestValidateSubclusteredPlacement(t *testing.T) {
 			instancesPerSubcluster: 6,
 			replicaFactor:          2,
 			instances: func() []Instance {
-				i1 := NewEmptyInstance("i1", "IG1", "z1", "endpoint1", 1).SetSubClusterID(1)
+				i1 := NewEmptyInstance("i1", "r1", "z1", "endpoint1", 1).SetSubClusterID(1)
 				i1.Shards().Add(shard.NewShard(1).SetState(shard.Available))
 				i1.Shards().Add(shard.NewShard(2).SetState(shard.Available))
-				i2 := NewEmptyInstance("i2", "IG1", "z1", "endpoint2", 1).SetSubClusterID(1)
+				i2 := NewEmptyInstance("i2", "r1", "z1", "endpoint2", 1).SetSubClusterID(1)
 				i2.Shards().Add(shard.NewShard(1).SetState(shard.Available))
 				i2.Shards().Add(shard.NewShard(2).SetState(shard.Available))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
- The replace instance operation can be performed across multiple subclusters which is why we have added the constraint that the number of adding should be equal to leaving instances  while replacing.
- The adding instance are assigned the subcluster IDs same as the removing instances mapping the indexes one to one, i.e the removing instance at index 0 is mapped to adding instance at index 0.
- Added the code for reclaimLeavingShards which is same as that in sharded algo.