### PR TITLE
Add consumer service for local development

### DIFF
--- a/scripts/development/m3_aggregator_local/m3aggregator.yml.template
+++ b/scripts/development/m3_aggregator_local/m3aggregator.yml.template
@@ -197,8 +197,27 @@ aggregator:
     forcedFlushWindowSize: 10s
   flush:
     handlers:
-      - staticBackend:
-          type: blackhole
+      - dynamicBackend:
+          name: m3msg
+          hashType: murmur32
+          storagePolicyFilters:
+            - serviceID:
+                environment: default_env
+                name: local-consumer-service
+                zone: embedded
+              storagePolicies:
+                - 10s:2d
+          producer:
+            writer:
+              topicName: {{TOPIC_NAME}}
+              topicServiceOverride:
+                zone: embedded
+                environment: default_env
+              messagePool:
+                size: 16384
+                watermark:
+                  low: 0.2
+                  high: 0.5
   forwarding:
     maxSingleDelay: 5s
   entryTTL: 1h

--- a/scripts/development/m3_consumer_service/Dockerfile
+++ b/scripts/development/m3_consumer_service/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+# Expect a prebuilt static Linux binary in ./bin relative to this Dockerfile
+COPY ./bin/m3consumer .
+
+EXPOSE 9000
+
+CMD ["./m3consumer"]

--- a/scripts/development/m3_consumer_service/README.md
+++ b/scripts/development/m3_consumer_service/README.md
@@ -1,0 +1,107 @@
+## m3_consumer_service (local dev)
+
+This directory contains a simple local m3msg consumer used during development to receive aggregated metrics produced by the local M3 Aggregator setup in `scripts/development/m3_aggregator_local`.
+
+The consumer:
+
+- Starts an m3msg server that listens on `0.0.0.0:9000` (overridable via `LISTEN_ADDR`).
+- Logs all received aggregated metrics (ID, value, timestamp, storage policy, annotation) and acknowledges them.
+- Includes a small bootstrap tool that seeds m3msg topic and placement metadata into the local environment so the aggregator can resolve and send to this consumer.
+
+### Prerequisites
+
+- Docker and Docker Compose
+- Go 1.21+ (used to build small helper binaries)
+- A running local M3 Aggregator environment started via `scripts/development/m3_aggregator_local/start_m3.sh`
+
+### Relationship to `m3_aggregator_local`
+
+The aggregator local environment (`m3_aggregator_local`):
+
+- Starts `etcd` and an `m3coordinator` exposed at `http://localhost:7201`.
+- Boots one or more `m3aggregator` nodes and initializes their placement.
+- Ensures the m3msg topic (default `aggregated_metrics`) exists. Aggregators publish rollups to this topic via the `m3msg` dynamic backend.
+
+This consumer service (`m3_consumer_service`):
+
+- Joins the same Docker network as the aggregator environment (`m3_aggregator_local_backend`).
+- Seeds a consumer service placement for `local-consumer-service` pointing at `m3consumer01:9000`.
+- Adds `local-consumer-service` as a shared consumer of the `aggregated_metrics` topic.
+- Receives messages directly from the aggregator’s m3msg producer, routed by topic+placement metadata stored in etcd.
+
+High-level data flow:
+
+1. Raw metrics -> M3 Aggregator (TCP ingest).
+2. Aggregator computes rollups and publishes to m3msg topic (default `aggregated_metrics`).
+3. m3msg producers resolve consumer placement and connect to `m3consumer01:9000`.
+4. This service logs each metric and acknowledges receipt.
+
+### Quick start
+
+1. Start the aggregator environment (in another shell):
+   - From repo root: `scripts/development/m3_aggregator_local/start_m3.sh`
+
+2. Start the consumer service (in this directory):
+
+   - From repo root:
+     ```bash
+     cd scripts/development/m3_consumer_service
+     ./start_m3.sh
+     ```
+   - What this does:
+     - Builds a static `m3consumer` Linux binary.
+     - Builds and starts the `m3consumer01` container on port `9000`.
+     - Builds and runs `m3bootstrap`, which initializes topic and placement using `m3msg-bootstrap.yaml`.
+
+3. Verify it’s receiving data:
+   - View logs: `docker-compose logs -f m3consumer01`
+   - You should see `received metric` log lines once the aggregator begins flushing rollups.
+
+### Configuration
+
+- Consumer listen address:
+
+  - `LISTEN_ADDR` environment variable (default: `0.0.0.0:9000`). Set via `docker-compose.yml`.
+
+- Topic and placement bootstrapping (`m3msg-bootstrap.yaml`):
+
+  - `topics[0].name`: The m3msg topic name (default `aggregated_metrics`).
+  - `topics[0].consumers[*]`: Includes `local-consumer-service` as a SHARED consumer.
+  - `placements[0]`: Creates a placement for service `local-consumer-service` with an instance `m3consumer01` at `m3consumer01:9000`.
+  - `kv.endpoints`: Points to the local `etcd` (default `etcd01:2379`) from the aggregator stack.
+  - `coordinator.baseURL`: Coordinator admin API (default `http://localhost:7201`).
+
+- Aggregator publishing topic:
+  - In `scripts/development/m3_aggregator_local/m3aggregator.yml.template`, the producer writes to `topicName: {{TOPIC_NAME}}`.
+  - The start script sets `TOPIC_NAME` (default `aggregated_metrics`). Ensure it matches the topic created here.
+
+### Useful commands
+
+- Tail consumer logs:
+
+  ```bash
+  cd scripts/development/m3_consumer_service
+  docker-compose logs -f m3consumer01
+  ```
+
+- Stop consumer service:
+
+  ```bash
+  cd scripts/development/m3_consumer_service
+  docker-compose down
+  ```
+
+- Re-run bootstrap (idempotent; tolerates already-exists):
+  ```bash
+  cd scripts/development/m3_consumer_service
+  docker-compose run --rm bootstrap
+  ```
+
+### Directory contents
+
+- `start_m3.sh`: Builds and runs the consumer and bootstrap jobs via Docker Compose.
+- `docker-compose.yml`: Defines `m3consumer01` and a `bootstrap` job; connects to the aggregator’s Docker network `m3_aggregator_local_backend`.
+- `Dockerfile`: Minimal image that runs the prebuilt `m3consumer` binary on port `9000`.
+- `main.go`: The consumer program. Starts an m3msg server and logs received metrics.
+- `bootstrap/`: Small Go program that initializes m3msg topics and placements from YAML.
+- `m3msg-bootstrap.yaml`: Declarative config used by the bootstrap program.

--- a/scripts/development/m3_consumer_service/bootstrap/main.go
+++ b/scripts/development/m3_consumer_service/bootstrap/main.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	etcdcfg "github.com/m3db/m3/src/cluster/client/etcd"
+	"github.com/m3db/m3/src/cluster/kv"
+	"github.com/m3db/m3/src/cluster/placement"
+	"github.com/m3db/m3/src/cluster/services"
+	"github.com/m3db/m3/src/x/instrument"
+	"gopkg.in/yaml.v3"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	coordinatorHealthTimeout = 30 * time.Second
+)
+
+type KVConfig struct {
+	Zone      string   `yaml:"zone"`
+	Env       string   `yaml:"env"`
+	Endpoints []string `yaml:"endpoints"`
+}
+
+type CoordinatorConfig struct {
+	BaseURL     string `yaml:"baseURL"`
+	Environment string `yaml:"environment"`
+	Zone        string `yaml:"zone"`
+}
+
+type ServiceID struct {
+	Name        string `json:"name" yaml:"name"`
+	Environment string `json:"environment" yaml:"environment"`
+	Zone        string `json:"zone" yaml:"zone"`
+}
+
+type TopicConsumerConfig struct {
+	ServiceID       ServiceID `yaml:"serviceId"`
+	ConsumptionType string    `yaml:"consumptionType"`
+	MessageTTLNanos int64     `yaml:"messageTtlNanos"`
+}
+
+type TopicConfig struct {
+	Name           string                `yaml:"name"`
+	NumberOfShards int                   `yaml:"numberOfShards"`
+	Consumers      []TopicConsumerConfig `yaml:"consumers"`
+}
+
+type PlacementInstance struct {
+	ID             string `json:"id" yaml:"id"`
+	IsolationGroup string `json:"isolation_group" yaml:"isolationGroup"`
+	Zone           string `json:"zone" yaml:"zone"`
+	Weight         int    `json:"weight" yaml:"weight"`
+	Endpoint       string `json:"endpoint" yaml:"endpoint"`
+	Hostname       string `json:"hostname" yaml:"hostname"`
+	Port           int    `json:"port" yaml:"port"`
+}
+
+type PlacementConfig struct {
+	Service           string              `yaml:"service"`
+	NumShards         int                 `yaml:"numShards"`
+	ReplicationFactor int                 `yaml:"replicationFactor"`
+	Instances         []PlacementInstance `yaml:"instances"`
+}
+
+type Config struct {
+	KV          KVConfig          `yaml:"kv"`
+	Coordinator CoordinatorConfig `yaml:"coordinator"`
+	Topics      []TopicConfig     `yaml:"topics"`
+	Placements  []PlacementConfig `yaml:"placements"`
+}
+
+func (c *Config) newCoordinatorClientFromConfig() *coordinatorClient {
+	if c.Coordinator.BaseURL == "" {
+		fatalf("coordinator.baseURL must be set in config")
+	}
+	if c.Coordinator.Environment == "" {
+		fatalf("coordinator.environment must be set in config")
+	}
+	return NewCoordinatorClient(c.Coordinator.BaseURL, c.Coordinator.Environment, nil)
+}
+
+func (c *Config) newKvClientFromConfig() *kvClient {
+	if c.KV.Zone == "" {
+		fatalf("kv.zone must be set in config")
+	}
+	if c.KV.Env == "" {
+		fatalf("kv.env must be set in config")
+	}
+	if len(c.KV.Endpoints) == 0 {
+		fatalf("kv.endpoints must include at least one endpoint in config")
+	}
+	return NewKVClient(c.KV.Env, c.KV.Zone, c.KV.Endpoints)
+}
+
+func main() {
+	var cfgPath string
+	flag.StringVar(&cfgPath, "config", "./scripts/development/m3_consumer_service/m3msg-bootstrap.yaml", "bootstrap yaml path")
+	flag.Parse()
+
+	f, err := os.Open(cfgPath)
+	if err != nil {
+		fatalf("open config: %v", err)
+	}
+	defer f.Close()
+
+	var cfg Config
+	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
+		fatalf("decode yaml: %v", err)
+	}
+
+	client := cfg.newCoordinatorClientFromConfig()
+	ctx := context.Background()
+	deadline := time.Now().Add(coordinatorHealthTimeout)
+	for {
+		if time.Now().After(deadline) {
+			fatalf("coordinator health timeout")
+		}
+		if err := client.HealthCheck(ctx); err == nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
+	for _, t := range cfg.Topics {
+		// init topic if missing
+		exists, err := client.TopicExists(ctx, t.Name)
+		if err != nil {
+			fatalf("check topic exists: %v", err)
+		}
+		if !exists {
+			if err := client.InitTopic(ctx, t.Name, t.NumberOfShards); err != nil {
+				fatalf("init topic: %v", err)
+			}
+		}
+		// add consumers
+		for _, c := range t.Consumers {
+			if err := client.AddConsumer(ctx, t.Name, c.ServiceID, c.ConsumptionType, c.MessageTTLNanos); err != nil {
+				fatalf("add consumer: %v", err)
+			}
+		}
+	}
+
+	kvClient := cfg.newKvClientFromConfig()
+	for _, p := range cfg.Placements {
+		if err := kvClient.BootstrapPlacement(p); err != nil {
+			fatalf("create placement: %v", err)
+		}
+	}
+}
+
+// coordinatorClient wraps the M3 Coordinator HTTP API interactions.
+type coordinatorClient struct {
+	BaseURL string
+	Env     string
+	HTTP    *http.Client
+}
+
+// NewCoordinatorClient constructs a coordinator client using the provided baseURL
+// and environment.
+func NewCoordinatorClient(baseURL, environment string, httpClient *http.Client) *coordinatorClient {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &coordinatorClient{BaseURL: baseURL, Env: environment, HTTP: httpClient}
+}
+
+// HealthCheck checks the coordinator health endpoint and returns an error if not healthy.
+func (c *coordinatorClient) HealthCheck(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/health", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("healthcheck failed: status=%d body=%s", resp.StatusCode, string(b))
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// TopicExists checks if a topic exists.
+func (c *coordinatorClient) TopicExists(ctx context.Context, topicName string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/v1/topic", nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Topic-Name", topicName)
+	req.Header.Set("Cluster-Environment-Name", c.Env)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return false, fmt.Errorf("GET topic failed: status=%d body=%s", resp.StatusCode, string(body))
+}
+
+// InitTopic initializes a topic with number of shards.
+func (c *coordinatorClient) InitTopic(ctx context.Context, topicName string, numShards int) error {
+	body := map[string]any{"numberOfShards": numShards}
+	return c.makeReq(ctx, http.MethodPost, c.BaseURL+"/api/v1/topic/init", body, map[string]string{
+		"Topic-Name":               topicName,
+		"Cluster-Environment-Name": c.Env,
+	})
+}
+
+// AddConsumer adds a consumer service to a topic. Idempotent 409 is treated as success.
+func (c *coordinatorClient) AddConsumer(ctx context.Context, topicName string, serviceID ServiceID, consumptionType string, messageTTLNanos int64) error {
+	body := map[string]any{
+		"consumerService": map[string]any{
+			"serviceId": map[string]any{
+				"name":        serviceID.Name,
+				"environment": serviceID.Environment,
+				"zone":        serviceID.Zone,
+			},
+			"consumptionType": consumptionType,
+			"messageTtlNanos": messageTTLNanos,
+		},
+	}
+    if err := c.makeReq(ctx, http.MethodPost, c.BaseURL+"/api/v1/topic", body, map[string]string{
+		"Topic-Name":               topicName,
+		"Cluster-Environment-Name": c.Env,
+    }); err != nil {
+        // Treat already-consuming error as success (idempotent)
+        if strings.Contains(err.Error(), "already consuming the topic") {
+            return nil
+        }
+        return err
+    }
+    return nil
+}
+
+func (c *coordinatorClient) makeReq(ctx context.Context, method, url string, body any, headers map[string]string) error {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(b))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("request %s %s: %w", method, url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode != http.StatusConflict {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s %s failed: status=%d body=%s", method, url, resp.StatusCode, string(data))
+	}
+	return nil
+}
+
+type kvClient struct {
+	servicesClient services.Services
+	env            string
+	zone           string
+}
+
+func NewKVClient(env string, zone string, endpoints []string) *kvClient {
+	etcdClientCfg := etcdcfg.Configuration{
+		Zone:    zone,
+		Env:     env,
+		Service: "local-consumer-service-bootstrap",
+		ETCDClusters: []etcdcfg.ClusterConfig{
+			{Zone: zone, Endpoints: endpoints},
+		},
+	}
+	csClient, err := etcdClientCfg.NewClient(instrument.NewOptions())
+	if err != nil {
+		fatalf("create etcd config service client: %v", err)
+	}
+	servicesClient, err := csClient.Services(nil)
+	if err != nil {
+		fatalf("create services client: %v", err)
+	}
+	return &kvClient{servicesClient: servicesClient, env: env, zone: zone}
+}
+
+func (c *kvClient) BootstrapPlacement(p PlacementConfig) error {
+	sid := services.NewServiceID().
+		SetName(p.Service).
+		SetEnvironment(c.env).
+		SetZone(c.zone)
+
+	popts := placement.NewOptions().SetValidZone(c.zone)
+
+	psvc, err := c.servicesClient.PlacementService(sid, popts)
+	if err != nil {
+		return fmt.Errorf("placement service for %s: %v", p.Service, err)
+	}
+
+	// If a placement already exists, treat as success (idempotent bootstrap)
+	if _, err := psvc.Placement(); err == nil {
+		return nil
+	} else if !errors.Is(err, kv.ErrNotFound) {
+		return fmt.Errorf("get existing placement: %v", err)
+	}
+
+	// Convert instances
+	insts := make([]placement.Instance, 0, len(p.Instances))
+	for _, in := range p.Instances {
+		pi, err := placement.NewInstance().
+			SetID(in.ID).
+			SetIsolationGroup(in.IsolationGroup).
+			SetZone(in.Zone).
+			SetWeight(uint32(in.Weight)).
+			SetEndpoint(in.Endpoint).
+			SetHostname(in.Hostname).
+			SetPort(uint32(in.Port)).Proto()
+		if err != nil {
+			return fmt.Errorf("build instance proto %s: %v", in.ID, err)
+		}
+		// Convert back to placement.Instance from proto to ensure consistency
+		inst, err := placement.NewInstanceFromProto(pi)
+		if err != nil {
+			return fmt.Errorf("build instance %s: %v", in.ID, err)
+		}
+		insts = append(insts, inst)
+	}
+
+	_, err = psvc.BuildInitialPlacement(insts, p.NumShards, p.ReplicationFactor)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/scripts/development/m3_consumer_service/docker-compose.yml
+++ b/scripts/development/m3_consumer_service/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.5"
+services:
+  m3consumer01:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    image: m3consumer:dev
+    ports:
+      - "0.0.0.0:9000:9000"
+    networks:
+      - m3_aggregator_local_backend
+    environment:
+      - LISTEN_ADDR=0.0.0.0:9000
+
+  bootstrap:
+    image: alpine:latest
+    working_dir: /work
+    volumes:
+      - ./:/work
+    command: ["./bin/m3bootstrap", "-config", "./m3msg-bootstrap.yaml"]
+    networks:
+      - m3_aggregator_local_backend
+    depends_on:
+      - m3consumer01
+
+networks:
+  m3_aggregator_local_backend:
+    external: true

--- a/scripts/development/m3_consumer_service/m3msg-bootstrap.yaml
+++ b/scripts/development/m3_consumer_service/m3msg-bootstrap.yaml
@@ -1,0 +1,34 @@
+kv:
+  zone: embedded
+  env: default_env
+  endpoints:
+    - etcd01:2379
+
+coordinator:
+  baseURL: http://m3coordinator01:7201
+  environment: default_env
+  zone: embedded
+
+topics:
+  - name: aggregated_metrics
+    numberOfShards: 64
+    consumers:
+      - serviceId:
+          name: local-consumer-service
+          environment: default_env
+          zone: embedded
+        consumptionType: SHARED
+        messageTtlNanos: 600000000000
+
+placements:
+  - service: local-consumer-service
+    numShards: 64
+    replicationFactor: 1
+    instances:
+      - id: m3consumer01
+        isolationGroup: rack-a
+        zone: embedded
+        weight: 1024
+        endpoint: m3consumer01:9000
+        hostname: m3consumer01
+        port: 9000

--- a/scripts/development/m3_consumer_service/main.go
+++ b/scripts/development/m3_consumer_service/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+
+	m3msgserver "github.com/m3db/m3/src/cmd/services/m3coordinator/server/m3msg"
+	"github.com/m3db/m3/src/metrics/policy"
+	"github.com/m3db/m3/src/msg/consumer"
+	"github.com/m3db/m3/src/x/instrument"
+	xio "github.com/m3db/m3/src/x/io"
+	"github.com/m3db/m3/src/x/pool"
+	"github.com/m3db/m3/src/x/server"
+)
+
+func main() {
+	log.Println("Starting M3 Aggregator Consumer Service...")
+
+	// Listen address - this is where m3aggregator will send aggregated metrics
+	listenAddr := "localhost:9000"
+	if addr := os.Getenv("LISTEN_ADDR"); addr != "" {
+		listenAddr = addr
+	}
+
+	// Create instrument options
+	instrumentOpts := instrument.NewOptions()
+	logger := instrumentOpts.Logger()
+
+	// Create IO options
+	ioOpts := xio.NewOptions()
+
+	// Define our write function that will handle incoming metrics
+	writeFn := func(
+		ctx context.Context,
+		id []byte,
+		metricNanos, encodeNanos int64,
+		value float64,
+		annotation []byte,
+		sp policy.StoragePolicy,
+		callback m3msgserver.Callbackable,
+	) {
+		timestamp := time.Unix(0, metricNanos)
+
+		logger.Info("received metric",
+			zap.ByteString("id", id),
+			zap.Float64("value", value),
+			zap.Time("timestamp", timestamp),
+			zap.String("storage_policy", sp.String()),
+			zap.ByteString("annotation", annotation))
+
+		// Here you could forward to other systems, store to DB, etc.
+		// For now, we just log the metrics
+
+		// Always call the callback to acknowledge processing
+		if callback != nil {
+			callback.Callback(m3msgserver.OnSuccess)
+		}
+	}
+
+	// Create m3msg server configuration using reflection of the internal handlerConfiguration struct
+	config := m3msgserver.Configuration{
+		Server: server.Configuration{
+			ListenAddress: listenAddr,
+		},
+		Handler: struct {
+			ProtobufDecoderPool pool.ObjectPoolConfiguration `yaml:"protobufDecoderPool"`
+			BlackholePolicies   []policy.StoragePolicy       `yaml:"blackholePolicies"`
+		}{
+			ProtobufDecoderPool: pool.ObjectPoolConfiguration{},
+			BlackholePolicies:   []policy.StoragePolicy{},
+		},
+		Consumer: consumer.Configuration{},
+	}
+
+	// Create the server
+	srv, err := config.NewServer(writeFn, ioOpts, instrumentOpts)
+	if err != nil {
+		log.Fatalf("Failed to create server: %v", err)
+	}
+
+	log.Printf("Consumer service starting on %s", listenAddr)
+
+	// Start the server
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("Failed to start server: %v", err)
+	}
+
+	// Set up graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Wait for shutdown signal
+	<-sigChan
+	log.Println("Shutting down consumer service...")
+
+	// Stop the server
+	srv.Close()
+
+	log.Println("Consumer service stopped")
+}

--- a/scripts/development/m3_consumer_service/start_m3.sh
+++ b/scripts/development/m3_consumer_service/start_m3.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -xe
+
+echo "Starting M3 Consumer Service..."
+
+echo "Building m3consumer linux binary"
+mkdir -p ./bin
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/m3consumer ./main.go
+
+docker-compose build
+
+docker-compose up -d
+
+echo "Building m3bootstrap linux binary"
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin/m3bootstrap ./bootstrap
+
+echo "Seeding m3msg topics and placements from m3_consumer_service/m3msg-bootstrap.yaml"
+docker-compose run --rm bootstrap
+
+echo "Consumer service started!"
+echo "- Consumer endpoint: localhost:9000"
+echo "- View logs: docker-compose logs -f m3consumer01"
+echo "- Stop: docker-compose down"

--- a/scripts/development/m3_consumer_service/stop_m3.sh
+++ b/scripts/development/m3_consumer_service/stop_m3.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -xe
+
+echo "Stopping M3 Consumer Service..."
+
+# Stop and remove the consumer
+docker-compose down
+
+echo "Consumer service stopped!"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a simple local m3msg consumer service and bootstrap tooling to enable end-to-end testing of aggregated metrics emitted by the local M3 Aggregator.

- Introduces `scripts/development/m3_consumer_service/` with a minimal consumer (`main.go`) that listens on `0.0.0.0:9000`, logs received aggregated metrics, and acknowledges them.
- Adds a bootstrap utility (`bootstrap/main.go` + `m3msg-bootstrap.yaml`) that:
  - Ensures the `aggregated_metrics` topic exists.
  - Adds `local-consumer-service` as a SHARED consumer.
  - Bootstraps a placement with instance `m3consumer01:9000`.
- Updates `scripts/development/m3_aggregator_local/m3aggregator.yml.template` to use an m3msg dynamic backend and publish to a configurable topic (`{{TOPIC_NAME}}`), with `start_m3.sh` wiring and a default of `aggregated_metrics`. Also ensures the topic exists via coordinator API.
- Provides Dockerfile and `docker-compose.yml` to run the consumer and bootstrap on the same network as the aggregator dev stack, plus helper scripts `start_m3.sh` and `stop_m3.sh`.

This improves local development by making it easy to observe, validate, and iterate on aggregator rollups without additional infrastructure.

Fixes #

**Special notes for your reviewer**:
- Dev-only change; no production paths modified.
- Bootstrapping is idempotent (existing topic/consumer/placement are tolerated).
- Default topic name is `aggregated_metrics`; can be overridden via `TOPIC_NAME` in `m3_aggregator_local/start_m3.sh`.
- Consumer exposes port `9000` and joins the `m3_aggregator_local_backend` network.

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
```release-note
NONE
```

**Does this PR require updating code package or user-facing documentation?**:
```documentation-note
Added `scripts/development/m3_consumer_service/README.md` with setup and usage instructions for the local consumer.
```