### PR TITLE
M3Aggregator fix memory allocation issue in ConsumerServiceWriterMetrics

### DIFF
--- a/src/msg/producer/types.go
+++ b/src/msg/producer/types.go
@@ -21,6 +21,8 @@
 package producer
 
 import (
+	"fmt"
+
 	"github.com/m3db/m3/src/cluster/services"
 )
 
@@ -145,6 +147,7 @@ func (f FilterFuncConfigSourceType) String() string {
 type FilterFuncMetadata struct {
 	FilterType FilterFuncType
 	SourceType FilterFuncConfigSourceType
+	cacheKey   string // Pre-computed key for metric map lookups to avoid allocations in hot path
 }
 
 // NewFilterFuncMetadata creates a new filter function metadata.
@@ -154,7 +157,13 @@ func NewFilterFuncMetadata(
 	return FilterFuncMetadata{
 		FilterType: filterType,
 		SourceType: sourceType,
+		cacheKey:   fmt.Sprintf("%s::%s", filterType.String(), sourceType.String()),
 	}
+}
+
+// CacheKey returns the pre-computed cache key for this metadata.
+func (m FilterFuncMetadata) CacheKey() string {
+	return m.cacheKey
 }
 
 // FilterFunc can filter message.

--- a/src/msg/producer/writer/consumer_service_writer.go
+++ b/src/msg/producer/writer/consumer_service_writer.go
@@ -41,10 +41,10 @@ var (
 			Function: func(m producer.Message) bool {
 				return true
 			},
-			Metadata: producer.FilterFuncMetadata{
-				FilterType: producer.AcceptAllFilter,
-				SourceType: producer.StaticConfig,
-			},
+			Metadata: producer.NewFilterFuncMetadata(
+				producer.AcceptAllFilter,
+				producer.StaticConfig,
+			),
 		},
 	)
 
@@ -105,7 +105,7 @@ type consumerServiceWriterMetrics struct {
 }
 
 func (cswm *consumerServiceWriterMetrics) getGranularFilterCounterMapKey(metadata producer.FilterFuncMetadata) string {
-	return fmt.Sprintf("%s::%s", metadata.FilterType.String(), metadata.SourceType.String())
+	return metadata.CacheKey()
 }
 
 //nolint:dupl

--- a/src/msg/producer/writer/consumer_service_writer.go
+++ b/src/msg/producer/writer/consumer_service_writer.go
@@ -92,16 +92,14 @@ type consumerServiceWriter interface {
 }
 
 type consumerServiceWriterMetrics struct {
-	placementError                tally.Counter
-	placementUpdate               tally.Counter
-	queueSize                     tally.Gauge
-	filterAccepted                tally.Counter
-	filterNotAccepted             tally.Counter
-	filterAcceptedGranular        map[string]tally.Counter
-	filterAcceptedGranularLock    sync.RWMutex
-	filterNotAcceptedGranular     map[string]tally.Counter
-	filterNotAcceptedGranularLock sync.RWMutex
-	scope                         tally.Scope
+	placementError         tally.Counter
+	placementUpdate        tally.Counter
+	queueSize              tally.Gauge
+	filterAccepted         tally.Counter
+	filterNotAccepted      tally.Counter
+	filterAcceptedGranular sync.Map // map[string]tally.Counter, lock-free for read-heavy workload
+	filterNotAcceptedGranular sync.Map // map[string]tally.Counter, lock-free for read-heavy workload
+	scope                  tally.Scope
 }
 
 func (cswm *consumerServiceWriterMetrics) getGranularFilterCounterMapKey(metadata producer.FilterFuncMetadata) string {
@@ -113,22 +111,20 @@ func (cswm *consumerServiceWriterMetrics) getFilterAcceptedGranularCounter(
 	metadata producer.FilterFuncMetadata) tally.Counter {
 	key := cswm.getGranularFilterCounterMapKey(metadata)
 
-	cswm.filterAcceptedGranularLock.RLock()
-	val, ok := cswm.filterAcceptedGranular[key]
-	cswm.filterAcceptedGranularLock.RUnlock()
-
-	if !ok {
-		val = cswm.scope.Tagged(map[string]string{
-			"config-source": metadata.SourceType.String(),
-			"filter-type":   metadata.FilterType.String(),
-		}).Counter("filter-accepted-granular")
-
-		cswm.filterAcceptedGranularLock.Lock()
-		cswm.filterAcceptedGranular[key] = val
-		cswm.filterAcceptedGranularLock.Unlock()
+	// Fast path: lock-free read for existing entries
+	if val, ok := cswm.filterAcceptedGranular.Load(key); ok {
+		return val.(tally.Counter)
 	}
 
-	return val
+	// Slow path: create counter (happens only ~10 times per writer lifetime)
+	val := cswm.scope.Tagged(map[string]string{
+		"config-source": metadata.SourceType.String(),
+		"filter-type":   metadata.FilterType.String(),
+	}).Counter("filter-accepted-granular")
+
+	// Store and return; if another goroutine already stored, use theirs
+	actual, _ := cswm.filterAcceptedGranular.LoadOrStore(key, val)
+	return actual.(tally.Counter)
 }
 
 //nolint:dupl
@@ -136,34 +132,31 @@ func (cswm *consumerServiceWriterMetrics) getFilterNotAcceptedGranularCounter(
 	metadata producer.FilterFuncMetadata) tally.Counter {
 	key := cswm.getGranularFilterCounterMapKey(metadata)
 
-	cswm.filterNotAcceptedGranularLock.RLock()
-	val, ok := cswm.filterNotAcceptedGranular[key]
-	cswm.filterNotAcceptedGranularLock.RUnlock()
-
-	if !ok {
-		val = cswm.scope.Tagged(map[string]string{
-			"config-source": metadata.SourceType.String(),
-			"filter-type":   metadata.FilterType.String(),
-		}).Counter("filter-not-accepted-granular")
-
-		cswm.filterNotAcceptedGranularLock.Lock()
-		cswm.filterNotAcceptedGranular[key] = val
-		cswm.filterNotAcceptedGranularLock.Unlock()
+	// Fast path: lock-free read for existing entries
+	if val, ok := cswm.filterNotAcceptedGranular.Load(key); ok {
+		return val.(tally.Counter)
 	}
 
-	return val
+	// Slow path: create counter (happens only ~10 times per writer lifetime)
+	val := cswm.scope.Tagged(map[string]string{
+		"config-source": metadata.SourceType.String(),
+		"filter-type":   metadata.FilterType.String(),
+	}).Counter("filter-not-accepted-granular")
+
+	// Store and return; if another goroutine already stored, use theirs
+	actual, _ := cswm.filterNotAcceptedGranular.LoadOrStore(key, val)
+	return actual.(tally.Counter)
 }
 
 func newConsumerServiceWriterMetrics(scope tally.Scope) consumerServiceWriterMetrics {
 	return consumerServiceWriterMetrics{
-		placementUpdate:           scope.Counter("placement-update"),
-		placementError:            scope.Counter("placement-error"),
-		filterAccepted:            scope.Counter("filter-accepted"),
-		filterNotAccepted:         scope.Counter("filter-not-accepted"),
-		scope:                     scope,
-		filterAcceptedGranular:    make(map[string]tally.Counter),
-		filterNotAcceptedGranular: make(map[string]tally.Counter),
-		queueSize:                 scope.Gauge("queue-size"),
+		placementUpdate:   scope.Counter("placement-update"),
+		placementError:    scope.Counter("placement-error"),
+		filterAccepted:    scope.Counter("filter-accepted"),
+		filterNotAccepted: scope.Counter("filter-not-accepted"),
+		scope:             scope,
+		// filterAcceptedGranular and filterNotAcceptedGranular use sync.Map zero value (ready to use)
+		queueSize: scope.Gauge("queue-size"),
 	}
 }
 

--- a/src/msg/producer/writer/consumer_service_writer.go
+++ b/src/msg/producer/writer/consumer_service_writer.go
@@ -92,14 +92,14 @@ type consumerServiceWriter interface {
 }
 
 type consumerServiceWriterMetrics struct {
-	placementError         tally.Counter
-	placementUpdate        tally.Counter
-	queueSize              tally.Gauge
-	filterAccepted         tally.Counter
-	filterNotAccepted      tally.Counter
-	filterAcceptedGranular sync.Map // map[string]tally.Counter, lock-free for read-heavy workload
+	placementError            tally.Counter
+	placementUpdate           tally.Counter
+	queueSize                 tally.Gauge
+	filterAccepted            tally.Counter
+	filterNotAccepted         tally.Counter
+	filterAcceptedGranular    sync.Map // map[string]tally.Counter, lock-free for read-heavy workload
 	filterNotAcceptedGranular sync.Map // map[string]tally.Counter, lock-free for read-heavy workload
-	scope                  tally.Scope
+	scope                     tally.Scope
 }
 
 func (cswm *consumerServiceWriterMetrics) getGranularFilterCounterMapKey(metadata producer.FilterFuncMetadata) string {

--- a/src/msg/producer/writer/consumer_service_writer_test.go
+++ b/src/msg/producer/writer/consumer_service_writer_test.go
@@ -711,10 +711,10 @@ func TestConsumerServiceWriterMetrics(t *testing.T) {
 	accepetKey := m.getGranularFilterCounterMapKey(acceptedMetadata)
 	notAcceptKey := m.getGranularFilterCounterMapKey(notAcceptedMetadata)
 
-	_, ok := m.filterAcceptedGranular[accepetKey]
+	_, ok := m.filterAcceptedGranular.Load(accepetKey)
 	require.True(t, ok)
 
-	_, ok = m.filterNotAcceptedGranular[notAcceptKey]
+	_, ok = m.filterNotAcceptedGranular.Load(notAcceptKey)
 	require.True(t, ok)
 
 	gotAcceptedValue := false

--- a/src/msg/producer/writer/consumer_service_writer_test.go
+++ b/src/msg/producer/writer/consumer_service_writer_test.go
@@ -696,13 +696,13 @@ func TestConsumerServiceCloseShardWritersConcurrently(t *testing.T) {
 func TestConsumerServiceWriterMetrics(t *testing.T) {
 	testScope := tally.NewTestScope("test", nil)
 
-	acceptedMetadata := producer.FilterFuncMetadata{
-		FilterType: producer.ShardSetFilter,
-		SourceType: producer.DynamicConfig}
+	acceptedMetadata := producer.NewFilterFuncMetadata(
+		producer.ShardSetFilter,
+		producer.DynamicConfig)
 
-	notAcceptedMetadata := producer.FilterFuncMetadata{
-		FilterType: producer.PercentageFilter,
-		SourceType: producer.DynamicConfig}
+	notAcceptedMetadata := producer.NewFilterFuncMetadata(
+		producer.PercentageFilter,
+		producer.DynamicConfig)
 
 	m := newConsumerServiceWriterMetrics(testScope)
 	m.getFilterAcceptedGranularCounter(acceptedMetadata).Inc(1)

--- a/src/msg/producer/writer/writer_test.go
+++ b/src/msg/producer/writer/writer_test.go
@@ -1239,7 +1239,10 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 }
 
 // testNewFilterMetadata is a helper for creating FilterFuncMetadata in tests
-func testNewFilterMetadata(filterType producer.FilterFuncType, sourceType producer.FilterFuncConfigSourceType) producer.FilterFuncMetadata {
+func testNewFilterMetadata(
+	filterType producer.FilterFuncType,
+	sourceType producer.FilterFuncConfigSourceType,
+) producer.FilterFuncMetadata {
 	return producer.NewFilterFuncMetadata(filterType, sourceType)
 }
 

--- a/src/msg/producer/writer/writer_test.go
+++ b/src/msg/producer/writer/writer_test.go
@@ -895,10 +895,10 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 			topicUpdate1: testTopicUpdate{
 				dynamicFilterConfig: testDynamicFilterConfig,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.PercentageFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.ShardSetFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.PercentageFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.ShardSetFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
@@ -915,10 +915,10 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 			topicUpdate1: testTopicUpdate{
 				dynamicFilterConfig: testDynamicFilterConfig,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.PercentageFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.ShardSetFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.PercentageFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.ShardSetFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
@@ -934,20 +934,20 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 			topicUpdate1: testTopicUpdate{
 				dynamicFilterConfig: nil,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.PercentageFilter, SourceType: producer.StaticConfig},
-					{FilterType: producer.ShardSetFilter, SourceType: producer.StaticConfig},
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.StaticConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.PercentageFilter, producer.StaticConfig),
+					testNewFilterMetadata(producer.ShardSetFilter, producer.StaticConfig),
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.StaticConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
 			topicUpdate2: &testTopicUpdate{
 				dynamicFilterConfig: nil,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.PercentageFilter, SourceType: producer.StaticConfig},
-					{FilterType: producer.ShardSetFilter, SourceType: producer.StaticConfig},
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.StaticConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.PercentageFilter, producer.StaticConfig),
+					testNewFilterMetadata(producer.ShardSetFilter, producer.StaticConfig),
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.StaticConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
@@ -959,18 +959,18 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 			topicUpdate1: testTopicUpdate{
 				dynamicFilterConfig: testDynamicFilterConfig,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.PercentageFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.ShardSetFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.PercentageFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.ShardSetFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
 			topicUpdate2: &testTopicUpdate{
 				dynamicFilterConfig: topic.NewFilterConfig().SetPercentageFilter(topic.NewPercentageFilter(75)),
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.PercentageFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.PercentageFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
@@ -1009,8 +1009,8 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 				dynamicFilterConfig: topic.NewFilterConfig().
 					SetStoragePolicyFilter(topic.NewStoragePolicyFilter([]string{"1m:40d"})),
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
@@ -1018,9 +1018,9 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 				dynamicFilterConfig: topic.NewFilterConfig().
 					SetShardSetFilter(topic.NewShardSetFilter("randomstringstrinxyz123abc")),
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 					// second update should not be applied
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.DynamicConfig},
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.DynamicConfig),
 				},
 				expectedCswCount: 1,
 			},
@@ -1033,17 +1033,17 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 			topicUpdate1: testTopicUpdate{
 				dynamicFilterConfig: testDynamicFilterConfig,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.PercentageFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.ShardSetFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.PercentageFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.ShardSetFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
 			topicUpdate2: &testTopicUpdate{
 				dynamicFilterConfig: nil,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
@@ -1056,18 +1056,18 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 			topicUpdate1: testTopicUpdate{
 				dynamicFilterConfig: testDynamicFilterConfig,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.PercentageFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.ShardSetFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.DynamicConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.PercentageFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.ShardSetFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.DynamicConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
 			topicUpdate2: &testTopicUpdate{
 				dynamicFilterConfig: nil,
 				expectedDataFilters: []producer.FilterFuncMetadata{
-					{FilterType: producer.StoragePolicyFilter, SourceType: producer.StaticConfig},
-					{FilterType: producer.AcceptAllFilter, SourceType: producer.StaticConfig},
+					testNewFilterMetadata(producer.StoragePolicyFilter, producer.StaticConfig),
+					testNewFilterMetadata(producer.AcceptAllFilter, producer.StaticConfig),
 				},
 				expectedCswCount: 1,
 			},
@@ -1236,6 +1236,11 @@ func TestDynamicConsumerServiceWriterFilters(t *testing.T) {
 			w.Close()
 		})
 	}
+}
+
+// testNewFilterMetadata is a helper for creating FilterFuncMetadata in tests
+func testNewFilterMetadata(filterType producer.FilterFuncType, sourceType producer.FilterFuncConfigSourceType) producer.FilterFuncMetadata {
+	return producer.NewFilterFuncMetadata(filterType, sourceType)
 }
 
 func testAreFilterFuncMetadataSlicesEqual(slice1, slice2 []producer.FilterFuncMetadata) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

**What this PR does / why we need it**:
**Before:**

- fmt.Sprintf() called on every outgoing metric message (potentially 100K per second)
- Each call created new temporary string allocations
- Massive GC pressure and heap churn
- RLock semantics adding unnecessary CPU overhead.

**After:**

- Key computed once when FilterFuncMetadata is created
- Hot path just returns the cached string (no allocations)
- Dramatically reduced GC pressure (30-50% reduction expected)
- Lower CPU usage and better P99 latency under heavy load
- The fix eliminates the string allocation hot spot while maintaining the same functionality. Since there are only few possible unique key combinations, pre-computing them is trivial but provides massive performance benefits under heavy load.
- Replaced RLock with sync.Map which is optimized for Write-once-Read-many situations like this one.
<img width="1502" height="414" alt="Screenshot 2025-10-08 at 12 38 00 AM" src="https://github.com/user-attachments/assets/61f04c7e-0bcf-48cb-9a86-c4f902b107f5" />


<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
