### PR TITLE
[m3db-client] Circuit breaker: break only on timeout errors

### DIFF
--- a/src/dbnode/client/circuitbreaker/middleware/metrics.go
+++ b/src/dbnode/client/circuitbreaker/middleware/metrics.go
@@ -5,17 +5,19 @@ import (
 )
 
 type circuitBreakerMetrics struct {
-	rejects       tally.Counter
-	shadowRejects tally.Counter
-	successes     tally.Counter
-	failures      tally.Counter
+	rejects          tally.Counter
+	shadowRejects    tally.Counter
+	successes        tally.Counter
+	failures         tally.Counter
+	filteredFailures tally.Counter
 }
 
 func newMetrics(scope tally.Scope, host string) *circuitBreakerMetrics {
 	return &circuitBreakerMetrics{
-		successes:     scope.Tagged(map[string]string{"host": host}).Counter("circuit_breaker_successes"),
-		failures:      scope.Tagged(map[string]string{"host": host}).Counter("circuit_breaker_failures"),
-		rejects:       scope.Tagged(map[string]string{"host": host, "mode": "live"}).Counter("circuit_breaker_rejects"),
-		shadowRejects: scope.Tagged(map[string]string{"host": host, "mode": "shadow"}).Counter("circuit_breaker_rejects"),
+		successes:        scope.Tagged(map[string]string{"host": host}).Counter("circuit_breaker_successes"),
+		failures:         scope.Tagged(map[string]string{"host": host}).Counter("circuit_breaker_failures"),
+		filteredFailures: scope.Tagged(map[string]string{"host": host}).Counter("circuit_breaker_filtered_failures"),
+		rejects:          scope.Tagged(map[string]string{"host": host, "mode": "live"}).Counter("circuit_breaker_rejects"),
+		shadowRejects:    scope.Tagged(map[string]string{"host": host, "mode": "shadow"}).Counter("circuit_breaker_rejects"),
 	}
 }

--- a/src/dbnode/client/circuitbreaker/middleware/middleware.go
+++ b/src/dbnode/client/circuitbreaker/middleware/middleware.go
@@ -14,13 +14,14 @@ import (
 
 // client is a client that wraps a TChannel client with a circuit breaker.
 type client struct {
-	logger    *zap.Logger
-	circuit   *circuitbreaker.Circuit
-	metrics   *circuitBreakerMetrics
-	host      string
-	next      rpc.TChanNode
-	provider  EnableProvider
-	lastError atomic.Value // stores *error atomically
+	logger      *zap.Logger
+	circuit     *circuitbreaker.Circuit
+	metrics     *circuitBreakerMetrics
+	host        string
+	next        rpc.TChanNode
+	provider    EnableProvider
+	errorFilter func(error) bool // returns true if the error should trip the circuit breaker
+	lastError   atomic.Value     // stores *error atomically
 }
 
 // M3DBMiddleware is a function that takes a TChannel client and returns a circuit breaker client interface.
@@ -45,6 +46,9 @@ type Params struct {
 	Scope          tally.Scope
 	Host           string
 	EnableProvider EnableProvider
+	// ErrorFilter returns true if the error should be considered a circuit breaker
+	// failure. If nil, all errors are considered failures (backward-compatible default).
+	ErrorFilter func(error) bool
 }
 
 // New creates a new circuit breaker middleware.
@@ -58,12 +62,13 @@ func New(params Params) (M3DBMiddleware, error) {
 
 	return func(next rpc.TChanNode) Client {
 		return &client{
-			next:     next,
-			logger:   params.Logger,
-			host:     params.Host,
-			metrics:  newMetrics(params.Scope, params.Host),
-			circuit:  c,
-			provider: params.EnableProvider,
+			next:        next,
+			logger:      params.Logger,
+			host:        params.Host,
+			metrics:     newMetrics(params.Scope, params.Host),
+			circuit:     c,
+			provider:    params.EnableProvider,
+			errorFilter: params.ErrorFilter,
 		}
 	}, nil
 }
@@ -96,17 +101,24 @@ func withBreaker[T any](c *client, ctx thrift.Context, req T, call func(thrift.C
 
 	// Execute the request and update metrics
 	err := call(ctx, req)
+	isCBFailure := err != nil
+	if isCBFailure && c.errorFilter != nil {
+		isCBFailure = c.errorFilter(err)
+	}
+
 	if err == nil {
 		c.metrics.successes.Inc(1)
 	} else {
 		c.metrics.failures.Inc(1)
-		// Store the last error for potential use when circuit breaker is open
-		c.lastError.Store(&err)
+		if isCBFailure {
+			c.lastError.Store(&err)
+			c.metrics.filteredFailures.Inc(1)
+		}
 	}
 
 	// Report request status to circuit breaker
 	if isAllowed {
-		c.circuit.ReportRequestStatus(err == nil)
+		c.circuit.ReportRequestStatus(!isCBFailure)
 	}
 	return err
 }

--- a/src/dbnode/client/circuitbreaker/middleware/middleware_test.go
+++ b/src/dbnode/client/circuitbreaker/middleware/middleware_test.go
@@ -361,3 +361,157 @@ func TestClient_NilProvider(t *testing.T) {
 	err = node.WriteBatchRaw(ctx, &rpc.WriteBatchRawRequest{})
 	assert.NoError(t, err, "Should not panic with nil provider")
 }
+
+func TestClient_ErrorFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	timeoutErr := errors.New("timeout error")
+	nonTimeoutErr := errors.New("bad request error")
+
+	// Filter that only considers timeout errors as CB failures
+	timeoutFilter := func(err error) bool {
+		return err != nil && err.Error() == "timeout error"
+	}
+
+	tests := []struct {
+		name           string
+		errorFilter    func(error) bool
+		mockError      error
+		expectCBTrip   bool
+		expectFiltered bool
+	}{
+		{
+			name:           "nil filter - all errors trip CB",
+			errorFilter:    nil,
+			mockError:      nonTimeoutErr,
+			expectCBTrip:   true,
+			expectFiltered: false,
+		},
+		{
+			name:           "with filter - timeout error trips CB",
+			errorFilter:    timeoutFilter,
+			mockError:      timeoutErr,
+			expectCBTrip:   true,
+			expectFiltered: true,
+		},
+		{
+			name:           "with filter - non-timeout error does NOT trip CB",
+			errorFilter:    timeoutFilter,
+			mockError:      nonTimeoutErr,
+			expectCBTrip:   false,
+			expectFiltered: true,
+		},
+		{
+			name:           "with filter - success does not trip CB",
+			errorFilter:    timeoutFilter,
+			mockError:      nil,
+			expectCBTrip:   false,
+			expectFiltered: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := Params{
+				Config:         newTestConfig(),
+				Logger:         zap.NewNop(),
+				Scope:          tally.NoopScope,
+				Host:           "test-host",
+				EnableProvider: newTestEnableProvider(true, false),
+				ErrorFilter:    tt.errorFilter,
+			}
+
+			middlewareFn, err := New(params)
+			require.NoError(t, err)
+
+			mockNode := rpc.NewMockTChanNode(ctrl)
+			// First call returns the configured error
+			mockNode.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Return(tt.mockError)
+			if !tt.expectCBTrip {
+				// If CB should NOT trip, second call should also go through
+				mockNode.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Return(nil)
+			}
+
+			clientInterface := middlewareFn(mockNode)
+			ctx, cancel := thrift.NewContext(time.Second)
+			defer cancel()
+
+			node, ok := clientInterface.(rpc.TChanNode)
+			require.True(t, ok)
+
+			// First request
+			err = node.WriteBatchRaw(ctx, &rpc.WriteBatchRawRequest{})
+			if tt.mockError != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Check circuit breaker state
+			clientImpl, ok := clientInterface.(*client)
+			require.True(t, ok)
+
+			if tt.expectCBTrip {
+				assert.Equal(t, circuitbreaker.Unhealthy, clientImpl.circuit.Status().State(),
+					"circuit breaker should be in unhealthy state")
+			} else {
+				assert.Equal(t, circuitbreaker.Healthy, clientImpl.circuit.Status().State(),
+					"circuit breaker should remain healthy")
+				// Verify second request goes through
+				err = node.WriteBatchRaw(ctx, &rpc.WriteBatchRawRequest{})
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestClient_ErrorFilter_LastErrorOnlyStoredForFilteredErrors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	timeoutErr := errors.New("timeout error")
+	nonTimeoutErr := errors.New("bad request error")
+
+	timeoutFilter := func(err error) bool {
+		return err != nil && err.Error() == "timeout error"
+	}
+
+	params := Params{
+		Config:         newTestConfig(),
+		Logger:         zap.NewNop(),
+		Scope:          tally.NoopScope,
+		Host:           "test-host",
+		EnableProvider: newTestEnableProvider(true, false),
+		ErrorFilter:    timeoutFilter,
+	}
+
+	// Use high minimum requests so CB doesn't trip on a single error
+	params.Config.CircuitBreakerConfig.MinimumRequests = 1000
+
+	middlewareFn, err := New(params)
+	require.NoError(t, err)
+
+	mockNode := rpc.NewMockTChanNode(ctrl)
+	// First call: non-timeout error (should NOT update lastError)
+	mockNode.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Return(nonTimeoutErr)
+	// Second call: timeout error (should update lastError)
+	mockNode.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Return(timeoutErr)
+
+	clientInterface := middlewareFn(mockNode)
+	ctx, cancel := thrift.NewContext(time.Second)
+	defer cancel()
+
+	node := clientInterface.(rpc.TChanNode)
+	clientImpl := clientInterface.(*client)
+
+	// First request: non-timeout error — lastError should NOT be set
+	_ = node.WriteBatchRaw(ctx, &rpc.WriteBatchRawRequest{})
+	assert.Nil(t, clientImpl.lastError.Load(), "lastError should not be set for non-timeout errors")
+
+	// Second request: timeout error — lastError should be set
+	_ = node.WriteBatchRaw(ctx, &rpc.WriteBatchRawRequest{})
+	assert.NotNil(t, clientImpl.lastError.Load(), "lastError should be set for timeout errors")
+	storedErr := clientImpl.lastError.Load().(*error)
+	assert.Equal(t, "timeout error", (*storedErr).Error())
+}

--- a/src/dbnode/client/host_queue.go
+++ b/src/dbnode/client/host_queue.go
@@ -105,6 +105,7 @@ func newHostQueue(
 		Scope:          scope,
 		Host:           host.ID(),
 		EnableProvider: provider,
+		ErrorFilter:    IsTimeoutError,
 	}
 
 	middlewareFn, err := middleware.New(params)

--- a/src/dbnode/client/host_queue_circuitbreaker_test.go
+++ b/src/dbnode/client/host_queue_circuitbreaker_test.go
@@ -30,6 +30,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/thrift"
 	"go.uber.org/zap"
 
 	"github.com/m3db/m3/src/cluster/kv"
@@ -232,6 +235,97 @@ func TestHostQueueCircuitBreakerIntegration(t *testing.T) {
 				for _, err := range actualErrs {
 					assert.NoError(t, err)
 				}
+			}
+		})
+	}
+}
+
+func TestHostQueueCircuitBreakerErrorFilter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cbConfig := middleware.Config{
+		CircuitBreakerConfig: circuitbreaker.Config{
+			MinimumRequests:      1,
+			FailureRatio:         0.1,
+			MinimumProbeRequests: 0,
+			WindowSize:           1,
+			BucketDuration:       time.Millisecond,
+		},
+	}
+
+	tests := []struct {
+		name                    string
+		mockError               error
+		expectCBRejectOnSecond  bool
+		expectFirstWriteError   bool
+	}{
+		{
+			name:                   "timeout error trips circuit breaker - second request rejected",
+			mockError:              tchannel.ErrTimeout,
+			expectCBRejectOnSecond: true,
+			expectFirstWriteError:  true,
+		},
+		{
+			name:                   "non-timeout error does NOT trip circuit breaker - second request passes",
+			mockError:              errors.New("bad request error"),
+			expectCBRejectOnSecond: false,
+			expectFirstWriteError:  true,
+		},
+		{
+			name:                   "successful write - second request passes",
+			mockError:              nil,
+			expectCBRejectOnSecond: false,
+			expectFirstWriteError:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockNode := rpc.NewMockTChanNode(ctrl)
+
+			enableProvider := &testEnableProvider{enabled: true, shadowMode: false}
+
+			// Create middleware with IsTimeoutError as the error filter
+			middlewareFn, err := middleware.New(middleware.Params{
+				Config:         cbConfig,
+				Logger:         zap.NewNop(),
+				Scope:          tally.NoopScope,
+				Host:           "test-host",
+				EnableProvider: enableProvider,
+				ErrorFilter:    IsTimeoutError,
+			})
+			require.NoError(t, err)
+
+			// First call returns the configured error
+			mockNode.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Return(test.mockError)
+			if !test.expectCBRejectOnSecond {
+				// If CB should NOT trip, second call should also reach the mock
+				mockNode.EXPECT().WriteBatchRaw(gomock.Any(), gomock.Any()).Return(nil)
+			}
+
+			wrappedNode := middlewareFn(mockNode)
+			ctx, cancel := thrift.NewContext(time.Second)
+			defer cancel()
+
+			node := wrappedNode.(rpc.TChanNode)
+
+			// First request
+			err = node.WriteBatchRaw(ctx, &rpc.WriteBatchRawRequest{})
+			if test.expectFirstWriteError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Second request — verifies whether CB tripped or not
+			err = node.WriteBatchRaw(ctx, &rpc.WriteBatchRawRequest{})
+			if test.expectCBRejectOnSecond {
+				assert.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), circuitBreakerRejectMessage),
+					"expected circuit breaker rejection, got: %v", err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Summary:
  Context:
    - Circuit breaker in M3DB client currently trips on all errors
    - Application errors (bad request, partial batch) should not trip the breaker

  Changes:
    - Add ErrorFilter func(error) bool to middleware Params for error classification
    - Modify withBreaker to only report filtered errors as CB failures
    - Only store lastError for CB-relevant errors (so rejection message shows timeout)
    - Add filteredFailures metric to distinguish CB failures from total failures
    - Wire IsTimeoutError as the error filter in host_queue.go
    - Add unit and integration tests for error filtering behavior

Test Plan:
  go test ./src/dbnode/client/circuitbreaker/middleware/... -v
  go test ./src/dbnode/client/ -run TestHostQueueCircuitBreaker -v

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/m3db/m3/blob/master/CONTRIBUTING.md and developer notes https://github.com/m3db/m3/blob/master/DEVELOPMENT.md
2. Please prefix the name of the pull request with the component you are updating in the format "[component] Change title" (for example "[dbnode] Support out of order writes") and also label this pull request according to what type of issue you are addressing. Furthermore, if this is a WIP or DRAFT PR, please create a draft PR instead: https://github.blog/2019-02-14-introducing-draft-pull-requests/
3. Ensure you have added or ran the appropriate tests for your PR: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#testing-changes
4. Follow the instructions for writing a changelog note: read more at https://github.com/m3db/m3/blob/master/DEVELOPMENT.md#updating-the-changelog
-->

<!--
If you have an issue this change addresses, please add the following details:
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing and/or backwards incompatible change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Does this PR require updating code package or user-facing documentation?**:
<!--
If no, just write "NONE" in the documentation-note block below.
If yes, describe which documentation you updated.
Note: Any changes that significantly updates how a code package is architectured or functions requires code package documentation updates in the form of updates to the README.md file in that package.
-->
```documentation-note

```
